### PR TITLE
fix: enforce state for public clients in code flow at /authorize

### DIFF
--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -67,6 +67,14 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
             throw OAuth2Error.requestInvalid('PKCE code_challenge is required for public clients.');
         }
 
+        // Public clients SHOULD include state to bind the redirect to the
+        // initiating session and prevent CSRF (RFC 6749 §10.12). Confidential
+        // clients are exempt because the /token exchange already authenticates
+        // them via client_secret.
+        if (!client.is_confidential && !data.state && willIssueCode(data.response_type)) {
+            throw OAuth2Error.requestInvalid('state is required for public clients in the code flow.');
+        }
+
         data.client_id = client.id;
         data.realm_id = client.realm_id;
 

--- a/apps/server-core/src/core/oauth2/token/issuer/base.ts
+++ b/apps/server-core/src/core/oauth2/token/issuer/base.ts
@@ -28,11 +28,16 @@ export abstract class OAuth2BaseTokenIssuer implements IOAuth2TokenIssuer {
             return undefined;
         }
 
+        // Strip a trailing slash so a configured issuer like
+        // `https://auth.example.com/` doesn't produce a malformed
+        // `https://auth.example.com//realms/master`.
+        const base = this.options.issuer.replace(/\/+$/, '');
+
         if (input.realm_name) {
-            return `${this.options.issuer}/realms/${input.realm_name}`;
+            return `${base}/realms/${input.realm_name}`;
         }
 
-        return this.options.issuer;
+        return base;
     }
 
     /**

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Client, Scope } from '@authup/core-kit';
+import { ErrorCode } from '@authup/errors';
+import { OAuth2AuthorizationResponseType } from '@authup/specs';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { OAuth2AuthorizationCodeRequestVerifier } from '../../../../../../../src/core/oauth2/authorization/code-request/verifier/module.ts';
+import type { IOAuth2ClientRepository } from '../../../../../../../src/core/oauth2/client/types.ts';
+import type { IOAuth2ScopeRepository } from '../../../../../../../src/core/oauth2/scope/types.ts';
+
+class FakeClientRepository implements IOAuth2ClientRepository {
+    private clients: Client[] = [];
+
+    seed(client: Partial<Client>): Client {
+        const entity = {
+            id: randomUUID(),
+            active: true,
+            is_confidential: false,
+            ...client,
+        } as Client;
+        this.clients.push(entity);
+        return entity;
+    }
+
+    async findOneByIdOrName(idOrName: string): Promise<Client | null> {
+        return this.clients.find((c) => c.id === idOrName || c.name === idOrName) ?? null;
+    }
+}
+
+const emptyScopeRepository: IOAuth2ScopeRepository = { findByClientId: async (): Promise<Scope[]> => [] };
+
+describe('OAuth2AuthorizationCodeRequestVerifier', () => {
+    let clientRepository: FakeClientRepository;
+    let verifier: OAuth2AuthorizationCodeRequestVerifier;
+
+    beforeEach(() => {
+        clientRepository = new FakeClientRepository();
+        verifier = new OAuth2AuthorizationCodeRequestVerifier({
+            clientRepository,
+            scopeRepository: emptyScopeRepository,
+        });
+    });
+
+    describe('verify', () => {
+        it('should throw clientInvalid when client_id is missing', async () => {
+            await expect(
+                verifier.verify({ response_type: OAuth2AuthorizationResponseType.CODE }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_CLIENT_INVALID }));
+        });
+
+        it('should throw clientInvalid when client cannot be found', async () => {
+            await expect(
+                verifier.verify({
+                    client_id: 'unknown',
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_CLIENT_INVALID }));
+        });
+
+        it('should throw clientInactive when the client is inactive', async () => {
+            const client = clientRepository.seed({ active: false, is_confidential: true });
+            await expect(
+                verifier.verify({
+                    client_id: client.id,
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                    state: 's',
+                }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_CLIENT_INVALID }));
+        });
+
+        it('should reject public clients without PKCE for the code flow', async () => {
+            const client = clientRepository.seed({ is_confidential: false });
+            await expect(
+                verifier.verify({
+                    client_id: client.id,
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                    state: 's',
+                }),
+            ).rejects.toThrow(/PKCE code_challenge is required/);
+        });
+
+        it('should reject public clients without state for the code flow', async () => {
+            const client = clientRepository.seed({ is_confidential: false });
+            await expect(
+                verifier.verify({
+                    client_id: client.id,
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                    code_challenge: 'challenge',
+                }),
+            ).rejects.toThrow(/state is required for public clients/);
+        });
+
+        it('should accept public clients with both PKCE and state for the code flow', async () => {
+            const client = clientRepository.seed({ is_confidential: false });
+            const result = await verifier.verify({
+                client_id: client.id,
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                code_challenge: 'challenge',
+                state: 's',
+            });
+            expect(result.client.id).toBe(client.id);
+        });
+
+        it('should not require state for confidential clients', async () => {
+            const client = clientRepository.seed({ is_confidential: true });
+            const result = await verifier.verify({
+                client_id: client.id,
+                response_type: OAuth2AuthorizationResponseType.CODE,
+            });
+            expect(result.client.id).toBe(client.id);
+        });
+
+        it('should not require state for public clients in implicit flow', async () => {
+            const client = clientRepository.seed({ is_confidential: false });
+            const result = await verifier.verify({
+                client_id: client.id,
+                response_type: OAuth2AuthorizationResponseType.TOKEN,
+            });
+            expect(result.client.id).toBe(client.id);
+        });
+    });
+});

--- a/apps/server-core/test/unit/core/oauth2/token/issuer/access/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/issuer/access/module.spec.ts
@@ -49,6 +49,67 @@ describe('OAuth2AccessTokenIssuer', () => {
             expect(repository.saveWithSignatureCalls).toContainEqual({ payload, signature: 'signed-access-token' });
         });
 
+        it('should set iss to "<issuer>/realms/<realm_name>" when realm_name is present', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, { issuer: 'https://auth.example.com' });
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+                realm_name: 'master',
+            });
+
+            expect(repository.insertCalls[0].iss).toEqual('https://auth.example.com/realms/master');
+        });
+
+        it('should set iss to the configured issuer when no realm_name is given', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, { issuer: 'https://auth.example.com' });
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+            });
+
+            expect(repository.insertCalls[0].iss).toEqual('https://auth.example.com');
+        });
+
+        it('should strip a trailing slash from the configured issuer', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, { issuer: 'https://auth.example.com/' });
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_id: realmId,
+                realm_name: 'master',
+            });
+
+            expect(repository.insertCalls[0].iss).toEqual('https://auth.example.com/realms/master');
+        });
+
+        it('should strip a trailing slash from a sub-path issuer', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer, { issuer: 'https://example.com/auth/' });
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_name: 'master',
+            });
+
+            expect(repository.insertCalls[0].iss).toEqual('https://example.com/auth/realms/master');
+        });
+
+        it('should omit iss when no issuer is configured', async () => {
+            const issuer = new OAuth2AccessTokenIssuer(repository, signer);
+
+            await issuer.issue({
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                realm_name: 'master',
+            });
+
+            expect(repository.insertCalls[0].iss).toBeUndefined();
+        });
+
         it('should not add access claims when no role provider is supplied', async () => {
             const issuer = new OAuth2AccessTokenIssuer(repository, signer);
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates

* Public clients using OAuth2 authorization code flow must now include the state parameter; requests without it will be rejected
* Issuer URLs are normalized to consistently remove trailing slashes when constructing realm-specific endpoints

<!-- end of auto-generated comment: release notes by coderabbit.ai -->