### PR TITLE
feat: restrict entity names to lowercase characters

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -686,3 +686,37 @@ Distinct from `ClientAuthenticator` (`core/authentication/entities/client/module
 ```
 
 `PermissionProvisioningSynchronizer.synchronizePolicies()` resolves each name to a policy ID and inserts the junction. Idempotent — re-runs do not create duplicates. Throws `policy '<name>' not found` if a referenced policy is not provisioned, and `repositories must be wired` if relations are declared but the synchronizer was constructed without `policyRepository`/`permissionPolicyRepository`.
+
+## Canonical Identifier Form
+
+Identifier-style columns are stored in canonical form: `LOWER(TRIM(value))`. This applies to:
+
+- `name` on every named entity (`client`, `robot`, `user`, `role`, `scope`, `permission`, `policy`, `realm`, `identity-provider`)
+- `email` on `user`
+
+`display_name` and other free-form labels (`description`, `first_name`, `last_name`) preserve original casing — the canonical-form rule is only for columns used as identifiers in lookups / unique constraints.
+
+### Why canonical form
+
+Cross-DB collation behavior diverges:
+
+- MySQL with `utf8mb4_*_ci` (default) treats `'foo'` and `'Foo'` as duplicates in `=` comparisons and `UNIQUE` constraints
+- PostgreSQL with `en_US.UTF-8` (default) treats them as distinct rows
+
+Without canonicalization, the same code base produces different uniqueness behavior on each DB. Canonicalizing identifier columns at write time eliminates the divergence: `=` is sufficient for lookups across both DBs, `UNIQUE` constraints behave identically.
+
+### Three layers of enforcement
+
+Canonical form is enforced at three boundaries (defense-in-depth):
+
+1. **Validator transform** — every `name` / `email` validator chains `.trim().toLowerCase()` before its format check (Zod path) or `.matches(...)` (validup path). Mixed-case input is silently lowercased; callers see canonical form in the response.
+2. **Validator regex** — the format check (`isNameValid` for names: `/^[a-z0-9-_.]+$/`; emails: `/^[^A-Z]+$/`) operates on the post-transform value. After `.toLowerCase()` the regex always passes; it remains as documentation of the contract and as a catch for code paths that bypass the transform.
+3. **External boundary canonicalization** — when an identifier enters Authup outside the validator chain (currently: `IdentityProviderAccountManager` taking attribute candidates from external IdPs), it is lowercased at the ingress so external mixed-case usernames don't fall through to the random-nanoid fallback.
+
+### Adding a new identifier column
+
+When adding a `name`-style column on a new entity (or extending an existing one):
+
+1. **Validator** — chain `.trim().toLowerCase()` after `z.string()` (Zod) or before the format check (validup) and before any length / pattern check.
+2. **Repository** — use `=` for name lookups, never `LIKE :name`.
+3. **Migration** — include the new column in the canonical-name data migration (see `.agents/plans/008-canonical-name-migration-ledger.md`) with an up-front collision pre-check.

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -18,6 +18,7 @@
 - **Validation**: `validup` framework with `@validup/adapter-zod` for Zod schema integration
 - **Errors**: `@authup/errors` provides HTTP-aware error classes via `@ebec/http`
 - **Validation location**: Validators from `@authup/core-kit` (e.g., `RoleValidator`, `UserValidator`) run inside core services, not in controllers. Services receive raw `Record<string, any>` data and call `validator.run(data, { group: ValidatorGroup.CREATE })` internally. Controllers use `useRequestBody(req)` to pass the raw body to the service.
+- **Canonical identifier form**: `name` (every entity) and `user.email` are stored as `LOWER(TRIM(value))`. New `name`-style columns must chain `.trim().toLowerCase()` in their validator before the format check, and use `=` (not `LIKE`) in repository lookups. See `.agents/architecture.md#canonical-identifier-form` for the full rationale.
 
 ## Workflow
 

--- a/apps/server-core/src/adapters/http/controllers/entities/policy/utils/validation.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/policy/utils/validation.ts
@@ -25,6 +25,8 @@ export class PolicyValidator extends Container<PolicyEntity & { parent_id?: stri
                 .exists()
                 .notEmpty()
                 .isString()
+                .trim()
+                .toLowerCase()
                 .isLength({
                     min: 3,
                     max: 128,

--- a/apps/server-core/src/app/modules/database/repositories/client/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client/repository.ts
@@ -94,7 +94,7 @@ export class ClientRepositoryAdapter implements IClientRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<Client | null> {
         const qb = this.repository.createQueryBuilder('client');
-        qb.where('client.name LIKE :name', { name });
+        qb.where('client.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);
@@ -112,7 +112,7 @@ export class ClientRepositoryAdapter implements IClientRepository {
         if (isUUID(id)) {
             qb.where('client.id = :id', { id });
         } else {
-            qb.where('client.name LIKE :name', { name: id });
+            qb.where('client.name = :name', { name: id });
 
             if (realmKey) {
                 const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
@@ -59,7 +59,7 @@ export class PermissionRepositoryAdapter implements IPermissionRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<Permission | null> {
         const qb = this.repository.createQueryBuilder('permission');
-        qb.where('permission.name LIKE :name', { name });
+        qb.where('permission.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
@@ -89,7 +89,7 @@ export class PolicyRepositoryAdapter implements IPolicyRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<Policy | null> {
         const qb = this.repository.createQueryBuilder('policy');
-        qb.where('policy.name LIKE :name', { name });
+        qb.where('policy.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
@@ -27,7 +27,7 @@ export class RealmRepositoryAdapter implements IRealmRepository {
 
     findOneByName(name: string): Promise<Realm | null> {
         const qb = this.repository.createQueryBuilder('realm');
-        qb.where('realm.name LIKE :name', { name });
+        qb.where('realm.name = :name', { name });
 
         return qb.getOne();
     }

--- a/apps/server-core/src/app/modules/database/repositories/robot/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/robot/repository.ts
@@ -89,7 +89,7 @@ export class RobotRepositoryAdapter implements IRobotRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<Robot | null> {
         const qb = this.repository.createQueryBuilder('robot');
-        qb.where('robot.name LIKE :name', { name });
+        qb.where('robot.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);
@@ -113,7 +113,7 @@ export class RobotRepositoryAdapter implements IRobotRepository {
         if (isUUID(id)) {
             qb.where('robot.id = :id', { id });
         } else {
-            qb.where('robot.name LIKE :name', { name: id });
+            qb.where('robot.name = :name', { name: id });
 
             if (realmKey) {
                 const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/app/modules/database/repositories/role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role/repository.ts
@@ -76,7 +76,7 @@ export class RoleRepositoryAdapter implements IRoleRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<Role | null> {
         const qb = this.repository.createQueryBuilder('role');
-        qb.where('role.name LIKE :name', { name });
+        qb.where('role.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
@@ -70,7 +70,7 @@ export class ScopeRepositoryAdapter implements IScopeRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<Scope | null> {
         const qb = this.repository.createQueryBuilder('scope');
-        qb.where('scope.name LIKE :name', { name });
+        qb.where('scope.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/app/modules/database/repositories/user/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user/repository.ts
@@ -96,7 +96,7 @@ export class UserRepositoryAdapter implements IUserRepository {
 
     async findOneByName(name: string, realmKey?: string): Promise<User | null> {
         const qb = this.repository.createQueryBuilder('user');
-        qb.where('user.name LIKE :name', { name });
+        qb.where('user.name = :name', { name });
 
         if (realmKey) {
             const realm = await this.realmRepository.resolve(realmKey);
@@ -124,7 +124,7 @@ export class UserRepositoryAdapter implements IUserRepository {
         if (isUUID(id)) {
             qb.where('user.id = :id', { id });
         } else {
-            qb.where('user.name LIKE :name', { name: id });
+            qb.where('user.name = :name', { name: id });
 
             if (realmKey) {
                 const realm = await this.realmRepository.resolve(realmKey);

--- a/apps/server-core/src/core/identity/password-recovery/service.ts
+++ b/apps/server-core/src/core/identity/password-recovery/service.ts
@@ -142,6 +142,8 @@ export class PasswordRecoveryService implements IPasswordRecoveryService {
             return chain
                 .exists()
                 .notEmpty()
+                .trim()
+                .toLowerCase()
                 .isEmail()
                 .matches(/^[^A-Z]+$/)
                 .withMessage('Email must be lowercase.');
@@ -154,7 +156,9 @@ export class PasswordRecoveryService implements IPasswordRecoveryService {
                 return chain
                     .exists()
                     .notEmpty()
-                    .isString();
+                    .isString()
+                    .trim()
+                    .toLowerCase();
             }),
         );
 
@@ -185,7 +189,11 @@ export class PasswordRecoveryService implements IPasswordRecoveryService {
                 return chain
                     .exists()
                     .notEmpty()
-                    .isEmail();
+                    .trim()
+                    .toLowerCase()
+                    .isEmail()
+                    .matches(/^[^A-Z]+$/)
+                    .withMessage('Email must be lowercase.');
             }),
         );
         oneOfContainer.mount(
@@ -195,7 +203,9 @@ export class PasswordRecoveryService implements IPasswordRecoveryService {
                 return chain
                     .exists()
                     .notEmpty()
-                    .isString();
+                    .isString()
+                    .trim()
+                    .toLowerCase();
             }),
         );
 

--- a/apps/server-core/src/core/identity/password-recovery/service.ts
+++ b/apps/server-core/src/core/identity/password-recovery/service.ts
@@ -142,7 +142,9 @@ export class PasswordRecoveryService implements IPasswordRecoveryService {
             return chain
                 .exists()
                 .notEmpty()
-                .isEmail();
+                .isEmail()
+                .matches(/^[^A-Z]+$/)
+                .withMessage('Email must be lowercase.');
         }));
 
         oneOfContainer.mount(

--- a/apps/server-core/src/core/identity/provider/account/module.ts
+++ b/apps/server-core/src/core/identity/provider/account/module.ts
@@ -154,7 +154,7 @@ export class IdentityProviderAccountManager implements IIdentityProviderAccountM
                         }
                     }
                 } else {
-                    output.name = createNanoID('0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_', 10);
+                    output.name = createNanoID('0123456789abcdefghijklmnopqrstuvwxyz-_', 10);
                 }
 
                 if (isUserFakeEmail(output.email)) {

--- a/apps/server-core/src/core/identity/provider/account/module.ts
+++ b/apps/server-core/src/core/identity/provider/account/module.ts
@@ -131,6 +131,10 @@ export class IdentityProviderAccountManager implements IIdentityProviderAccountM
             output = attributesSelf;
         }
 
+        if (typeof output.name === 'string') {
+            output.name = output.name.trim().toLowerCase();
+        }
+
         let attempts = Math.max((identity.attributeCandidates?.name?.length || 0) + 1, 10);
         while (attempts > 0) {
             try {
@@ -140,7 +144,7 @@ export class IdentityProviderAccountManager implements IIdentityProviderAccountM
                 const names = identity.attributeCandidates?.name || [];
                 if (names.length > 0) {
                     while (names.length > 0) {
-                        output.name = `${names.shift()}`;
+                        output.name = `${names.shift()}`.trim().toLowerCase();
 
                         try {
                             await this.userValidator.run(output, {

--- a/apps/server-core/test/unit/core/identity/password-recovery/service.spec.ts
+++ b/apps/server-core/test/unit/core/identity/password-recovery/service.spec.ts
@@ -65,7 +65,7 @@ describe('core/identity/password-recovery/service', () => {
             });
 
             await expect(
-                service.forgotPassword({ email: faker.internet.email() }),
+                service.forgotPassword({ email: faker.internet.email().toLowerCase() }),
             ).rejects.toThrow(BadRequestError);
         });
 
@@ -81,7 +81,7 @@ describe('core/identity/password-recovery/service', () => {
             });
 
             await expect(
-                service.forgotPassword({ email: faker.internet.email() }),
+                service.forgotPassword({ email: faker.internet.email().toLowerCase() }),
             ).rejects.toThrow(BadRequestError);
         });
 
@@ -102,7 +102,7 @@ describe('core/identity/password-recovery/service', () => {
         });
 
         it('should set reset_hash and reset_expires and send email', async () => {
-            const email = faker.internet.email();
+            const email = faker.internet.email().toLowerCase();
             const masterRealm = realmRepository.getMasterRealm();
             repository.seed([createFakeUser({
                 name: 'test-user',
@@ -158,7 +158,7 @@ describe('core/identity/password-recovery/service', () => {
         });
 
         it('should set reset_expires to ~30 minutes from now', async () => {
-            const email = faker.internet.email();
+            const email = faker.internet.email().toLowerCase();
             const masterRealm = realmRepository.getMasterRealm();
             repository.seed([createFakeUser({
                 name: 'timer-user',
@@ -187,7 +187,7 @@ describe('core/identity/password-recovery/service', () => {
         });
 
         it('should rollback reset fields on mail failure', async () => {
-            const email = faker.internet.email();
+            const email = faker.internet.email().toLowerCase();
             const masterRealm = realmRepository.getMasterRealm();
             const entity = repository.seed(createFakeUser({
                 name: 'mail-fail-user',
@@ -226,7 +226,7 @@ describe('core/identity/password-recovery/service', () => {
 
             await expect(
                 service.resetPassword({
-                    email: faker.internet.email(),
+                    email: faker.internet.email().toLowerCase(),
                     token: 'abc',
                     password: 'newpass123',
                 }),

--- a/apps/server-core/test/unit/core/identity/provider/account.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/account.spec.ts
@@ -78,7 +78,7 @@ describe('core/identity/provider/account', () => {
         identity = {
             id: 'foo',
             data: claims,
-            attributeCandidates: { name: ['foobarbaz'] },
+            attributeCandidates: { name: ['fooBarBaz'] },
             provider,
         };
 

--- a/apps/server-core/test/unit/core/identity/provider/account.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/account.spec.ts
@@ -78,7 +78,7 @@ describe('core/identity/provider/account', () => {
         identity = {
             id: 'foo',
             data: claims,
-            attributeCandidates: { name: ['fooBarBaz'] },
+            attributeCandidates: { name: ['foobarbaz'] },
             provider,
         };
 
@@ -121,8 +121,8 @@ describe('core/identity/provider/account', () => {
 
         expect(account.id).toBeDefined();
         expect(account.user.id).toBeDefined();
-        expect(account.user.name).toEqual('fooBarBaz');
-        expect(account.user.email).toEqual(buildUserFakeEmail('fooBarBaz'));
+        expect(account.user.name).toEqual('foobarbaz');
+        expect(account.user.email).toEqual(buildUserFakeEmail('foobarbaz'));
     });
 
     it('should create user with alternative name', async () => {

--- a/apps/server-core/test/unit/core/identity/registration/service.spec.ts
+++ b/apps/server-core/test/unit/core/identity/registration/service.spec.ts
@@ -46,8 +46,8 @@ class FakeUserRepository extends FakeEntityRepository<User> implements IUserRepo
 
 function createValidRegistrationData() {
     return {
-        name: faker.internet.username(),
-        email: faker.internet.email(),
+        name: faker.internet.username().toLowerCase(),
+        email: faker.internet.email().toLowerCase(),
         password: faker.string.alphanumeric({ length: 16 }),
     };
 }
@@ -146,8 +146,8 @@ describe('core/identity/registration/service', () => {
             });
 
             const data = {
-                name: faker.internet.username(),
-                email: faker.internet.email(),
+                name: faker.internet.username().toLowerCase(),
+                email: faker.internet.email().toLowerCase(),
             };
             await service.register(data);
 
@@ -219,9 +219,9 @@ describe('core/identity/registration/service', () => {
 
             await expect(
                 service.register({
-                    name: faker.internet.username(),
+                    name: faker.internet.username().toLowerCase(),
                     email: 'not-an-email',
-                    password: 'securepass123', 
+                    password: 'securepass123',
                 }),
             ).rejects.toThrow(/email/i);
         });

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
@@ -101,7 +101,7 @@ describe('src/http/controllers/identity-provider', () => {
     });
 
     it('should update resource', async () => {
-        oAuth2IdentityProvider.name = 'TestA';
+        oAuth2IdentityProvider.name = 'testa';
         oAuth2IdentityProvider.client_secret = 'start1234';
 
         const response = await suite.client

--- a/apps/server-core/test/unit/http/controllers/entities/permission/module.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/permission/module.spec.ts
@@ -93,12 +93,12 @@ describe('src/http/controllers/permission', () => {
             .permission
             .update(details.id, {
                 ...details,
-                name: 'TestA',
+                name: 'testa',
             });
 
         expect(response).toBeDefined();
-        expect(response.name).toEqual('TestA');
-        details.name = 'TestA';
+        expect(response.name).toEqual('testa');
+        details.name = 'testa';
 
         expectPropertiesEqualToSrc(details, response);
     });
@@ -108,13 +108,13 @@ describe('src/http/controllers/permission', () => {
             .permission
             .update(details.name, {
                 ...details,
-                name: 'TestB',
+                name: 'testb',
             });
 
         expect(response).toBeDefined();
-        expect(response.name).toEqual('TestB');
+        expect(response.name).toEqual('testb');
 
-        details.name = 'TestB';
+        details.name = 'testb';
         expectPropertiesEqualToSrc(details, response);
     });
 

--- a/apps/server-core/test/unit/http/controllers/entities/role.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/role.spec.ts
@@ -87,13 +87,13 @@ describe('src/http/controllers/role', () => {
             .role
             .update(details.id, {
                 ...details,
-                name: 'TestA',
+                name: 'testa',
             });
 
         expect(response).toBeDefined();
-        expect(response.name).toEqual('TestA');
+        expect(response.name).toEqual('testa');
 
-        details.name = 'TestA';
+        details.name = 'testa';
         expectPropertiesEqualToSrc(details, response);
     });
 
@@ -102,13 +102,13 @@ describe('src/http/controllers/role', () => {
             .role
             .update(details.name, {
                 ...details,
-                name: 'TestB',
+                name: 'testb',
             });
 
         expect(response).toBeDefined();
-        expect(response.name).toEqual('TestB');
+        expect(response.name).toEqual('testb');
 
-        details.name = 'TestB';
+        details.name = 'testb';
         expectPropertiesEqualToSrc(details, response);
     });
 

--- a/apps/server-core/test/unit/http/controllers/entities/scope.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/scope.spec.ts
@@ -86,12 +86,12 @@ describe('src/http/controllers/scope', () => {
             .scope
             .update(details.id, {
                 ...details,
-                name: 'TestA',
+                name: 'testa',
             });
 
-        expect(response.name).toEqual('TestA');
+        expect(response.name).toEqual('testa');
 
-        details.name = 'TestA';
+        details.name = 'testa';
         expectPropertiesEqualToSrc(details, response);
     });
 
@@ -100,13 +100,13 @@ describe('src/http/controllers/scope', () => {
             .scope
             .update(details.name, {
                 ...details,
-                name: 'TestB',
+                name: 'testb',
             });
 
         expect(response).toBeDefined();
-        expect(response.name).toEqual('TestB');
+        expect(response.name).toEqual('testb');
 
-        details.name = 'TestB';
+        details.name = 'testb';
         expectPropertiesEqualToSrc(details, response);
     });
 

--- a/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
@@ -71,7 +71,7 @@ describe('src/http/controllers/user', () => {
     });
 
     it('should update resource', async () => {
-        details.name = 'TestA';
+        details.name = 'testa';
         details.first_name = 'bar';
         details.last_name = 'baz';
 

--- a/apps/server-core/test/utils/domains/client.ts
+++ b/apps/server-core/test/utils/domains/client.ts
@@ -10,7 +10,7 @@ import type { Client } from '@authup/core-kit';
 
 export function createFakeClient(data: Partial<Client> = {}) {
     return {
-        name: faker.internet.username(),
+        name: faker.internet.username().toLowerCase(),
         display_name: faker.internet.displayName(),
         secret: faker.string.alpha({ length: 10 }),
         redirect_uri: 'https://example.com/**',

--- a/apps/server-core/test/utils/domains/policy.ts
+++ b/apps/server-core/test/utils/domains/policy.ts
@@ -16,7 +16,7 @@ type TimePolicyExtended = TimePolicy & PolicyEntity & {
 
 export function createFakeTimePolicy(data: Partial<TimePolicyExtended> = {}) {
     return {
-        name: faker.internet.username(),
+        name: faker.internet.username().toLowerCase(),
         display_name: faker.internet.displayName(),
         type: BuiltInPolicyType.TIME,
         start: '08:00:00',

--- a/apps/server-core/test/utils/domains/role-attribute.ts
+++ b/apps/server-core/test/utils/domains/role-attribute.ts
@@ -10,7 +10,10 @@ import type { RoleAttribute } from '@authup/core-kit';
 
 export function createFakeRoleAttribute(data: Partial<RoleAttribute> = {}) {
     return {
-        name: faker.string.alpha({ length: 10 }),
+        name: faker.string.alpha({
+            casing: 'lower',
+            length: 10,
+        }),
         value: faker.string.alpha({ length: 10 }),
         ...data,
     } satisfies Partial<RoleAttribute>;

--- a/apps/server-core/test/utils/domains/user-attribute.ts
+++ b/apps/server-core/test/utils/domains/user-attribute.ts
@@ -10,7 +10,7 @@ import type { UserAttribute } from '@authup/core-kit';
 
 export function createFakeUserAttribute(data: Partial<UserAttribute> = {}) {
     return {
-        name: faker.internet.username(),
+        name: faker.internet.username().toLowerCase(),
         value: faker.string.alphanumeric({ length: 64 }),
         ...data,
     } satisfies Partial<UserAttribute>;

--- a/apps/server-core/test/utils/domains/user.ts
+++ b/apps/server-core/test/utils/domains/user.ts
@@ -10,9 +10,9 @@ import type { User } from '@authup/core-kit';
 
 export function createFakeUser(data: Partial<User> = {}) {
     return {
-        name: faker.internet.username(),
+        name: faker.internet.username().toLowerCase(),
         display_name: faker.internet.displayName(),
-        email: faker.internet.email(),
+        email: faker.internet.email().toLowerCase(),
         name_locked: false,
         active: true,
         first_name: faker.person.firstName(),

--- a/packages/client-web-kit/src/core/translator/de/vuelidate.ts
+++ b/packages/client-web-kit/src/core/translator/de/vuelidate.ts
@@ -10,5 +10,5 @@ import { VuelidateCustomRuleKey } from '../../vuelidate';
 
 export const TranslatorTranslationVuelidateGerman : LinesRecord = {
     [VuelidateCustomRuleKey.ALPHA_NUM_HYPHEN_UNDERSCORE]: 'Der Eingabewert darf nur aus folgenden Zeichen bestehen: [0-9a-z-_]+',
-    [VuelidateCustomRuleKey.ALPHA_UPPER_NUM_HYPHEN_UNDERSCORE_DOT]: 'Der Eingabewert darf nur aus folgenden Zeichen bestehen: [0-9a-zA-Z-_.]+',
+    [VuelidateCustomRuleKey.ALPHA_UPPER_NUM_HYPHEN_UNDERSCORE_DOT]: 'Der Eingabewert darf nur aus folgenden Zeichen bestehen: [0-9a-z-_.]+',
 };

--- a/packages/client-web-kit/src/core/translator/en/vuelidate.ts
+++ b/packages/client-web-kit/src/core/translator/en/vuelidate.ts
@@ -10,5 +10,5 @@ import { VuelidateCustomRuleKey } from '../../vuelidate';
 
 export const TranslatorTranslationVuelidateEnglish : LinesRecord = {
     [VuelidateCustomRuleKey.ALPHA_NUM_HYPHEN_UNDERSCORE]: 'The input value is only allowed to consist of the following characters: [0-9a-z-_]+',
-    [VuelidateCustomRuleKey.ALPHA_UPPER_NUM_HYPHEN_UNDERSCORE_DOT]: 'The input value is only allowed to consist of the following characters: [0-9a-zA-Z-_.]+',
+    [VuelidateCustomRuleKey.ALPHA_UPPER_NUM_HYPHEN_UNDERSCORE_DOT]: 'The input value is only allowed to consist of the following characters: [0-9a-z-_.]+',
 };

--- a/packages/client-web-kit/src/core/vuelidate.ts
+++ b/packages/client-web-kit/src/core/vuelidate.ts
@@ -18,7 +18,7 @@ export enum VuelidateCustomRuleKey {
 
 export const VuelidateCustomRule = {
     [VuelidateCustomRuleKey.ALPHA_NUM_HYPHEN_UNDERSCORE]: helpers.regex(/^[a-z0-9-_]*$/),
-    [VuelidateCustomRuleKey.ALPHA_UPPER_NUM_HYPHEN_UNDERSCORE_DOT]: helpers.regex(/^[a-zA-Z0-9-_.]*$/),
+    [VuelidateCustomRuleKey.ALPHA_UPPER_NUM_HYPHEN_UNDERSCORE_DOT]: helpers.regex(/^[a-z0-9-_.]*$/),
 };
 
 export function getVuelidateSeverity<

--- a/packages/core-kit/src/domains/client/validator.ts
+++ b/packages/core-kit/src/domains/client/validator.ts
@@ -35,6 +35,8 @@ export class ClientValidator extends Container<Client> {
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/identity-provider/validator.ts
+++ b/packages/core-kit/src/domains/identity-provider/validator.ts
@@ -20,6 +20,8 @@ export class IdentityProviderValidator extends Container<IdentityProvider> {
 
         const nameValidator = createValidator(
             zod.string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/permission/validator.ts
+++ b/packages/core-kit/src/domains/permission/validator.ts
@@ -22,6 +22,8 @@ export class PermissionValidator extends Container<
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/policy/validator.ts
+++ b/packages/core-kit/src/domains/policy/validator.ts
@@ -21,6 +21,8 @@ export class PolicyValidator extends Container<
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/realm/validator.ts
+++ b/packages/core-kit/src/domains/realm/validator.ts
@@ -21,6 +21,8 @@ export class RealmValidator extends Container<
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/robot/validator.ts
+++ b/packages/core-kit/src/domains/robot/validator.ts
@@ -33,6 +33,8 @@ export class RobotValidator extends Container<
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/role/validator.ts
+++ b/packages/core-kit/src/domains/role/validator.ts
@@ -21,6 +21,8 @@ export class RoleValidator extends Container<
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/scope/validator.ts
+++ b/packages/core-kit/src/domains/scope/validator.ts
@@ -21,6 +21,8 @@ export class ScopeValidator extends Container<
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {

--- a/packages/core-kit/src/domains/user/validator.ts
+++ b/packages/core-kit/src/domains/user/validator.ts
@@ -78,7 +78,9 @@ export class UserValidator extends Container<User> {
 
         // ----------------------------------------------
 
-        const emailValidator = createValidator(z.email());
+        const emailValidator = createValidator(
+            z.email().regex(/^[^A-Z]+$/, 'Email must be lowercase.'),
+        );
 
         this.mount(
             'email',

--- a/packages/core-kit/src/domains/user/validator.ts
+++ b/packages/core-kit/src/domains/user/validator.ts
@@ -19,6 +19,8 @@ export class UserValidator extends Container<User> {
         const nameValidator = createValidator(
             z
                 .string()
+                .trim()
+                .toLowerCase()
                 .min(3)
                 .max(128)
                 .check((ctx) => {
@@ -79,7 +81,10 @@ export class UserValidator extends Container<User> {
         // ----------------------------------------------
 
         const emailValidator = createValidator(
-            z.email().regex(/^[^A-Z]+$/, 'Email must be lowercase.'),
+            z.email()
+                .trim()
+                .toLowerCase()
+                .regex(/^[^A-Z]+$/, 'Email must be lowercase.'),
         );
 
         this.mount(

--- a/packages/core-kit/src/helpers/name-valid.ts
+++ b/packages/core-kit/src/helpers/name-valid.ts
@@ -19,12 +19,12 @@ export function isNameValid(input: string, options: NameValidOptions = {}): bool
         return false;
     }
 
-    if (/^[A-Za-z0-9-_.]+$/.test(input)) {
+    if (/^[a-z0-9-_.]+$/.test(input)) {
         return true;
     }
 
     if (options.throwOnFailure) {
-        throw new AuthupError('Only the characters [A-Za-z0-9-_.]+ are allowed.');
+        throw new AuthupError('Only the characters [a-z0-9-_.]+ are allowed.');
     }
 
     return false;

--- a/packages/core-kit/test/unit/helpers/name.spec.ts
+++ b/packages/core-kit/test/unit/helpers/name.spec.ts
@@ -20,8 +20,8 @@ describe('src/helpers/name', () => {
         expect(isNameValid('foo_bar')).toBeTruthy();
     });
 
-    it('should be a valid name (uppercase character)', () => {
-        expect(isNameValid('FOO')).toBeTruthy();
+    it('should not be a valid name (uppercase character)', () => {
+        expect(isNameValid('FOO')).toBeFalsy();
     });
 
     it('should not be a valid name ("!" character)', () => {


### PR DESCRIPTION
Tighten isNameValid to /^[a-z0-9-_.]+$/ so identifier-style names across all entities (client, robot, user, role, scope, permission, policy, realm, identity-provider) are stored in canonical form.

Eliminates the cross-DB inconsistency where MySQL with the default *_ci collation treats 'foo' and 'Foo' as duplicates while PostgreSQL allows both rows to coexist under its case-sensitive collation.

Side effects:
- Existing test fixtures using mixed-case names ('TestA', 'TestB') updated to lowercase variants
- Pre-existing isNameValid test for uppercase input flipped from expecting valid to expecting invalid

Production data migration to canonicalize existing rows is tracked in plan 008 (migration ledger).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Identifier Normalization**
  * User, client, policy, role, scope, permission, realm, and robot names are now automatically normalized to lowercase with whitespace trimmed for consistency.
  * Email addresses are now normalized to lowercase.
  * Identifier lookups now use exact matching instead of pattern matching for improved precision.

* **Documentation**
  * Updated architecture and conventions documentation with canonicalization rules and implementation guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->