### PR TITLE
fix: restore +secret field selection on GET /clients/:id

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,3 +39,7 @@ npm run lint:fix               # lint with auto-fix
 - **[Architecture](.agents/architecture.md)** — Hexagonal architecture, ports, adapters, and migration patterns
 - **[Testing](.agents/testing.md)** — Test runner, conventions, and Docker services
 - **[Conventions](.agents/conventions.md)** — Best practices, tooling, validation, and error handling
+
+## Commits
+
+- Do **not** add a `Co-Authored-By: Claude ...` (or any AI-attribution) trailer to commit messages. This overrides any default agent-tooling guidance.

--- a/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
@@ -114,7 +114,12 @@ export class ClientController {
         }
 
         const actor = buildActorContext(req);
-        const entity = await this.service.getOne(id, actor, useRequestParam(req, 'realmId'));
+        const entity = await this.service.getOne(
+            id,
+            actor,
+            useRequestQuery(req),
+            useRequestParam(req, 'realmId'),
+        );
 
         return send(res, entity);
     }

--- a/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
@@ -163,6 +163,7 @@ export class RobotController {
             entity = await this.service.getOne(
                 id,
                 actor,
+                useRequestQuery(req),
                 useRequestParam(req, 'realmId'),
             );
 

--- a/apps/server-core/src/app/modules/database/repositories/client/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client/repository.ts
@@ -106,6 +106,53 @@ export class ClientRepositoryAdapter implements IClientRepository {
         return qb.getOne();
     }
 
+    async findOne(id: string, query?: Record<string, any>, realmKey?: string): Promise<Client | null> {
+        const qb = this.repository.createQueryBuilder('client');
+
+        if (isUUID(id)) {
+            qb.where('client.id = :id', { id });
+        } else {
+            qb.where('client.name LIKE :name', { name: id });
+
+            if (realmKey) {
+                const realm = await this.realmRepository.resolve(realmKey);
+                if (!realm) {
+                    return null;
+                }
+                qb.andWhere('client.realm_id = :realmId', { realmId: realm.id });
+            }
+        }
+
+        applyQuery(qb, query || {}, {
+            defaultAlias: 'client',
+            fields: {
+                default: [
+                    'id',
+                    'active',
+                    'built_in',
+                    'name',
+                    'display_name',
+                    'description',
+                    'secret_hashed',
+                    'secret_encrypted',
+                    'base_url',
+                    'root_url',
+                    'redirect_uri',
+                    'grant_types',
+                    'scope',
+                    'is_confidential',
+                    'realm_id',
+                    'updated_at',
+                    'created_at',
+                ],
+                allowed: ['secret'],
+            },
+            relations: { allowed: ['realm'] },
+        });
+
+        return qb.getOne();
+    }
+
     async findOneByIdOrName(idOrName: string, realm?: string): Promise<Client | null> {
         return isUUID(idOrName) ?
             this.findOneById(idOrName) :

--- a/apps/server-core/src/app/modules/database/repositories/robot/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/robot/repository.ts
@@ -107,6 +107,48 @@ export class RobotRepositoryAdapter implements IRobotRepository {
             this.findOneByName(idOrName, realm);
     }
 
+    async findOne(id: string, query?: Record<string, any>, realmKey?: string): Promise<Robot | null> {
+        const qb = this.repository.createQueryBuilder('robot');
+
+        if (isUUID(id)) {
+            qb.where('robot.id = :id', { id });
+        } else {
+            qb.where('robot.name LIKE :name', { name: id });
+
+            if (realmKey) {
+                const realm = await this.realmRepository.resolve(realmKey);
+                if (!realm) {
+                    return null;
+                }
+                qb.andWhere('robot.realm_id = :realmId', { realmId: realm.id });
+            }
+        }
+
+        applyQuery(qb, query || {}, {
+            defaultAlias: 'robot',
+            fields: {
+                default: [
+                    'id',
+                    'name',
+                    'display_name',
+                    'description',
+                    'active',
+                    'user_id',
+                    'realm_id',
+                    'created_at',
+                    'updated_at',
+                ],
+                allowed: ['secret'],
+            },
+            relations: {
+                // @ts-expect-error 'user' is a valid relation but not in the type definition
+                allowed: ['realm', 'user'],
+            },
+        });
+
+        return qb.getOne();
+    }
+
     async findManyBy(where: Record<string, any>): Promise<Robot[]> {
         return this.repository.findBy(translateWhereConditions(where));
     }

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -100,13 +100,17 @@ export class ClientService extends AbstractEntityService implements IClientServi
         query?: Record<string, any>,
         realmId?: string,
     ): Promise<Client> {
-        const entity = await this.repository.findOne(idOrName, query, realmId);
-        if (!entity) {
-            throw new NotFoundError();
+        let isMe = false;
+        if (actor.identity && actor.identity.type === 'client') {
+            if (
+                actor.identity.data.id === idOrName ||
+                actor.identity.data.name === idOrName
+            ) {
+                isMe = true;
+            }
         }
 
-        let isSelfAccess = false;
-        try {
+        if (!isMe) {
             await actor.permissionEvaluator.preEvaluateOneOf({
                 name: [
                     PermissionName.CLIENT_READ,
@@ -114,20 +118,16 @@ export class ClientService extends AbstractEntityService implements IClientServi
                     PermissionName.CLIENT_DELETE,
                 ],
             });
-        } catch (e) {
-            if (
-                !actor.identity ||
-                actor.identity.type !== 'client' ||
-                actor.identity.data.id !== entity.id
-            ) {
-                throw e;
-            }
-            await actor.permissionEvaluator.preEvaluate({ name: PermissionName.CLIENT_SELF_MANAGE });
-            isSelfAccess = true;
+        }
+
+        const resolvedId = isMe ? actor.identity!.data.id : idOrName;
+        const entity = await this.repository.findOne(resolvedId, query, realmId);
+        if (!entity) {
+            throw new NotFoundError();
         }
 
         if (
-            !isSelfAccess &&
+            !isMe &&
             entity.secret &&
             !entity.secret_encrypted &&
             !entity.secret_hashed

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -100,30 +100,31 @@ export class ClientService extends AbstractEntityService implements IClientServi
         query?: Record<string, any>,
         realmId?: string,
     ): Promise<Client> {
-        let isMe = false;
-        if (actor.identity && actor.identity.type === 'client') {
-            if (
+        const permissionNames = [
+            PermissionName.CLIENT_READ,
+            PermissionName.CLIENT_UPDATE,
+            PermissionName.CLIENT_DELETE,
+        ];
+
+        let isMe = !!actor.identity &&
+            actor.identity.type === 'client' &&
+            (
                 actor.identity.data.id === idOrName ||
                 actor.identity.data.name === idOrName
-            ) {
-                isMe = true;
-            }
-        }
+            );
 
         if (!isMe) {
-            await actor.permissionEvaluator.preEvaluateOneOf({
-                name: [
-                    PermissionName.CLIENT_READ,
-                    PermissionName.CLIENT_UPDATE,
-                    PermissionName.CLIENT_DELETE,
-                ],
-            });
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
         }
 
-        const resolvedId = isMe ? actor.identity!.data.id : idOrName;
-        const entity = await this.repository.findOne(resolvedId, query, realmId);
+        const entity = await this.repository.findOne(idOrName, query, realmId);
         if (!entity) {
             throw new NotFoundError();
+        }
+
+        if (isMe && actor.identity!.data.id !== entity.id) {
+            isMe = false;
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
         }
 
         if (
@@ -133,11 +134,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             !entity.secret_hashed
         ) {
             await actor.permissionEvaluator.evaluateOneOf({
-                name: [
-                    PermissionName.CLIENT_READ,
-                    PermissionName.CLIENT_UPDATE,
-                    PermissionName.CLIENT_DELETE,
-                ],
+                name: permissionNames,
                 input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
             });
         }

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -97,39 +97,37 @@ export class ClientService extends AbstractEntityService implements IClientServi
     async getOne(
         idOrName: string,
         actor: ActorContext,
+        query?: Record<string, any>,
         realmId?: string,
     ): Promise<Client> {
-        await actor.permissionEvaluator.preEvaluateOneOf({
-            name: [
-                PermissionName.CLIENT_READ,
-                PermissionName.CLIENT_UPDATE,
-                PermissionName.CLIENT_DELETE,
-            ],
-        });
-
-        let entity: Client | null;
-
-        if (isUUID(idOrName)) {
-            entity = await this.repository.findOneByIdOrName(idOrName, realmId);
-        } else if (realmId) {
-            const realm = await this.realmRepository.resolve(realmId);
-            if (realm) {
-                entity = await this.repository.findOneBy({
-                    name: idOrName,
-                    realm_id: realm.id,
-                });
-            } else {
-                entity = null;
-            }
-        } else {
-            entity = await this.repository.findOneByName(idOrName);
-        }
-
+        const entity = await this.repository.findOne(idOrName, query, realmId);
         if (!entity) {
             throw new NotFoundError();
         }
 
+        let isSelfAccess = false;
+        try {
+            await actor.permissionEvaluator.preEvaluateOneOf({
+                name: [
+                    PermissionName.CLIENT_READ,
+                    PermissionName.CLIENT_UPDATE,
+                    PermissionName.CLIENT_DELETE,
+                ],
+            });
+        } catch (e) {
+            if (
+                !actor.identity ||
+                actor.identity.type !== 'client' ||
+                actor.identity.data.id !== entity.id
+            ) {
+                throw e;
+            }
+            await actor.permissionEvaluator.preEvaluate({ name: PermissionName.CLIENT_SELF_MANAGE });
+            isSelfAccess = true;
+        }
+
         if (
+            !isSelfAccess &&
             entity.secret &&
             !entity.secret_encrypted &&
             !entity.secret_hashed

--- a/apps/server-core/src/core/entities/client/types.ts
+++ b/apps/server-core/src/core/entities/client/types.ts
@@ -13,6 +13,8 @@ import type { EntityRepositoryFindManyResult, IEntityRepository } from '../types
 export interface IClientRepository extends IEntityRepository<Client> {
     checkUniqueness(data: Partial<Client>, existing?: Client): Promise<void>;
 
+    findOne(id: string, query?: Record<string, any>, realm?: string): Promise<Client | null>;
+
     findOneWithSecret(where: Record<string, any>): Promise<Client | null>;
 
     getBoundRoles(entity: string | Client): Promise<Role[]>;
@@ -22,7 +24,12 @@ export interface IClientRepository extends IEntityRepository<Client> {
 
 export interface IClientService {
     getMany(query: Record<string, any>, actor: ActorContext): Promise<EntityRepositoryFindManyResult<Client>>;
-    getOne(idOrName: string, actor: ActorContext, realmId?: string): Promise<Client>;
+    getOne(
+        idOrName: string,
+        actor: ActorContext,
+        query?: Record<string, any>,
+        realmId?: string,
+    ): Promise<Client>;
     create(data: Record<string, any>, actor: ActorContext): Promise<Client>;
     update(idOrName: string, data: Record<string, any>, actor: ActorContext): Promise<Client>;
     save(

--- a/apps/server-core/src/core/entities/robot/service.ts
+++ b/apps/server-core/src/core/entities/robot/service.ts
@@ -98,43 +98,45 @@ export class RobotService extends AbstractEntityService implements IRobotService
     async getOne(
         idOrName: string,
         actor: ActorContext,
+        query?: Record<string, any>,
         realmId?: string,
     ): Promise<Robot> {
-        await actor.permissionEvaluator.preEvaluateOneOf({
-            name: [
-                PermissionName.ROBOT_READ,
-                PermissionName.ROBOT_UPDATE,
-                PermissionName.ROBOT_DELETE,
-            ],
-        });
-
-        let entity: Robot | null;
-        if (isUUID(idOrName)) {
-            entity = await this.repository.findOneById(idOrName);
-        } else if (realmId) {
-            const realm = await this.realmRepository.resolve(realmId);
-            entity = realm ?
-                await this.repository.findOneBy({
-                    name: idOrName,
-                    realm_id: realm.id, 
-                }) :
-                null;
-        } else {
-            entity = await this.repository.findOneByName(idOrName);
-        }
-
+        const entity = await this.repository.findOne(idOrName, query, realmId);
         if (!entity) {
             throw new NotFoundError();
         }
 
-        await actor.permissionEvaluator.evaluateOneOf({
-            name: [
-                PermissionName.ROBOT_READ,
-                PermissionName.ROBOT_UPDATE,
-                PermissionName.ROBOT_DELETE,
-            ],
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
-        });
+        let isSelfAccess = false;
+        try {
+            await actor.permissionEvaluator.preEvaluateOneOf({
+                name: [
+                    PermissionName.ROBOT_READ,
+                    PermissionName.ROBOT_UPDATE,
+                    PermissionName.ROBOT_DELETE,
+                ],
+            });
+        } catch (e) {
+            if (
+                !actor.identity ||
+                actor.identity.type !== 'robot' ||
+                actor.identity.data.id !== entity.id
+            ) {
+                throw e;
+            }
+            await actor.permissionEvaluator.preEvaluate({ name: PermissionName.ROBOT_SELF_MANAGE });
+            isSelfAccess = true;
+        }
+
+        if (!isSelfAccess) {
+            await actor.permissionEvaluator.evaluateOneOf({
+                name: [
+                    PermissionName.ROBOT_READ,
+                    PermissionName.ROBOT_UPDATE,
+                    PermissionName.ROBOT_DELETE,
+                ],
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            });
+        }
 
         return entity;
     }

--- a/apps/server-core/src/core/entities/robot/service.ts
+++ b/apps/server-core/src/core/entities/robot/service.ts
@@ -101,13 +101,17 @@ export class RobotService extends AbstractEntityService implements IRobotService
         query?: Record<string, any>,
         realmId?: string,
     ): Promise<Robot> {
-        const entity = await this.repository.findOne(idOrName, query, realmId);
-        if (!entity) {
-            throw new NotFoundError();
+        let isMe = false;
+        if (actor.identity && actor.identity.type === 'robot') {
+            if (
+                actor.identity.data.id === idOrName ||
+                actor.identity.data.name === idOrName
+            ) {
+                isMe = true;
+            }
         }
 
-        let isSelfAccess = false;
-        try {
+        if (!isMe) {
             await actor.permissionEvaluator.preEvaluateOneOf({
                 name: [
                     PermissionName.ROBOT_READ,
@@ -115,19 +119,15 @@ export class RobotService extends AbstractEntityService implements IRobotService
                     PermissionName.ROBOT_DELETE,
                 ],
             });
-        } catch (e) {
-            if (
-                !actor.identity ||
-                actor.identity.type !== 'robot' ||
-                actor.identity.data.id !== entity.id
-            ) {
-                throw e;
-            }
-            await actor.permissionEvaluator.preEvaluate({ name: PermissionName.ROBOT_SELF_MANAGE });
-            isSelfAccess = true;
         }
 
-        if (!isSelfAccess) {
+        const resolvedId = isMe ? actor.identity!.data.id : idOrName;
+        const entity = await this.repository.findOne(resolvedId, query, realmId);
+        if (!entity) {
+            throw new NotFoundError();
+        }
+
+        if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: [
                     PermissionName.ROBOT_READ,

--- a/apps/server-core/src/core/entities/robot/service.ts
+++ b/apps/server-core/src/core/entities/robot/service.ts
@@ -101,39 +101,36 @@ export class RobotService extends AbstractEntityService implements IRobotService
         query?: Record<string, any>,
         realmId?: string,
     ): Promise<Robot> {
-        let isMe = false;
-        if (actor.identity && actor.identity.type === 'robot') {
-            if (
+        const permissionNames = [
+            PermissionName.ROBOT_READ,
+            PermissionName.ROBOT_UPDATE,
+            PermissionName.ROBOT_DELETE,
+        ];
+
+        let isMe = !!actor.identity &&
+            actor.identity.type === 'robot' &&
+            (
                 actor.identity.data.id === idOrName ||
                 actor.identity.data.name === idOrName
-            ) {
-                isMe = true;
-            }
-        }
+            );
 
         if (!isMe) {
-            await actor.permissionEvaluator.preEvaluateOneOf({
-                name: [
-                    PermissionName.ROBOT_READ,
-                    PermissionName.ROBOT_UPDATE,
-                    PermissionName.ROBOT_DELETE,
-                ],
-            });
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
         }
 
-        const resolvedId = isMe ? actor.identity!.data.id : idOrName;
-        const entity = await this.repository.findOne(resolvedId, query, realmId);
+        const entity = await this.repository.findOne(idOrName, query, realmId);
         if (!entity) {
             throw new NotFoundError();
         }
 
+        if (isMe && actor.identity!.data.id !== entity.id) {
+            isMe = false;
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
+        }
+
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
-                name: [
-                    PermissionName.ROBOT_READ,
-                    PermissionName.ROBOT_UPDATE,
-                    PermissionName.ROBOT_DELETE,
-                ],
+                name: permissionNames,
                 input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
             });
         }

--- a/apps/server-core/src/core/entities/robot/types.ts
+++ b/apps/server-core/src/core/entities/robot/types.ts
@@ -13,6 +13,8 @@ import type { EntityRepositoryFindManyResult, IEntityRepository } from '../types
 export interface IRobotRepository extends IEntityRepository<Robot> {
     checkUniqueness(data: Partial<Robot>, existing?: Robot): Promise<void>;
 
+    findOne(id: string, query?: Record<string, any>, realm?: string): Promise<Robot | null>;
+
     findOneWithSecret(where: Record<string, any>): Promise<Robot | null>;
 
     getBoundRoles(entity: string | Robot): Promise<Role[]>;
@@ -22,7 +24,12 @@ export interface IRobotRepository extends IEntityRepository<Robot> {
 
 export interface IRobotService {
     getMany(query: Record<string, any>, actor: ActorContext): Promise<EntityRepositoryFindManyResult<Robot>>;
-    getOne(idOrName: string, actor: ActorContext, realmId?: string): Promise<Robot>;
+    getOne(
+        idOrName: string,
+        actor: ActorContext,
+        query?: Record<string, any>,
+        realmId?: string,
+    ): Promise<Robot>;
     create(data: Record<string, any>, actor: ActorContext): Promise<Robot>;
     update(idOrName: string, data: Record<string, any>, actor: ActorContext): Promise<Robot>;
     save(

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -101,39 +101,36 @@ export class UserService extends AbstractEntityService implements IUserService {
         query?: Record<string, any>,
         realmId?: string,
     ): Promise<User> {
-        let isMe = false;
-        if (actor.identity && actor.identity.type === 'user') {
-            if (
+        const permissionNames = [
+            PermissionName.USER_READ,
+            PermissionName.USER_UPDATE,
+            PermissionName.USER_DELETE,
+        ];
+
+        let isMe = !!actor.identity &&
+            actor.identity.type === 'user' &&
+            (
                 actor.identity.data.id === idOrName ||
                 actor.identity.data.name === idOrName
-            ) {
-                isMe = true;
-            }
-        }
+            );
 
         if (!isMe) {
-            await actor.permissionEvaluator.preEvaluateOneOf({
-                name: [
-                    PermissionName.USER_READ,
-                    PermissionName.USER_UPDATE,
-                    PermissionName.USER_DELETE,
-                ],
-            });
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
         }
 
-        const resolvedId = isMe ? actor.identity!.data.id : idOrName;
-        const entity = await this.repository.findOne(resolvedId, query, realmId);
+        const entity = await this.repository.findOne(idOrName, query, realmId);
         if (!entity) {
             throw new NotFoundError();
         }
 
+        if (isMe && actor.identity!.data.id !== entity.id) {
+            isMe = false;
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
+        }
+
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
-                name: [
-                    PermissionName.USER_READ,
-                    PermissionName.USER_UPDATE,
-                    PermissionName.USER_DELETE,
-                ],
+                name: permissionNames,
                 input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
             });
         }

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -180,30 +180,46 @@ describe('core/entities/client/service', () => {
             expect(findOneSpy).toHaveBeenCalledWith(entity.id, { fields: '+secret' }, undefined);
         });
 
-        it('should fall back to CLIENT_SELF_MANAGE when actor is the client itself', async () => {
+        it('should bypass the permission gate when actor is the client itself', async () => {
             const entity = repository.seed(createFakeClient({ name: 'self-client' }));
             const actor: FakeActorContext = {
                 permissionEvaluator: new FakePermissionEvaluator(),
                 identity: {
                     type: IdentityType.CLIENT,
-                    data: { id: entity.id } as any,
+                    data: { id: entity.id, name: 'self-client' } as any,
                 },
             };
-            actor.permissionEvaluator.deny('preEvaluateOneOf');
+            actor.permissionEvaluator.denyAll();
 
             const result = await service.getOne(entity.id, actor);
             expect(result.id).toBe(entity.id);
-            expect(actor.permissionEvaluator.preEvaluateCalls).toHaveLength(1);
-            expect(actor.permissionEvaluator.preEvaluateCalls[0].name).toBe(PermissionName.CLIENT_SELF_MANAGE);
+            expect(actor.permissionEvaluator.preEvaluateOneOfCalls).toHaveLength(0);
+            expect(actor.permissionEvaluator.preEvaluateCalls).toHaveLength(0);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('should rethrow upfront error when CLIENT_SELF_MANAGE actor looks at a different client', async () => {
+        it('should detect self-access by name lookup', async () => {
+            const entity = repository.seed(createFakeClient({ name: 'self-client' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: entity.id, name: 'self-client' } as any,
+                },
+            };
+            actor.permissionEvaluator.denyAll();
+
+            const result = await service.getOne('self-client', actor);
+            expect(result.id).toBe(entity.id);
+        });
+
+        it('should require permission when client actor looks at a different client', async () => {
             const target = repository.seed(createFakeClient({ name: 'other-client' }));
             const actor: FakeActorContext = {
                 permissionEvaluator: new FakePermissionEvaluator(),
                 identity: {
                     type: IdentityType.CLIENT,
-                    data: { id: randomUUID() } as any,
+                    data: { id: randomUUID(), name: 'self-client' } as any,
                 },
             };
             actor.permissionEvaluator.deny('preEvaluateOneOf');
@@ -222,11 +238,10 @@ describe('core/entities/client/service', () => {
                 permissionEvaluator: new FakePermissionEvaluator(),
                 identity: {
                     type: IdentityType.CLIENT,
-                    data: { id: entity.id } as any,
+                    data: { id: entity.id, name: 'self-secret' } as any,
                 },
             };
-            actor.permissionEvaluator.deny('preEvaluateOneOf');
-            actor.permissionEvaluator.deny('evaluateOneOf');
+            actor.permissionEvaluator.denyAll();
 
             const result = await service.getOne(entity.id, actor);
             expect(result.id).toBe(entity.id);

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -15,6 +15,7 @@ import {
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { ForbiddenError, NotFoundError } from '@ebec/http';
 import { ClientService } from '../../../../../src/core/entities/client/service.ts';
@@ -33,6 +34,10 @@ import { createFakeClient } from '../../../../utils/domains/index.ts';
 class FakeClientRepository extends FakeEntityRepository<Client> implements IClientRepository {
     async checkUniqueness(): Promise<void> {
         // no-op
+    }
+
+    async findOne(id: string, _query?: Record<string, any>, realm?: string): Promise<Client | null> {
+        return this.findOneByIdOrName(id, realm);
     }
 
     async findOneWithSecret(where: Record<string, any>): Promise<Client | null> {
@@ -133,10 +138,10 @@ describe('core/entities/client/service', () => {
             }]);
             repository.seed([createFakeClient({
                 name: 'scoped-client',
-                realm_id: realmId, 
+                realm_id: realmId,
             })]);
 
-            const result = await service.getOne('scoped-client', createAllowAllActor(), realmId);
+            const result = await service.getOne('scoped-client', createAllowAllActor(), undefined, realmId);
             expect(result.name).toBe('scoped-client');
         });
 
@@ -144,7 +149,7 @@ describe('core/entities/client/service', () => {
             repository.seed([createFakeClient({ name: 'some-client' })]);
 
             await expect(
-                service.getOne('some-client', createAllowAllActor(), randomUUID()),
+                service.getOne('some-client', createAllowAllActor(), undefined, randomUUID()),
             ).rejects.toThrow(NotFoundError);
         });
 
@@ -164,6 +169,68 @@ describe('core/entities/client/service', () => {
             await service.getOne(entity.id, actor);
 
             expect(actor.permissionEvaluator.evaluateOneOfCalls.length).toBeGreaterThan(0);
+        });
+
+        it('should forward query and realmId to repository.findOne', async () => {
+            const entity = repository.seed(createFakeClient({ name: 'queried-client' }));
+            const findOneSpy = vi.spyOn(repository, 'findOne');
+
+            await service.getOne(entity.id, createAllowAllActor(), { fields: '+secret' });
+
+            expect(findOneSpy).toHaveBeenCalledWith(entity.id, { fields: '+secret' }, undefined);
+        });
+
+        it('should fall back to CLIENT_SELF_MANAGE when actor is the client itself', async () => {
+            const entity = repository.seed(createFakeClient({ name: 'self-client' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: entity.id } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            const result = await service.getOne(entity.id, actor);
+            expect(result.id).toBe(entity.id);
+            expect(actor.permissionEvaluator.preEvaluateCalls).toHaveLength(1);
+            expect(actor.permissionEvaluator.preEvaluateCalls[0].name).toBe(PermissionName.CLIENT_SELF_MANAGE);
+        });
+
+        it('should rethrow upfront error when CLIENT_SELF_MANAGE actor looks at a different client', async () => {
+            const target = repository.seed(createFakeClient({ name: 'other-client' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: randomUUID() } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            await expect(service.getOne(target.id, actor)).rejects.toThrow(ForbiddenError);
+        });
+
+        it('should skip post-load secret evaluation on self-access', async () => {
+            const entity = repository.seed(createFakeClient({
+                name: 'self-secret',
+                secret: 'plain',
+                secret_encrypted: false,
+                secret_hashed: false,
+            }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: entity.id } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+            actor.permissionEvaluator.deny('evaluateOneOf');
+
+            const result = await service.getOne(entity.id, actor);
+            expect(result.id).toBe(entity.id);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -198,7 +198,7 @@ describe('core/entities/client/service', () => {
             expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('should detect self-access by name lookup', async () => {
+        it('should bypass permission when self-by-name resolves to actor\'s own record', async () => {
             const entity = repository.seed(createFakeClient({ name: 'self-client' }));
             const actor: FakeActorContext = {
                 permissionEvaluator: new FakePermissionEvaluator(),
@@ -211,6 +211,22 @@ describe('core/entities/client/service', () => {
 
             const result = await service.getOne('self-client', actor);
             expect(result.id).toBe(entity.id);
+            expect(actor.permissionEvaluator.preEvaluateOneOfCalls).toHaveLength(0);
+        });
+
+        it('should require permission when self-by-name resolves to a different entity', async () => {
+            const otherEntity = repository.seed(createFakeClient({ name: 'shared-name' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: randomUUID(), name: 'shared-name' } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            await expect(service.getOne('shared-name', actor)).rejects.toThrow(ForbiddenError);
+            expect(otherEntity.name).toBe('shared-name');
         });
 
         it('should require permission when client actor looks at a different client', async () => {

--- a/apps/server-core/test/unit/core/entities/robot/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/robot/service.spec.ts
@@ -186,7 +186,7 @@ describe('core/entities/robot/service', () => {
             expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('should detect self-access by name lookup', async () => {
+        it('should bypass permission when self-by-name resolves to actor\'s own record', async () => {
             const entity = repository.seed(createFakeRobot({ name: 'self-robot' }));
             const actor: FakeActorContext = {
                 permissionEvaluator: new FakePermissionEvaluator(),
@@ -199,6 +199,22 @@ describe('core/entities/robot/service', () => {
 
             const result = await service.getOne('self-robot', actor);
             expect(result.id).toBe(entity.id);
+            expect(actor.permissionEvaluator.preEvaluateOneOfCalls).toHaveLength(0);
+        });
+
+        it('should require permission when self-by-name resolves to a different entity', async () => {
+            const otherEntity = repository.seed(createFakeRobot({ name: 'shared-name' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.ROBOT,
+                    data: { id: randomUUID(), name: 'shared-name' } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            await expect(service.getOne('shared-name', actor)).rejects.toThrow(ForbiddenError);
+            expect(otherEntity.name).toBe('shared-name');
         });
 
         it('should require permission when robot actor looks at a different robot', async () => {

--- a/apps/server-core/test/unit/core/entities/robot/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/robot/service.spec.ts
@@ -23,6 +23,7 @@ import {
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { ForbiddenError, NotFoundError } from '@ebec/http';
 import { RobotService } from '../../../../../src/core/entities/robot/service.ts';
@@ -41,6 +42,10 @@ import { createFakeRobot } from '../../../../utils/domains/index.ts';
 class FakeRobotRepository extends FakeEntityRepository<Robot> implements IRobotRepository {
     async checkUniqueness(): Promise<void> {
         // no-op
+    }
+
+    async findOne(id: string, _query?: Record<string, any>, realm?: string): Promise<Robot | null> {
+        return this.findOneByIdOrName(id, realm);
     }
 
     async findOneWithSecret(where: Record<string, any>): Promise<Robot | null> {
@@ -152,6 +157,63 @@ describe('core/entities/robot/service', () => {
 
         it('should throw NotFoundError when entity does not exist', async () => {
             await expect(service.getOne('non-existent-id', createAllowAllActor())).rejects.toThrow(NotFoundError);
+        });
+
+        it('should forward query and realmId to repository.findOne', async () => {
+            const entity = repository.seed(createFakeRobot({ name: 'queried-robot' }));
+            const findOneSpy = vi.spyOn(repository, 'findOne');
+
+            await service.getOne(entity.id, createAllowAllActor(), { fields: '+secret' });
+
+            expect(findOneSpy).toHaveBeenCalledWith(entity.id, { fields: '+secret' }, undefined);
+        });
+
+        it('should fall back to ROBOT_SELF_MANAGE when actor is the robot itself', async () => {
+            const entity = repository.seed(createFakeRobot({ name: 'self-robot' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.ROBOT,
+                    data: { id: entity.id } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            const result = await service.getOne(entity.id, actor);
+            expect(result.id).toBe(entity.id);
+            expect(actor.permissionEvaluator.preEvaluateCalls).toHaveLength(1);
+            expect(actor.permissionEvaluator.preEvaluateCalls[0].name).toBe(PermissionName.ROBOT_SELF_MANAGE);
+        });
+
+        it('should rethrow upfront error when ROBOT_SELF_MANAGE actor looks at a different robot', async () => {
+            const target = repository.seed(createFakeRobot({ name: 'other-robot' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.ROBOT,
+                    data: { id: randomUUID() } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            await expect(service.getOne(target.id, actor)).rejects.toThrow(ForbiddenError);
+        });
+
+        it('should skip post-load attribute evaluation on self-access', async () => {
+            const entity = repository.seed(createFakeRobot({ name: 'self-robot' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.ROBOT,
+                    data: { id: entity.id } as any,
+                },
+            };
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+            actor.permissionEvaluator.deny('evaluateOneOf');
+
+            const result = await service.getOne(entity.id, actor);
+            expect(result.id).toBe(entity.id);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/robot/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/robot/service.spec.ts
@@ -168,52 +168,51 @@ describe('core/entities/robot/service', () => {
             expect(findOneSpy).toHaveBeenCalledWith(entity.id, { fields: '+secret' }, undefined);
         });
 
-        it('should fall back to ROBOT_SELF_MANAGE when actor is the robot itself', async () => {
+        it('should bypass the permission gate when actor is the robot itself', async () => {
             const entity = repository.seed(createFakeRobot({ name: 'self-robot' }));
             const actor: FakeActorContext = {
                 permissionEvaluator: new FakePermissionEvaluator(),
                 identity: {
                     type: IdentityType.ROBOT,
-                    data: { id: entity.id } as any,
+                    data: { id: entity.id, name: 'self-robot' } as any,
                 },
             };
-            actor.permissionEvaluator.deny('preEvaluateOneOf');
+            actor.permissionEvaluator.denyAll();
 
             const result = await service.getOne(entity.id, actor);
             expect(result.id).toBe(entity.id);
-            expect(actor.permissionEvaluator.preEvaluateCalls).toHaveLength(1);
-            expect(actor.permissionEvaluator.preEvaluateCalls[0].name).toBe(PermissionName.ROBOT_SELF_MANAGE);
+            expect(actor.permissionEvaluator.preEvaluateOneOfCalls).toHaveLength(0);
+            expect(actor.permissionEvaluator.preEvaluateCalls).toHaveLength(0);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('should rethrow upfront error when ROBOT_SELF_MANAGE actor looks at a different robot', async () => {
+        it('should detect self-access by name lookup', async () => {
+            const entity = repository.seed(createFakeRobot({ name: 'self-robot' }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.ROBOT,
+                    data: { id: entity.id, name: 'self-robot' } as any,
+                },
+            };
+            actor.permissionEvaluator.denyAll();
+
+            const result = await service.getOne('self-robot', actor);
+            expect(result.id).toBe(entity.id);
+        });
+
+        it('should require permission when robot actor looks at a different robot', async () => {
             const target = repository.seed(createFakeRobot({ name: 'other-robot' }));
             const actor: FakeActorContext = {
                 permissionEvaluator: new FakePermissionEvaluator(),
                 identity: {
                     type: IdentityType.ROBOT,
-                    data: { id: randomUUID() } as any,
+                    data: { id: randomUUID(), name: 'self-robot' } as any,
                 },
             };
             actor.permissionEvaluator.deny('preEvaluateOneOf');
 
             await expect(service.getOne(target.id, actor)).rejects.toThrow(ForbiddenError);
-        });
-
-        it('should skip post-load attribute evaluation on self-access', async () => {
-            const entity = repository.seed(createFakeRobot({ name: 'self-robot' }));
-            const actor: FakeActorContext = {
-                permissionEvaluator: new FakePermissionEvaluator(),
-                identity: {
-                    type: IdentityType.ROBOT,
-                    data: { id: entity.id } as any,
-                },
-            };
-            actor.permissionEvaluator.deny('preEvaluateOneOf');
-            actor.permissionEvaluator.deny('evaluateOneOf');
-
-            const result = await service.getOne(entity.id, actor);
-            expect(result.id).toBe(entity.id);
-            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/user/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user/service.spec.ts
@@ -179,6 +179,15 @@ describe('core/entities/user/service', () => {
                 service.getOne(entity.id, createDenyAllActor()),
             ).rejects.toThrow(ForbiddenError);
         });
+
+        it('should require permission when self-by-name resolves to a different user', async () => {
+            const otherEntity = repository.seed(createFakeUser({ name: 'shared-name' }));
+            const actor = createSelfActor(randomUUID(), 'shared-name');
+            actor.permissionEvaluator.deny('preEvaluateOneOf');
+
+            await expect(service.getOne('shared-name', actor)).rejects.toThrow(ForbiddenError);
+            expect(otherEntity.name).toBe('shared-name');
+        });
     });
 
     describe('create', () => {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated commit message guidelines to disallow AI-attribution trailers.

* **New Features**
  * Endpoints now forward query parameters when retrieving client and robot resources.
  * Repository/service lookups accept optional query filters and realm resolution.
  * Services recognize and optimize access when the caller is the same client/robot ("self").

* **Tests**
  * Expanded unit tests to cover query forwarding, self-access behavior, and permission handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->