### PR TITLE
feat: include realm_access and global_access role claims in access to…

### DIFF
--- a/apps/server-core/src/app/modules/oauth2/module.ts
+++ b/apps/server-core/src/app/modules/oauth2/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { DataSource, Repository  } from 'typeorm';
+import type { DataSource, Repository } from 'typeorm';
 import { CacheInjectionKey } from '../cache/index.ts';
 import type { IContainer } from 'eldin';
 import type { IModule } from 'orkos';

--- a/apps/server-core/src/app/modules/oauth2/module.ts
+++ b/apps/server-core/src/app/modules/oauth2/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Repository } from 'typeorm';
+import type { DataSource, Repository  } from 'typeorm';
 import { CacheInjectionKey } from '../cache/index.ts';
 import type { IContainer } from 'eldin';
 import type { IModule } from 'orkos';
@@ -20,6 +20,7 @@ import {
     OAuth2TokenRepository,
 } from './repositories/index.ts';
 import {
+    IdentityPermissionProvider,
     OAuth2AccessTokenIssuer,
     OAuth2AuthorizationCodeIssuer,
     OAuth2AuthorizationCodeRequestVerifier,
@@ -33,7 +34,15 @@ import {
 } from '../../../core/index.ts';
 import { OAuth2InjectionToken } from './constants.ts';
 import { IdentityInjectionKey } from '../identity/index.ts';
-import { ClientEntity, ClientScopeEntity } from '../../../adapters/database/domains/index.ts';
+import {
+    ClientEntity,
+    ClientRepository,
+    ClientScopeEntity,
+    RobotRepository,
+    RoleRepository,
+    UserRepository,
+} from '../../../adapters/database/domains/index.ts';
+import { DatabaseInjectionKey } from '../database/index.ts';
 import { ConfigInjectionKey } from '../config/index.ts';
 
 export class OAuth2Module implements IModule {
@@ -162,6 +171,13 @@ export class OAuth2Module implements IModule {
             useFactory: (c) => {
                 const tokenRepository = c.resolve(OAuth2InjectionToken.TokenRepository);
                 const tokenSigner = c.resolve(OAuth2InjectionToken.TokenSigner);
+                const dataSource = c.resolve<DataSource>(DatabaseInjectionKey.DataSource);
+                const identityRoleProvider = new IdentityPermissionProvider({
+                    clientRepository: new ClientRepository(dataSource),
+                    userRepository: new UserRepository(dataSource),
+                    robotRepository: new RobotRepository(dataSource),
+                    roleRepository: new RoleRepository(dataSource),
+                });
                 return new OAuth2AccessTokenIssuer(
                     tokenRepository,
                     tokenSigner,
@@ -169,6 +185,7 @@ export class OAuth2Module implements IModule {
                         maxAge: config.tokenAccessMaxAge,
                         issuer: config.publicUrl,
                     },
+                    identityRoleProvider,
                 );
             },
         });

--- a/apps/server-core/src/core/identity/permission/module.ts
+++ b/apps/server-core/src/core/identity/permission/module.ts
@@ -10,17 +10,18 @@ import type {
     PermissionPolicyBinding,
 } from '@authup/access';
 import { isPermissionPolicyBindingEqual, mergePermissionPolicyBindings } from '@authup/access';
-import type { Policy } from '@authup/core-kit';
+import type { Policy, Role } from '@authup/core-kit';
 import { isPolicy } from '@authup/core-kit';
 import type {
     IIdentityBindingRepository,
     IIdentityPermissionProvider,
+    IIdentityRoleProvider,
     IRoleBindingRepository,
     IdentityPermissionProviderContext,
     ResolveJunctionPolicyOptions,
 } from './types.ts';
 
-export class IdentityPermissionProvider implements IIdentityPermissionProvider {
+export class IdentityPermissionProvider implements IIdentityPermissionProvider, IIdentityRoleProvider {
     protected clientRepository: IIdentityBindingRepository;
 
     protected userRepository: IIdentityBindingRepository;
@@ -117,6 +118,24 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
             }
             case 'role': {
                 return this.getForRole(identity);
+            }
+        }
+
+        return [];
+    }
+
+    async getRolesFor(identity: IdentityPolicyData) : Promise<Role[]> {
+        switch (identity.type) {
+            case 'client': {
+                return this.clientRepository.getBoundRoles(identity.id);
+            }
+            case 'user': {
+                return this.userRepository.getBoundRoles(identity.id)
+                    .then((data) => this.reduceEntitiesByIdentityClient(data, identity));
+            }
+            case 'robot': {
+                return this.robotRepository.getBoundRoles(identity.id)
+                    .then((data) => this.reduceEntitiesByIdentityClient(data, identity));
             }
         }
 

--- a/apps/server-core/src/core/identity/permission/types.ts
+++ b/apps/server-core/src/core/identity/permission/types.ts
@@ -23,6 +23,10 @@ export interface IIdentityPermissionProvider {
     resolveJunctionPolicy(identity: IdentityPolicyData, options: ResolveJunctionPolicyOptions): Promise<Policy | undefined>;
 }
 
+export interface IIdentityRoleProvider {
+    getRolesFor(identity: IdentityPolicyData): Promise<Role[]>;
+}
+
 export interface IIdentityBindingRepository {
     getBoundPermissions(entity: string): Promise<PermissionPolicyBinding[]>;
     getBoundRoles(entity: string): Promise<Role[]>;

--- a/apps/server-core/src/core/oauth2/token/issuer/access/module.ts
+++ b/apps/server-core/src/core/oauth2/token/issuer/access/module.ts
@@ -11,31 +11,39 @@ import type { IOAuth2TokenSigner } from '../../signer/index.ts';
 import type { IOAuth2TokenRepository } from '../../repository/index.ts';
 import { OAuth2BaseTokenIssuer } from '../base.ts';
 import type { IOAuth2TokenIssuer, OAuth2TokenIssuerOptions, OAuth2TokenIssuerResponse } from '../types.ts';
+import type { IIdentityRoleProvider } from '../../../../identity/index.ts';
 
 export class OAuth2AccessTokenIssuer extends OAuth2BaseTokenIssuer implements IOAuth2TokenIssuer {
     protected repository: IOAuth2TokenRepository;
 
     protected signer : IOAuth2TokenSigner;
 
+    protected identityRoleProvider?: IIdentityRoleProvider;
+
     constructor(
         repository: IOAuth2TokenRepository,
         signer: IOAuth2TokenSigner,
         options: OAuth2TokenIssuerOptions = {},
+        identityRoleProvider?: IIdentityRoleProvider,
     ) {
         super(options);
 
         this.repository = repository;
         this.signer = signer;
+        this.identityRoleProvider = identityRoleProvider;
     }
 
     async issue(input: OAuth2TokenPayload = {}) : Promise<OAuth2TokenIssuerResponse> {
         const iss = this.buildIss(input);
+
+        const accessClaims = await this.buildAccessClaims(input);
 
         const data = await this.repository.insert({
             ...input,
             kind: OAuth2TokenKind.ACCESS,
             exp: this.buildExp(input),
             ...(iss ? { iss } : {}),
+            ...accessClaims,
         });
 
         const token = await this.signer.sign(data);
@@ -43,5 +51,35 @@ export class OAuth2AccessTokenIssuer extends OAuth2BaseTokenIssuer implements IO
         await this.repository.saveWithSignature(data, token);
 
         return [token, data];
+    }
+
+    protected async buildAccessClaims(input: OAuth2TokenPayload) : Promise<Pick<OAuth2TokenPayload, 'realm_access' | 'global_access'>> {
+        if (!this.identityRoleProvider || !input.sub || !input.sub_kind) {
+            return {};
+        }
+
+        const roles = await this.identityRoleProvider.getRolesFor({
+            type: input.sub_kind,
+            id: input.sub,
+            clientId: input.client_id,
+            realmId: input.realm_id,
+            realmName: input.realm_name,
+        });
+
+        const realmRoles: string[] = [];
+        const globalRoles: string[] = [];
+
+        for (const role of roles) {
+            if (role.realm_id) {
+                realmRoles.push(role.name);
+            } else {
+                globalRoles.push(role.name);
+            }
+        }
+
+        return {
+            realm_access: { roles: realmRoles },
+            global_access: { roles: globalRoles },
+        };
     }
 }

--- a/apps/server-core/src/core/oauth2/token/issuer/access/module.ts
+++ b/apps/server-core/src/core/oauth2/token/issuer/access/module.ts
@@ -70,10 +70,10 @@ export class OAuth2AccessTokenIssuer extends OAuth2BaseTokenIssuer implements IO
         const globalRoles: string[] = [];
 
         for (const role of roles) {
-            if (role.realm_id) {
-                realmRoles.push(role.name);
-            } else {
+            if (!role.realm_id) {
                 globalRoles.push(role.name);
+            } else if (input.realm_id && role.realm_id === input.realm_id) {
+                realmRoles.push(role.name);
             }
         }
 

--- a/apps/server-core/test/unit/core/oauth2/token/issuer/access/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/issuer/access/module.spec.ts
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Role } from '@authup/core-kit';
+import type { OAuth2TokenPayload } from '@authup/specs';
+import { OAuth2SubKind, OAuth2TokenKind } from '@authup/specs';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import { OAuth2AccessTokenIssuer } from '../../../../../../../src/core/oauth2/token/issuer/access/module.ts';
+import type { IOAuth2TokenRepository } from '../../../../../../../src/core/oauth2/token/repository/types.ts';
+import type { IOAuth2TokenSigner } from '../../../../../../../src/core/oauth2/token/signer/types.ts';
+import type { IIdentityRoleProvider } from '../../../../../../../src/core/identity/permission/types.ts';
+
+function createTokenRepo(): IOAuth2TokenRepository {
+    return {
+        setInactive: vi.fn(),
+        isInactive: vi.fn(),
+        findOneById: vi.fn(),
+        findOneBySignature: vi.fn(),
+        removeById: vi.fn(),
+        insert: vi.fn().mockImplementation(async (payload: OAuth2TokenPayload) => ({
+            jti: randomUUID(),
+            ...payload,
+        })),
+        save: vi.fn(),
+        saveWithSignature: vi.fn(),
+    };
+}
+
+function createRoleProvider(roles: Role[]): IIdentityRoleProvider {
+    return { getRolesFor: vi.fn().mockResolvedValue(roles) };
+}
+
+describe('OAuth2AccessTokenIssuer', () => {
+    const realmId = randomUUID();
+    const userId = randomUUID();
+
+    let repository: IOAuth2TokenRepository;
+    let signer: IOAuth2TokenSigner;
+
+    beforeEach(() => {
+        repository = createTokenRepo();
+        signer = { sign: vi.fn().mockResolvedValue('signed-access-token') };
+    });
+
+    describe('issue', () => {
+        it('should insert with kind=ACCESS, sign, and persist', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer);
+
+            const [token, payload] = await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+            });
+
+            expect(token).toBe('signed-access-token');
+            expect(repository.insert).toHaveBeenCalledWith(
+                expect.objectContaining({ kind: OAuth2TokenKind.ACCESS }),
+            );
+            expect(signer.sign).toHaveBeenCalledWith(payload);
+            expect(repository.saveWithSignature).toHaveBeenCalledWith(payload, 'signed-access-token');
+        });
+
+        it('should not add access claims when no permission provider is supplied', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+            });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.realm_access).toBeUndefined();
+            expect(insertCall.global_access).toBeUndefined();
+        });
+
+        it('should not add access claims when sub or sub_kind is missing', async () => {
+            const provider = createRoleProvider([]);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+
+            await issuer.issue({ realm_id: realmId });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.realm_access).toBeUndefined();
+            expect(insertCall.global_access).toBeUndefined();
+            expect(provider.getRolesFor).not.toHaveBeenCalled();
+        });
+
+        it('should split roles by realm_id into realm_access and global_access', async () => {
+            const roles: Role[] = [
+                {
+                    id: randomUUID(), 
+                    name: 'editor', 
+                    realm_id: realmId, 
+                } as Role,
+                {
+                    id: randomUUID(), 
+                    name: 'viewer', 
+                    realm_id: realmId, 
+                } as Role,
+                {
+                    id: randomUUID(), 
+                    name: 'admin', 
+                    realm_id: null, 
+                } as Role,
+            ];
+            const provider = createRoleProvider(roles);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+            });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.realm_access).toEqual({ roles: ['editor', 'viewer'] });
+            expect(insertCall.global_access).toEqual({ roles: ['admin'] });
+        });
+
+        it('should treat undefined realm_id as global', async () => {
+            const roles: Role[] = [
+                { id: randomUUID(), name: 'system' } as Role,
+            ];
+            const provider = createRoleProvider(roles);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+            });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.global_access).toEqual({ roles: ['system'] });
+            expect(insertCall.realm_access).toEqual({ roles: [] });
+        });
+
+        it('should produce empty role arrays when identity has no roles', async () => {
+            const provider = createRoleProvider([]);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+            });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.realm_access).toEqual({ roles: [] });
+            expect(insertCall.global_access).toEqual({ roles: [] });
+        });
+
+        it('should pass identity context to the permission provider', async () => {
+            const provider = createRoleProvider([]);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+            const clientId = randomUUID();
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+                realm_name: 'master',
+                client_id: clientId,
+            });
+
+            expect(provider.getRolesFor).toHaveBeenCalledWith({
+                type: OAuth2SubKind.USER,
+                id: userId,
+                clientId,
+                realmId,
+                realmName: 'master',
+            });
+        });
+    });
+});

--- a/apps/server-core/test/unit/core/oauth2/token/issuer/access/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/issuer/access/module.spec.ts
@@ -71,7 +71,7 @@ describe('OAuth2AccessTokenIssuer', () => {
             expect(repository.saveWithSignature).toHaveBeenCalledWith(payload, 'signed-access-token');
         });
 
-        it('should not add access claims when no permission provider is supplied', async () => {
+        it('should not add access claims when no role provider is supplied', async () => {
             const issuer = new OAuth2AccessTokenIssuer(repository, signer);
 
             await issuer.issue({
@@ -129,7 +129,7 @@ describe('OAuth2AccessTokenIssuer', () => {
             expect(insertCall.global_access).toEqual({ roles: ['admin'] });
         });
 
-        it('should treat undefined realm_id as global', async () => {
+        it('should treat a role with no realm_id as global', async () => {
             const roles: Role[] = [
                 { id: randomUUID(), name: 'system' } as Role,
             ];
@@ -144,6 +144,65 @@ describe('OAuth2AccessTokenIssuer', () => {
             const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
             expect(insertCall.global_access).toEqual({ roles: ['system'] });
             expect(insertCall.realm_access).toEqual({ roles: [] });
+        });
+
+        it('should drop roles bound to a different realm', async () => {
+            const otherRealmId = randomUUID();
+            const roles: Role[] = [
+                {
+                    id: randomUUID(),
+                    name: 'editor',
+                    realm_id: realmId,
+                } as Role,
+                {
+                    id: randomUUID(),
+                    name: 'foreign',
+                    realm_id: otherRealmId,
+                } as Role,
+                {
+                    id: randomUUID(),
+                    name: 'admin',
+                    realm_id: null,
+                } as Role,
+            ];
+            const provider = createRoleProvider(roles);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+            });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.realm_access).toEqual({ roles: ['editor'] });
+            expect(insertCall.global_access).toEqual({ roles: ['admin'] });
+        });
+
+        it('should drop realm-bound roles when input has no realm_id', async () => {
+            const roles: Role[] = [
+                {
+                    id: randomUUID(),
+                    name: 'editor',
+                    realm_id: realmId,
+                } as Role,
+                {
+                    id: randomUUID(),
+                    name: 'admin',
+                    realm_id: null,
+                } as Role,
+            ];
+            const provider = createRoleProvider(roles);
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+            });
+
+            const insertCall = (repository.insert as ReturnType<typeof vi.fn>).mock.calls[0][0];
+            expect(insertCall.realm_access).toEqual({ roles: [] });
+            expect(insertCall.global_access).toEqual({ roles: ['admin'] });
         });
 
         it('should produce empty role arrays when identity has no roles', async () => {
@@ -161,7 +220,7 @@ describe('OAuth2AccessTokenIssuer', () => {
             expect(insertCall.global_access).toEqual({ roles: [] });
         });
 
-        it('should pass identity context to the permission provider', async () => {
+        it('should pass identity context to the role provider', async () => {
             const provider = createRoleProvider([]);
             const issuer = new OAuth2AccessTokenIssuer(repository, signer, {}, provider);
             const clientId = randomUUID();

--- a/apps/server-core/ui/vite.config.ts
+++ b/apps/server-core/ui/vite.config.ts
@@ -13,7 +13,7 @@ import vuePlugin from '@vitejs/plugin-vue';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packagesRoot = path.resolve(__dirname, '..', '..', '..', 'packages');
 
-export default defineConfig(() => ({
+export default defineConfig({
     base: '/public/',
     plugins: [
         vuePlugin(),
@@ -28,4 +28,4 @@ export default defineConfig(() => ({
         },
     },
     ssr: { noExternal: true },
-}));
+});

--- a/packages/specs/src/oauth2/types.ts
+++ b/packages/specs/src/oauth2/types.ts
@@ -85,7 +85,7 @@ export type OAuth2TokenPayload = JWTClaims & {
     realm_access?: OAuth2AccessGrantClaim,
 
     /**
-     * Global role claims (roles with realm_id = null).
+     * Global role claims (roles whose realm_id is null or missing).
      */
     global_access?: OAuth2AccessGrantClaim
 };

--- a/packages/specs/src/oauth2/types.ts
+++ b/packages/specs/src/oauth2/types.ts
@@ -77,7 +77,21 @@ export type OAuth2TokenPayload = JWTClaims & {
     /**
      * Self: user agent
      */
-    user_agent?: string
+    user_agent?: string,
+
+    /**
+     * Realm-scoped role claims (roles where realm_id matches a realm).
+     */
+    realm_access?: OAuth2AccessGrantClaim,
+
+    /**
+     * Global role claims (roles with realm_id = null).
+     */
+    global_access?: OAuth2AccessGrantClaim
+};
+
+export type OAuth2AccessGrantClaim = {
+    roles: string[]
 };
 
 // todo: this should be removed.


### PR DESCRIPTION
…kens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth2 access tokens can include realm-scoped and global role claims (`realm_access`, `global_access`).
  * Dynamic identity role resolution added so token issuance can incorporate roles per identity and client context.

* **Tests**
  * Added comprehensive unit tests covering token issuance, access-claim generation, and role-partitioning scenarios.

* **Refactor**
  * Simplified Vite config export form for the UI build.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->