### PR TITLE
fix: align openid issuer with jwt iss claim across realms

### DIFF
--- a/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
@@ -100,12 +100,14 @@ export class RealmController {
     ): Promise<OpenIDProviderMetadata> {
         const entity = await this.service.getOne(id);
 
+        const baseURL = this.options.baseURL.replace(/\/+$/, '');
+
         return {
-            issuer: this.options.baseURL,
+            issuer: `${baseURL}/realms/${entity.name}`,
 
             authorization_endpoint: new URL('authorize', this.options.baseURL).href,
 
-            jwks_uri: new URL(`realms/${entity.id}/jwks`, this.options.baseURL).href,
+            jwks_uri: new URL(`realms/${entity.name}/jwks`, this.options.baseURL).href,
 
             response_types_supported: [
                 OAuth2AuthorizationResponseType.CODE,
@@ -144,20 +146,20 @@ export class RealmController {
     @DGet('/:id/jwks', [])
     async getCerts(
         @DPath('id') id: string,
-        @DRequest() req: any,
         @DResponse() res: any,
     ): Promise<OAuth2JsonWebKey[]> {
-        return getJwksRouteHandler(req, res, this.keyRepository, 'id');
+        const entity = await this.service.getOne(id);
+        return getJwksRouteHandler(res, this.keyRepository, entity.id);
     }
 
     @DGet('/:id/jwks/:keyId', [])
     async getCert(
         @DPath('id') id: string,
         @DPath('keyId') keyId: string,
-        @DRequest() req: any,
         @DResponse() res: any,
     ): Promise<OAuth2JsonWebKey> {
-        return getJwkRouteHandler(req, res, this.keyRepository, 'keyId');
+        const entity = await this.service.getOne(id);
+        return getJwkRouteHandler(res, this.keyRepository, keyId, entity.id);
     }
 
     @DPost('/:id', [ForceLoggedInMiddleware])

--- a/apps/server-core/src/adapters/http/controllers/workflows/jwks/handlers/read.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/jwks/handlers/read.ts
@@ -7,22 +7,18 @@
 
 import { AsymmetricKey } from '@authup/server-kit';
 import { JWKType } from '@authup/specs';
-import type { Request, Response } from 'routup';
+import type { Response } from 'routup';
 import { send } from 'routup';
 import type { Repository } from 'typeorm';
 import { In } from 'typeorm';
 import { BadRequestError, NotFoundError } from '@ebec/http';
 import type { KeyEntity } from '../../../../../database/domains/index.ts';
-import { getRequestStringParam, getRequestStringParamOrFail } from '../../../../request/index.ts';
 
 export async function getJwksRouteHandler(
-    req: Request,
     res: Response,
     repository: Repository<KeyEntity>,
-    realmIdParamKey?: string,
+    realmId?: string,
 ) : Promise<any> {
-    const realmId = getRequestStringParam(req, realmIdParamKey || 'realmId');
-
     const entities = await repository.find({
         where: {
             type: In([JWKType.RSA, JWKType.EC]),
@@ -54,17 +50,16 @@ export async function getJwksRouteHandler(
 }
 
 export async function getJwkRouteHandler(
-    req: Request,
     res: Response,
     repository: Repository<KeyEntity>,
-    idParamKey?: string,
+    keyId: string,
+    realmId?: string,
 ) : Promise<any> {
-    const id = getRequestStringParamOrFail(req, idParamKey || 'id');
-
     const entity = await repository.findOne({
         where: {
             type: In([JWKType.RSA, JWKType.EC]),
-            id,
+            id: keyId,
+            ...(realmId ? { realm_id: realmId } : {}),
         },
     });
 

--- a/apps/server-core/src/core/oauth2/grant-types/client-credentials.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/client-credentials.ts
@@ -34,7 +34,7 @@ export class ClientCredentialsGrant extends OAuth2BaseGrant<Client> {
             sub: input.id,
             sub_kind: OAuth2SubKind.CLIENT,
             realm_id: input.realm.id,
-            realm_name: input.realm.id,
+            realm_name: input.realm.name,
             client_id: input.id,
         });
 

--- a/apps/server-core/src/core/oauth2/grant-types/robot-credentials.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/robot-credentials.ts
@@ -34,7 +34,7 @@ export class RobotCredentialsGrant extends OAuth2BaseGrant<Robot> {
             sub: input.id,
             sub_kind: OAuth2SubKind.ROBOT,
             realm_id: input.realm.id,
-            realm_name: input.realm?.id,
+            realm_name: input.realm?.name,
             client_id: input.client_id || undefined,
         });
 

--- a/apps/server-core/src/core/oauth2/grant-types/robot-credentials.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/robot-credentials.ts
@@ -34,7 +34,7 @@ export class RobotCredentialsGrant extends OAuth2BaseGrant<Robot> {
             sub: input.id,
             sub_kind: OAuth2SubKind.ROBOT,
             realm_id: input.realm.id,
-            realm_name: input.realm?.name,
+            realm_name: input.realm.name,
             client_id: input.client_id || undefined,
         });
 

--- a/apps/server-core/test/unit/core/oauth2/grant-types/client-credentials.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/grant-types/client-credentials.spec.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Client, Realm } from '@authup/core-kit';
+import { IdentityType, ScopeName } from '@authup/core-kit';
+import { OAuth2SubKind } from '@authup/specs';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { ClientCredentialsGrant } from '../../../../../src/core/oauth2/grant-types/client-credentials.ts';
+import { FakeOAuth2TokenIssuer } from '../../helpers/fake-oauth2-token-issuer.ts';
+import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
+
+describe('ClientCredentialsGrant', () => {
+    let accessTokenIssuer: FakeOAuth2TokenIssuer;
+    let sessionManager: FakeSessionManager;
+    let grant: ClientCredentialsGrant;
+
+    const realmId = randomUUID();
+    const clientId = randomUUID();
+
+    const client = {
+        id: clientId,
+        realm_id: realmId,
+        realm: {
+            id: realmId,
+            name: 'master',
+        } as Realm,
+    } as Client;
+
+    beforeEach(() => {
+        accessTokenIssuer = new FakeOAuth2TokenIssuer();
+        sessionManager = new FakeSessionManager();
+        grant = new ClientCredentialsGrant({
+            accessTokenIssuer,
+            sessionManager,
+        });
+    });
+
+    it('should issue access token with realm_name set to the realm name (not the realm id)', async () => {
+        await grant.runWith(client);
+
+        expect(accessTokenIssuer.issueCalls).toHaveLength(1);
+        const payload = accessTokenIssuer.issueCalls[0];
+
+        expect(payload.realm_id).toEqual(realmId);
+        expect(payload.realm_name).toEqual('master');
+        expect(payload.realm_name).not.toEqual(realmId);
+    });
+
+    it('should issue access token with client_id and sub set to the client id', async () => {
+        await grant.runWith(client);
+
+        const payload = accessTokenIssuer.issueCalls[0];
+
+        expect(payload.sub).toEqual(clientId);
+        expect(payload.sub_kind).toEqual(OAuth2SubKind.CLIENT);
+        expect(payload.client_id).toEqual(clientId);
+        expect(payload.scope).toEqual(ScopeName.GLOBAL);
+    });
+
+    it('should create a session bound to the client', async () => {
+        await grant.runWith(client);
+
+        expect(sessionManager.createCalls).toContainEqual(
+            expect.objectContaining({
+                realm_id: realmId,
+                sub: clientId,
+                sub_kind: IdentityType.CLIENT,
+            }),
+        );
+    });
+});

--- a/apps/server-core/test/unit/core/oauth2/grant-types/robot-credentials.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/grant-types/robot-credentials.spec.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Realm, Robot } from '@authup/core-kit';
+import { IdentityType, ScopeName } from '@authup/core-kit';
+import { OAuth2SubKind } from '@authup/specs';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { RobotCredentialsGrant } from '../../../../../src/core/oauth2/grant-types/robot-credentials.ts';
+import { FakeOAuth2TokenIssuer } from '../../helpers/fake-oauth2-token-issuer.ts';
+import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
+
+describe('RobotCredentialsGrant', () => {
+    let accessTokenIssuer: FakeOAuth2TokenIssuer;
+    let sessionManager: FakeSessionManager;
+    let grant: RobotCredentialsGrant;
+
+    const realmId = randomUUID();
+    const robotId = randomUUID();
+    const clientId = randomUUID();
+
+    const robot = {
+        id: robotId,
+        realm_id: realmId,
+        client_id: clientId,
+        realm: {
+            id: realmId,
+            name: 'master',
+        } as Realm,
+    } as Robot;
+
+    beforeEach(() => {
+        accessTokenIssuer = new FakeOAuth2TokenIssuer();
+        sessionManager = new FakeSessionManager();
+        grant = new RobotCredentialsGrant({
+            accessTokenIssuer,
+            sessionManager,
+        });
+    });
+
+    it('should issue access token with realm_name set to the realm name (not the realm id)', async () => {
+        await grant.runWith(robot);
+
+        expect(accessTokenIssuer.issueCalls).toHaveLength(1);
+        const payload = accessTokenIssuer.issueCalls[0];
+
+        expect(payload.realm_id).toEqual(realmId);
+        expect(payload.realm_name).toEqual('master');
+        expect(payload.realm_name).not.toEqual(realmId);
+    });
+
+    it('should issue access token with sub set to the robot id and client_id propagated', async () => {
+        await grant.runWith(robot);
+
+        const payload = accessTokenIssuer.issueCalls[0];
+
+        expect(payload.sub).toEqual(robotId);
+        expect(payload.sub_kind).toEqual(OAuth2SubKind.ROBOT);
+        expect(payload.client_id).toEqual(clientId);
+        expect(payload.scope).toEqual(ScopeName.GLOBAL);
+    });
+
+    it('should create a session bound to the robot', async () => {
+        await grant.runWith(robot);
+
+        expect(sessionManager.createCalls).toContainEqual(
+            expect.objectContaining({
+                realm_id: realmId,
+                sub: robotId,
+                sub_kind: IdentityType.ROBOT,
+            }),
+        );
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Realm } from '@authup/core-kit';
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { Repository } from 'typeorm';
+import type { IRealmService } from '../../../../../src/core/index.ts';
+import { RealmController } from '../../../../../src/adapters/http/controllers/entities/realm/module.ts';
+import type { KeyEntity } from '../../../../../src/adapters/database/domains/index.ts';
+
+function createController(realm: Realm, baseURL = 'https://auth.example.com') {
+    const service: Pick<IRealmService, 'getOne'> = { getOne: async () => realm };
+    return new RealmController({
+        options: { baseURL },
+        service: service as IRealmService,
+        keyRepository: {} as Repository<KeyEntity>,
+    });
+}
+
+describe('RealmController.getOpenIdConfiguration', () => {
+    const realmId = randomUUID();
+    const realm = {
+        id: realmId,
+        name: 'master',
+    } as Realm;
+
+    it('should construct issuer from realm name (matching the JWT iss claim format)', async () => {
+        const controller = createController(realm);
+        const config = await controller.getOpenIdConfiguration(realmId);
+
+        expect(config.issuer).toEqual('https://auth.example.com/realms/master');
+    });
+
+    it('should construct jwks_uri from realm name', async () => {
+        const controller = createController(realm);
+        const config = await controller.getOpenIdConfiguration(realmId);
+
+        expect(config.jwks_uri).toEqual('https://auth.example.com/realms/master/jwks');
+    });
+
+    it('should strip a trailing slash from baseURL when building issuer', async () => {
+        const controller = createController(realm, 'https://auth.example.com/');
+        const config = await controller.getOpenIdConfiguration(realmId);
+
+        expect(config.issuer).toEqual('https://auth.example.com/realms/master');
+    });
+
+    it('should resolve realm via service so name and id forms produce the same issuer', async () => {
+        const controller = createController(realm);
+
+        const byId = await controller.getOpenIdConfiguration(realmId);
+        const byName = await controller.getOpenIdConfiguration('master');
+
+        expect(byId.issuer).toEqual(byName.issuer);
+        expect(byId.jwks_uri).toEqual(byName.jwks_uri);
+    });
+});


### PR DESCRIPTION
The realm-scoped OIDC discovery endpoint advertised issuer: ${publicUrl}, while every JWT minted for that realm carries iss: ${publicUrl}/realms/${realm_name}. Tokens failed `issuer` checks against the discovery doc.

- realm controller: discovery `issuer` and `jwks_uri` now use ${baseURL}/realms/${entity.name}, matching JWT iss
- client_credentials and robot_credentials grants: pass realm.name (not realm.id) for the realm_name claim, so tokens from these grants match the realm-scoped issuer like all other grants
- realm-scoped /jwks and /jwks/:keyId now resolve the realm via service.getOne() so the URL works with both realm name and UUID, and /jwks/:keyId verifies the key belongs to the named realm
- jwks handler signatures simplified: caller passes resolved realmId/keyId directly instead of param-key indirection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * OpenID discovery endpoints now use realm names instead of realm identifiers for better readability.
  * Issued access tokens now contain realm names instead of IDs, improving clarity in token debugging and auditing.
  * Enhanced URL handling with automatic normalization of base URLs to ensure consistent endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->