### PR TITLE
fix: enforce OAuth2 client authentication and PKCE per RFC 6749/7636

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -571,9 +571,11 @@ Each policy is a built-in `ATTRIBUTE_NAMES` policy with `invert: true`, where `n
 
 | Policy | Denylist `names` |
 |---|---|
-| `system.client-names-self-manage` | `active, realm_id` |
+| `system.client-names-self-manage` | `active, realm_id, is_confidential, secret_hashed, secret_encrypted` |
 | `system.robot-names-self-manage` | `active, realm_id, user_id` |
 | `system.user-names-self-manage` | `active, name_locked, status, status_message, realm_id` |
+
+The client denylist additionally blocks `is_confidential` (toggling clears the secret) and the `secret_hashed` / `secret_encrypted` storage flags (downgrading either would persist the secret in plaintext). FK fields like `realm_id` are usually validator-stripped on UPDATE already, but stay in the denylist as defense in depth.
 
 Self-editable fields (e.g. `name`, `display_name`, `email`, `password`, `secret`, `redirect_uri`, etc.) are NOT enumerated — they're permitted by virtue of being absent from the denylist. The validator already strips system-managed columns (`built_in`, `id`, `created_at`, `updated_at`) before they reach the policy, so the denylist only needs to cover what validators let through but admin-only state should still block.
 
@@ -628,6 +630,44 @@ Two-layer rejection:
 ### EA loading on tree roots
 
 `AttributeNamesPolicyValidator` reads the policy's `names` field from extra-attributes (`policy_attributes`). For top-level policies bound directly to permissions, the policy is loaded as the root of a closure-table descendants tree. `EATreeRepository.findDescendantsTree()` calls `extendOneWithEA(entity)` after building the children — without that, the root entity's EA fields stay unloaded and the validator fails with "value_invalid". Both Layer 1 (`PermissionDatabaseProvider`) and Layer 2 (`bindings.ts`) depend on this fix.
+
+## OAuth2 Token Endpoint Authentication
+
+The `/token` endpoint authenticates the calling client according to RFC 6749. Confidential clients MUST present a `client_secret`; public clients identify with `client_id` only.
+
+### Per-grant requirements
+
+| Grant | Client auth requirement |
+|---|---|
+| `client_credentials` | Authentication is the grant's purpose. Confidential client only — public clients are rejected. |
+| `authorization_code` | Confidential client MUST authenticate (RFC §4.1.3). Authenticated `client_id` MUST match the auth code's bound `client_id` — mismatch = `invalid_grant`. |
+| `refresh_token` | Confidential client MUST authenticate (RFC §6). If the refresh token's payload has `client_id`, the request MUST authenticate as that client. Authenticated `client_id` MUST match — mismatch = `invalid_grant`. Tokens with no bound client may refresh without auth (legacy/no-client flow). |
+| `password` | Confidential client MUST authenticate (RFC §4.3.2). The token's `client_id` claim and the OpenID `aud` claim use the **authenticated** client's id, not any user-side association. |
+| `robot_credentials` | Authentication is the grant's purpose (Authup-specific extension). |
+
+### Credential transport
+
+Per RFC 6749 §2.3.1, the server MUST NOT support multiple authentication methods in one request. Authup enforces this:
+
+- Body: `client_id` and `client_secret` form parameters
+- Header: `Authorization: Basic base64(client_id:client_secret)`
+- Both at once → `invalid_request`
+
+`extractClientCredentialsFromRequest` (`adapters/http/adapters/oauth2/grant-types/utils/credentials.ts`) is the shared helper enforcing this. Used by all grants that authenticate clients.
+
+### `OAuth2ClientAuthenticator`
+
+Single core class (`core/oauth2/client/authenticator.ts`) used by `authorization_code`, `refresh_token`, and `password` grants. Resolves the client by id/name, verifies `is_confidential`, and:
+- Confidential: requires `client_secret` and verifies via `ClientCredentialsService.verify`
+- Public: returns the client without secret check
+
+Distinct from `ClientAuthenticator` (`core/authentication/entities/client/module.ts`) which is used for `client_credentials` grant — that one rejects public clients outright since they can't authenticate themselves with credentials.
+
+### PKCE for public clients
+
+`/authorize` rejects public clients without `code_challenge` when an authorization code will be issued (RFC 7636 §4.4.1, OAuth 2.1). At `/token`, the code verifier double-checks: if the resolved client is public and the auth code has no challenge stored, reject. Defense in depth in case the authorize-side check was bypassed or the client's `is_confidential` flag changed mid-flow.
+
+`code_challenge_method` defaults to `plain` per RFC 7636 §4.3 — only `S256` triggers SHA-256 verification.
 
 ## Provisioning Permissions With Policies
 

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/authorize.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/authorize.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025.
+ * Copyright (c) 2025-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
@@ -12,16 +12,23 @@ import { useRequestQuery } from '@routup/basic/query';
 import type { Request } from 'routup';
 import { getRequestHeader, getRequestIP } from 'routup';
 import { OAuth2AuthorizeGrant } from '../../../../../core/index.ts';
-import type { IOAuth2AuthorizationCodeVerifier } from '../../../../../core/index.ts';
+import type {
+    IOAuth2AuthorizationCodeVerifier,
+    OAuth2ClientAuthenticator,
+} from '../../../../../core/index.ts';
 import type { HTTPOAuth2AuthorizeGrantContext, IHTTPOAuth2Grant } from './types.ts';
+import { extractClientCredentialsFromRequest } from './utils/index.ts';
 
 export class HTTPOAuth2AuthorizeGrant extends OAuth2AuthorizeGrant implements IHTTPOAuth2Grant {
     protected codeVerifier : IOAuth2AuthorizationCodeVerifier;
+
+    protected clientAuthenticator : OAuth2ClientAuthenticator;
 
     constructor(ctx: HTTPOAuth2AuthorizeGrantContext) {
         super(ctx);
 
         this.codeVerifier = ctx.codeVerifier;
+        this.clientAuthenticator = ctx.clientAuthenticator;
     }
 
     async runWithRequest(req: Request): Promise<OAuth2TokenGrantResponse> {
@@ -32,9 +39,16 @@ export class HTTPOAuth2AuthorizeGrant extends OAuth2AuthorizeGrant implements IH
             throw OAuth2Error.requestInvalid();
         }
 
+        const { clientId, clientSecret } = extractClientCredentialsFromRequest(req);
+        const realmId = this.extractParam(req, 'realm_id');
+
+        const client = await this.clientAuthenticator.authenticate(clientId, clientSecret, realmId);
+
         const entity = await this.codeVerifier.verify(code, {
             redirectUri,
             codeVerifier,
+            clientId: client.id,
+            clientIsPublic: !client.is_confidential,
         });
 
         return this.runWith(entity, {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/client-credentials.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/client-credentials.ts
@@ -6,16 +6,15 @@
  */
 
 import type { OAuth2TokenGrantResponse } from '@authup/specs';
-import { OAuth2Error } from '@authup/specs';
 import { useRequestBody } from '@routup/basic/body';
 import type { Client } from '@authup/core-kit';
 import { ClientError } from '@authup/core-kit';
-import { AuthorizationHeaderType, parseAuthorizationHeader } from 'hapic';
 import type { Request } from 'routup';
 import { getRequestHeader, getRequestIP } from 'routup';
 import type { ICredentialsAuthenticator } from '../../../../../core/index.ts';
 import { ClientCredentialsGrant } from '../../../../../core/index.ts';
 import type { HTTPOAuth2ClientCredentialsGrantContext, IHTTPOAuth2Grant } from './types.ts';
+import { extractClientCredentialsFromRequest } from './utils/index.ts';
 
 export class HTTPClientCredentialsGrant extends ClientCredentialsGrant implements IHTTPOAuth2Grant {
     protected authenticator : ICredentialsAuthenticator<Client>;
@@ -27,28 +26,14 @@ export class HTTPClientCredentialsGrant extends ClientCredentialsGrant implement
     }
 
     async runWithRequest(req: Request): Promise<OAuth2TokenGrantResponse> {
-        let clientId = useRequestBody(req, 'client_id');
-        let clientSecret = useRequestBody(req, 'client_secret');
+        const { clientId, clientSecret } = extractClientCredentialsFromRequest(req);
         const realmId = useRequestBody(req, 'realm_id');
 
-        if (!clientId && !clientSecret) {
-            const { authorization: headerValue } = req.headers;
-
-            if (typeof headerValue !== 'string') {
-                throw ClientError.credentialsInvalid();
-            }
-
-            const header = parseAuthorizationHeader(headerValue);
-
-            if (header.type !== AuthorizationHeaderType.BASIC) {
-                throw OAuth2Error.requestInvalid();
-            }
-
-            clientId = header.username;
-            clientSecret = header.password;
+        if (!clientId) {
+            throw ClientError.credentialsInvalid();
         }
 
-        const client = await this.authenticator.authenticate(clientId, clientSecret, realmId);
+        const client = await this.authenticator.authenticate(clientId, clientSecret ?? '', realmId);
 
         return this.runWith(client, {
             ipAddress: getRequestIP(req, { trustProxy: true }),

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025.
+ * Copyright (c) 2025-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
@@ -10,17 +10,21 @@ import type { OAuth2TokenGrantResponse } from '@authup/specs';
 import { useRequestBody } from '@routup/basic/body';
 import type { Request } from 'routup';
 import { getRequestHeader, getRequestIP } from 'routup';
-import type { ICredentialsAuthenticator } from '../../../../../core/index.ts';
+import type { ICredentialsAuthenticator, OAuth2ClientAuthenticator } from '../../../../../core/index.ts';
 import { PasswordGrantType } from '../../../../../core/index.ts';
 import type { HTTPOAuth2PasswordGrantContext, IHTTPOAuth2Grant } from './types.ts';
+import { extractClientCredentialsFromRequest } from './utils/index.ts';
 
 export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2Grant {
     protected authenticator : ICredentialsAuthenticator<User>;
+
+    protected clientAuthenticator : OAuth2ClientAuthenticator;
 
     constructor(ctx: HTTPOAuth2PasswordGrantContext) {
         super(ctx);
 
         this.authenticator = ctx.authenticator;
+        this.clientAuthenticator = ctx.clientAuthenticator;
     }
 
     async runWithRequest(req: Request): Promise<OAuth2TokenGrantResponse> {
@@ -30,10 +34,20 @@ export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2G
             realm_id: realmId,
         } = useRequestBody(req);
 
-        const data = await this.authenticator.authenticate(username, password, realmId);
+        const { clientId, clientSecret } = extractClientCredentialsFromRequest(req);
+
+        const client = clientId ?
+            await this.clientAuthenticator.authenticate(
+                clientId,
+                clientSecret,
+                typeof realmId === 'string' ? realmId : undefined,
+            ) :
+            undefined;
+
+        const user = await this.authenticator.authenticate(username, password, realmId);
 
         return this.runWith(
-            data,
+            { user, client },
             {
                 ipAddress: getRequestIP(req, { trustProxy: true }),
                 userAgent: getRequestHeader(req, 'user-agent'),

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/refresh_token.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/refresh_token.ts
@@ -1,22 +1,67 @@
 /*
- * Copyright (c) 2025.
+ * Copyright (c) 2025-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
 import type { OAuth2TokenGrantResponse } from '@authup/specs';
+import { OAuth2Error } from '@authup/specs';
 import { useRequestBody } from '@routup/basic/body';
 import type { Request } from 'routup';
 import { getRequestHeader, getRequestIP } from 'routup';
 import { OAuth2RefreshTokenGrant } from '../../../../../core/index.ts';
-import type { IHTTPOAuth2Grant } from './types.ts';
+import type {
+    IOAuth2TokenVerifier,
+    OAuth2ClientAuthenticator,
+} from '../../../../../core/index.ts';
+import type { HTTPOAuth2RefreshTokenGrantContext, IHTTPOAuth2Grant } from './types.ts';
+import { extractClientCredentialsFromRequest } from './utils/index.ts';
 
 export class HTTPOAuth2RefreshTokenGrant extends OAuth2RefreshTokenGrant implements IHTTPOAuth2Grant {
+    protected clientAuthenticator : OAuth2ClientAuthenticator;
+
+    protected refreshTokenVerifier : IOAuth2TokenVerifier;
+
+    constructor(ctx: HTTPOAuth2RefreshTokenGrantContext) {
+        super(ctx);
+
+        this.clientAuthenticator = ctx.clientAuthenticator;
+        this.refreshTokenVerifier = ctx.tokenVerifier;
+    }
+
     async runWithRequest(req: Request): Promise<OAuth2TokenGrantResponse> {
         const refreshToken = useRequestBody(req, 'refresh_token');
+        if (typeof refreshToken !== 'string' || refreshToken.length === 0) {
+            throw OAuth2Error.requestInvalid();
+        }
 
-        return this.runWith(refreshToken, {
+        const { clientId, clientSecret } = extractClientCredentialsFromRequest(req);
+        const realmId = useRequestBody(req, 'realm_id');
+
+        // RFC 6749 §6: verify the refresh token first to learn its bound
+        // client (if any), then enforce binding. Authenticate the requesting
+        // client when credentials are present, or when the token requires
+        // a client binding.
+        const payload = await this.refreshTokenVerifier.verify(refreshToken);
+
+        if (clientId) {
+            const client = await this.clientAuthenticator.authenticate(
+                clientId,
+                clientSecret,
+                typeof realmId === 'string' ? realmId : undefined,
+            );
+
+            if (payload.client_id && payload.client_id !== client.id) {
+                throw OAuth2Error.grantInvalid();
+            }
+        } else if (payload.client_id) {
+            // Token was issued to a specific client — that client MUST
+            // re-authenticate (RFC 6749 §6 binding requirement).
+            throw OAuth2Error.clientInvalid();
+        }
+
+        return this.runWith(payload, {
             ipAddress: getRequestIP(req, { trustProxy: true }),
             userAgent: getRequestHeader(req, 'user-agent'),
         });

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/types.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/types.ts
@@ -13,11 +13,14 @@ import type {
     ICredentialsAuthenticator,
     IOAuth2AuthorizationCodeVerifier,
     OAuth2AuthorizeGrantContext,
+    OAuth2ClientAuthenticator,
     OAuth2PasswordGrantContext,
+    OAuth2RefreshTokenGrantContext,
 } from '../../../../../core/index.ts';
 
 export type HTTPOAuth2AuthorizeGrantContext = OAuth2AuthorizeGrantContext & {
-    codeVerifier: IOAuth2AuthorizationCodeVerifier
+    codeVerifier: IOAuth2AuthorizationCodeVerifier,
+    clientAuthenticator: OAuth2ClientAuthenticator,
 };
 
 export interface IHTTPOAuth2Grant {
@@ -25,7 +28,12 @@ export interface IHTTPOAuth2Grant {
 }
 
 export type HTTPOAuth2PasswordGrantContext = OAuth2PasswordGrantContext & {
-    authenticator : ICredentialsAuthenticator<User>
+    authenticator : ICredentialsAuthenticator<User>,
+    clientAuthenticator: OAuth2ClientAuthenticator,
+};
+
+export type HTTPOAuth2RefreshTokenGrantContext = OAuth2RefreshTokenGrantContext & {
+    clientAuthenticator: OAuth2ClientAuthenticator,
 };
 
 export type HTTPOAuth2ClientCredentialsGrantContext = BaseGrantContext & {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/credentials.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/credentials.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2025-2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { OAuth2Error } from '@authup/specs';
+import { useRequestBody } from '@routup/basic/body';
+import { AuthorizationHeaderType, parseAuthorizationHeader } from 'hapic';
+import type { Request } from 'routup';
+
+export type ExtractedClientCredentials = {
+    clientId?: string,
+    clientSecret?: string,
+};
+
+/**
+ * Extract client credentials from an OAuth2 token endpoint request.
+ *
+ * Per RFC 6749 §2.3.1, the server MUST NOT support multiple client
+ * authentication methods in a single request. This helper rejects requests
+ * that present credentials in BOTH the Basic Authorization header and the
+ * request body.
+ */
+export function extractClientCredentialsFromRequest(req: Request): ExtractedClientCredentials {
+    const bodyClientId = readStringBody(req, 'client_id');
+    const bodyClientSecret = readStringBody(req, 'client_secret');
+    const hasBodyCredentials = !!bodyClientId || !!bodyClientSecret;
+
+    const basicCredentials = parseBasicCredentials(req);
+
+    if (hasBodyCredentials && basicCredentials) {
+        throw OAuth2Error.requestInvalid(
+            'Client credentials must be provided either via Basic Authorization header or request body, not both.',
+        );
+    }
+
+    if (hasBodyCredentials) {
+        return { clientId: bodyClientId, clientSecret: bodyClientSecret };
+    }
+
+    if (basicCredentials) {
+        return basicCredentials;
+    }
+
+    return {};
+}
+
+function readStringBody(req: Request, key: string): string | undefined {
+    const value = useRequestBody(req, key);
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function parseBasicCredentials(req: Request): ExtractedClientCredentials | undefined {
+    const headerValue = req.headers.authorization;
+    if (typeof headerValue !== 'string') {
+        return undefined;
+    }
+
+    let header;
+    try {
+        header = parseAuthorizationHeader(headerValue);
+    } catch {
+        // Malformed Authorization header — surface as 400 invalid_request
+        // rather than letting hapic's error propagate as 500.
+        throw OAuth2Error.requestInvalid('Malformed Authorization header.');
+    }
+
+    if (header.type !== AuthorizationHeaderType.BASIC) {
+        return undefined;
+    }
+
+    return { clientId: header.username, clientSecret: header.password };
+}

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/credentials.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/credentials.ts
@@ -37,6 +37,12 @@ export function extractClientCredentialsFromRequest(req: Request): ExtractedClie
     }
 
     if (hasBodyCredentials) {
+        // Reject stray client_secret without client_id — otherwise grants
+        // that gate auth on `if (clientId)` would silently skip
+        // authentication and leak through with the secret discarded.
+        if (!bodyClientId) {
+            throw OAuth2Error.requestInvalid('client_secret was provided without client_id.');
+        }
         return { clientId: bodyClientId, clientSecret: bodyClientSecret };
     }
 
@@ -71,5 +77,25 @@ function parseBasicCredentials(req: Request): ExtractedClientCredentials | undef
         return undefined;
     }
 
-    return { clientId: header.username, clientSecret: header.password };
+    // RFC 6749 §2.3.1 + Appendix B: client_id and client_secret are
+    // application/x-www-form-urlencoded BEFORE base64 encoding in the
+    // Authorization header. hapic only base64-decodes; we form-decode here
+    // so credentials containing reserved characters (`:`, `+`, `%`, `&`,
+    // `=`, etc.) round-trip correctly.
+    return {
+        clientId: formDecode(header.username),
+        clientSecret: formDecode(header.password),
+    };
+}
+
+function formDecode(value: string): string {
+    try {
+        // application/x-www-form-urlencoded: '+' represents space; %XX is
+        // percent-encoded UTF-8.
+        return decodeURIComponent(value.replace(/\+/g, ' '));
+    } catch {
+        // Malformed percent-encoding — return raw value rather than
+        // throwing; the caller will still validate via authentication.
+        return value;
+    }
 }

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/index.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/index.ts
@@ -5,4 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './credentials.ts';
 export * from './guess.ts';

--- a/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
@@ -69,6 +69,7 @@ export class TokenController {
         this.tokenGrants = {
             [OAuth2TokenGrant.AUTHORIZATION_CODE]: new HTTPOAuth2AuthorizeGrant({
                 codeVerifier: ctx.codeVerifier,
+                clientAuthenticator: ctx.oauth2ClientAuthenticator,
                 accessTokenIssuer: ctx.accessTokenIssuer,
                 refreshTokenIssuer: ctx.refreshTokenIssuer,
                 sessionManager: ctx.sessionManager,
@@ -87,6 +88,7 @@ export class TokenController {
                 accessTokenIssuer: ctx.accessTokenIssuer,
                 refreshTokenIssuer: ctx.refreshTokenIssuer,
                 authenticator: ctx.userAuthenticator,
+                clientAuthenticator: ctx.oauth2ClientAuthenticator,
                 sessionManager: ctx.sessionManager,
             }),
             [OAuth2TokenGrant.REFRESH_TOKEN]: new HTTPOAuth2RefreshTokenGrant({
@@ -95,6 +97,7 @@ export class TokenController {
                 tokenVerifier: ctx.tokenVerifier,
                 tokenRevoker: ctx.tokenRevoker,
                 sessionManager: ctx.sessionManager,
+                clientAuthenticator: ctx.oauth2ClientAuthenticator,
             }),
         };
     }

--- a/apps/server-core/src/adapters/http/controllers/workflows/token/types.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/token/types.ts
@@ -12,9 +12,10 @@ import type {
     IIdentityResolver,
     IOAuth2AuthorizationCodeVerifier,
     IOAuth2TokenIssuer,
-    IOAuth2TokenRevoker, 
-    IOAuth2TokenVerifier, 
-    ISessionManager, 
+    IOAuth2TokenRevoker,
+    IOAuth2TokenVerifier,
+    ISessionManager,
+    OAuth2ClientAuthenticator,
 } from '../../../../../core/index.ts';
 
 export type TokenControllerContext = {
@@ -33,4 +34,6 @@ export type TokenControllerContext = {
     clientAuthenticator: ICredentialsAuthenticator<Client>
     robotAuthenticator: ICredentialsAuthenticator<Robot>
     userAuthenticator: ICredentialsAuthenticator<User>
+
+    oauth2ClientAuthenticator: OAuth2ClientAuthenticator
 };

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -123,6 +123,7 @@ import {
     ClientService,
     CredentialsAuthenticator,
     IdentityProviderRoleMappingService,
+    OAuth2ClientAuthenticator,
     PasswordRecoveryService,
     PermissionPolicyService,
     PermissionService,
@@ -282,6 +283,8 @@ export class HTTPControllerModule {
             new UserAuthenticator(identityResolver),
         ]);
 
+        const oauth2ClientAuthenticator = new OAuth2ClientAuthenticator(identityResolver);
+
         return new TokenController({
             codeVerifier,
 
@@ -297,6 +300,8 @@ export class HTTPControllerModule {
             clientAuthenticator,
             robotAuthenticator,
             userAuthenticator,
+
+            oauth2ClientAuthenticator,
 
             sessionManager,
         });

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -8,7 +8,11 @@
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
 import { isSimpleMatch } from '@authup/kit';
-import { OAuth2Error, hasOAuth2Scopes } from '@authup/specs';
+import {
+    OAuth2AuthorizationResponseType,
+    OAuth2Error,
+    hasOAuth2Scopes,
+} from '@authup/specs';
 import type { IOAuth2ClientRepository } from '../../../client/index.ts';
 import type { IOAuth2ScopeRepository } from '../../../scope/index.ts';
 import type {
@@ -16,6 +20,13 @@ import type {
     OAuth2AuthorizationCodeRequestVerificationResult,
     OAuth2AuthorizationCodeRequestVerifierContext,
 } from './types.ts';
+
+function willIssueCode(responseType: string | undefined): boolean {
+    if (!responseType) {
+        return false;
+    }
+    return responseType.split(' ').includes(OAuth2AuthorizationResponseType.CODE);
+}
 
 export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2AuthorizationCodeRequestVerifier {
     protected clientRepository: IOAuth2ClientRepository;
@@ -45,6 +56,15 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
 
         if (!client.active) {
             throw OAuth2Error.clientInactive();
+        }
+
+        // Public clients MUST use PKCE for the code flow (RFC 7636 §4.4.1,
+        // OAuth 2.1). Without PKCE a public client's code flow has no second
+        // factor — anyone who intercepts the redirect can redeem the code at
+        // /token. Only enforce when an authorization code will actually be
+        // issued; implicit/id_token-only flows don't involve a code.
+        if (!client.is_confidential && !data.code_challenge && willIssueCode(data.response_type)) {
+            throw OAuth2Error.requestInvalid('PKCE code_challenge is required for public clients.');
         }
 
         data.client_id = client.id;

--- a/apps/server-core/src/core/oauth2/authorization/code/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code/verifier/module.ts
@@ -25,26 +25,44 @@ export class OAuth2AuthorizationCodeVerifier implements IOAuth2AuthorizationCode
             throw OAuth2Error.grantInvalid();
         }
 
+        // RFC 6749 §4.1.3: if the client was issued a client_id, verify the
+        // authorization code was issued to the authenticated client. Always
+        // require a clientId to be supplied so a malformed token request can't
+        // bypass the binding by omitting it.
+        if (entity.client_id) {
+            if (!options.clientId || options.clientId !== entity.client_id) {
+                throw OAuth2Error.grantInvalid();
+            }
+        }
+
         if (entity.redirect_uri) {
             if (!options.redirectUri || entity.redirect_uri !== options.redirectUri) {
                 throw OAuth2Error.redirectUriMismatch();
             }
         }
 
-        if (entity.code_challenge) {
-            if (entity.code_challenge_method === OAuth2AuthorizationCodeChallengeMethod.PLAIN) {
-                if (options.codeVerifier !== entity.code_challenge) {
-                    throw OAuth2Error.grantInvalid('PKCE code_verifier mismatch.');
-                }
-            } else {
-                if (!options.codeVerifier) {
-                    throw OAuth2Error.grantInvalid('Code verifier invalid.');
-                }
+        // Public clients MUST use PKCE (RFC 7636). Defense in depth in case
+        // the authorize-side check was bypassed or the client's
+        // is_confidential flag changed between authorize and token.
+        if (options.clientIsPublic && !entity.code_challenge) {
+            throw OAuth2Error.grantInvalid('PKCE is required for public clients.');
+        }
 
+        if (entity.code_challenge) {
+            if (!options.codeVerifier) {
+                throw OAuth2Error.grantInvalid('Code verifier invalid.');
+            }
+
+            // RFC 7636 §4.3: code_challenge_method defaults to "plain" when
+            // absent. Only treat the challenge as S256 when the client
+            // explicitly sent code_challenge_method=S256.
+            if (entity.code_challenge_method === OAuth2AuthorizationCodeChallengeMethod.SHA_256) {
                 const codeVerifierHash = await buildOAuth2CodeChallenge(options.codeVerifier);
                 if (codeVerifierHash !== entity.code_challenge) {
                     throw OAuth2Error.grantInvalid('PKCE code_verifier mismatch.');
                 }
+            } else if (options.codeVerifier !== entity.code_challenge) {
+                throw OAuth2Error.grantInvalid('PKCE code_verifier mismatch.');
             }
         }
 

--- a/apps/server-core/src/core/oauth2/authorization/code/verifier/types.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code/verifier/types.ts
@@ -9,7 +9,9 @@ import type { OAuth2AuthorizationCode } from '@authup/core-kit';
 
 export type IOAuth2AuthorizationCodeVerifyOptions = {
     redirectUri?: string,
-    codeVerifier?: string
+    codeVerifier?: string,
+    clientId?: string,
+    clientIsPublic?: boolean,
 };
 
 export interface IOAuth2AuthorizationCodeVerifier {

--- a/apps/server-core/src/core/oauth2/client/authenticator.ts
+++ b/apps/server-core/src/core/oauth2/client/authenticator.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2025-2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Client } from '@authup/core-kit';
+import { IdentityType } from '@authup/core-kit';
+import { OAuth2Error } from '@authup/specs';
+import { ClientCredentialsService } from '../../authentication/credential/index.ts';
+import type { IIdentityResolver } from '../../identity/index.ts';
+
+/**
+ * Authenticates a client at the OAuth2 token endpoint. Confidential clients
+ * MUST present a valid client_secret (RFC 6749 §3.2.1, §4.1.3, §4.3.2, §6);
+ * public clients identify via client_id only.
+ *
+ * Used by authorization_code, refresh_token, and password grants.
+ */
+export class OAuth2ClientAuthenticator {
+    protected identityResolver: IIdentityResolver;
+
+    protected credentialsService: ClientCredentialsService;
+
+    constructor(identityResolver: IIdentityResolver) {
+        this.identityResolver = identityResolver;
+        this.credentialsService = new ClientCredentialsService();
+    }
+
+    async authenticate(
+        clientId: string | undefined,
+        clientSecret?: string,
+        realmId?: string,
+    ): Promise<Client> {
+        if (!clientId) {
+            throw OAuth2Error.clientInvalid();
+        }
+
+        const identity = await this.identityResolver.resolve(IdentityType.CLIENT, clientId, realmId);
+        if (!identity || identity.type !== IdentityType.CLIENT) {
+            throw OAuth2Error.clientInvalid();
+        }
+
+        if (!identity.data.active) {
+            throw OAuth2Error.clientInactive();
+        }
+
+        if (identity.data.is_confidential) {
+            if (!clientSecret) {
+                throw OAuth2Error.clientInvalid();
+            }
+
+            const verified = await this.credentialsService.verify(clientSecret, identity.data);
+            if (!verified) {
+                throw OAuth2Error.clientInvalid();
+            }
+        }
+
+        return identity.data;
+    }
+}

--- a/apps/server-core/src/core/oauth2/client/index.ts
+++ b/apps/server-core/src/core/oauth2/client/index.ts
@@ -5,4 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './authenticator.ts';
 export * from './types.ts';

--- a/apps/server-core/src/core/oauth2/grant-types/password.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/password.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022.
+ * Copyright (c) 2022-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
@@ -7,7 +7,7 @@
 
 import type { OAuth2TokenGrantResponse, OAuth2TokenPayload } from '@authup/specs';
 import { OAuth2SubKind } from '@authup/specs';
-import type { User } from '@authup/core-kit';
+import type { Client, User } from '@authup/core-kit';
 import {
     IdentityType,
     ScopeName,
@@ -17,7 +17,12 @@ import type { IOAuth2TokenIssuer } from '../token/index.ts';
 import { OAuth2BaseGrant } from './base.ts';
 import type { OAuth2GrantRunWIthOptions, OAuth2PasswordGrantContext } from './types.ts';
 
-export class PasswordGrantType extends OAuth2BaseGrant<User> {
+export type OAuth2PasswordGrantInput = {
+    user: User,
+    client?: Client,
+};
+
+export class PasswordGrantType extends OAuth2BaseGrant<OAuth2PasswordGrantInput> {
     protected refreshTokenIssuer : IOAuth2TokenIssuer;
 
     constructor(ctx: OAuth2PasswordGrantContext) {
@@ -29,26 +34,29 @@ export class PasswordGrantType extends OAuth2BaseGrant<User> {
         this.refreshTokenIssuer = ctx.refreshTokenIssuer;
     }
 
-    async runWith(input: User, options: OAuth2GrantRunWIthOptions = {}) : Promise<OAuth2TokenGrantResponse> {
+    async runWith(input: OAuth2PasswordGrantInput, options: OAuth2GrantRunWIthOptions = {}) : Promise<OAuth2TokenGrantResponse> {
+        const { user, client } = input;
+        const clientId = client?.id;
+
         const session = await this.sessionManager.create({
             user_agent: options.userAgent,
             ip_address: options.ipAddress,
-            realm_id: input.realm_id,
-            client_id: input.client_id || undefined,
-            sub: input.id,
+            realm_id: user.realm_id,
+            client_id: clientId,
+            sub: user.id,
             sub_kind: IdentityType.USER,
         });
 
         const issuePayload : Partial<OAuth2TokenPayload> = {
-            client_id: input.client_id || undefined,
+            client_id: clientId,
             session_id: session.id,
             user_agent: session.user_agent,
             remote_address: session.ip_address,
             scope: ScopeName.GLOBAL,
-            sub: input.id,
+            sub: user.id,
             sub_kind: OAuth2SubKind.USER,
-            realm_id: input.realm_id,
-            realm_name: input.realm?.name,
+            realm_id: user.realm_id,
+            realm_name: user.realm?.name,
         };
 
         const [accessToken, accessTokenPayload] = await this.accessTokenIssuer.issue(issuePayload);

--- a/apps/server-core/test/unit/core/oauth2/authorization/code/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code/verifier/module.spec.ts
@@ -75,8 +75,29 @@ describe('OAuth2AuthorizationCodeVerifier', () => {
                 client_id: 'client-1',
                 scope: 'openid',
             });
-            const result = await verifier.verify(code.id, {});
+            const result = await verifier.verify(code.id, { clientId: 'client-1' });
             expect(result.id).toBe(code.id);
+        });
+
+        it('should throw grantInvalid when clientId does not match the code', async () => {
+            const code = repository.seed({ client_id: 'client-1' });
+            await expect(
+                verifier.verify(code.id, { clientId: 'client-2' }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_GRANT_INVALID }));
+        });
+
+        it('should throw grantInvalid when clientId is missing but code has one', async () => {
+            const code = repository.seed({ client_id: 'client-1' });
+            await expect(
+                verifier.verify(code.id, {}),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_GRANT_INVALID }));
+        });
+
+        it('should throw grantInvalid when public client omits PKCE', async () => {
+            const code = repository.seed({ client_id: 'client-1' });
+            await expect(
+                verifier.verify(code.id, { clientId: 'client-1', clientIsPublic: true }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_GRANT_INVALID }));
         });
 
         it('should throw grantInvalid for non-existent code', async () => {
@@ -111,6 +132,13 @@ describe('OAuth2AuthorizationCodeVerifier', () => {
                 code_challenge: codeVerifier,
                 code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.PLAIN,
             });
+            const result = await verifier.verify(code.id, { codeVerifier });
+            expect(result.id).toBe(code.id);
+        });
+
+        it('should verify PKCE plain challenge when method is omitted (RFC 7636 default)', async () => {
+            const codeVerifier = 'my-plain-verifier-no-method';
+            const code = repository.seed({ code_challenge: codeVerifier });
             const result = await verifier.verify(code.id, { codeVerifier });
             expect(result.id).toBe(code.id);
         });
@@ -162,15 +190,15 @@ describe('OAuth2AuthorizationCodeVerifier', () => {
     describe('atomic consumption', () => {
         it('should consume code on verify (single-use)', async () => {
             const code = repository.seed({ client_id: 'c' });
-            await verifier.verify(code.id, {});
+            await verifier.verify(code.id, { clientId: 'c' });
             expect(repository.has(code.id)).toBe(false);
         });
 
         it('should reject second verify of same code', async () => {
             const code = repository.seed({ client_id: 'c' });
-            await verifier.verify(code.id, {});
+            await verifier.verify(code.id, { clientId: 'c' });
             await expect(
-                verifier.verify(code.id, {}),
+                verifier.verify(code.id, { clientId: 'c' }),
             ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_GRANT_INVALID }));
         });
     });

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
@@ -1,41 +1,66 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import type { Client, OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
-import { OAuth2AuthorizationResponseType } from '@authup/specs';
+import {
+    OAuth2AuthorizationCodeChallengeMethod,
+    OAuth2AuthorizationResponseType,
+    OAuth2ErrorCode,
+} from '@authup/specs';
 import { ErrorCode } from '@authup/errors';
 import { isClientError } from 'hapic';
 import { buildOAuth2CodeChallenge, generateOAuth2CodeVerifier } from '../../../../../../src/core';
 import { createFakeClient } from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
-describe('refresh-token', () => {
-    let client : Client;
+describe('grant-authorize', () => {
+    let confidentialClient : Client;
+    let confidentialSecret : string;
+
+    let publicClient : Client;
 
     const suite = createTestApplication();
 
     beforeAll(async () => {
         await suite.setup();
 
-        client = await suite.client
+        confidentialSecret = generateOAuth2CodeVerifier();
+        confidentialClient = await suite.client
             .client
-            .create(createFakeClient());
+            .create(createFakeClient({
+                secret: confidentialSecret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
 
         const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
         await suite.client.clientScope.create({
             scope_id: scope.id,
-            client_id: client.id,
+            client_id: confidentialClient.id,
+        });
+
+        publicClient = await suite.client
+            .client
+            .create(createFakeClient({
+                is_confidential: false,
+                secret: null,
+            }));
+
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: publicClient.id,
         });
     });
 
@@ -49,13 +74,13 @@ describe('refresh-token', () => {
         expect(codeChallenge).toEqual('lFtvTpirsB96UMQJgoRhKofsa0w7ShdPkJ3eJ6MgYVY');
     });
 
-    it('should work with authorize grant', async () => {
+    it('should work with authorize grant for confidential client', async () => {
         const state = generateOAuth2CodeVerifier();
         const response = await suite.client
             .authorize
             .confirm({
                 response_type: OAuth2AuthorizationResponseType.CODE,
-                client_id: client.id,
+                client_id: confidentialClient.id,
                 redirect_uri: 'https://example.com/redirect',
                 scope: `${ScopeName.GLOBAL} ${ScopeName.OPEN_ID}`,
                 state,
@@ -68,11 +93,13 @@ describe('refresh-token', () => {
         expect(url.searchParams.get('code')).toBeDefined();
         expect(url.searchParams.get('id_token')).toEqual(null);
 
-        const code = url.searchParams.get('code');
+        const code = url.searchParams.get('code')!;
 
         const tokenResponse = await suite.client
             .token
             .createWithAuthorizationCode({
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
                 redirect_uri: 'https://example.com/redirect',
                 code,
             });
@@ -84,17 +111,18 @@ describe('refresh-token', () => {
         expect(tokenResponse.refresh_token).toBeDefined();
     });
 
-    it('should work with authorize grant and PKCE', async () => {
+    it('should work with authorize grant and PKCE for confidential client', async () => {
         const state = generateOAuth2CodeVerifier();
         const codeVerifier = generateOAuth2CodeVerifier();
         const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
 
         const payload : OAuth2AuthorizationCodeRequest = {
             response_type: OAuth2AuthorizationResponseType.CODE,
-            client_id: client.id,
+            client_id: confidentialClient.id,
             redirect_uri: 'https://example.com/redirect',
             scope: `${ScopeName.GLOBAL}`,
             code_challenge: codeChallenge,
+            code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
             state,
         };
         const response = await suite.client
@@ -104,11 +132,13 @@ describe('refresh-token', () => {
         expect(response.url).toBeDefined();
 
         const url = new URL(response.url);
-        const code = url.searchParams.get('code');
+        const code = url.searchParams.get('code')!;
 
         const tokenResponse = await suite.client
             .token
             .createWithAuthorizationCode({
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
                 redirect_uri: 'https://example.com/redirect',
                 code,
                 code_verifier: codeVerifier,
@@ -126,10 +156,11 @@ describe('refresh-token', () => {
         const payload : OAuth2AuthorizationCodeRequest = {
             state,
             response_type: OAuth2AuthorizationResponseType.CODE,
-            client_id: client.id,
+            client_id: confidentialClient.id,
             redirect_uri: 'https://example.com/redirect',
             scope: `${ScopeName.GLOBAL}`,
             code_challenge: codeChallenge,
+            code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
         };
 
         const response = await suite.client
@@ -139,21 +170,228 @@ describe('refresh-token', () => {
         expect(response.url).toBeDefined();
 
         const url = new URL(response.url);
-        const code = url.searchParams.get('code');
+        const code = url.searchParams.get('code')!;
+
+        expect.assertions(3);
 
         try {
             await suite.client
                 .token
                 .createWithAuthorizationCode({
+                    client_id: confidentialClient.id,
+                    client_secret: confidentialSecret,
                     redirect_uri: 'https://example.com/redirect',
                     code,
                     code_verifier: generateOAuth2CodeVerifier(),
                 });
         } catch (e) {
             if (isClientError(e)) {
-                expect(e.response.data).toBeDefined();
-                expect(e.response.data.code).toEqual(ErrorCode.OAUTH_GRANT_INVALID);
+                expect(e.response?.data).toBeDefined();
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_GRANT_INVALID);
             }
         }
+    });
+
+    it('should reject token exchange when confidential client omits client_secret', async () => {
+        const state = generateOAuth2CodeVerifier();
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: confidentialClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        expect.assertions(2);
+
+        try {
+            await suite.client
+                .token
+                .createWithAuthorizationCode({
+                    client_id: confidentialClient.id,
+                    redirect_uri: 'https://example.com/redirect',
+                    code,
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_CLIENT_INVALID);
+                expect(e.response?.data?.error).toEqual(OAuth2ErrorCode.INVALID_CLIENT);
+            }
+        }
+    });
+
+    it('should reject token exchange when confidential client provides wrong client_secret', async () => {
+        const state = generateOAuth2CodeVerifier();
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: confidentialClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .token
+                .createWithAuthorizationCode({
+                    client_id: confidentialClient.id,
+                    client_secret: 'wrong-secret',
+                    redirect_uri: 'https://example.com/redirect',
+                    code,
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_CLIENT_INVALID);
+            }
+        }
+    });
+
+    it('should reject token exchange when authenticated client_id does not match the code', async () => {
+        const state = generateOAuth2CodeVerifier();
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: confidentialClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        const otherSecret = generateOAuth2CodeVerifier();
+        const otherClient = await suite.client
+            .client
+            .create(createFakeClient({
+                secret: otherSecret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .token
+                .createWithAuthorizationCode({
+                    client_id: otherClient.id,
+                    client_secret: otherSecret,
+                    redirect_uri: 'https://example.com/redirect',
+                    code,
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_GRANT_INVALID);
+            }
+        }
+    });
+
+    it('should reject /authorize for public client without code_challenge', async () => {
+        const state = generateOAuth2CodeVerifier();
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .authorize
+                .confirm({
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                    client_id: publicClient.id,
+                    redirect_uri: 'https://example.com/redirect',
+                    scope: `${ScopeName.GLOBAL}`,
+                    state,
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.error).toEqual(OAuth2ErrorCode.INVALID_REQUEST);
+            }
+        }
+    });
+
+    it('should reject token exchange when client credentials are sent via both Basic header and body', async () => {
+        const state = generateOAuth2CodeVerifier();
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: confidentialClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        // hapic's TokenAPI deletes the Authorization header by default; bypass
+        // the typed client and send raw to exercise the dual-method path.
+        const basic = Buffer
+            .from(`${confidentialClient.id}:${confidentialSecret}`)
+            .toString('base64');
+        const tokenResponse = await fetch(`${suite.baseURL}/token`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Authorization: `Basic ${basic}`,
+            },
+            body: new URLSearchParams({
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: 'https://example.com/redirect',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            }).toString(),
+        });
+
+        expect(tokenResponse.status).toEqual(400);
+        const body = await tokenResponse.json() as { error?: string };
+        expect(body.error).toEqual(OAuth2ErrorCode.INVALID_REQUEST);
+    });
+
+    it('should work with authorize grant + PKCE for public client (no client_secret)', async () => {
+        const state = generateOAuth2CodeVerifier();
+        const codeVerifier = generateOAuth2CodeVerifier();
+        const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
+
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: publicClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                code_challenge: codeChallenge,
+                code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        const tokenResponse = await suite.client
+            .token
+            .createWithAuthorizationCode({
+                client_id: publicClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                code,
+                code_verifier: codeVerifier,
+            });
+
+        expect(tokenResponse.access_token).toBeDefined();
     });
 });

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
@@ -323,6 +323,94 @@ describe('grant-authorize', () => {
         }
     });
 
+    it('should reject token exchange when client_secret is provided without client_id', async () => {
+        const state = generateOAuth2CodeVerifier();
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: confidentialClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        const tokenResponse = await fetch(`${suite.baseURL}/token`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body: new URLSearchParams({
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: 'https://example.com/redirect',
+                client_secret: confidentialSecret,
+            }).toString(),
+        });
+
+        expect(tokenResponse.status).toEqual(400);
+        const body = await tokenResponse.json() as { error?: string };
+        expect(body.error).toEqual(OAuth2ErrorCode.INVALID_REQUEST);
+    });
+
+    it('should accept Basic auth credentials with URL-encoded special characters', async () => {
+        const specialSecret = 'secret with spaces & + : %';
+        const specialClient = await suite.client
+            .client
+            .create(createFakeClient({
+                secret: specialSecret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: specialClient.id,
+        });
+
+        const state = generateOAuth2CodeVerifier();
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: specialClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state,
+            });
+
+        const url = new URL(response.url);
+        const code = url.searchParams.get('code')!;
+
+        // RFC 6749 §2.3.1 + Appendix B: form-urlencode credentials before
+        // base64. encodeURIComponent matches the percent-encoding part;
+        // hapic doesn't apply form-encoding from the client side, but a
+        // spec-compliant client would send it this way.
+        const encodedId = encodeURIComponent(specialClient.id);
+        const encodedSecret = encodeURIComponent(specialSecret);
+        const basic = Buffer.from(`${encodedId}:${encodedSecret}`).toString('base64');
+
+        const tokenResponse = await fetch(`${suite.baseURL}/token`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/x-www-form-urlencoded',
+                Authorization: `Basic ${basic}`,
+            },
+            body: new URLSearchParams({
+                grant_type: 'authorization_code',
+                code,
+                redirect_uri: 'https://example.com/redirect',
+            }).toString(),
+        });
+
+        expect(tokenResponse.status).toEqual(200);
+        const body = await tokenResponse.json() as { access_token?: string };
+        expect(body.access_token).toBeDefined();
+    });
+
     it('should reject token exchange when client credentials are sent via both Basic header and body', async () => {
         const state = generateOAuth2CodeVerifier();
         const response = await suite.client

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-idp-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-idp-authorize.spec.ts
@@ -5,20 +5,23 @@
  * view the LICENSE file that was distributed with this source code.
  */
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import { createServer } from 'node:http';
 import type { Server } from 'node:http';
 import type { AddressInfo } from 'node:net';
+import type { Client } from '@authup/core-kit';
 import {
+    ScopeName,
     buildIdentityProviderAuthorizeCallbackPath,
     buildIdentityProviderAuthorizePath,
 } from '@authup/core-kit';
-import { createFakeOAuth2IdentityProvider } from '../../../../../utils';
+import { base64URLEncode } from '@authup/kit';
+import { createFakeClient, createFakeOAuth2IdentityProvider } from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
 function buildFakeAccessToken(claims: Record<string, unknown>): string {
@@ -81,6 +84,9 @@ describe('identity-provider authorization code grant', () => {
     const fakeIdp = createFakeIdpServer();
     let fakeIdpBaseURL: string;
     let providerId: string;
+    let client: Client;
+    let clientSecret: string;
+    let encodedCodeRequest: string;
 
     beforeAll(async () => {
         await suite.setup();
@@ -94,6 +100,29 @@ describe('identity-provider authorization code grant', () => {
             }));
 
         providerId = provider.id;
+
+        clientSecret = 'idp-test-secret';
+        client = await suite.client
+            .client
+            .create(createFakeClient({
+                secret: clientSecret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: client.id,
+        });
+
+        encodedCodeRequest = base64URLEncode(JSON.stringify({
+            response_type: 'code',
+            client_id: client.id,
+            redirect_uri: 'https://example.com/redirect',
+            scope: ScopeName.GLOBAL,
+        }));
     });
 
     afterAll(async () => {
@@ -104,7 +133,7 @@ describe('identity-provider authorization code grant', () => {
     it('should redirect to external IDP with state on authorize-out', async () => {
         const response = await suite.client
             .get(
-                buildIdentityProviderAuthorizePath(providerId),
+                `${buildIdentityProviderAuthorizePath(providerId)}?codeRequest=${encodedCodeRequest}`,
                 { redirect: 'manual' },
             );
 
@@ -121,7 +150,7 @@ describe('identity-provider authorization code grant', () => {
     it('should exchange IDP code for authup authorization code via authorize-in, then for tokens', async () => {
         const authorizeOutResponse = await suite.client
             .get(
-                buildIdentityProviderAuthorizePath(providerId),
+                `${buildIdentityProviderAuthorizePath(providerId)}?codeRequest=${encodedCodeRequest}`,
                 { redirect: 'manual' },
             );
 
@@ -149,7 +178,12 @@ describe('identity-provider authorization code grant', () => {
 
         const tokenResponse = await suite.client
             .token
-            .createWithAuthorizationCode({ code: authupCode! });
+            .createWithAuthorizationCode({
+                client_id: client.id,
+                client_secret: clientSecret,
+                redirect_uri: 'https://example.com/redirect',
+                code: authupCode!,
+            });
 
         expect(tokenResponse).toBeDefined();
         expect(tokenResponse.access_token).toBeDefined();
@@ -160,7 +194,7 @@ describe('identity-provider authorization code grant', () => {
     it('should reject reuse of authorization code (single-use)', async () => {
         const authorizeOutResponse = await suite.client
             .get(
-                buildIdentityProviderAuthorizePath(providerId),
+                `${buildIdentityProviderAuthorizePath(providerId)}?codeRequest=${encodedCodeRequest}`,
                 { redirect: 'manual' },
             );
 
@@ -178,14 +212,24 @@ describe('identity-provider authorization code grant', () => {
 
         await suite.client
             .token
-            .createWithAuthorizationCode({ code: authupCode! });
+            .createWithAuthorizationCode({
+                client_id: client.id,
+                client_secret: clientSecret,
+                redirect_uri: 'https://example.com/redirect',
+                code: authupCode!,
+            });
 
         let error: any;
 
         try {
             await suite.client
                 .token
-                .createWithAuthorizationCode({ code: authupCode! });
+                .createWithAuthorizationCode({
+                    client_id: client.id,
+                    client_secret: clientSecret,
+                    redirect_uri: 'https://example.com/redirect',
+                    code: authupCode!,
+                });
         } catch (e) {
             error = e;
         }

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
@@ -1,19 +1,19 @@
 /*
- * Copyright (c) 2021-2022.
+ * Copyright (c) 2021-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
 import { isClientError } from 'hapic';
-import { createFakeUser } from '../../../../../utils';
+import { createFakeClient, createFakeUser } from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
 describe('src/http/controllers/token', () => {
@@ -57,6 +57,59 @@ describe('src/http/controllers/token', () => {
                     .toEqual(400);
                 expect(e.response.data.code)
                     .toEqual(ErrorCode.ENTITY_CREDENTIALS_INVALID);
+            }
+        }
+    });
+
+    it('should grant token with password and confidential client authentication', async () => {
+        const secret = 'password-grant-test-secret';
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                secret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+
+        const response = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: client.id,
+                client_secret: secret,
+            });
+
+        expect(response.access_token).toBeDefined();
+        expect(response.refresh_token).toBeDefined();
+    });
+
+    it('should reject password grant when confidential client provides wrong secret', async () => {
+        const secret = 'password-grant-wrong-secret-test';
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                secret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .token
+                .createWithPassword({
+                    username: 'admin',
+                    password: 'start123',
+                    client_id: client.id,
+                    client_secret: 'wrong-secret',
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_CLIENT_INVALID);
             }
         }
     });

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
@@ -1,30 +1,47 @@
 /*
- * Copyright (c) 2024.
+ * Copyright (c) 2024-2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
+import type { Client } from '@authup/core-kit';
+import { ErrorCode } from '@authup/errors';
+import { isClientError } from 'hapic';
+import { createFakeClient } from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
 describe('refresh-token', () => {
     const suite = createTestApplication();
 
+    let confidentialClient: Client;
+    let confidentialSecret: string;
+
     beforeAll(async () => {
         await suite.setup();
+
+        confidentialSecret = 'refresh-token-test-secret';
+        confidentialClient = await suite.client
+            .client
+            .create(createFakeClient({
+                secret: confidentialSecret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
     });
 
     afterAll(async () => {
         await suite.teardown();
     });
 
-    it('should grant token with refresh token', async () => {
+    it('should grant token with refresh token issued by password grant (no client)', async () => {
         let response = await suite.client
             .token
             .createWithPassword({
@@ -42,5 +59,126 @@ describe('refresh-token', () => {
         expect(response.access_token).toBeDefined();
         expect(response.expires_in).toBeDefined();
         expect(response.refresh_token).toBeDefined();
+    });
+
+    it('should grant refresh when authenticated client matches token client_id', async () => {
+        const initial = await suite.client
+            .token
+            .createWithClientCredentials({
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        // client_credentials grant doesn't issue a refresh_token; use the
+        // password grant with explicit client auth instead to obtain a
+        // refresh_token bound to the confidential client.
+        const passwordResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect(initial.access_token).toBeDefined();
+        expect(passwordResponse.refresh_token).toBeDefined();
+
+        const refreshed = await suite.client
+            .token
+            .createWithRefreshToken({
+                refresh_token: passwordResponse.refresh_token,
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect(refreshed.access_token).toBeDefined();
+    });
+
+    it('should reject refresh when token has client_id but request omits client auth', async () => {
+        const passwordResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .token
+                .createWithRefreshToken({ refresh_token: passwordResponse.refresh_token });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_CLIENT_INVALID);
+            }
+        }
+    });
+
+    it('should reject refresh when authenticated client_id does not match token client_id', async () => {
+        const otherSecret = 'other-refresh-secret';
+        const otherClient = await suite.client
+            .client
+            .create(createFakeClient({
+                secret: otherSecret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+
+        const passwordResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .token
+                .createWithRefreshToken({
+                    refresh_token: passwordResponse.refresh_token,
+                    client_id: otherClient.id,
+                    client_secret: otherSecret,
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_GRANT_INVALID);
+            }
+        }
+    });
+
+    it('should reject refresh when client provides wrong secret', async () => {
+        const passwordResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect.assertions(1);
+
+        try {
+            await suite.client
+                .token
+                .createWithRefreshToken({
+                    refresh_token: passwordResponse.refresh_token,
+                    client_id: confidentialClient.id,
+                    client_secret: 'wrong-secret',
+                });
+        } catch (e) {
+            if (isClientError(e)) {
+                expect(e.response?.data?.code).toEqual(ErrorCode.OAUTH_CLIENT_INVALID);
+            }
+        }
     });
 });

--- a/packages/errors/src/constants.ts
+++ b/packages/errors/src/constants.ts
@@ -28,6 +28,8 @@ export enum ErrorCode {
     OAUTH_CLIENT_INVALID = 'invalid_client',
     OAUTH_GRANT_INVALID = 'invalid_grant',
     OAUTH_GRANT_TYPE_UNSUPPORTED = 'unsupported_token_grant_type',
+    OAUTH_REQUEST_INVALID = 'invalid_request',
+    OAUTH_RESPONSE_TYPE_UNSUPPORTED = 'unsupported_response_type',
     OAUTH_SCOPE_INVALID = 'invalid_scope',
     OAUTH_SCOPE_INSUFFICIENT = 'insufficient_scope',
 

--- a/packages/specs/src/oauth2/constants.ts
+++ b/packages/specs/src/oauth2/constants.ts
@@ -51,5 +51,7 @@ export enum OAuth2ErrorCode {
 
     UNSUPPORTED_GRANT_TYPE = 'unsupported_grant_type',
 
+    UNSUPPORTED_RESPONSE_TYPE = 'unsupported_response_type',
+
     INVALID_SCOPE = 'invalid_scope',
 }

--- a/packages/specs/src/oauth2/error.ts
+++ b/packages/specs/src/oauth2/error.ts
@@ -130,6 +130,12 @@ export class OAuth2Error extends AuthupError {
     }
 
     static signingKeyMissing() {
-        return new OAuth2Error({ message: 'A token signing key could not be retrieved.' });
+        // Server-side misconfiguration — the client did nothing wrong.
+        // Surface as 500 so clients back off rather than retrying with
+        // the same payload.
+        return new OAuth2Error({
+            message: 'A token signing key could not be retrieved.',
+            statusCode: 500,
+        });
     }
 }

--- a/packages/specs/src/oauth2/error.ts
+++ b/packages/specs/src/oauth2/error.ts
@@ -12,8 +12,8 @@ import { OAuth2ErrorCode } from './constants';
 export class OAuth2Error extends AuthupError {
     constructor(...input: AuthupErrorOptionsInput[]) {
         super({
-            code: ErrorCode.JWT_INVALID,
-            message: 'The Token is invalid',
+            code: ErrorCode.OAUTH_REQUEST_INVALID,
+            message: 'OAuth2 request invalid',
             statusCode: 400,
             data: { error: OAuth2ErrorCode.INVALID_REQUEST },
         }, ...input);
@@ -61,6 +61,7 @@ export class OAuth2Error extends AuthupError {
     static identityInvalid() {
         return new OAuth2Error({
             message: 'The identity is not valid.',
+            code: ErrorCode.OAUTH_REQUEST_INVALID,
             data: { error: OAuth2ErrorCode.INVALID_REQUEST },
         });
     }
@@ -68,6 +69,7 @@ export class OAuth2Error extends AuthupError {
     static codeRequestInvalid() {
         return new OAuth2Error({
             message: 'The authorization code request is invalid.',
+            code: ErrorCode.OAUTH_REQUEST_INVALID,
             data: {
                 hint: 'Check if the code request is valid and contains all required parameters',
                 error: OAuth2ErrorCode.INVALID_REQUEST,
@@ -79,6 +81,7 @@ export class OAuth2Error extends AuthupError {
         return new OAuth2Error({
             message: message || 'The request is missing a required parameter, includes an unsupported parameter value, ' +
                 'repeats a parameter, or is otherwise malformed.',
+            code: ErrorCode.OAUTH_REQUEST_INVALID,
             data: {
                 hint: 'Check that all parameters have been provided correctly',
                 error: OAuth2ErrorCode.INVALID_REQUEST,
@@ -89,6 +92,7 @@ export class OAuth2Error extends AuthupError {
     static stateInvalid() {
         return new OAuth2Error({
             message: 'The request state is invalid, unknown or malformed.',
+            code: ErrorCode.OAUTH_REQUEST_INVALID,
             data: { error: OAuth2ErrorCode.INVALID_REQUEST },
         });
     }
@@ -118,7 +122,11 @@ export class OAuth2Error extends AuthupError {
     }
 
     static responseTypeUnsupported() {
-        return new OAuth2Error({ message: 'The authorization server does not support obtaining an access token using this method.' });
+        return new OAuth2Error({
+            message: 'The authorization server does not support obtaining an access token using this method.',
+            code: ErrorCode.OAUTH_RESPONSE_TYPE_UNSUPPORTED,
+            data: { error: OAuth2ErrorCode.UNSUPPORTED_RESPONSE_TYPE },
+        });
     }
 
     static signingKeyMissing() {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added OAuth2 client authentication across authorization, password, and refresh token grant flows.
  * Implemented PKCE (Proof Key for Code Exchange) requirement for public clients during authorization.
  * Enhanced refresh token security with client binding and authentication enforcement.

* **Improvements**
  * Improved client credential extraction and validation across token endpoints.
  * Added comprehensive error handling for OAuth2 validation failures.

* **Tests**
  * Expanded test coverage for client authentication scenarios and PKCE validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->