### PR TITLE
feat(core-http-kit, server-core): typed request/response signatures f…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -295,13 +295,13 @@ Feature gates check these options before proceeding (e.g. `if (!this.options.reg
 
 ### Thin Controller Pattern (HTTP Adapter)
 
-Controllers are thin HTTP adapters. They extract input from the routup `IRoutupEvent`, build an `ActorContext`, delegate to the service, and format the HTTP response. Request body and response types are imported from `@authup/core-http-kit` so the same contract is shared between the typed Client, the controller, and `@trapi/swagger` schema generation:
+Controllers are thin HTTP adapters. They extract input from the routup `IRoutupEvent`, build an `ActorContext`, delegate to the service, and format the HTTP response. Request body payload types come from `@authup/core-http-kit` (shared between the typed Client, the controller, and `@trapi/swagger` schema generation); response types are the domain entity from `@authup/core-kit` directly:
 
 ```typescript
+import type { Role } from '@authup/core-kit';
 import type {
     EntityCollectionResponse,
-    RoleCreateInput,
-    RoleResponse,
+    RoleCreatePayload,
 } from '@authup/core-http-kit';
 
 export type RoleControllerContext = {
@@ -317,14 +317,14 @@ export class RoleController {
     }
 
     @DGet('')
-    async getMany(@DContext() event: IRoutupEvent): Promise<EntityCollectionResponse<RoleResponse>> {
+    async getMany(@DContext() event: IRoutupEvent): Promise<EntityCollectionResponse<Role>> {
         const actor = buildActorContext(event);
         const { data, meta } = await this.service.getMany(useRequestQuery(event), actor);
         return { data, meta };
     }
 
     @DPost('')
-    async add(@DBody() data: RoleCreateInput, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
+    async add(@DBody() data: RoleCreatePayload, @DContext() event: IRoutupEvent): Promise<Role> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
         event.response.status = 201;
@@ -332,7 +332,7 @@ export class RoleController {
     }
 
     @DDelete('/:id')
-    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
+    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<Role> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
         event.response.status = 202;
@@ -342,8 +342,8 @@ export class RoleController {
 ```
 
 Controller conventions:
-- Return type is the concrete response type (`Promise<RoleResponse>`, `Promise<EntityCollectionResponse<RoleResponse>>`) — sourced from `@authup/core-http-kit`. This lets `@trapi/swagger` extract the response schema from the method signature.
-- Body parameter type is the concrete request type (`@DBody() data: RoleCreateInput`) — also sourced from `@authup/core-http-kit`. Naming convention: `<Entity>CreateInput` for POST, `<Entity>UpdateInput` for POST `/:id`, `<Entity>SaveInput` for PUT `/:id`, `<Entity>Response` for the response shape.
+- Return type is the domain entity directly (`Promise<Role>`, `Promise<EntityCollectionResponse<Role>>`). This lets `@trapi/swagger` extract the response schema from the method signature.
+- Body parameter type is the concrete payload type (`@DBody() data: RoleCreatePayload`) — sourced from `@authup/core-http-kit`. Naming convention: `<Entity>CreatePayload` for POST, `<Entity>UpdatePayload` for POST `/:id`, `<Entity>SavePayload` for PUT `/:id`. Response shapes that genuinely diverge from the domain entity (e.g. `PolicyResponse`, `RegisterResponse`, `PasswordForgotResponse`) keep a named alias; trivial passthrough aliases are not introduced.
 - **No business logic** — no permission checks, no validation, no entity manipulation
 - Read the routup event via `@DContext() event: IRoutupEvent`
 - Read the body via `@DBody() data: <RequestType>` (decorator awaits `readRequestBody` internally)

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -295,9 +295,15 @@ Feature gates check these options before proceeding (e.g. `if (!this.options.reg
 
 ### Thin Controller Pattern (HTTP Adapter)
 
-Controllers are thin HTTP adapters. They extract input from the routup `IRoutupEvent`, build an `ActorContext`, delegate to the service, and format the HTTP response:
+Controllers are thin HTTP adapters. They extract input from the routup `IRoutupEvent`, build an `ActorContext`, delegate to the service, and format the HTTP response. Request body and response types are imported from `@authup/core-http-kit` so the same contract is shared between the typed Client, the controller, and `@trapi/swagger` schema generation:
 
 ```typescript
+import type {
+    EntityCollectionResponse,
+    RoleCreateInput,
+    RoleResponse,
+} from '@authup/core-http-kit';
+
 export type RoleControllerContext = {
     service: IRoleService,
 };
@@ -311,38 +317,41 @@ export class RoleController {
     }
 
     @DGet('')
-    async getMany(@DContext() event: IRoutupEvent): Promise<any> {
+    async getMany(@DContext() event: IRoutupEvent): Promise<EntityCollectionResponse<RoleResponse>> {
         const actor = buildActorContext(event);
         const { data, meta } = await this.service.getMany(useRequestQuery(event), actor);
         return { data, meta };
     }
 
     @DPost('')
-    async add(@DBody() data: any, @DContext() event: IRoutupEvent): Promise<any> {
+    async add(@DBody() data: RoleCreateInput, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
-        return sendCreated(event, entity);
+        event.response.status = 201;
+        return entity;
     }
 
     @DDelete('/:id')
-    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<any> {
+    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
-        return sendAccepted(event, entity);
+        event.response.status = 202;
+        return entity;
     }
 }
 ```
 
 Controller conventions:
-- Return type is always `Promise<any>`
+- Return type is the concrete response type (`Promise<RoleResponse>`, `Promise<EntityCollectionResponse<RoleResponse>>`) — sourced from `@authup/core-http-kit`. This lets `@trapi/swagger` extract the response schema from the method signature.
+- Body parameter type is the concrete request type (`@DBody() data: RoleCreateInput`) — also sourced from `@authup/core-http-kit`. Naming convention: `<Entity>CreateInput` for POST, `<Entity>UpdateInput` for POST `/:id`, `<Entity>SaveInput` for PUT `/:id`, `<Entity>Response` for the response shape.
 - **No business logic** — no permission checks, no validation, no entity manipulation
 - Read the routup event via `@DContext() event: IRoutupEvent`
-- Read the body via `@DBody() data: any` (decorator awaits `readRequestBody` internally)
+- Read the body via `@DBody() data: <RequestType>` (decorator awaits `readRequestBody` internally)
 - Read query via `useRequestQuery(event)` from `@routup/basic/query`
 - Read path params via `@DPath('id') id: string` or `event.params.id`
 - Build actor via `buildActorContext(event)`
 - Delegate all work to `this.service.*()` methods
-- Plain values from a handler are sent as the response body. For 201/202 use `sendCreated(event, entity)` / `sendAccepted(event, entity)` from `routup`. For typed-return ergonomics (so `@trapi/swagger` can extract the response shape from the method signature) prefer `event.response.status = 202; return entity;` over `sendAccepted` — see `register/password-forgot/password-reset` controllers for examples.
+- For non-200 statuses, set `event.response.status = 201/202` and return the value — never use `sendCreated`/`sendAccepted` because they erase the typed return value that trapi extracts.
 
 Exceptions where controllers retain some logic:
 - **Self-access resolution** (client, robot, user): Resolve `@me`/`@self` tokens to actual IDs before delegating

--- a/apps/server-core/src/adapters/http/controllers/entities/client-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client-permission/module.ts
@@ -18,11 +18,11 @@ import {
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
-    ClientPermissionCreateInput,
-    ClientPermissionResponse,
-    ClientPermissionUpdateInput,
+    ClientPermissionCreatePayload,
+    ClientPermissionUpdatePayload,
     EntityCollectionResponse,
 } from '@authup/core-http-kit';
+import type { ClientPermission } from '@authup/core-kit';
 import type { IClientPermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,7 +43,7 @@ export class ClientPermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<ClientPermissionResponse>> {
+    ): Promise<EntityCollectionResponse<ClientPermission>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,9 +58,9 @@ export class ClientPermissionController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: ClientPermissionCreateInput,
+        @DBody() data: ClientPermissionCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientPermissionResponse> {
+    ): Promise<ClientPermission> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -73,9 +73,9 @@ export class ClientPermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: ClientPermissionUpdateInput,
+        @DBody() data: ClientPermissionUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientPermissionResponse> {
+    ): Promise<ClientPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -88,7 +88,7 @@ export class ClientPermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientPermissionResponse> {
+    ): Promise<ClientPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -99,7 +99,7 @@ export class ClientPermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientPermissionResponse> {
+    ): Promise<ClientPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(
             id,

--- a/apps/server-core/src/adapters/http/controllers/entities/client-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client-permission/module.ts
@@ -17,6 +17,12 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    ClientPermissionCreateInput,
+    ClientPermissionResponse,
+    ClientPermissionUpdateInput,
+    EntityCollectionResponse,
+} from '@authup/core-http-kit';
 import type { IClientPermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +43,24 @@ export class ClientPermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<ClientPermissionResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: ClientPermissionCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientPermissionResponse> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -67,9 +73,9 @@ export class ClientPermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: ClientPermissionUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -82,7 +88,7 @@ export class ClientPermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -93,7 +99,7 @@ export class ClientPermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(
             id,

--- a/apps/server-core/src/adapters/http/controllers/entities/client-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client-role/module.ts
@@ -18,10 +18,10 @@ import {
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
-    ClientRoleCreateInput,
-    ClientRoleResponse,
+    ClientRoleCreatePayload,
     EntityCollectionResponse,
 } from '@authup/core-http-kit';
+import type { ClientRole } from '@authup/core-kit';
 import type { IClientRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
@@ -44,7 +44,7 @@ export class ClientRoleController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<ClientRoleResponse>> {
+    ): Promise<EntityCollectionResponse<ClientRole>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -59,9 +59,9 @@ export class ClientRoleController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: ClientRoleCreateInput,
+        @DBody() data: ClientRoleCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientRoleResponse> {
+    ): Promise<ClientRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -74,7 +74,7 @@ export class ClientRoleController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientRoleResponse> {
+    ): Promise<ClientRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -85,7 +85,7 @@ export class ClientRoleController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientRoleResponse> {
+    ): Promise<ClientRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/client-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client-role/module.ts
@@ -17,6 +17,11 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    ClientRoleCreateInput,
+    ClientRoleResponse,
+    EntityCollectionResponse,
+} from '@authup/core-http-kit';
 import type { IClientRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
@@ -39,24 +44,24 @@ export class ClientRoleController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<ClientRoleResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: ClientRoleCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -69,7 +74,7 @@ export class ClientRoleController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -80,7 +85,7 @@ export class ClientRoleController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/client-scope/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client-scope/module.ts
@@ -17,6 +17,11 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    ClientScopeCreateInput,
+    ClientScopeResponse,
+    EntityCollectionResponse,
+} from '@authup/core-http-kit';
 import type { IClientScopeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +42,24 @@ export class ClientScopeController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<ClientScopeResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: ClientScopeCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientScopeResponse> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -68,7 +73,7 @@ export class ClientScopeController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientScopeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -79,7 +84,7 @@ export class ClientScopeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientScopeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/client-scope/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client-scope/module.ts
@@ -18,10 +18,10 @@ import {
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
-    ClientScopeCreateInput,
-    ClientScopeResponse,
+    ClientScopeCreatePayload,
     EntityCollectionResponse,
 } from '@authup/core-http-kit';
+import type { ClientScope } from '@authup/core-kit';
 import type { IClientScopeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -42,7 +42,7 @@ export class ClientScopeController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<ClientScopeResponse>> {
+    ): Promise<EntityCollectionResponse<ClientScope>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -57,9 +57,9 @@ export class ClientScopeController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: ClientScopeCreateInput,
+        @DBody() data: ClientScopeCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientScopeResponse> {
+    ): Promise<ClientScope> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -73,7 +73,7 @@ export class ClientScopeController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientScopeResponse> {
+    ): Promise<ClientScope> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -84,7 +84,7 @@ export class ClientScopeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientScopeResponse> {
+    ): Promise<ClientScope> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
@@ -21,6 +21,13 @@ import { NotFoundError } from '@ebec/http';
 import type { Client } from '@authup/core-kit';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    ClientCreateInput,
+    ClientResponse,
+    ClientSaveInput,
+    ClientUpdateInput,
+    EntityCollectionResponse,
+} from '@authup/core-http-kit';
 import type { IClientRepository, IClientService } from '../../../../../core/index.ts';
 import { OAuth2ScopeAttributesResolver } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
@@ -51,16 +58,16 @@ export class ClientController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<ClientResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
@@ -68,7 +75,7 @@ export class ClientController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientResponse> {
         const identity = useRequestIdentity(event);
 
         let isMe = false;
@@ -118,9 +125,9 @@ export class ClientController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: ClientCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -132,9 +139,9 @@ export class ClientController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: ClientUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -146,13 +153,13 @@ export class ClientController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: ClientSaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientResponse> {
         const actor = buildActorContext(event);
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -167,7 +174,7 @@ export class ClientController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ClientResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
@@ -22,10 +22,9 @@ import type { Client } from '@authup/core-kit';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
-    ClientCreateInput,
-    ClientResponse,
-    ClientSaveInput,
-    ClientUpdateInput,
+    ClientCreatePayload,
+    ClientSavePayload,
+    ClientUpdatePayload,
     EntityCollectionResponse,
 } from '@authup/core-http-kit';
 import type { IClientRepository, IClientService } from '../../../../../core/index.ts';
@@ -58,7 +57,7 @@ export class ClientController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<ClientResponse>> {
+    ): Promise<EntityCollectionResponse<Client>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -75,7 +74,7 @@ export class ClientController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientResponse> {
+    ): Promise<Client> {
         const identity = useRequestIdentity(event);
 
         let isMe = false;
@@ -125,9 +124,9 @@ export class ClientController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: ClientCreateInput,
+        @DBody() data: ClientCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientResponse> {
+    ): Promise<Client> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -139,9 +138,9 @@ export class ClientController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: ClientUpdateInput,
+        @DBody() data: ClientUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientResponse> {
+    ): Promise<Client> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -153,9 +152,9 @@ export class ClientController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: ClientSaveInput,
+        @DBody() data: ClientSavePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientResponse> {
+    ): Promise<Client> {
         const actor = buildActorContext(event);
         const {
             entity,
@@ -174,7 +173,7 @@ export class ClientController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ClientResponse> {
+    ): Promise<Client> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provide-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provide-role/module.ts
@@ -19,10 +19,10 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    IdentityProviderRoleMappingCreateInput,
-    IdentityProviderRoleMappingResponse,
-    IdentityProviderRoleMappingUpdateInput,
+    IdentityProviderRoleMappingCreatePayload,
+    IdentityProviderRoleMappingUpdatePayload,
 } from '@authup/core-http-kit';
+import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 import type {
     IIdentityProviderRoleMappingService,
 } from '../../../../../core/index.ts';
@@ -47,7 +47,7 @@ export class IdentityProviderRoleMappingController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<IdentityProviderRoleMappingResponse>> {
+    ): Promise<EntityCollectionResponse<IdentityProviderRoleMapping>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -64,7 +64,7 @@ export class IdentityProviderRoleMappingController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<IdentityProviderRoleMappingResponse> {
+    ): Promise<IdentityProviderRoleMapping> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -73,9 +73,9 @@ export class IdentityProviderRoleMappingController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: IdentityProviderRoleMappingCreateInput,
+        @DBody() data: IdentityProviderRoleMappingCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<IdentityProviderRoleMappingResponse> {
+    ): Promise<IdentityProviderRoleMapping> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -87,9 +87,9 @@ export class IdentityProviderRoleMappingController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: IdentityProviderRoleMappingUpdateInput,
+        @DBody() data: IdentityProviderRoleMappingUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<IdentityProviderRoleMappingResponse> {
+    ): Promise<IdentityProviderRoleMapping> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -102,7 +102,7 @@ export class IdentityProviderRoleMappingController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<IdentityProviderRoleMappingResponse> {
+    ): Promise<IdentityProviderRoleMapping> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provide-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provide-role/module.ts
@@ -18,6 +18,12 @@ import {
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
+    EntityCollectionResponse,
+    IdentityProviderRoleMappingCreateInput,
+    IdentityProviderRoleMappingResponse,
+    IdentityProviderRoleMappingUpdateInput,
+} from '@authup/core-http-kit';
+import type {
     IIdentityProviderRoleMappingService,
 } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
@@ -41,7 +47,7 @@ export class IdentityProviderRoleMappingController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<IdentityProviderRoleMappingResponse>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,7 +64,7 @@ export class IdentityProviderRoleMappingController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<IdentityProviderRoleMappingResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -67,9 +73,9 @@ export class IdentityProviderRoleMappingController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: IdentityProviderRoleMappingCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<IdentityProviderRoleMappingResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -81,9 +87,9 @@ export class IdentityProviderRoleMappingController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: IdentityProviderRoleMappingUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<IdentityProviderRoleMappingResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -96,7 +102,7 @@ export class IdentityProviderRoleMappingController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<IdentityProviderRoleMappingResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -42,10 +42,9 @@ import { readRequestBody } from '@routup/basic/body';
 import { OAuth2Error } from '@authup/specs';
 import type {
     EntityCollectionResponse,
-    IdentityProviderCreateInput,
-    IdentityProviderResponse,
-    IdentityProviderSaveInput,
-    IdentityProviderUpdateInput,
+    IdentityProviderCreatePayload,
+    IdentityProviderSavePayload,
+    IdentityProviderUpdatePayload,
 } from '@authup/core-http-kit';
 import { URL } from 'node:url';
 import type {
@@ -109,7 +108,7 @@ export class IdentityProviderController {
     @DGet('', [])
     async getProviders(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<IdentityProviderResponse>> {
+    ): Promise<EntityCollectionResponse<IdentityProvider>> {
         const {
             data, 
             meta, 
@@ -143,7 +142,7 @@ export class IdentityProviderController {
     async getProvider(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<IdentityProviderResponse> {
+    ): Promise<IdentityProvider> {
         const paramId = useRequestParamID(event, { isUUID: false });
 
         const entity = await this.repository.findOneByIdOrName(
@@ -171,18 +170,18 @@ export class IdentityProviderController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async editProvider(
         @DPath('id') id: string,
-        @DBody() user: IdentityProviderUpdateInput,
+        @DBody() user: IdentityProviderUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ) : Promise<IdentityProviderResponse> {
+    ) : Promise<IdentityProvider> {
         return this.write(event, { updateOnly: true });
     }
 
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() user: IdentityProviderSaveInput,
+        @DBody() user: IdentityProviderSavePayload,
         @DContext() event: IRoutupEvent,
-    ) : Promise<IdentityProviderResponse> {
+    ) : Promise<IdentityProvider> {
         return this.write(event);
     }
 
@@ -190,7 +189,7 @@ export class IdentityProviderController {
     async dropProvider(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ) : Promise<IdentityProviderResponse> {
+    ) : Promise<IdentityProvider> {
         const paramId = useRequestParamID(event);
 
         const permissionEvaluator = useRequestPermissionEvaluator(event);
@@ -220,9 +219,9 @@ export class IdentityProviderController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async addProvider(
-        @DBody() user: IdentityProviderCreateInput,
+        @DBody() user: IdentityProviderCreatePayload,
         @DContext() event: IRoutupEvent,
-    ) : Promise<IdentityProviderResponse> {
+    ) : Promise<IdentityProvider> {
         return this.write(event);
     }
 
@@ -358,7 +357,7 @@ export class IdentityProviderController {
 
     private async write(event: IRoutupEvent, options: {
         updateOnly?: boolean
-    } = {}): Promise<IdentityProviderResponse> {
+    } = {}): Promise<IdentityProvider> {
         let group: string;
         const id = getRequestParamID(event, { isUUID: false });
         const body = await readRequestBody(event);

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -40,6 +40,13 @@ import type { AuthorizeParameters } from '@hapic/oauth2';
 import { useRequestQuery } from '@routup/basic/query';
 import { readRequestBody } from '@routup/basic/body';
 import { OAuth2Error } from '@authup/specs';
+import type {
+    EntityCollectionResponse,
+    IdentityProviderCreateInput,
+    IdentityProviderResponse,
+    IdentityProviderSaveInput,
+    IdentityProviderUpdateInput,
+} from '@authup/core-http-kit';
 import { URL } from 'node:url';
 import type {
     IIdentityProviderAccountManager,
@@ -102,7 +109,7 @@ export class IdentityProviderController {
     @DGet('', [])
     async getProviders(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<IdentityProviderResponse>> {
         const {
             data, 
             meta, 
@@ -136,7 +143,7 @@ export class IdentityProviderController {
     async getProvider(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<IdentityProviderResponse> {
         const paramId = useRequestParamID(event, { isUUID: false });
 
         const entity = await this.repository.findOneByIdOrName(
@@ -164,18 +171,18 @@ export class IdentityProviderController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async editProvider(
         @DPath('id') id: string,
-        @DBody() user: NonNullable<IdentityProvider>,
+        @DBody() user: IdentityProviderUpdateInput,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<IdentityProviderResponse> {
         return this.write(event, { updateOnly: true });
     }
 
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() user: NonNullable<IdentityProvider>,
+        @DBody() user: IdentityProviderSaveInput,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<IdentityProviderResponse> {
         return this.write(event);
     }
 
@@ -183,7 +190,7 @@ export class IdentityProviderController {
     async dropProvider(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<IdentityProviderResponse> {
         const paramId = useRequestParamID(event);
 
         const permissionEvaluator = useRequestPermissionEvaluator(event);
@@ -213,9 +220,9 @@ export class IdentityProviderController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async addProvider(
-        @DBody() user: NonNullable<IdentityProvider>,
+        @DBody() user: IdentityProviderCreateInput,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<IdentityProviderResponse> {
         return this.write(event);
     }
 
@@ -351,7 +358,7 @@ export class IdentityProviderController {
 
     private async write(event: IRoutupEvent, options: {
         updateOnly?: boolean
-    } = {}): Promise<any> {
+    } = {}): Promise<IdentityProviderResponse> {
         let group: string;
         const id = getRequestParamID(event, { isUUID: false });
         const body = await readRequestBody(event);

--- a/apps/server-core/src/adapters/http/controllers/entities/permission-policy/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/permission-policy/module.ts
@@ -19,9 +19,9 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    PermissionPolicyCreateInput,
-    PermissionPolicyResponse,
+    PermissionPolicyCreatePayload,
 } from '@authup/core-http-kit';
+import type { PermissionPolicy } from '@authup/core-kit';
 import type { IPermissionPolicyService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -42,7 +42,7 @@ export class PermissionPolicyController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<PermissionPolicyResponse>> {
+    ): Promise<EntityCollectionResponse<PermissionPolicy>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -57,9 +57,9 @@ export class PermissionPolicyController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: PermissionPolicyCreateInput,
+        @DBody() data: PermissionPolicyCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionPolicyResponse> {
+    ): Promise<PermissionPolicy> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -73,7 +73,7 @@ export class PermissionPolicyController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionPolicyResponse> {
+    ): Promise<PermissionPolicy> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -84,7 +84,7 @@ export class PermissionPolicyController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionPolicyResponse> {
+    ): Promise<PermissionPolicy> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/permission-policy/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/permission-policy/module.ts
@@ -17,6 +17,11 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    PermissionPolicyCreateInput,
+    PermissionPolicyResponse,
+} from '@authup/core-http-kit';
 import type { IPermissionPolicyService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +42,24 @@ export class PermissionPolicyController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<PermissionPolicyResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: PermissionPolicyCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionPolicyResponse> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -68,7 +73,7 @@ export class PermissionPolicyController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionPolicyResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -79,7 +84,7 @@ export class PermissionPolicyController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionPolicyResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/permission/module.ts
@@ -8,11 +8,11 @@
 import type {
     EntityCollectionResponse,
     PermissionAPICheckResponse,
-    PermissionCreateInput,
-    PermissionResponse,
-    PermissionSaveInput,
-    PermissionUpdateInput,
+    PermissionCreatePayload,
+    PermissionSavePayload,
+    PermissionUpdatePayload,
 } from '@authup/core-http-kit';
+import type { Permission } from '@authup/core-kit';
 import type { IPermissionProvider, PermissionEvaluationContext } from '@authup/access';
 import {
     BuiltInPolicyType,
@@ -80,7 +80,7 @@ export class PermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<PermissionResponse>> {
+    ): Promise<EntityCollectionResponse<Permission>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -95,9 +95,9 @@ export class PermissionController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: PermissionCreateInput,
+        @DBody() data: PermissionCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionResponse> {
+    ): Promise<Permission> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -170,7 +170,7 @@ export class PermissionController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionResponse> {
+    ): Promise<Permission> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(
             id,
@@ -184,9 +184,9 @@ export class PermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: PermissionUpdateInput,
+        @DBody() data: PermissionUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionResponse> {
+    ): Promise<Permission> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -202,9 +202,9 @@ export class PermissionController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: PermissionSaveInput,
+        @DBody() data: PermissionSavePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionResponse> {
+    ): Promise<Permission> {
         const actor = buildActorContext(event);
         const {
             entity,
@@ -223,7 +223,7 @@ export class PermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<PermissionResponse> {
+    ): Promise<Permission> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/permission/module.ts
@@ -5,7 +5,14 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PermissionAPICheckResponse } from '@authup/core-http-kit';
+import type {
+    EntityCollectionResponse,
+    PermissionAPICheckResponse,
+    PermissionCreateInput,
+    PermissionResponse,
+    PermissionSaveInput,
+    PermissionUpdateInput,
+} from '@authup/core-http-kit';
 import type { IPermissionProvider, PermissionEvaluationContext } from '@authup/access';
 import {
     BuiltInPolicyType,
@@ -73,24 +80,24 @@ export class PermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<PermissionResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: PermissionCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -103,7 +110,7 @@ export class PermissionController {
     async check(
         @DBody() data: any,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionAPICheckResponse> {
         const { id } = event.params;
 
         let criteria: Record<string, any>;
@@ -163,7 +170,7 @@ export class PermissionController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(
             id,
@@ -177,9 +184,9 @@ export class PermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: PermissionUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -195,13 +202,13 @@ export class PermissionController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: PermissionSaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionResponse> {
         const actor = buildActorContext(event);
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -216,7 +223,7 @@ export class PermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/policy/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/policy/module.ts
@@ -8,10 +8,10 @@
 import type {
     EntityCollectionResponse,
     PolicyAPICheckResponse,
-    PolicyCreateInput,
+    PolicyCreatePayload,
     PolicyResponse,
-    PolicySaveInput,
-    PolicyUpdateInput,
+    PolicySavePayload,
+    PolicyUpdatePayload,
 } from '@authup/core-http-kit';
 import { BuiltInPolicyType, PolicyData, definePolicyEvaluationContext } from '@authup/access';
 import { isUUID } from '@authup/kit';
@@ -161,7 +161,7 @@ export class PolicyController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async update(
         @DPath('id') id: string,
-        @DBody() data: PolicyUpdateInput,
+        @DBody() data: PolicyUpdatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
@@ -179,7 +179,7 @@ export class PolicyController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async replace(
         @DPath('id') id: string,
-        @DBody() data: PolicySaveInput,
+        @DBody() data: PolicySavePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
@@ -212,7 +212,7 @@ export class PolicyController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async create(
-        @DBody() data: PolicyCreateInput,
+        @DBody() data: PolicyCreatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);

--- a/apps/server-core/src/adapters/http/controllers/entities/policy/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/policy/module.ts
@@ -5,7 +5,14 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PolicyAPICheckResponse } from '@authup/core-http-kit';
+import type {
+    EntityCollectionResponse,
+    PolicyAPICheckResponse,
+    PolicyCreateInput,
+    PolicyResponse,
+    PolicySaveInput,
+    PolicyUpdateInput,
+} from '@authup/core-http-kit';
 import { BuiltInPolicyType, PolicyData, definePolicyEvaluationContext } from '@authup/access';
 import { isUUID } from '@authup/kit';
 import { NotFoundError } from '@ebec/http';
@@ -64,16 +71,16 @@ export class PolicyController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<PolicyResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
@@ -81,7 +88,7 @@ export class PolicyController {
     async getOneExpanded(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PolicyResponse> {
         return this.getOne(id, event, { expanded: true });
     }
 
@@ -91,7 +98,7 @@ export class PolicyController {
         @DContext() event: IRoutupEvent,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         options: { expanded?: boolean } = {},
-    ): Promise<any> {
+    ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(
             id,
@@ -107,7 +114,7 @@ export class PolicyController {
         @DPath('id') id: string,
         @DBody() data: any,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PolicyAPICheckResponse> {
         const paramId = event.params.id;
 
         let criteria: Record<string, any>;
@@ -154,9 +161,9 @@ export class PolicyController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async update(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: PolicyUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -172,14 +179,14 @@ export class PolicyController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async replace(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: PolicySaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
 
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -194,7 +201,7 @@ export class PolicyController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 
@@ -205,9 +212,9 @@ export class PolicyController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async create(
-        @DBody() data: any,
+        @DBody() data: PolicyCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<PolicyResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
@@ -21,6 +21,13 @@ import { OAuth2AuthorizationResponseType } from '@authup/specs';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type { Repository } from 'typeorm';
+import type {
+    EntityCollectionResponse,
+    RealmCreateInput,
+    RealmResponse,
+    RealmSaveInput,
+    RealmUpdateInput,
+} from '@authup/core-http-kit';
 import type { IRealmService } from '../../../../../core/index.ts';
 import { resolveURL } from '../../../../../utils/index.ts';
 import type { KeyEntity } from '../../../../database/domains/index.ts';
@@ -56,23 +63,23 @@ export class RealmController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<RealmResponse>> {
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event));
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: RealmCreateInput,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<RealmResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -82,7 +89,7 @@ export class RealmController {
     }
 
     @DGet('/:id', [])
-    async get(@DPath('id') id: string): Promise<any> {
+    async get(@DPath('id') id: string): Promise<RealmResponse> {
         return this.service.getOne(id);
     }
 
@@ -136,7 +143,7 @@ export class RealmController {
     }
 
     @DGet('/:id/jwks', [])
-    async getCerts(@DPath('id') id: string): Promise<OAuth2JsonWebKey[]> {
+    async getCerts(@DPath('id') id: string): Promise<{ keys: OAuth2JsonWebKey[] }> {
         const entity = await this.service.getOne(id);
         return getJwksRouteHandler(this.keyRepository, entity.id);
     }
@@ -153,9 +160,9 @@ export class RealmController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RealmUpdateInput,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<RealmResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -171,13 +178,13 @@ export class RealmController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RealmSaveInput,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<RealmResponse> {
         const actor = buildActorContext(event);
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -192,7 +199,7 @@ export class RealmController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ) : Promise<any> {
+    ) : Promise<RealmResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
@@ -23,11 +23,11 @@ import { useRequestQuery } from '@routup/basic/query';
 import type { Repository } from 'typeorm';
 import type {
     EntityCollectionResponse,
-    RealmCreateInput,
-    RealmResponse,
-    RealmSaveInput,
-    RealmUpdateInput,
+    RealmCreatePayload,
+    RealmSavePayload,
+    RealmUpdatePayload,
 } from '@authup/core-http-kit';
+import type { Realm } from '@authup/core-kit';
 import type { IRealmService } from '../../../../../core/index.ts';
 import { resolveURL } from '../../../../../utils/index.ts';
 import type { KeyEntity } from '../../../../database/domains/index.ts';
@@ -63,7 +63,7 @@ export class RealmController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<RealmResponse>> {
+    ): Promise<EntityCollectionResponse<Realm>> {
         const {
             data,
             meta,
@@ -77,9 +77,9 @@ export class RealmController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: RealmCreateInput,
+        @DBody() data: RealmCreatePayload,
         @DContext() event: IRoutupEvent,
-    ) : Promise<RealmResponse> {
+    ) : Promise<Realm> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -89,7 +89,7 @@ export class RealmController {
     }
 
     @DGet('/:id', [])
-    async get(@DPath('id') id: string): Promise<RealmResponse> {
+    async get(@DPath('id') id: string): Promise<Realm> {
         return this.service.getOne(id);
     }
 
@@ -160,9 +160,9 @@ export class RealmController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: RealmUpdateInput,
+        @DBody() data: RealmUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ) : Promise<RealmResponse> {
+    ) : Promise<Realm> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -178,9 +178,9 @@ export class RealmController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: RealmSaveInput,
+        @DBody() data: RealmSavePayload,
         @DContext() event: IRoutupEvent,
-    ) : Promise<RealmResponse> {
+    ) : Promise<Realm> {
         const actor = buildActorContext(event);
         const {
             entity,
@@ -199,7 +199,7 @@ export class RealmController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ) : Promise<RealmResponse> {
+    ) : Promise<Realm> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/robot-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot-permission/module.ts
@@ -19,10 +19,10 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    RobotPermissionCreateInput,
-    RobotPermissionResponse,
-    RobotPermissionUpdateInput,
+    RobotPermissionCreatePayload,
+    RobotPermissionUpdatePayload,
 } from '@authup/core-http-kit';
+import type { RobotPermission } from '@authup/core-kit';
 import type { IRobotPermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,7 +43,7 @@ export class RobotPermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<RobotPermissionResponse>> {
+    ): Promise<EntityCollectionResponse<RobotPermission>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,9 +58,9 @@ export class RobotPermissionController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: RobotPermissionCreateInput,
+        @DBody() data: RobotPermissionCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotPermissionResponse> {
+    ): Promise<RobotPermission> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -73,9 +73,9 @@ export class RobotPermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: RobotPermissionUpdateInput,
+        @DBody() data: RobotPermissionUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotPermissionResponse> {
+    ): Promise<RobotPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -88,7 +88,7 @@ export class RobotPermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotPermissionResponse> {
+    ): Promise<RobotPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -99,7 +99,7 @@ export class RobotPermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotPermissionResponse> {
+    ): Promise<RobotPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(
             id,

--- a/apps/server-core/src/adapters/http/controllers/entities/robot-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot-permission/module.ts
@@ -17,6 +17,12 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    RobotPermissionCreateInput,
+    RobotPermissionResponse,
+    RobotPermissionUpdateInput,
+} from '@authup/core-http-kit';
 import type { IRobotPermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +43,24 @@ export class RobotPermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<RobotPermissionResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: RobotPermissionCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotPermissionResponse> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -67,9 +73,9 @@ export class RobotPermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RobotPermissionUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -82,7 +88,7 @@ export class RobotPermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -93,7 +99,7 @@ export class RobotPermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(
             id,

--- a/apps/server-core/src/adapters/http/controllers/entities/robot-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot-role/module.ts
@@ -17,6 +17,11 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    RobotRoleCreateInput,
+    RobotRoleResponse,
+} from '@authup/core-http-kit';
 import type { IRobotRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
@@ -39,24 +44,24 @@ export class RobotRoleController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<RobotRoleResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: RobotRoleCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -69,7 +74,7 @@ export class RobotRoleController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -80,7 +85,7 @@ export class RobotRoleController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/robot-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot-role/module.ts
@@ -19,9 +19,9 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    RobotRoleCreateInput,
-    RobotRoleResponse,
+    RobotRoleCreatePayload,
 } from '@authup/core-http-kit';
+import type { RobotRole } from '@authup/core-kit';
 import type { IRobotRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
@@ -44,7 +44,7 @@ export class RobotRoleController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<RobotRoleResponse>> {
+    ): Promise<EntityCollectionResponse<RobotRole>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -59,9 +59,9 @@ export class RobotRoleController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: RobotRoleCreateInput,
+        @DBody() data: RobotRoleCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotRoleResponse> {
+    ): Promise<RobotRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -74,7 +74,7 @@ export class RobotRoleController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotRoleResponse> {
+    ): Promise<RobotRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -85,7 +85,7 @@ export class RobotRoleController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotRoleResponse> {
+    ): Promise<RobotRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
@@ -23,6 +23,13 @@ import type { Robot } from '@authup/core-kit';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type { DataSource } from 'typeorm';
+import type {
+    EntityCollectionResponse,
+    RobotCreateInput,
+    RobotResponse,
+    RobotSaveInput,
+    RobotUpdateInput,
+} from '@authup/core-http-kit';
 import type { IRealmRepository, IRobotRepository, IRobotService } from '../../../../../core/index.ts';
 import { OAuth2ScopeAttributesResolver } from '../../../../../core/index.ts';
 import { RobotEntity } from '../../../../database/domains/index.ts';
@@ -62,24 +69,24 @@ export class RobotController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<RobotResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: RobotCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotResponse> {
         const actor = buildActorContext(event);
         const { entity } = await this.service.save(undefined, data, actor);
 
@@ -92,7 +99,7 @@ export class RobotController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotResponse> {
         const identity = useRequestIdentity(event);
         let isMe = false;
 
@@ -173,9 +180,9 @@ export class RobotController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RobotUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotResponse> {
         const actor = buildActorContext(event);
         const { entity } = await this.service.save(
             id,
@@ -192,13 +199,13 @@ export class RobotController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RobotSaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotResponse> {
         const actor = buildActorContext(event);
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -213,7 +220,7 @@ export class RobotController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RobotResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
@@ -25,10 +25,9 @@ import { useRequestQuery } from '@routup/basic/query';
 import type { DataSource } from 'typeorm';
 import type {
     EntityCollectionResponse,
-    RobotCreateInput,
-    RobotResponse,
-    RobotSaveInput,
-    RobotUpdateInput,
+    RobotCreatePayload,
+    RobotSavePayload,
+    RobotUpdatePayload,
 } from '@authup/core-http-kit';
 import type { IRealmRepository, IRobotRepository, IRobotService } from '../../../../../core/index.ts';
 import { OAuth2ScopeAttributesResolver } from '../../../../../core/index.ts';
@@ -69,7 +68,7 @@ export class RobotController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<RobotResponse>> {
+    ): Promise<EntityCollectionResponse<Robot>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -84,9 +83,9 @@ export class RobotController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: RobotCreateInput,
+        @DBody() data: RobotCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotResponse> {
+    ): Promise<Robot> {
         const actor = buildActorContext(event);
         const { entity } = await this.service.save(undefined, data, actor);
 
@@ -99,7 +98,7 @@ export class RobotController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotResponse> {
+    ): Promise<Robot> {
         const identity = useRequestIdentity(event);
         let isMe = false;
 
@@ -180,9 +179,9 @@ export class RobotController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: RobotUpdateInput,
+        @DBody() data: RobotUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotResponse> {
+    ): Promise<Robot> {
         const actor = buildActorContext(event);
         const { entity } = await this.service.save(
             id,
@@ -199,9 +198,9 @@ export class RobotController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: RobotSaveInput,
+        @DBody() data: RobotSavePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotResponse> {
+    ): Promise<Robot> {
         const actor = buildActorContext(event);
         const {
             entity,
@@ -220,7 +219,7 @@ export class RobotController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RobotResponse> {
+    ): Promise<Robot> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/role-attribute/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/role-attribute/module.ts
@@ -19,10 +19,10 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    RoleAttributeCreateInput,
-    RoleAttributeResponse,
-    RoleAttributeUpdateInput,
+    RoleAttributeCreatePayload,
+    RoleAttributeUpdatePayload,
 } from '@authup/core-http-kit';
+import type { RoleAttribute } from '@authup/core-kit';
 import type { IRoleAttributeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,7 +43,7 @@ export class RoleAttributeController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<RoleAttributeResponse>> {
+    ): Promise<EntityCollectionResponse<RoleAttribute>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,9 +58,9 @@ export class RoleAttributeController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: RoleAttributeCreateInput,
+        @DBody() data: RoleAttributeCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RoleAttributeResponse> {
+    ): Promise<RoleAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -73,7 +73,7 @@ export class RoleAttributeController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RoleAttributeResponse> {
+    ): Promise<RoleAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -83,9 +83,9 @@ export class RoleAttributeController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: RoleAttributeUpdateInput,
+        @DBody() data: RoleAttributeUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RoleAttributeResponse> {
+    ): Promise<RoleAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -98,7 +98,7 @@ export class RoleAttributeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RoleAttributeResponse> {
+    ): Promise<RoleAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/role-attribute/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/role-attribute/module.ts
@@ -17,6 +17,12 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    RoleAttributeCreateInput,
+    RoleAttributeResponse,
+    RoleAttributeUpdateInput,
+} from '@authup/core-http-kit';
 import type { IRoleAttributeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +43,24 @@ export class RoleAttributeController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<RoleAttributeResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: RoleAttributeCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RoleAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -67,7 +73,7 @@ export class RoleAttributeController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RoleAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -77,9 +83,9 @@ export class RoleAttributeController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RoleAttributeUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RoleAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -92,7 +98,7 @@ export class RoleAttributeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RoleAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/role-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/role-permission/module.ts
@@ -19,10 +19,10 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    RolePermissionCreateInput,
-    RolePermissionResponse,
-    RolePermissionUpdateInput,
+    RolePermissionCreatePayload,
+    RolePermissionUpdatePayload,
 } from '@authup/core-http-kit';
+import type { RolePermission } from '@authup/core-kit';
 import type { IRolePermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,7 +43,7 @@ export class RolePermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<RolePermissionResponse>> {
+    ): Promise<EntityCollectionResponse<RolePermission>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,9 +58,9 @@ export class RolePermissionController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: RolePermissionCreateInput,
+        @DBody() data: RolePermissionCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RolePermissionResponse> {
+    ): Promise<RolePermission> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -73,9 +73,9 @@ export class RolePermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: RolePermissionUpdateInput,
+        @DBody() data: RolePermissionUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RolePermissionResponse> {
+    ): Promise<RolePermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -88,7 +88,7 @@ export class RolePermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RolePermissionResponse> {
+    ): Promise<RolePermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -99,7 +99,7 @@ export class RolePermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<RolePermissionResponse> {
+    ): Promise<RolePermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/role-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/role-permission/module.ts
@@ -17,6 +17,12 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    RolePermissionCreateInput,
+    RolePermissionResponse,
+    RolePermissionUpdateInput,
+} from '@authup/core-http-kit';
 import type { IRolePermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +43,24 @@ export class RolePermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<RolePermissionResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: RolePermissionCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RolePermissionResponse> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -67,9 +73,9 @@ export class RolePermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RolePermissionUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RolePermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -82,7 +88,7 @@ export class RolePermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RolePermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -93,7 +99,7 @@ export class RolePermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RolePermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/role/module.ts
@@ -18,6 +18,13 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    RoleCreateInput,
+    RoleResponse,
+    RoleSaveInput,
+    RoleUpdateInput,
+} from '@authup/core-http-kit';
 import type { IRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -36,14 +43,14 @@ export class RoleController {
     }
 
     @DGet('', [ForceLoggedInMiddleware])
-    async getMany(@DContext() event: IRoutupEvent): Promise<any> {
+    async getMany(@DContext() event: IRoutupEvent): Promise<EntityCollectionResponse<RoleResponse>> {
         const actor = buildActorContext(event);
         const { data, meta } = await this.service.getMany(useRequestQuery(event), actor);
         return { data, meta };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
-    async add(@DBody() data: any, @DContext() event: IRoutupEvent): Promise<any> {
+    async add(@DBody() data: RoleCreateInput, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
         event.response.status = 201;
@@ -51,7 +58,7 @@ export class RoleController {
     }
 
     @DGet('/:id', [ForceLoggedInMiddleware])
-    async get(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<any> {
+    async get(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         return this.service.getOne(id, actor);
     }
@@ -59,9 +66,9 @@ export class RoleController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RoleUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
         event.response.status = 202;
@@ -71,9 +78,9 @@ export class RoleController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: RoleSaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         const { entity, created } = await this.service.save(id || undefined, data, actor);
 
@@ -82,7 +89,7 @@ export class RoleController {
     }
 
     @DDelete('/:id', [ForceLoggedInMiddleware])
-    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<any> {
+    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
         event.response.status = 202;

--- a/apps/server-core/src/adapters/http/controllers/entities/role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/role/module.ts
@@ -20,11 +20,11 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    RoleCreateInput,
-    RoleResponse,
-    RoleSaveInput,
-    RoleUpdateInput,
+    RoleCreatePayload,
+    RoleSavePayload,
+    RoleUpdatePayload,
 } from '@authup/core-http-kit';
+import type { Role } from '@authup/core-kit';
 import type { IRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,14 +43,14 @@ export class RoleController {
     }
 
     @DGet('', [ForceLoggedInMiddleware])
-    async getMany(@DContext() event: IRoutupEvent): Promise<EntityCollectionResponse<RoleResponse>> {
+    async getMany(@DContext() event: IRoutupEvent): Promise<EntityCollectionResponse<Role>> {
         const actor = buildActorContext(event);
         const { data, meta } = await this.service.getMany(useRequestQuery(event), actor);
         return { data, meta };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
-    async add(@DBody() data: RoleCreateInput, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
+    async add(@DBody() data: RoleCreatePayload, @DContext() event: IRoutupEvent): Promise<Role> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
         event.response.status = 201;
@@ -58,7 +58,7 @@ export class RoleController {
     }
 
     @DGet('/:id', [ForceLoggedInMiddleware])
-    async get(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
+    async get(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<Role> {
         const actor = buildActorContext(event);
         return this.service.getOne(id, actor);
     }
@@ -66,9 +66,9 @@ export class RoleController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: RoleUpdateInput,
+        @DBody() data: RoleUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RoleResponse> {
+    ): Promise<Role> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
         event.response.status = 202;
@@ -78,9 +78,9 @@ export class RoleController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: RoleSaveInput,
+        @DBody() data: RoleSavePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<RoleResponse> {
+    ): Promise<Role> {
         const actor = buildActorContext(event);
         const { entity, created } = await this.service.save(id || undefined, data, actor);
 
@@ -89,7 +89,7 @@ export class RoleController {
     }
 
     @DDelete('/:id', [ForceLoggedInMiddleware])
-    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<RoleResponse> {
+    async drop(@DPath('id') id: string, @DContext() event: IRoutupEvent): Promise<Role> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
         event.response.status = 202;

--- a/apps/server-core/src/adapters/http/controllers/entities/scope/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/scope/module.ts
@@ -20,11 +20,11 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    ScopeCreateInput,
-    ScopeResponse,
-    ScopeSaveInput,
-    ScopeUpdateInput,
+    ScopeCreatePayload,
+    ScopeSavePayload,
+    ScopeUpdatePayload,
 } from '@authup/core-http-kit';
+import type { Scope } from '@authup/core-kit';
 import type { IScopeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -45,7 +45,7 @@ export class ScopeController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<ScopeResponse>> {
+    ): Promise<EntityCollectionResponse<Scope>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -60,9 +60,9 @@ export class ScopeController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: ScopeCreateInput,
+        @DBody() data: ScopeCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ScopeResponse> {
+    ): Promise<Scope> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -75,7 +75,7 @@ export class ScopeController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ScopeResponse> {
+    ): Promise<Scope> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(
             id,
@@ -88,9 +88,9 @@ export class ScopeController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: ScopeUpdateInput,
+        @DBody() data: ScopeUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ScopeResponse> {
+    ): Promise<Scope> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -106,9 +106,9 @@ export class ScopeController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: ScopeSaveInput,
+        @DBody() data: ScopeSavePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<ScopeResponse> {
+    ): Promise<Scope> {
         const actor = buildActorContext(event);
         const {
             entity,
@@ -127,7 +127,7 @@ export class ScopeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<ScopeResponse> {
+    ): Promise<Scope> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/scope/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/scope/module.ts
@@ -18,6 +18,13 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    ScopeCreateInput,
+    ScopeResponse,
+    ScopeSaveInput,
+    ScopeUpdateInput,
+} from '@authup/core-http-kit';
 import type { IScopeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -38,24 +45,24 @@ export class ScopeController {
     @DGet('', [])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<ScopeResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: ScopeCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ScopeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -68,7 +75,7 @@ export class ScopeController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ScopeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(
             id,
@@ -81,9 +88,9 @@ export class ScopeController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: ScopeUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ScopeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -99,13 +106,13 @@ export class ScopeController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: ScopeSaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ScopeResponse> {
         const actor = buildActorContext(event);
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -120,7 +127,7 @@ export class ScopeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<ScopeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-attribute/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-attribute/module.ts
@@ -19,10 +19,10 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    UserAttributeCreateInput,
-    UserAttributeResponse,
-    UserAttributeUpdateInput,
+    UserAttributeCreatePayload,
+    UserAttributeUpdatePayload,
 } from '@authup/core-http-kit';
+import type { UserAttribute } from '@authup/core-kit';
 import type { IUserAttributeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,7 +43,7 @@ export class UserAttributeController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<UserAttributeResponse>> {
+    ): Promise<EntityCollectionResponse<UserAttribute>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,9 +58,9 @@ export class UserAttributeController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: UserAttributeCreateInput,
+        @DBody() data: UserAttributeCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserAttributeResponse> {
+    ): Promise<UserAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -73,7 +73,7 @@ export class UserAttributeController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserAttributeResponse> {
+    ): Promise<UserAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -83,9 +83,9 @@ export class UserAttributeController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: UserAttributeUpdateInput,
+        @DBody() data: UserAttributeUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserAttributeResponse> {
+    ): Promise<UserAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -98,7 +98,7 @@ export class UserAttributeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserAttributeResponse> {
+    ): Promise<UserAttribute> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-attribute/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-attribute/module.ts
@@ -17,6 +17,12 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    UserAttributeCreateInput,
+    UserAttributeResponse,
+    UserAttributeUpdateInput,
+} from '@authup/core-http-kit';
 import type { IUserAttributeService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +43,24 @@ export class UserAttributeController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<UserAttributeResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: UserAttributeCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -67,7 +73,7 @@ export class UserAttributeController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -77,9 +83,9 @@ export class UserAttributeController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: UserAttributeUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -92,7 +98,7 @@ export class UserAttributeController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserAttributeResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-permission/module.ts
@@ -19,10 +19,10 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    UserPermissionCreateInput,
-    UserPermissionResponse,
-    UserPermissionUpdateInput,
+    UserPermissionCreatePayload,
+    UserPermissionUpdatePayload,
 } from '@authup/core-http-kit';
+import type { UserPermission } from '@authup/core-kit';
 import type { IUserPermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -43,7 +43,7 @@ export class UserPermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<UserPermissionResponse>> {
+    ): Promise<EntityCollectionResponse<UserPermission>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -58,9 +58,9 @@ export class UserPermissionController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: UserPermissionCreateInput,
+        @DBody() data: UserPermissionCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserPermissionResponse> {
+    ): Promise<UserPermission> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -73,9 +73,9 @@ export class UserPermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: UserPermissionUpdateInput,
+        @DBody() data: UserPermissionUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserPermissionResponse> {
+    ): Promise<UserPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -88,7 +88,7 @@ export class UserPermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserPermissionResponse> {
+    ): Promise<UserPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -99,7 +99,7 @@ export class UserPermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserPermissionResponse> {
+    ): Promise<UserPermission> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-permission/module.ts
@@ -17,6 +17,12 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    UserPermissionCreateInput,
+    UserPermissionResponse,
+    UserPermissionUpdateInput,
+} from '@authup/core-http-kit';
 import type { IUserPermissionService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext } from '../../../request/index.ts';
@@ -37,24 +43,24 @@ export class UserPermissionController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<UserPermissionResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: UserPermissionCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserPermissionResponse> {
         const actor = buildActorContext(event);
 
         const entity = await this.service.create(data, actor);
@@ -67,9 +73,9 @@ export class UserPermissionController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: UserPermissionUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -82,7 +88,7 @@ export class UserPermissionController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -93,7 +99,7 @@ export class UserPermissionController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserPermissionResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-role/module.ts
@@ -19,9 +19,9 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    UserRoleCreateInput,
-    UserRoleResponse,
+    UserRoleCreatePayload,
 } from '@authup/core-http-kit';
+import type { UserRole } from '@authup/core-kit';
 import type { IUserRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
@@ -44,7 +44,7 @@ export class UserRoleController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<UserRoleResponse>> {
+    ): Promise<EntityCollectionResponse<UserRole>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -59,9 +59,9 @@ export class UserRoleController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: UserRoleCreateInput,
+        @DBody() data: UserRoleCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserRoleResponse> {
+    ): Promise<UserRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -74,7 +74,7 @@ export class UserRoleController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserRoleResponse> {
+    ): Promise<UserRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -85,7 +85,7 @@ export class UserRoleController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserRoleResponse> {
+    ): Promise<UserRole> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-role/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-role/module.ts
@@ -17,6 +17,11 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    UserRoleCreateInput,
+    UserRoleResponse,
+} from '@authup/core-http-kit';
 import type { IUserRoleService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
@@ -39,24 +44,24 @@ export class UserRoleController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<UserRoleResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: UserRoleCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -69,7 +74,7 @@ export class UserRoleController {
     async getOne(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.getOne(id, actor);
 
@@ -80,7 +85,7 @@ export class UserRoleController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserRoleResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user/module.ts
@@ -18,6 +18,13 @@ import {
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
+import type {
+    EntityCollectionResponse,
+    UserCreateInput,
+    UserResponse,
+    UserSaveInput,
+    UserUpdateInput,
+} from '@authup/core-http-kit';
 import type { IUserService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { isSelfToken } from '../../../../../utils/index.ts';
@@ -39,16 +46,16 @@ export class UserController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<EntityCollectionResponse<UserResponse>> {
         const actor = buildActorContext(event);
         const {
-            data, 
-            meta, 
+            data,
+            meta,
         } = await this.service.getMany(useRequestQuery(event), actor);
 
         return {
             data,
-            meta, 
+            meta,
         };
     }
 
@@ -56,7 +63,7 @@ export class UserController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserResponse> {
         const actor = buildActorContext(event);
         let paramId = id;
 
@@ -80,9 +87,9 @@ export class UserController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: any,
+        @DBody() data: UserCreateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -94,9 +101,9 @@ export class UserController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: UserUpdateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -112,13 +119,13 @@ export class UserController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: any,
+        @DBody() data: UserSaveInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserResponse> {
         const actor = buildActorContext(event);
         const {
-            entity, 
-            created, 
+            entity,
+            created,
         } = await this.service.save(
             id || undefined,
             data,
@@ -133,7 +140,7 @@ export class UserController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<UserResponse> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user/module.ts
@@ -20,11 +20,11 @@ import type { IRoutupEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
     EntityCollectionResponse,
-    UserCreateInput,
-    UserResponse,
-    UserSaveInput,
-    UserUpdateInput,
+    UserCreatePayload,
+    UserSavePayload,
+    UserUpdatePayload,
 } from '@authup/core-http-kit';
+import type { User } from '@authup/core-kit';
 import type { IUserService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { isSelfToken } from '../../../../../utils/index.ts';
@@ -46,7 +46,7 @@ export class UserController {
     @DGet('', [ForceLoggedInMiddleware])
     async getMany(
         @DContext() event: IRoutupEvent,
-    ): Promise<EntityCollectionResponse<UserResponse>> {
+    ): Promise<EntityCollectionResponse<User>> {
         const actor = buildActorContext(event);
         const {
             data,
@@ -63,7 +63,7 @@ export class UserController {
     async get(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserResponse> {
+    ): Promise<User> {
         const actor = buildActorContext(event);
         let paramId = id;
 
@@ -87,9 +87,9 @@ export class UserController {
 
     @DPost('', [ForceLoggedInMiddleware])
     async add(
-        @DBody() data: UserCreateInput,
+        @DBody() data: UserCreatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserResponse> {
+    ): Promise<User> {
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -101,9 +101,9 @@ export class UserController {
     @DPost('/:id', [ForceLoggedInMiddleware])
     async edit(
         @DPath('id') id: string,
-        @DBody() data: UserUpdateInput,
+        @DBody() data: UserUpdatePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserResponse> {
+    ): Promise<User> {
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -119,9 +119,9 @@ export class UserController {
     @DPut('/:id', [ForceLoggedInMiddleware])
     async put(
         @DPath('id') id: string,
-        @DBody() data: UserSaveInput,
+        @DBody() data: UserSavePayload,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserResponse> {
+    ): Promise<User> {
         const actor = buildActorContext(event);
         const {
             entity,
@@ -140,7 +140,7 @@ export class UserController {
     async drop(
         @DPath('id') id: string,
         @DContext() event: IRoutupEvent,
-    ): Promise<UserResponse> {
+    ): Promise<User> {
         const actor = buildActorContext(event);
         const entity = await this.service.delete(id, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/workflows/activate/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/activate/module.ts
@@ -12,7 +12,7 @@ import {
     DPost,
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
-import type { ActivateInput } from '@authup/core-http-kit';
+import type { ActivatePayload } from '@authup/core-http-kit';
 import type { IRegistrationService } from '../../../../../core/index.ts';
 import { ActivateRequestValidator } from './validator.ts';
 
@@ -30,7 +30,7 @@ export class ActivateController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: ActivateInput,
+        @DBody() data: ActivatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<null> {
         const validator = new ActivateRequestValidator();

--- a/apps/server-core/src/adapters/http/controllers/workflows/activate/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/activate/module.ts
@@ -12,6 +12,7 @@ import {
     DPost,
 } from '@routup/decorators';
 import type { IRoutupEvent } from 'routup';
+import type { ActivateInput } from '@authup/core-http-kit';
 import type { IRegistrationService } from '../../../../../core/index.ts';
 import { ActivateRequestValidator } from './validator.ts';
 
@@ -29,9 +30,9 @@ export class ActivateController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: any,
+        @DBody() data: ActivateInput,
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<null> {
         const validator = new ActivateRequestValidator();
         const validated = await validator.run(data);
 

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
@@ -63,7 +63,7 @@ export class AuthorizeController {
     // ---------------------------------------------------------
 
     @DPost('', [ForceUserLoggedInMiddleware])
-    async confirm(@DContext() event: IRoutupEvent): Promise<any> {
+    async confirm(@DContext() event: IRoutupEvent): Promise<{ url: string }> {
         const result = await this.authorizer.authorizeWithRequest(event);
 
         const url = new URL(result.redirectUri);
@@ -87,7 +87,7 @@ export class AuthorizeController {
     }
 
     @DGet('', [])
-    async serve(@DContext() event: IRoutupEvent): Promise<any> {
+    async serve(@DContext() event: IRoutupEvent): Promise<string> {
         let codeRequest : OAuth2AuthorizationCodeRequest | undefined;
 
         let client : Client | undefined;

--- a/apps/server-core/src/adapters/http/controllers/workflows/jwks/handlers/read.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/jwks/handlers/read.ts
@@ -6,6 +6,7 @@
  */
 
 import { AsymmetricKey } from '@authup/server-kit';
+import type { OAuth2JsonWebKey } from '@authup/specs';
 import { JWKType } from '@authup/specs';
 import type { Repository } from 'typeorm';
 import { In } from 'typeorm';
@@ -15,7 +16,7 @@ import type { KeyEntity } from '../../../../../database/domains/index.ts';
 export async function getJwksRouteHandler(
     repository: Repository<KeyEntity>,
     realmId?: string,
-) : Promise<any> {
+) : Promise<{ keys: OAuth2JsonWebKey[] }> {
     const entities = await repository.find({
         where: {
             type: In([JWKType.RSA, JWKType.EC]),
@@ -43,14 +44,14 @@ export async function getJwksRouteHandler(
 
     const keys = await Promise.all(promises);
 
-    return { keys };
+    return { keys: keys as OAuth2JsonWebKey[] };
 }
 
 export async function getJwkRouteHandler(
     repository: Repository<KeyEntity>,
     keyId: string,
     realmId?: string,
-) : Promise<any> {
+) : Promise<OAuth2JsonWebKey> {
     const entity = await repository.findOne({
         where: {
             type: In([JWKType.RSA, JWKType.EC]),
@@ -80,5 +81,5 @@ export async function getJwkRouteHandler(
     return {
         ...jsonWebKey,
         kid: entity.id,
-    };
+    } as OAuth2JsonWebKey;
 }

--- a/apps/server-core/src/adapters/http/controllers/workflows/jwks/handlers/read.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/jwks/handlers/read.ts
@@ -44,7 +44,7 @@ export async function getJwksRouteHandler(
 
     const keys = await Promise.all(promises);
 
-    return { keys: keys as OAuth2JsonWebKey[] };
+    return { keys };
 }
 
 export async function getJwkRouteHandler(
@@ -76,10 +76,10 @@ export async function getJwkRouteHandler(
         });
 
     const jsonWebKey = await container.toJWK();
-    jsonWebKey.alg = entity.signature_algorithm;
 
     return {
         ...jsonWebKey,
         kid: entity.id,
-    } as OAuth2JsonWebKey;
+        alg: entity.signature_algorithm,
+    };
 }

--- a/apps/server-core/src/adapters/http/controllers/workflows/jwks/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/jwks/module.ts
@@ -66,7 +66,7 @@ export class JwkController {
 
         const keys = await Promise.all(promises);
 
-        return { keys: keys as OAuth2JsonWebKey[] };
+        return { keys };
     }
 
     @DGet('/jwks/:id', [])
@@ -94,11 +94,11 @@ export class JwkController {
             });
 
         const jsonWebKey = await container.toJWK();
-        jsonWebKey.alg = entity.signature_algorithm;
 
         return {
             ...jsonWebKey,
             kid: entity.id,
-        } as OAuth2JsonWebKey;
+            alg: entity.signature_algorithm,
+        };
     }
 }

--- a/apps/server-core/src/adapters/http/controllers/workflows/jwks/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/jwks/module.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { OAuth2JsonWebKey } from '@authup/specs';
 import { JWKType } from '@authup/specs';
 import { AsymmetricKey } from '@authup/server-kit';
 import {
@@ -35,7 +36,7 @@ export class JwkController {
     @DGet('/jwks', [])
     async getManyJwks(
         @DContext() event: IRoutupEvent,
-    ): Promise<any> {
+    ): Promise<{ keys: OAuth2JsonWebKey[] }> {
         const realmId = getRequestStringParam(event, 'realmId');
 
         const entities = await this.repository.find({
@@ -65,11 +66,11 @@ export class JwkController {
 
         const keys = await Promise.all(promises);
 
-        return { keys };
+        return { keys: keys as OAuth2JsonWebKey[] };
     }
 
     @DGet('/jwks/:id', [])
-    async getOneJwks(@DPath('id') id: string): Promise<any> {
+    async getOneJwks(@DPath('id') id: string): Promise<OAuth2JsonWebKey> {
         const entity = await this.repository.findOne({
             where: {
                 type: In([JWKType.RSA, JWKType.EC]),
@@ -98,6 +99,6 @@ export class JwkController {
         return {
             ...jsonWebKey,
             kid: entity.id,
-        };
+        } as OAuth2JsonWebKey;
     }
 }

--- a/apps/server-core/src/adapters/http/controllers/workflows/password-forgot/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/password-forgot/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PasswordForgotInput, PasswordForgotResponse } from '@authup/core-http-kit';
+import type { PasswordForgotPayload, PasswordForgotResponse } from '@authup/core-http-kit';
 import {
     DBody,
     DContext,
@@ -29,7 +29,7 @@ export class PasswordForgotController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: PasswordForgotInput,
+        @DBody() data: PasswordForgotPayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PasswordForgotResponse> {
         const result = await this.service.forgotPassword(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/password-forgot/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/password-forgot/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PasswordForgotResponse } from '@authup/core-http-kit';
+import type { PasswordForgotInput, PasswordForgotResponse } from '@authup/core-http-kit';
 import {
     DBody,
     DContext,
@@ -29,7 +29,7 @@ export class PasswordForgotController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: any,
+        @DBody() data: PasswordForgotInput,
         @DContext() event: IRoutupEvent,
     ): Promise<PasswordForgotResponse> {
         const result = await this.service.forgotPassword(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/password-reset/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/password-reset/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PasswordResetInput, PasswordResetResponse } from '@authup/core-http-kit';
+import type { PasswordResetPayload, PasswordResetResponse } from '@authup/core-http-kit';
 import {
     DBody,
     DContext,
@@ -29,7 +29,7 @@ export class PasswordResetController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: PasswordResetInput,
+        @DBody() data: PasswordResetPayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PasswordResetResponse> {
         const result = await this.service.resetPassword(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/password-reset/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/password-reset/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { PasswordResetResponse } from '@authup/core-http-kit';
+import type { PasswordResetInput, PasswordResetResponse } from '@authup/core-http-kit';
 import {
     DBody,
     DContext,
@@ -29,7 +29,7 @@ export class PasswordResetController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: any,
+        @DBody() data: PasswordResetInput,
         @DContext() event: IRoutupEvent,
     ): Promise<PasswordResetResponse> {
         const result = await this.service.resetPassword(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/register/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/register/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { RegisterInput, RegisterResponse } from '@authup/core-http-kit';
+import type { RegisterPayload, RegisterResponse } from '@authup/core-http-kit';
 import {
     DBody,
     DContext,
@@ -29,7 +29,7 @@ export class RegisterController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: RegisterInput,
+        @DBody() data: RegisterPayload,
         @DContext() event: IRoutupEvent,
     ): Promise<RegisterResponse> {
         const result = await this.service.register(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/register/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/register/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { RegisterResponse } from '@authup/core-http-kit';
+import type { RegisterInput, RegisterResponse } from '@authup/core-http-kit';
 import {
     DBody,
     DContext,
@@ -29,7 +29,7 @@ export class RegisterController {
 
     @DPost('', [])
     async execute(
-        @DBody() data: any,
+        @DBody() data: RegisterInput,
         @DContext() event: IRoutupEvent,
     ): Promise<RegisterResponse> {
         const result = await this.service.register(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
@@ -172,7 +172,7 @@ export class TokenController {
     @DPost('/revoke', [])
     async revokeToken(
         @DContext() event: IRoutupEvent,
-    ) {
+    ): Promise<null> {
         try {
             const token = await extractTokenFromRequest(event);
 

--- a/apps/server-core/test/unit/http/controllers/entities/client.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/client.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Client } from '@authup/core-kit';
+import type { ClientCreatePayload } from '@authup/core-http-kit';
 import {
     afterAll, 
     beforeAll, 
@@ -50,7 +51,7 @@ describe('http/controllers/client', () => {
             redirect_uri: redirectUri,
         } = createFakeClient();
 
-        const input : Partial<Client> = {
+        const input: Partial<Client> = {
             name,
             display_name: displayName,
             redirect_uri: redirectUri,
@@ -61,7 +62,7 @@ describe('http/controllers/client', () => {
 
         const response = await suite.client
             .client
-            .create(input);
+            .create(input as ClientCreatePayload);
 
         expect(response).toBeDefined();
         expect(response.secret).toBeDefined();
@@ -76,7 +77,7 @@ describe('http/controllers/client', () => {
             redirect_uri: redirectUri,
         } = createFakeClient();
 
-        const input : Partial<Client> = {
+        const input: Partial<Client> = {
             name,
             display_name: displayName,
             redirect_uri: redirectUri,
@@ -88,7 +89,7 @@ describe('http/controllers/client', () => {
 
         const response = await suite.client
             .client
-            .create(input);
+            .create(input as ClientCreatePayload);
 
         expect(response).toBeDefined();
 

--- a/apps/server-core/test/unit/http/controllers/entities/client.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/client.spec.ts
@@ -51,7 +51,7 @@ describe('http/controllers/client', () => {
             redirect_uri: redirectUri,
         } = createFakeClient();
 
-        const input: Partial<Client> = {
+        const input: ClientCreatePayload = {
             name,
             display_name: displayName,
             redirect_uri: redirectUri,
@@ -62,7 +62,7 @@ describe('http/controllers/client', () => {
 
         const response = await suite.client
             .client
-            .create(input as ClientCreatePayload);
+            .create(input);
 
         expect(response).toBeDefined();
         expect(response.secret).toBeDefined();
@@ -77,7 +77,7 @@ describe('http/controllers/client', () => {
             redirect_uri: redirectUri,
         } = createFakeClient();
 
-        const input: Partial<Client> = {
+        const input: ClientCreatePayload = {
             name,
             display_name: displayName,
             redirect_uri: redirectUri,
@@ -89,15 +89,11 @@ describe('http/controllers/client', () => {
 
         const response = await suite.client
             .client
-            .create(input as ClientCreatePayload);
+            .create(input);
 
         expect(response).toBeDefined();
 
-        expectPropertiesEqualToSrc(input, response, [
-            'secret',
-            'created_at',
-            'updated_at',
-        ]);
+        expectPropertiesEqualToSrc(input, response, ['secret']);
 
         const credentialsService = new ClientCredentialsService();
         const verified = await credentialsService.verify(input.secret!, response);

--- a/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
@@ -28,12 +28,12 @@ describe('src/http/controllers/user', () => {
         await suite.teardown();
     });
 
-    const details: Partial<User> = createFakeUser();
+    const details: UserCreatePayload & { id?: User['id'] } = createFakeUser();
 
     it('should create resource', async () => {
         const response = await suite.client
             .user
-            .create(details as UserCreatePayload);
+            .create(details);
 
         expect(response).toBeDefined();
 

--- a/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
@@ -13,6 +13,7 @@ import {
     it,
 } from 'vitest';
 import type { User } from '@authup/core-kit';
+import type { UserCreatePayload } from '@authup/core-http-kit';
 import { createTestApplication } from '../../../../app';
 import { createFakeUser, expectPropertiesEqualToSrc } from '../../../../utils';
 
@@ -27,12 +28,12 @@ describe('src/http/controllers/user', () => {
         await suite.teardown();
     });
 
-    const details : Partial<User> = createFakeUser();
+    const details: Partial<User> = createFakeUser();
 
     it('should create resource', async () => {
         const response = await suite.client
             .user
-            .create(details);
+            .create(details as UserCreatePayload);
 
         expect(response).toBeDefined();
 

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-ldap.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-ldap.spec.ts
@@ -6,20 +6,20 @@
  */
 
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
-import type { LdapIdentityProvider } from '@authup/core-kit';
+import type { IdentityProviderCreatePayload } from '@authup/core-http-kit';
 import { IdentityProviderProtocol } from '@authup/core-kit';
 import { createTestApplication } from '../../../../../app';
 import { createFakeLdapIdentityProvider } from '../../../../../utils/index.ts';
 import {
-    createLdapTestClient, 
-    createLdapTestClientURL, 
-    createLdapTestUserAccount, 
+    createLdapTestClient,
+    createLdapTestClientURL,
+    createLdapTestUserAccount,
     dropLdapTestUserAccount,
 } from '../../../../adapters/ldap/helpers';
 
@@ -45,7 +45,7 @@ describe('src/http/controllers/identity-provider', () => {
     });
 
     it('should use ldap provider for login', async () => {
-        const data : Partial<LdapIdentityProvider> = createFakeLdapIdentityProvider({
+        const data : IdentityProviderCreatePayload = createFakeLdapIdentityProvider({
             enabled: true,
             protocol: IdentityProviderProtocol.LDAP,
             url: createLdapTestClientURL(),

--- a/apps/server-core/test/utils/domains/identity-provider.ts
+++ b/apps/server-core/test/utils/domains/identity-provider.ts
@@ -26,11 +26,11 @@ export function createFakeOAuth2IdentityProvider(data: Partial<OAuth2IdentityPro
     } satisfies Partial<OAuth2IdentityProvider>;
 }
 
-export function createFakeLdapIdentityProvider(data: Partial<LdapIdentityProvider> = {}): Partial<LdapIdentityProvider> {
+export function createFakeLdapIdentityProvider(data: Partial<LdapIdentityProvider> = {}) {
     return {
         name: faker.string.alpha({
             length: 16,
-            casing: 'lower', 
+            casing: 'lower',
         }),
         display_name: faker.internet.displayName(),
         enabled: true,
@@ -41,5 +41,5 @@ export function createFakeLdapIdentityProvider(data: Partial<LdapIdentityProvide
         base_dn: 'dc=example,dc=com',
         user_name_attribute: 'cn',
         ...data,
-    };
+    } satisfies Partial<LdapIdentityProvider>;
 }

--- a/packages/core-http-kit/src/client/module.ts
+++ b/packages/core-http-kit/src/client/module.ts
@@ -164,7 +164,7 @@ export class Client extends BaseClient {
         }));
     }
 
-    async getJwks() : Promise<OAuth2JsonWebKey[]> {
+    async getJwks() : Promise<{ keys: OAuth2JsonWebKey[] }> {
         const response = await this.get('jwks');
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-permission/index.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/client-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/module.ts
@@ -10,32 +10,37 @@ import { buildQuery } from 'rapiq';
 import type { ClientPermission } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    ClientPermissionCreateInput,
+    ClientPermissionResponse,
+    ClientPermissionUpdateInput,
+} from './types';
 
 export class ClientPermissionAPI extends BaseAPI implements EntityAPI<ClientPermission> {
-    async getMany(data?: BuildInput<ClientPermission>) : Promise<EntityCollectionResponse<ClientPermission>> {
+    async getMany(data?: BuildInput<ClientPermission>) : Promise<EntityCollectionResponse<ClientPermissionResponse>> {
         const response = await this.client.get(`client-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: ClientPermission['id'], data?: BuildInput<ClientPermission>) : Promise<EntityRecordResponse<ClientPermission>> {
+    async getOne(id: ClientPermission['id'], data?: BuildInput<ClientPermission>) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
         const response = await this.client.get(`client-permissions/${id}${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async delete(id: ClientPermission['id']) : Promise<EntityRecordResponse<ClientPermission>> {
+    async delete(id: ClientPermission['id']) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
         const response = await this.client.delete(`client-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<ClientPermission>) : Promise<EntityRecordResponse<ClientPermission>> {
+    async create(data: ClientPermissionCreateInput) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
         const response = await this.client.post('client-permissions', data);
 
         return response.data;
     }
 
-    async update(id: ClientPermission['id'], data: Partial<ClientPermission>) : Promise<EntityRecordResponse<ClientPermission>> {
+    async update(id: ClientPermission['id'], data: ClientPermissionUpdateInput) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
         const response = await this.client.post(`client-permissions/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/module.ts
@@ -11,36 +11,35 @@ import type { ClientPermission } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    ClientPermissionCreateInput,
-    ClientPermissionResponse,
-    ClientPermissionUpdateInput,
+    ClientPermissionCreatePayload,
+    ClientPermissionUpdatePayload,
 } from './types';
 
 export class ClientPermissionAPI extends BaseAPI implements EntityAPI<ClientPermission> {
-    async getMany(data?: BuildInput<ClientPermission>) : Promise<EntityCollectionResponse<ClientPermissionResponse>> {
+    async getMany(data?: BuildInput<ClientPermission>) : Promise<EntityCollectionResponse<ClientPermission>> {
         const response = await this.client.get(`client-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: ClientPermission['id'], data?: BuildInput<ClientPermission>) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
+    async getOne(id: ClientPermission['id'], data?: BuildInput<ClientPermission>) : Promise<EntityRecordResponse<ClientPermission>> {
         const response = await this.client.get(`client-permissions/${id}${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async delete(id: ClientPermission['id']) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
+    async delete(id: ClientPermission['id']) : Promise<EntityRecordResponse<ClientPermission>> {
         const response = await this.client.delete(`client-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: ClientPermissionCreateInput) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
+    async create(data: ClientPermissionCreatePayload) : Promise<EntityRecordResponse<ClientPermission>> {
         const response = await this.client.post('client-permissions', data);
 
         return response.data;
     }
 
-    async update(id: ClientPermission['id'], data: ClientPermissionUpdateInput) : Promise<EntityRecordResponse<ClientPermissionResponse>> {
+    async update(id: ClientPermission['id'], data: ClientPermissionUpdatePayload) : Promise<EntityRecordResponse<ClientPermission>> {
         const response = await this.client.post(`client-permissions/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/types.ts
@@ -7,5 +7,7 @@
 
 import type { ClientPermission } from '@authup/core-kit';
 
-export type ClientPermissionCreatePayload = Partial<ClientPermission>;
-export type ClientPermissionUpdatePayload = Partial<ClientPermission>;
+// Mirrors `ClientPermissionValidator` mounts in @authup/core-kit.
+export type ClientPermissionCreatePayload =    & Pick<ClientPermission, 'client_id' | 'permission_id'> &
+    Partial<Pick<ClientPermission, 'policy_id'>>;
+export type ClientPermissionUpdatePayload = Partial<ClientPermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/client-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/types.ts
@@ -8,6 +8,6 @@
 import type { ClientPermission } from '@authup/core-kit';
 
 // Mirrors `ClientPermissionValidator` mounts in @authup/core-kit.
-export type ClientPermissionCreatePayload =    & Pick<ClientPermission, 'client_id' | 'permission_id'> &
+export type ClientPermissionCreatePayload = Pick<ClientPermission, 'client_id' | 'permission_id'> &
     Partial<Pick<ClientPermission, 'policy_id'>>;
 export type ClientPermissionUpdatePayload = Partial<ClientPermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/client-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/types.ts
@@ -7,6 +7,5 @@
 
 import type { ClientPermission } from '@authup/core-kit';
 
-export type ClientPermissionCreateInput = Partial<ClientPermission>;
-export type ClientPermissionUpdateInput = Partial<ClientPermission>;
-export type ClientPermissionResponse = ClientPermission;
+export type ClientPermissionCreatePayload = Partial<ClientPermission>;
+export type ClientPermissionUpdatePayload = Partial<ClientPermission>;

--- a/packages/core-http-kit/src/domains/entities/client-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-permission/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ClientPermission } from '@authup/core-kit';
+
+export type ClientPermissionCreateInput = Partial<ClientPermission>;
+export type ClientPermissionUpdateInput = Partial<ClientPermission>;
+export type ClientPermissionResponse = ClientPermission;

--- a/packages/core-http-kit/src/domains/entities/client-role/index.ts
+++ b/packages/core-http-kit/src/domains/entities/client-role/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/client-role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client-role/module.ts
@@ -10,27 +10,28 @@ import { buildQuery } from 'rapiq';
 import type { ClientRole } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type { ClientRoleCreateInput, ClientRoleResponse } from './types';
 
 export class ClientRoleAPI extends BaseAPI implements EntityAPISlim<ClientRole> {
-    async getMany(data: BuildInput<ClientRole> = {}): Promise<EntityCollectionResponse<ClientRole>> {
+    async getMany(data: BuildInput<ClientRole> = {}): Promise<EntityCollectionResponse<ClientRoleResponse>> {
         const response = await this.client.get(`client-roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRole>> {
+    async getOne(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRoleResponse>> {
         const response = await this.client.get(`client-roles/${id}`);
 
         return response.data;
     }
 
-    async delete(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRole>> {
+    async delete(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRoleResponse>> {
         const response = await this.client.delete(`client-roles/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<ClientRole>): Promise<EntityRecordResponse<ClientRole>> {
+    async create(data: ClientRoleCreateInput): Promise<EntityRecordResponse<ClientRoleResponse>> {
         const response = await this.client.post('client-roles', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client-role/module.ts
@@ -10,28 +10,28 @@ import { buildQuery } from 'rapiq';
 import type { ClientRole } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-import type { ClientRoleCreateInput, ClientRoleResponse } from './types';
+import type { ClientRoleCreatePayload } from './types';
 
 export class ClientRoleAPI extends BaseAPI implements EntityAPISlim<ClientRole> {
-    async getMany(data: BuildInput<ClientRole> = {}): Promise<EntityCollectionResponse<ClientRoleResponse>> {
+    async getMany(data: BuildInput<ClientRole> = {}): Promise<EntityCollectionResponse<ClientRole>> {
         const response = await this.client.get(`client-roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRoleResponse>> {
+    async getOne(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRole>> {
         const response = await this.client.get(`client-roles/${id}`);
 
         return response.data;
     }
 
-    async delete(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRoleResponse>> {
+    async delete(id: ClientRole['id']): Promise<EntityRecordResponse<ClientRole>> {
         const response = await this.client.delete(`client-roles/${id}`);
 
         return response.data;
     }
 
-    async create(data: ClientRoleCreateInput): Promise<EntityRecordResponse<ClientRoleResponse>> {
+    async create(data: ClientRoleCreatePayload): Promise<EntityRecordResponse<ClientRole>> {
         const response = await this.client.post('client-roles', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-role/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ClientRole } from '@authup/core-kit';
+
+export type ClientRoleCreateInput = Partial<ClientRole>;
+export type ClientRoleResponse = ClientRole;

--- a/packages/core-http-kit/src/domains/entities/client-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-role/types.ts
@@ -7,5 +7,4 @@
 
 import type { ClientRole } from '@authup/core-kit';
 
-export type ClientRoleCreateInput = Partial<ClientRole>;
-export type ClientRoleResponse = ClientRole;
+export type ClientRoleCreatePayload = Partial<ClientRole>;

--- a/packages/core-http-kit/src/domains/entities/client-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-role/types.ts
@@ -7,4 +7,5 @@
 
 import type { ClientRole } from '@authup/core-kit';
 
-export type ClientRoleCreatePayload = Partial<ClientRole>;
+// Mirrors `ClientRoleValidator` mounts in @authup/core-kit.
+export type ClientRoleCreatePayload = Pick<ClientRole, 'client_id' | 'role_id'>;

--- a/packages/core-http-kit/src/domains/entities/client-scope/index.ts
+++ b/packages/core-http-kit/src/domains/entities/client-scope/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/client-scope/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client-scope/module.ts
@@ -10,27 +10,27 @@ import { buildQuery } from 'rapiq';
 import type { ClientScope } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-import type { ClientScopeCreateInput, ClientScopeResponse } from './types';
+import type { ClientScopeCreatePayload } from './types';
 
 export class ClientScopeAPI extends BaseAPI implements EntityAPISlim<ClientScope> {
-    async getMany(data?: BuildInput<ClientScope>) : Promise<EntityCollectionResponse<ClientScopeResponse>> {
+    async getMany(data?: BuildInput<ClientScope>) : Promise<EntityCollectionResponse<ClientScope>> {
         const response = await this.client.get(`client-scopes${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScopeResponse>> {
+    async getOne(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScope>> {
         const response = await this.client.get(`client-scopes/${id}`);
 
         return response.data;
     }
 
-    async delete(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScopeResponse>> {
+    async delete(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScope>> {
         const response = await this.client.delete(`client-scopes/${id}`);
 
         return response.data;
     }
 
-    async create(data: ClientScopeCreateInput) : Promise<EntityRecordResponse<ClientScopeResponse>> {
+    async create(data: ClientScopeCreatePayload) : Promise<EntityRecordResponse<ClientScope>> {
         const response = await this.client.post('client-scopes', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-scope/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client-scope/module.ts
@@ -10,26 +10,27 @@ import { buildQuery } from 'rapiq';
 import type { ClientScope } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type { ClientScopeCreateInput, ClientScopeResponse } from './types';
 
 export class ClientScopeAPI extends BaseAPI implements EntityAPISlim<ClientScope> {
-    async getMany(data?: BuildInput<ClientScope>) : Promise<EntityCollectionResponse<ClientScope>> {
+    async getMany(data?: BuildInput<ClientScope>) : Promise<EntityCollectionResponse<ClientScopeResponse>> {
         const response = await this.client.get(`client-scopes${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScope>> {
+    async getOne(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScopeResponse>> {
         const response = await this.client.get(`client-scopes/${id}`);
 
         return response.data;
     }
 
-    async delete(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScope>> {
+    async delete(id: ClientScope['id']) : Promise<EntityRecordResponse<ClientScopeResponse>> {
         const response = await this.client.delete(`client-scopes/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<ClientScope>) : Promise<EntityRecordResponse<ClientScope>> {
+    async create(data: ClientScopeCreateInput) : Promise<EntityRecordResponse<ClientScopeResponse>> {
         const response = await this.client.post('client-scopes', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client-scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-scope/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ClientScope } from '@authup/core-kit';
+
+export type ClientScopeCreateInput = Partial<ClientScope>;
+export type ClientScopeResponse = ClientScope;

--- a/packages/core-http-kit/src/domains/entities/client-scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-scope/types.ts
@@ -7,5 +7,4 @@
 
 import type { ClientScope } from '@authup/core-kit';
 
-export type ClientScopeCreateInput = Partial<ClientScope>;
-export type ClientScopeResponse = ClientScope;
+export type ClientScopeCreatePayload = Partial<ClientScope>;

--- a/packages/core-http-kit/src/domains/entities/client-scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client-scope/types.ts
@@ -7,4 +7,5 @@
 
 import type { ClientScope } from '@authup/core-kit';
 
-export type ClientScopeCreatePayload = Partial<ClientScope>;
+// Mirrors `ClientScopeValidator` mounts in @authup/core-kit.
+export type ClientScopeCreatePayload = Pick<ClientScope, 'client_id' | 'scope_id'>;

--- a/packages/core-http-kit/src/domains/entities/client/index.ts
+++ b/packages/core-http-kit/src/domains/entities/client/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './module';
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/client/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client/module.ts
@@ -11,11 +11,17 @@ import type { Client } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    ClientCreateInput,
+    ClientResponse,
+    ClientSaveInput,
+    ClientUpdateInput,
+} from './types';
 
 export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
     async getMany(
         options?: BuildInput<Client>,
-    ): Promise<EntityCollectionResponse<Client>> {
+    ): Promise<EntityCollectionResponse<ClientResponse>> {
         const response = await this.client
             .get(`clients${buildQuery(options)}`);
 
@@ -25,7 +31,7 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
     async getOne(
         id: Client['id'],
         options?: BuildInput<Client>,
-    ): Promise<EntityRecordResponse<Client>> {
+    ): Promise<EntityRecordResponse<ClientResponse>> {
         const response = await this.client
             .get(`clients/${id}${buildQuery(options)}`);
 
@@ -34,7 +40,7 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
 
     async delete(
         id: Client['id'],
-    ): Promise<EntityRecordResponse<Client>> {
+    ): Promise<EntityRecordResponse<ClientResponse>> {
         const response = await this.client
             .delete(`clients/${id}`);
 
@@ -42,8 +48,8 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
     }
 
     async create(
-        data: Partial<Client>,
-    ): Promise<EntityRecordResponse<Client>> {
+        data: ClientCreateInput,
+    ): Promise<EntityRecordResponse<ClientResponse>> {
         const response = await this.client
             .post('clients', nullifyEmptyObjectProperties(data));
 
@@ -52,8 +58,8 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
 
     async update(
         id: Client['id'],
-        data: Partial<Client>,
-    ): Promise<EntityRecordResponse<Client>> {
+        data: ClientUpdateInput,
+    ): Promise<EntityRecordResponse<ClientResponse>> {
         const response = await this.client.post(`clients/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -61,8 +67,8 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<Client>,
-    ): Promise<EntityRecordResponse<Client>> {
+        data: ClientSaveInput,
+    ): Promise<EntityRecordResponse<ClientResponse>> {
         const response = await this.client.put(`clients/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client/module.ts
+++ b/packages/core-http-kit/src/domains/entities/client/module.ts
@@ -12,16 +12,15 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    ClientCreateInput,
-    ClientResponse,
-    ClientSaveInput,
-    ClientUpdateInput,
+    ClientCreatePayload,
+    ClientSavePayload,
+    ClientUpdatePayload,
 } from './types';
 
 export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
     async getMany(
         options?: BuildInput<Client>,
-    ): Promise<EntityCollectionResponse<ClientResponse>> {
+    ): Promise<EntityCollectionResponse<Client>> {
         const response = await this.client
             .get(`clients${buildQuery(options)}`);
 
@@ -31,7 +30,7 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
     async getOne(
         id: Client['id'],
         options?: BuildInput<Client>,
-    ): Promise<EntityRecordResponse<ClientResponse>> {
+    ): Promise<EntityRecordResponse<Client>> {
         const response = await this.client
             .get(`clients/${id}${buildQuery(options)}`);
 
@@ -40,7 +39,7 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
 
     async delete(
         id: Client['id'],
-    ): Promise<EntityRecordResponse<ClientResponse>> {
+    ): Promise<EntityRecordResponse<Client>> {
         const response = await this.client
             .delete(`clients/${id}`);
 
@@ -48,8 +47,8 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
     }
 
     async create(
-        data: ClientCreateInput,
-    ): Promise<EntityRecordResponse<ClientResponse>> {
+        data: ClientCreatePayload,
+    ): Promise<EntityRecordResponse<Client>> {
         const response = await this.client
             .post('clients', nullifyEmptyObjectProperties(data));
 
@@ -58,8 +57,8 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
 
     async update(
         id: Client['id'],
-        data: ClientUpdateInput,
-    ): Promise<EntityRecordResponse<ClientResponse>> {
+        data: ClientUpdatePayload,
+    ): Promise<EntityRecordResponse<Client>> {
         const response = await this.client.post(`clients/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -67,8 +66,8 @@ export class ClientAPI extends BaseAPI implements EntityAPI<Client> {
 
     async createOrUpdate(
         idOrName: string,
-        data: ClientSaveInput,
-    ): Promise<EntityRecordResponse<ClientResponse>> {
+        data: ClientSavePayload,
+    ): Promise<EntityRecordResponse<Client>> {
         const response = await this.client.put(`clients/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/client/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client/types.ts
@@ -7,7 +7,6 @@
 
 import type { Client } from '@authup/core-kit';
 
-export type ClientCreateInput = Partial<Client>;
-export type ClientUpdateInput = Partial<Client>;
-export type ClientSaveInput = Partial<Client>;
-export type ClientResponse = Client;
+export type ClientCreatePayload = Partial<Client>;
+export type ClientUpdatePayload = Partial<Client>;
+export type ClientSavePayload = Partial<Client>;

--- a/packages/core-http-kit/src/domains/entities/client/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client/types.ts
@@ -7,6 +7,20 @@
 
 import type { Client } from '@authup/core-kit';
 
-export type ClientCreatePayload = Partial<Client>;
-export type ClientUpdatePayload = Partial<Client>;
-export type ClientSavePayload = Partial<Client>;
+// Mirrors `ClientValidator` mounts in @authup/core-kit.
+export type ClientCreatePayload =    & Pick<Client, 'name'> &
+    Partial<Pick<Client, 'active' |
+        'is_confidential' |
+        'display_name' |
+        'description' |
+        'secret' |
+        'secret_encrypted' |
+        'secret_hashed' |
+        'redirect_uri' |
+        'base_url' |
+        'root_url' |
+        'grant_types' |
+        'scope' |
+        'realm_id'>>;
+export type ClientUpdatePayload = Partial<ClientCreatePayload>;
+export type ClientSavePayload = ClientCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/client/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Client } from '@authup/core-kit';
+
+export type ClientCreateInput = Partial<Client>;
+export type ClientUpdateInput = Partial<Client>;
+export type ClientSaveInput = Partial<Client>;
+export type ClientResponse = Client;

--- a/packages/core-http-kit/src/domains/entities/client/types.ts
+++ b/packages/core-http-kit/src/domains/entities/client/types.ts
@@ -8,7 +8,7 @@
 import type { Client } from '@authup/core-kit';
 
 // Mirrors `ClientValidator` mounts in @authup/core-kit.
-export type ClientCreatePayload =    & Pick<Client, 'name'> &
+export type ClientCreatePayload = Pick<Client, 'name'> &
     Partial<Pick<Client, 'active' |
         'is_confidential' |
         'display_name' |

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/index.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/module.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/module.ts
@@ -11,27 +11,32 @@ import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    IdentityProviderRoleMappingCreateInput,
+    IdentityProviderRoleMappingResponse,
+    IdentityProviderRoleMappingUpdateInput,
+} from './types';
 
 export class IdentityProviderRoleMappingAPI extends BaseAPI implements EntityAPI<IdentityProviderRoleMapping> {
-    async getMany(data: BuildInput<IdentityProviderRoleMapping>): Promise<EntityCollectionResponse<IdentityProviderRoleMapping>> {
+    async getMany(data: BuildInput<IdentityProviderRoleMapping>): Promise<EntityCollectionResponse<IdentityProviderRoleMappingResponse>> {
         const response = await this.client.get(`identity-provider-role-mappings${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
+    async getOne(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
         const response = await this.client.get(`identity-provider-role-mappings/${id}`);
 
         return response.data;
     }
 
-    async delete(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
+    async delete(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
         const response = await this.client.delete(`identity-provider-role-mappings/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<IdentityProviderRoleMapping>): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
+    async create(data: IdentityProviderRoleMappingCreateInput): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
         const response = await this.client.post('identity-provider-role-mappings', nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -39,8 +44,8 @@ export class IdentityProviderRoleMappingAPI extends BaseAPI implements EntityAPI
 
     async update(
         id: IdentityProviderRoleMapping['id'],
-        data: Partial<IdentityProviderRoleMapping>,
-    ): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
+        data: IdentityProviderRoleMappingUpdateInput,
+    ): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
         const response = await this.client.post(`identity-provider-role-mappings/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/module.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/module.ts
@@ -12,31 +12,30 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    IdentityProviderRoleMappingCreateInput,
-    IdentityProviderRoleMappingResponse,
-    IdentityProviderRoleMappingUpdateInput,
+    IdentityProviderRoleMappingCreatePayload,
+    IdentityProviderRoleMappingUpdatePayload,
 } from './types';
 
 export class IdentityProviderRoleMappingAPI extends BaseAPI implements EntityAPI<IdentityProviderRoleMapping> {
-    async getMany(data: BuildInput<IdentityProviderRoleMapping>): Promise<EntityCollectionResponse<IdentityProviderRoleMappingResponse>> {
+    async getMany(data: BuildInput<IdentityProviderRoleMapping>): Promise<EntityCollectionResponse<IdentityProviderRoleMapping>> {
         const response = await this.client.get(`identity-provider-role-mappings${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
+    async getOne(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
         const response = await this.client.get(`identity-provider-role-mappings/${id}`);
 
         return response.data;
     }
 
-    async delete(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
+    async delete(id: IdentityProviderRoleMapping['id']): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
         const response = await this.client.delete(`identity-provider-role-mappings/${id}`);
 
         return response.data;
     }
 
-    async create(data: IdentityProviderRoleMappingCreateInput): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
+    async create(data: IdentityProviderRoleMappingCreatePayload): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
         const response = await this.client.post('identity-provider-role-mappings', nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -44,8 +43,8 @@ export class IdentityProviderRoleMappingAPI extends BaseAPI implements EntityAPI
 
     async update(
         id: IdentityProviderRoleMapping['id'],
-        data: IdentityProviderRoleMappingUpdateInput,
-    ): Promise<EntityRecordResponse<IdentityProviderRoleMappingResponse>> {
+        data: IdentityProviderRoleMappingUpdatePayload,
+    ): Promise<EntityRecordResponse<IdentityProviderRoleMapping>> {
         const response = await this.client.post(`identity-provider-role-mappings/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
@@ -7,6 +7,5 @@
 
 import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 
-export type IdentityProviderRoleMappingCreateInput = Partial<IdentityProviderRoleMapping>;
-export type IdentityProviderRoleMappingUpdateInput = Partial<IdentityProviderRoleMapping>;
-export type IdentityProviderRoleMappingResponse = IdentityProviderRoleMapping;
+export type IdentityProviderRoleMappingCreatePayload = Partial<IdentityProviderRoleMapping>;
+export type IdentityProviderRoleMappingUpdatePayload = Partial<IdentityProviderRoleMapping>;

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
@@ -8,6 +8,6 @@
 import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 
 // Mirrors `IdentityProviderRoleMappingValidator` mounts in @authup/core-kit.
-export type IdentityProviderRoleMappingCreatePayload =    & Pick<IdentityProviderRoleMapping, 'provider_id' | 'role_id'> &
+export type IdentityProviderRoleMappingCreatePayload = Pick<IdentityProviderRoleMapping, 'provider_id' | 'role_id'> &
     Partial<Pick<IdentityProviderRoleMapping, 'name' | 'value' | 'value_is_regex' | 'synchronization_mode'>>;
 export type IdentityProviderRoleMappingUpdatePayload = Partial<IdentityProviderRoleMappingCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IdentityProviderRoleMapping } from '@authup/core-kit';
+
+export type IdentityProviderRoleMappingCreateInput = Partial<IdentityProviderRoleMapping>;
+export type IdentityProviderRoleMappingUpdateInput = Partial<IdentityProviderRoleMapping>;
+export type IdentityProviderRoleMappingResponse = IdentityProviderRoleMapping;

--- a/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider-role-mapping/types.ts
@@ -7,5 +7,7 @@
 
 import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 
-export type IdentityProviderRoleMappingCreatePayload = Partial<IdentityProviderRoleMapping>;
-export type IdentityProviderRoleMappingUpdatePayload = Partial<IdentityProviderRoleMapping>;
+// Mirrors `IdentityProviderRoleMappingValidator` mounts in @authup/core-kit.
+export type IdentityProviderRoleMappingCreatePayload =    & Pick<IdentityProviderRoleMapping, 'provider_id' | 'role_id'> &
+    Partial<Pick<IdentityProviderRoleMapping, 'name' | 'value' | 'value_is_regex' | 'synchronization_mode'>>;
+export type IdentityProviderRoleMappingUpdatePayload = Partial<IdentityProviderRoleMappingCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/index.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/identity-provider/module.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/module.ts
@@ -13,10 +13,9 @@ import { cleanDoubleSlashes, nullifyEmptyObjectProperties } from '../../../utils
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import { BaseAPI } from '../../base';
 import type {
-    IdentityProviderCreateInput,
-    IdentityProviderResponse,
-    IdentityProviderSaveInput,
-    IdentityProviderUpdateInput,
+    IdentityProviderCreatePayload,
+    IdentityProviderSavePayload,
+    IdentityProviderUpdatePayload,
 } from './types';
 
 export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityProvider> {
@@ -24,7 +23,7 @@ export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityPr
         return cleanDoubleSlashes(`${this.client.defaults.baseURL}/${buildIdentityProviderAuthorizePath(id)}`);
     }
 
-    async getMany(record?: BuildInput<IdentityProvider>): Promise<EntityCollectionResponse<IdentityProviderResponse>> {
+    async getMany(record?: BuildInput<IdentityProvider>): Promise<EntityCollectionResponse<IdentityProvider>> {
         const response = await this.client.get(`identity-providers${buildQuery(record)}`);
 
         return response.data;
@@ -33,25 +32,25 @@ export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityPr
     async getOne(
         id: IdentityProvider['id'],
         record?: BuildInput<IdentityProvider>,
-    ): Promise<EntityRecordResponse<IdentityProviderResponse>> {
+    ): Promise<EntityRecordResponse<IdentityProvider>> {
         const response = await this.client.get(`identity-providers/${id}${buildQuery(record)}`);
 
         return response.data;
     }
 
-    async delete(id: IdentityProvider['id']): Promise<EntityRecordResponse<IdentityProviderResponse>> {
+    async delete(id: IdentityProvider['id']): Promise<EntityRecordResponse<IdentityProvider>> {
         const response = await this.client.delete(`identity-providers/${id}`);
 
         return response.data;
     }
 
-    async create(data: IdentityProviderCreateInput): Promise<EntityRecordResponse<IdentityProviderResponse>> {
+    async create(data: IdentityProviderCreatePayload): Promise<EntityRecordResponse<IdentityProvider>> {
         const response = await this.client.post('identity-providers', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: IdentityProvider['id'], data: IdentityProviderUpdateInput): Promise<EntityRecordResponse<IdentityProviderResponse>> {
+    async update(id: IdentityProvider['id'], data: IdentityProviderUpdatePayload): Promise<EntityRecordResponse<IdentityProvider>> {
         const response = await this.client.post(`identity-providers/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -59,8 +58,8 @@ export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityPr
 
     async createOrUpdate(
         idOrName: string,
-        data: IdentityProviderSaveInput,
-    ): Promise<EntityRecordResponse<IdentityProviderResponse>> {
+        data: IdentityProviderSavePayload,
+    ): Promise<EntityRecordResponse<IdentityProvider>> {
         const response = await this.client.put(`identity-providers/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/module.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/module.ts
@@ -12,13 +12,19 @@ import { buildIdentityProviderAuthorizePath } from '@authup/core-kit';
 import { cleanDoubleSlashes, nullifyEmptyObjectProperties } from '../../../utils';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import { BaseAPI } from '../../base';
+import type {
+    IdentityProviderCreateInput,
+    IdentityProviderResponse,
+    IdentityProviderSaveInput,
+    IdentityProviderUpdateInput,
+} from './types';
 
 export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityProvider> {
     getAuthorizeUri(id: IdentityProvider['id']): string {
         return cleanDoubleSlashes(`${this.client.defaults.baseURL}/${buildIdentityProviderAuthorizePath(id)}`);
     }
 
-    async getMany(record?: BuildInput<IdentityProvider>): Promise<EntityCollectionResponse<IdentityProvider>> {
+    async getMany(record?: BuildInput<IdentityProvider>): Promise<EntityCollectionResponse<IdentityProviderResponse>> {
         const response = await this.client.get(`identity-providers${buildQuery(record)}`);
 
         return response.data;
@@ -27,25 +33,25 @@ export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityPr
     async getOne(
         id: IdentityProvider['id'],
         record?: BuildInput<IdentityProvider>,
-    ): Promise<EntityRecordResponse<IdentityProvider>> {
+    ): Promise<EntityRecordResponse<IdentityProviderResponse>> {
         const response = await this.client.get(`identity-providers/${id}${buildQuery(record)}`);
 
         return response.data;
     }
 
-    async delete(id: IdentityProvider['id']): Promise<EntityRecordResponse<IdentityProvider>> {
+    async delete(id: IdentityProvider['id']): Promise<EntityRecordResponse<IdentityProviderResponse>> {
         const response = await this.client.delete(`identity-providers/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<IdentityProvider>): Promise<EntityRecordResponse<IdentityProvider>> {
+    async create(data: IdentityProviderCreateInput): Promise<EntityRecordResponse<IdentityProviderResponse>> {
         const response = await this.client.post('identity-providers', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: IdentityProvider['id'], data: Partial<IdentityProvider>): Promise<EntityRecordResponse<IdentityProvider>> {
+    async update(id: IdentityProvider['id'], data: IdentityProviderUpdateInput): Promise<EntityRecordResponse<IdentityProviderResponse>> {
         const response = await this.client.post(`identity-providers/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -53,8 +59,8 @@ export class IdentityProviderAPI extends BaseAPI implements EntityAPI<IdentityPr
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<IdentityProvider>,
-    ): Promise<EntityRecordResponse<IdentityProvider>> {
+        data: IdentityProviderSaveInput,
+    ): Promise<EntityRecordResponse<IdentityProviderResponse>> {
         const response = await this.client.put(`identity-providers/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
@@ -13,10 +13,10 @@ import type { IdentityProvider } from '@authup/core-kit';
 //
 // `protocol` is mounted unconditionally (no group filter, no `optional: true`), so the
 // validator demands it on both CREATE and UPDATE — UpdatePayload reflects that.
-export type IdentityProviderCreatePayload =    & Pick<IdentityProvider, 'name' | 'enabled' | 'protocol'> &
+export type IdentityProviderCreatePayload = Pick<IdentityProvider, 'name' | 'enabled' | 'protocol'> &
     Partial<Pick<IdentityProvider, 'display_name' | 'realm_id' | 'preset'>> &
     Record<string, any>;
-export type IdentityProviderUpdatePayload =    & Pick<IdentityProvider, 'protocol'> &
+export type IdentityProviderUpdatePayload = Pick<IdentityProvider, 'protocol'> &
     Partial<Pick<IdentityProvider, 'name' | 'enabled' | 'display_name' | 'realm_id' | 'preset'>> &
     Record<string, any>;
 export type IdentityProviderSavePayload = IdentityProviderCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
@@ -7,7 +7,6 @@
 
 import type { IdentityProvider } from '@authup/core-kit';
 
-export type IdentityProviderCreateInput = Partial<IdentityProvider>;
-export type IdentityProviderUpdateInput = Partial<IdentityProvider>;
-export type IdentityProviderSaveInput = Partial<IdentityProvider>;
-export type IdentityProviderResponse = IdentityProvider;
+export type IdentityProviderCreatePayload = Partial<IdentityProvider>;
+export type IdentityProviderUpdatePayload = Partial<IdentityProvider>;
+export type IdentityProviderSavePayload = Partial<IdentityProvider>;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
@@ -10,8 +10,13 @@ import type { IdentityProvider } from '@authup/core-kit';
 // Mirrors `IdentityProviderValidator` mounts in @authup/core-kit. IdPs carry per-protocol
 // attributes (e.g. client_id/client_secret for OAuth2) handled by an attributes validator
 // outside the main schema; the `& Record<string, any>` keeps those open.
-type IdentityProviderValidatedFields =    & Pick<IdentityProvider, 'name' | 'enabled' | 'protocol'> &
-    Partial<Pick<IdentityProvider, 'display_name' | 'realm_id' | 'preset'>>;
-export type IdentityProviderCreatePayload = IdentityProviderValidatedFields & Record<string, any>;
-export type IdentityProviderUpdatePayload = Partial<IdentityProviderValidatedFields> & Record<string, any>;
+//
+// `protocol` is mounted unconditionally (no group filter, no `optional: true`), so the
+// validator demands it on both CREATE and UPDATE — UpdatePayload reflects that.
+export type IdentityProviderCreatePayload =    & Pick<IdentityProvider, 'name' | 'enabled' | 'protocol'> &
+    Partial<Pick<IdentityProvider, 'display_name' | 'realm_id' | 'preset'>> &
+    Record<string, any>;
+export type IdentityProviderUpdatePayload =    & Pick<IdentityProvider, 'protocol'> &
+    Partial<Pick<IdentityProvider, 'name' | 'enabled' | 'display_name' | 'realm_id' | 'preset'>> &
+    Record<string, any>;
 export type IdentityProviderSavePayload = IdentityProviderCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
@@ -7,6 +7,11 @@
 
 import type { IdentityProvider } from '@authup/core-kit';
 
-export type IdentityProviderCreatePayload = Partial<IdentityProvider>;
-export type IdentityProviderUpdatePayload = Partial<IdentityProvider>;
-export type IdentityProviderSavePayload = Partial<IdentityProvider>;
+// Mirrors `IdentityProviderValidator` mounts in @authup/core-kit. IdPs carry per-protocol
+// attributes (e.g. client_id/client_secret for OAuth2) handled by an attributes validator
+// outside the main schema; the `& Record<string, any>` keeps those open.
+type IdentityProviderValidatedFields =    & Pick<IdentityProvider, 'name' | 'enabled' | 'protocol'> &
+    Partial<Pick<IdentityProvider, 'display_name' | 'realm_id' | 'preset'>>;
+export type IdentityProviderCreatePayload = IdentityProviderValidatedFields & Record<string, any>;
+export type IdentityProviderUpdatePayload = Partial<IdentityProviderValidatedFields> & Record<string, any>;
+export type IdentityProviderSavePayload = IdentityProviderCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IdentityProvider } from '@authup/core-kit';
+
+export type IdentityProviderCreateInput = Partial<IdentityProvider>;
+export type IdentityProviderUpdateInput = Partial<IdentityProvider>;
+export type IdentityProviderSaveInput = Partial<IdentityProvider>;
+export type IdentityProviderResponse = IdentityProvider;

--- a/packages/core-http-kit/src/domains/entities/permission-policy/index.ts
+++ b/packages/core-http-kit/src/domains/entities/permission-policy/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/permission-policy/module.ts
+++ b/packages/core-http-kit/src/domains/entities/permission-policy/module.ts
@@ -10,27 +10,27 @@ import { buildQuery } from 'rapiq';
 import type { PermissionPolicy } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-import type { PermissionPolicyCreateInput, PermissionPolicyResponse } from './types';
+import type { PermissionPolicyCreatePayload } from './types';
 
 export class PermissionPolicyAPI extends BaseAPI implements EntityAPISlim<PermissionPolicy> {
-    async getMany(data?: BuildInput<PermissionPolicy>) : Promise<EntityCollectionResponse<PermissionPolicyResponse>> {
+    async getMany(data?: BuildInput<PermissionPolicy>) : Promise<EntityCollectionResponse<PermissionPolicy>> {
         const response = await this.client.get(`permission-policies${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicyResponse>> {
+    async getOne(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicy>> {
         const response = await this.client.get(`permission-policies/${id}`);
 
         return response.data;
     }
 
-    async delete(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicyResponse>> {
+    async delete(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicy>> {
         const response = await this.client.delete(`permission-policies/${id}`);
 
         return response.data;
     }
 
-    async create(data: PermissionPolicyCreateInput) : Promise<EntityRecordResponse<PermissionPolicyResponse>> {
+    async create(data: PermissionPolicyCreatePayload) : Promise<EntityRecordResponse<PermissionPolicy>> {
         const response = await this.client.post('permission-policies', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/permission-policy/module.ts
+++ b/packages/core-http-kit/src/domains/entities/permission-policy/module.ts
@@ -10,26 +10,27 @@ import { buildQuery } from 'rapiq';
 import type { PermissionPolicy } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type { PermissionPolicyCreateInput, PermissionPolicyResponse } from './types';
 
 export class PermissionPolicyAPI extends BaseAPI implements EntityAPISlim<PermissionPolicy> {
-    async getMany(data?: BuildInput<PermissionPolicy>) : Promise<EntityCollectionResponse<PermissionPolicy>> {
+    async getMany(data?: BuildInput<PermissionPolicy>) : Promise<EntityCollectionResponse<PermissionPolicyResponse>> {
         const response = await this.client.get(`permission-policies${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicy>> {
+    async getOne(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicyResponse>> {
         const response = await this.client.get(`permission-policies/${id}`);
 
         return response.data;
     }
 
-    async delete(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicy>> {
+    async delete(id: PermissionPolicy['id']) : Promise<EntityRecordResponse<PermissionPolicyResponse>> {
         const response = await this.client.delete(`permission-policies/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<PermissionPolicy>) : Promise<EntityRecordResponse<PermissionPolicy>> {
+    async create(data: PermissionPolicyCreateInput) : Promise<EntityRecordResponse<PermissionPolicyResponse>> {
         const response = await this.client.post('permission-policies', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/permission-policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission-policy/types.ts
@@ -7,5 +7,6 @@
 
 import type { PermissionPolicy } from '@authup/core-kit';
 
-export type PermissionPolicyCreatePayload = Partial<PermissionPolicy>;
-export type PermissionPolicyUpdatePayload = Partial<PermissionPolicy>;
+// Mirrors `PermissionPolicyValidator` mounts in @authup/core-kit.
+export type PermissionPolicyCreatePayload = Pick<PermissionPolicy, 'permission_id' | 'policy_id'>;
+export type PermissionPolicyUpdatePayload = Partial<PermissionPolicyCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/permission-policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission-policy/types.ts
@@ -7,6 +7,5 @@
 
 import type { PermissionPolicy } from '@authup/core-kit';
 
-export type PermissionPolicyCreateInput = Partial<PermissionPolicy>;
-export type PermissionPolicyUpdateInput = Partial<PermissionPolicy>;
-export type PermissionPolicyResponse = PermissionPolicy;
+export type PermissionPolicyCreatePayload = Partial<PermissionPolicy>;
+export type PermissionPolicyUpdatePayload = Partial<PermissionPolicy>;

--- a/packages/core-http-kit/src/domains/entities/permission-policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission-policy/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { PermissionPolicy } from '@authup/core-kit';
+
+export type PermissionPolicyCreateInput = Partial<PermissionPolicy>;
+export type PermissionPolicyUpdateInput = Partial<PermissionPolicy>;
+export type PermissionPolicyResponse = PermissionPolicy;

--- a/packages/core-http-kit/src/domains/entities/permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/permission/module.ts
@@ -13,37 +13,36 @@ import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
     PermissionAPICheckResponse,
-    PermissionCreateInput,
-    PermissionResponse,
-    PermissionSaveInput,
-    PermissionUpdateInput,
+    PermissionCreatePayload,
+    PermissionSavePayload,
+    PermissionUpdatePayload,
 } from './types';
 
 export class PermissionAPI extends BaseAPI implements EntityAPI<Permission> {
-    async getMany(data?: BuildInput<Permission>): Promise<EntityCollectionResponse<PermissionResponse>> {
+    async getMany(data?: BuildInput<Permission>): Promise<EntityCollectionResponse<Permission>> {
         const response = await this.client.get(`permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async delete(id: Permission['id']): Promise<EntityRecordResponse<PermissionResponse>> {
+    async delete(id: Permission['id']): Promise<EntityRecordResponse<Permission>> {
         const response = await this.client.delete(`permissions/${id}`);
 
         return response.data;
     }
 
-    async getOne(id: Permission['id'], record?: BuildInput<Permission>): Promise<EntityRecordResponse<PermissionResponse>> {
+    async getOne(id: Permission['id'], record?: BuildInput<Permission>): Promise<EntityRecordResponse<Permission>> {
         const response = await this.client.get(`permissions/${id}${buildQuery(record)}`);
 
         return response.data;
     }
 
-    async create(data: PermissionCreateInput): Promise<EntityRecordResponse<PermissionResponse>> {
+    async create(data: PermissionCreatePayload): Promise<EntityRecordResponse<Permission>> {
         const response = await this.client.post('permissions', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: Permission['id'], data: PermissionUpdateInput): Promise<EntityRecordResponse<PermissionResponse>> {
+    async update(id: Permission['id'], data: PermissionUpdatePayload): Promise<EntityRecordResponse<Permission>> {
         const response = await this.client.post(`permissions/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -51,8 +50,8 @@ export class PermissionAPI extends BaseAPI implements EntityAPI<Permission> {
 
     async createOrUpdate(
         idOrName: string,
-        data: PermissionSaveInput,
-    ): Promise<EntityRecordResponse<PermissionResponse>> {
+        data: PermissionSavePayload,
+    ): Promise<EntityRecordResponse<Permission>> {
         const response = await this.client.put(`permissions/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/permission/module.ts
@@ -11,33 +11,39 @@ import type { Permission } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-import type { PermissionAPICheckResponse } from './types';
+import type {
+    PermissionAPICheckResponse,
+    PermissionCreateInput,
+    PermissionResponse,
+    PermissionSaveInput,
+    PermissionUpdateInput,
+} from './types';
 
 export class PermissionAPI extends BaseAPI implements EntityAPI<Permission> {
-    async getMany(data?: BuildInput<Permission>): Promise<EntityCollectionResponse<Permission>> {
+    async getMany(data?: BuildInput<Permission>): Promise<EntityCollectionResponse<PermissionResponse>> {
         const response = await this.client.get(`permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async delete(id: Permission['id']): Promise<EntityRecordResponse<Permission>> {
+    async delete(id: Permission['id']): Promise<EntityRecordResponse<PermissionResponse>> {
         const response = await this.client.delete(`permissions/${id}`);
 
         return response.data;
     }
 
-    async getOne(id: Permission['id'], record?: BuildInput<Permission>) {
+    async getOne(id: Permission['id'], record?: BuildInput<Permission>): Promise<EntityRecordResponse<PermissionResponse>> {
         const response = await this.client.get(`permissions/${id}${buildQuery(record)}`);
 
         return response.data;
     }
 
-    async create(data: Partial<Permission>): Promise<EntityRecordResponse<Permission>> {
+    async create(data: PermissionCreateInput): Promise<EntityRecordResponse<PermissionResponse>> {
         const response = await this.client.post('permissions', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: Permission['id'], data: Partial<Permission>): Promise<EntityRecordResponse<Permission>> {
+    async update(id: Permission['id'], data: PermissionUpdateInput): Promise<EntityRecordResponse<PermissionResponse>> {
         const response = await this.client.post(`permissions/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -45,8 +51,8 @@ export class PermissionAPI extends BaseAPI implements EntityAPI<Permission> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<Permission>,
-    ): Promise<EntityRecordResponse<Permission>> {
+        data: PermissionSaveInput,
+    ): Promise<EntityRecordResponse<PermissionResponse>> {
         const response = await this.client.put(`permissions/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission/types.ts
@@ -12,6 +12,8 @@ export type PermissionAPICheckResponse = {
     data?: Record<string, any>
 };
 
-export type PermissionCreatePayload = Partial<Permission>;
-export type PermissionUpdatePayload = Partial<Permission>;
-export type PermissionSavePayload = Partial<Permission>;
+// Mirrors `PermissionValidator` mounts in @authup/core-kit.
+export type PermissionCreatePayload =    & Pick<Permission, 'name'> &
+    Partial<Pick<Permission, 'display_name' | 'description' | 'client_id' | 'realm_id' | 'decision_strategy'>>;
+export type PermissionUpdatePayload = Partial<PermissionCreatePayload>;
+export type PermissionSavePayload = PermissionCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission/types.ts
@@ -12,7 +12,6 @@ export type PermissionAPICheckResponse = {
     data?: Record<string, any>
 };
 
-export type PermissionCreateInput = Partial<Permission>;
-export type PermissionUpdateInput = Partial<Permission>;
-export type PermissionSaveInput = Partial<Permission>;
-export type PermissionResponse = Permission;
+export type PermissionCreatePayload = Partial<Permission>;
+export type PermissionUpdatePayload = Partial<Permission>;
+export type PermissionSavePayload = Partial<Permission>;

--- a/packages/core-http-kit/src/domains/entities/permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission/types.ts
@@ -5,7 +5,14 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Permission } from '@authup/core-kit';
+
 export type PermissionAPICheckResponse = {
     status: 'success' | 'error',
     data?: Record<string, any>
 };
+
+export type PermissionCreateInput = Partial<Permission>;
+export type PermissionUpdateInput = Partial<Permission>;
+export type PermissionSaveInput = Partial<Permission>;
+export type PermissionResponse = Permission;

--- a/packages/core-http-kit/src/domains/entities/permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/permission/types.ts
@@ -13,7 +13,7 @@ export type PermissionAPICheckResponse = {
 };
 
 // Mirrors `PermissionValidator` mounts in @authup/core-kit.
-export type PermissionCreatePayload =    & Pick<Permission, 'name'> &
+export type PermissionCreatePayload = Pick<Permission, 'name'> &
     Partial<Pick<Permission, 'display_name' | 'description' | 'client_id' | 'realm_id' | 'decision_strategy'>>;
 export type PermissionUpdatePayload = Partial<PermissionCreatePayload>;
 export type PermissionSavePayload = PermissionCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/policy/module.ts
+++ b/packages/core-http-kit/src/domains/entities/policy/module.ts
@@ -12,13 +12,13 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    BuiltInPolicyCreateRequest,
-    BuiltInPolicyResponse, 
-    BuiltInPolicyUpdateRequest, 
-    PolicyAPICheckResponse, 
-    PolicyCreateRequest, 
-    PolicyResponse, 
-    PolicyUpdateRequest,
+    BuiltInPolicyCreatePayload,
+    BuiltInPolicyResponse,
+    BuiltInPolicyUpdatePayload,
+    PolicyAPICheckResponse,
+    PolicyCreatePayload,
+    PolicyResponse,
+    PolicyUpdatePayload,
 } from './types';
 
 export class PolicyAPI extends BaseAPI implements EntityAPI<Policy> {
@@ -54,7 +54,7 @@ export class PolicyAPI extends BaseAPI implements EntityAPI<Policy> {
     }
 
     async create<
-        INPUT extends PolicyCreateRequest = PolicyCreateRequest,
+        INPUT extends PolicyCreatePayload = PolicyCreatePayload,
         OUTPUT extends PolicyResponse = PolicyResponse,
     >(data: INPUT): Promise<EntityRecordResponse<OUTPUT>> {
         const response = await this.client.post('policies', nullifyEmptyObjectProperties(data));
@@ -63,13 +63,13 @@ export class PolicyAPI extends BaseAPI implements EntityAPI<Policy> {
     }
 
     async createBuiltIn(
-        data: BuiltInPolicyCreateRequest,
+        data: BuiltInPolicyCreatePayload,
     ): Promise<EntityRecordResponse<BuiltInPolicyResponse>> {
         return this.create(data);
     }
 
     async update<
-        INPUT extends PolicyUpdateRequest = PolicyUpdateRequest,
+        INPUT extends PolicyUpdatePayload = PolicyUpdatePayload,
         OUTPUT extends PolicyResponse = PolicyResponse,
     >(id: Policy['id'], data: INPUT): Promise<EntityRecordResponse<OUTPUT>> {
         const response = await this.client.post(`policies/${id}`, nullifyEmptyObjectProperties(data));
@@ -79,13 +79,13 @@ export class PolicyAPI extends BaseAPI implements EntityAPI<Policy> {
 
     async updateBuiltIn(
         id: Policy['id'],
-        data: BuiltInPolicyUpdateRequest,
+        data: BuiltInPolicyUpdatePayload,
     ): Promise<EntityRecordResponse<BuiltInPolicyResponse>> {
         return this.update(id, data);
     }
 
     async createOrUpdate<
-        INPUT extends PolicyCreateRequest = PolicyCreateRequest,
+        INPUT extends PolicyCreatePayload = PolicyCreatePayload,
         OUTPUT extends PolicyResponse = PolicyResponse,
     >(
         idOrName: string,
@@ -98,7 +98,7 @@ export class PolicyAPI extends BaseAPI implements EntityAPI<Policy> {
 
     async createOrUpdateBuiltin(
         idOrName: string,
-        data: BuiltInPolicyCreateRequest,
+        data: BuiltInPolicyCreatePayload,
     ): Promise<EntityRecordResponse<BuiltInPolicyResponse>> {
         return this.createOrUpdate(idOrName, data);
     }

--- a/packages/core-http-kit/src/domains/entities/policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/policy/types.ts
@@ -21,7 +21,7 @@ export type BuiltInPolicyResponse<
 
 // Mirrors `PolicyValidator` mounts in @authup/core-kit. Policies carry dynamic per-type
 // attributes loaded as extra-attributes; the `& Record<string, any>` keeps those open.
-type PolicyValidatedFields =    & Pick<Policy, 'name' | 'type'> &
+type PolicyValidatedFields = Pick<Policy, 'name' | 'type'> &
     Partial<Pick<Policy, 'display_name' | 'invert' | 'parent_id' | 'realm_id'>>;
 export type PolicyCreatePayload = PolicyValidatedFields & Record<string, any>;
 export type PolicyUpdatePayload = Partial<PolicyValidatedFields> & Record<string, any>;
@@ -32,4 +32,4 @@ export type BuiltInPolicyCreatePayload<
 > = Omit<PolicyValidatedFields, 'type'> & BuiltInPolicies<T>;
 export type BuiltInPolicyUpdatePayload<
     T extends Record<string, any> = Record<string, any>,
-> = Partial<Omit<PolicyValidatedFields, 'type'>> & BuiltInPolicies<T>;
+> = Partial<Omit<PolicyValidatedFields, 'type'>> & Partial<BuiltInPolicies<T>>;

--- a/packages/core-http-kit/src/domains/entities/policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/policy/types.ts
@@ -19,20 +19,18 @@ export type BuiltInPolicyResponse<
     T extends Record<string, any> = Record<string, any>,
 > = Omit<Policy, 'type'> & BuiltInPolicies<T>;
 
-type PolicyCreateSubset = Pick<Policy, 'name'> &
-Partial<Pick<Policy, 'display_name' | 'description' | 'invert'>> & {
-    parent_id?: string | null
-};
-export type PolicyCreatePayload = PolicyCreateSubset & Record<string, any>;
+// Mirrors `PolicyValidator` mounts in @authup/core-kit. Policies carry dynamic per-type
+// attributes loaded as extra-attributes; the `& Record<string, any>` keeps those open.
+type PolicyValidatedFields =    & Pick<Policy, 'name' | 'type'> &
+    Partial<Pick<Policy, 'display_name' | 'invert' | 'realm_id'>> &
+    { parent_id?: string | null };
+export type PolicyCreatePayload = PolicyValidatedFields & Record<string, any>;
+export type PolicyUpdatePayload = Partial<PolicyValidatedFields> & Record<string, any>;
 export type PolicySavePayload = PolicyCreatePayload;
 
 export type BuiltInPolicyCreatePayload<
     T extends Record<string, any> = Record<string, any>,
-> = PolicyCreateSubset & BuiltInPolicies<T>;
-
-type PolicyUpdateSubset = Partial<PolicyCreateSubset>;
-
-export type PolicyUpdatePayload = PolicyUpdateSubset & Record<string, any>;
+> = Omit<PolicyValidatedFields, 'type'> & BuiltInPolicies<T>;
 export type BuiltInPolicyUpdatePayload<
     T extends Record<string, any> = Record<string, any>,
-> = PolicyUpdateSubset & BuiltInPolicies<T>;
+> = Partial<Omit<PolicyValidatedFields, 'type'>> & BuiltInPolicies<T>;

--- a/packages/core-http-kit/src/domains/entities/policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/policy/types.ts
@@ -24,6 +24,7 @@ Partial<Pick<Policy, 'display_name' | 'description' | 'invert'>> & {
     parent_id?: string | null
 };
 export type PolicyCreateRequest = PolicyCreateSubset & Record<string, any>;
+export type PolicyCreateInput = PolicyCreateRequest;
 
 export type BuiltInPolicyCreateRequest<
     T extends Record<string, any> = Record<string, any>,
@@ -32,6 +33,8 @@ export type BuiltInPolicyCreateRequest<
 type PolicyUpdateSubset = Partial<PolicyCreateSubset>;
 
 export type PolicyUpdateRequest = PolicyUpdateSubset & Record<string, any>;
+export type PolicyUpdateInput = PolicyUpdateRequest;
+export type PolicySaveInput = PolicyCreateRequest;
 export type BuiltInPolicyUpdateRequest<
     T extends Record<string, any> = Record<string, any>,
 > = PolicyUpdateSubset & BuiltInPolicies<T>;

--- a/packages/core-http-kit/src/domains/entities/policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/policy/types.ts
@@ -22,8 +22,7 @@ export type BuiltInPolicyResponse<
 // Mirrors `PolicyValidator` mounts in @authup/core-kit. Policies carry dynamic per-type
 // attributes loaded as extra-attributes; the `& Record<string, any>` keeps those open.
 type PolicyValidatedFields =    & Pick<Policy, 'name' | 'type'> &
-    Partial<Pick<Policy, 'display_name' | 'invert' | 'realm_id'>> &
-    { parent_id?: string | null };
+    Partial<Pick<Policy, 'display_name' | 'invert' | 'parent_id' | 'realm_id'>>;
 export type PolicyCreatePayload = PolicyValidatedFields & Record<string, any>;
 export type PolicyUpdatePayload = Partial<PolicyValidatedFields> & Record<string, any>;
 export type PolicySavePayload = PolicyCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/policy/types.ts
+++ b/packages/core-http-kit/src/domains/entities/policy/types.ts
@@ -23,18 +23,16 @@ type PolicyCreateSubset = Pick<Policy, 'name'> &
 Partial<Pick<Policy, 'display_name' | 'description' | 'invert'>> & {
     parent_id?: string | null
 };
-export type PolicyCreateRequest = PolicyCreateSubset & Record<string, any>;
-export type PolicyCreateInput = PolicyCreateRequest;
+export type PolicyCreatePayload = PolicyCreateSubset & Record<string, any>;
+export type PolicySavePayload = PolicyCreatePayload;
 
-export type BuiltInPolicyCreateRequest<
+export type BuiltInPolicyCreatePayload<
     T extends Record<string, any> = Record<string, any>,
 > = PolicyCreateSubset & BuiltInPolicies<T>;
 
 type PolicyUpdateSubset = Partial<PolicyCreateSubset>;
 
-export type PolicyUpdateRequest = PolicyUpdateSubset & Record<string, any>;
-export type PolicyUpdateInput = PolicyUpdateRequest;
-export type PolicySaveInput = PolicyCreateRequest;
-export type BuiltInPolicyUpdateRequest<
+export type PolicyUpdatePayload = PolicyUpdateSubset & Record<string, any>;
+export type BuiltInPolicyUpdatePayload<
     T extends Record<string, any> = Record<string, any>,
 > = PolicyUpdateSubset & BuiltInPolicies<T>;

--- a/packages/core-http-kit/src/domains/entities/realm/index.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/realm/module.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/module.ts
@@ -11,33 +11,39 @@ import type { Realm } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    RealmCreateInput,
+    RealmResponse,
+    RealmSaveInput,
+    RealmUpdateInput,
+} from './types';
 
 export class RealmAPI extends BaseAPI implements EntityAPI<Realm> {
-    async getMany(data?: BuildInput<Realm>): Promise<EntityCollectionResponse<Realm>> {
+    async getMany(data?: BuildInput<Realm>): Promise<EntityCollectionResponse<RealmResponse>> {
         const response = await this.client.get(`realms${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: Realm['id']): Promise<EntityRecordResponse<Realm>> {
+    async getOne(id: Realm['id']): Promise<EntityRecordResponse<RealmResponse>> {
         const response = await this.client.get(`realms/${id}`);
 
         return response.data;
     }
 
-    async delete(id: Realm['id']): Promise<EntityRecordResponse<Realm>> {
+    async delete(id: Realm['id']): Promise<EntityRecordResponse<RealmResponse>> {
         const response = await this.client.delete(`realms/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<Realm>): Promise<EntityRecordResponse<Realm>> {
+    async create(data: RealmCreateInput): Promise<EntityRecordResponse<RealmResponse>> {
         const response = await this.client.post('realms', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(realmId: Realm['id'], data: Partial<Realm>): Promise<EntityRecordResponse<Realm>> {
+    async update(realmId: Realm['id'], data: RealmUpdateInput): Promise<EntityRecordResponse<RealmResponse>> {
         const response = await this.client.post(`realms/${realmId}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -45,8 +51,8 @@ export class RealmAPI extends BaseAPI implements EntityAPI<Realm> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<Realm>,
-    ): Promise<EntityRecordResponse<Realm>> {
+        data: RealmSaveInput,
+    ): Promise<EntityRecordResponse<RealmResponse>> {
         const response = await this.client.put(`realms/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/realm/module.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/module.ts
@@ -12,38 +12,37 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    RealmCreateInput,
-    RealmResponse,
-    RealmSaveInput,
-    RealmUpdateInput,
+    RealmCreatePayload,
+    RealmSavePayload,
+    RealmUpdatePayload,
 } from './types';
 
 export class RealmAPI extends BaseAPI implements EntityAPI<Realm> {
-    async getMany(data?: BuildInput<Realm>): Promise<EntityCollectionResponse<RealmResponse>> {
+    async getMany(data?: BuildInput<Realm>): Promise<EntityCollectionResponse<Realm>> {
         const response = await this.client.get(`realms${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: Realm['id']): Promise<EntityRecordResponse<RealmResponse>> {
+    async getOne(id: Realm['id']): Promise<EntityRecordResponse<Realm>> {
         const response = await this.client.get(`realms/${id}`);
 
         return response.data;
     }
 
-    async delete(id: Realm['id']): Promise<EntityRecordResponse<RealmResponse>> {
+    async delete(id: Realm['id']): Promise<EntityRecordResponse<Realm>> {
         const response = await this.client.delete(`realms/${id}`);
 
         return response.data;
     }
 
-    async create(data: RealmCreateInput): Promise<EntityRecordResponse<RealmResponse>> {
+    async create(data: RealmCreatePayload): Promise<EntityRecordResponse<Realm>> {
         const response = await this.client.post('realms', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(realmId: Realm['id'], data: RealmUpdateInput): Promise<EntityRecordResponse<RealmResponse>> {
+    async update(realmId: Realm['id'], data: RealmUpdatePayload): Promise<EntityRecordResponse<Realm>> {
         const response = await this.client.post(`realms/${realmId}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -51,8 +50,8 @@ export class RealmAPI extends BaseAPI implements EntityAPI<Realm> {
 
     async createOrUpdate(
         idOrName: string,
-        data: RealmSaveInput,
-    ): Promise<EntityRecordResponse<RealmResponse>> {
+        data: RealmSavePayload,
+    ): Promise<EntityRecordResponse<Realm>> {
         const response = await this.client.put(`realms/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/realm/types.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/types.ts
@@ -8,7 +8,7 @@
 import type { Realm } from '@authup/core-kit';
 
 // Mirrors `RealmValidator` mounts in @authup/core-kit.
-export type RealmCreatePayload =    & Pick<Realm, 'name'> &
+export type RealmCreatePayload = Pick<Realm, 'name'> &
     Partial<Pick<Realm, 'display_name' | 'description'>>;
 export type RealmUpdatePayload = Partial<RealmCreatePayload>;
 export type RealmSavePayload = RealmCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/realm/types.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/types.ts
@@ -7,7 +7,6 @@
 
 import type { Realm } from '@authup/core-kit';
 
-export type RealmCreateInput = Partial<Realm>;
-export type RealmUpdateInput = Partial<Realm>;
-export type RealmSaveInput = Partial<Realm>;
-export type RealmResponse = Realm;
+export type RealmCreatePayload = Partial<Realm>;
+export type RealmUpdatePayload = Partial<Realm>;
+export type RealmSavePayload = Partial<Realm>;

--- a/packages/core-http-kit/src/domains/entities/realm/types.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/types.ts
@@ -7,6 +7,8 @@
 
 import type { Realm } from '@authup/core-kit';
 
-export type RealmCreatePayload = Partial<Realm>;
-export type RealmUpdatePayload = Partial<Realm>;
-export type RealmSavePayload = Partial<Realm>;
+// Mirrors `RealmValidator` mounts in @authup/core-kit.
+export type RealmCreatePayload =    & Pick<Realm, 'name'> &
+    Partial<Pick<Realm, 'display_name' | 'description'>>;
+export type RealmUpdatePayload = Partial<RealmCreatePayload>;
+export type RealmSavePayload = RealmCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/realm/types.ts
+++ b/packages/core-http-kit/src/domains/entities/realm/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Realm } from '@authup/core-kit';
+
+export type RealmCreateInput = Partial<Realm>;
+export type RealmUpdateInput = Partial<Realm>;
+export type RealmSaveInput = Partial<Realm>;
+export type RealmResponse = Realm;

--- a/packages/core-http-kit/src/domains/entities/robot-permission/index.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/robot-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/module.ts
@@ -10,32 +10,37 @@ import { buildQuery } from 'rapiq';
 import type { RobotPermission } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    RobotPermissionCreateInput,
+    RobotPermissionResponse,
+    RobotPermissionUpdateInput,
+} from './types';
 
 export class RobotPermissionAPI extends BaseAPI implements EntityAPI<RobotPermission> {
-    async getMany(data?: BuildInput<RobotPermission>) : Promise<EntityCollectionResponse<RobotPermission>> {
+    async getMany(data?: BuildInput<RobotPermission>) : Promise<EntityCollectionResponse<RobotPermissionResponse>> {
         const response = await this.client.get(`robot-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: RobotPermission['id'], data?: BuildInput<RobotPermission>) : Promise<EntityRecordResponse<RobotPermission>> {
+    async getOne(id: RobotPermission['id'], data?: BuildInput<RobotPermission>) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
         const response = await this.client.get(`robot-permissions/${id}${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async delete(id: RobotPermission['id']) : Promise<EntityRecordResponse<RobotPermission>> {
+    async delete(id: RobotPermission['id']) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
         const response = await this.client.delete(`robot-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<RobotPermission>) : Promise<EntityRecordResponse<RobotPermission>> {
+    async create(data: RobotPermissionCreateInput) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
         const response = await this.client.post('robot-permissions', data);
 
         return response.data;
     }
 
-    async update(id: RobotPermission['id'], data: Partial<RobotPermission>) : Promise<EntityRecordResponse<RobotPermission>> {
+    async update(id: RobotPermission['id'], data: RobotPermissionUpdateInput) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
         const response = await this.client.post(`robot-permissions/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/robot-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/module.ts
@@ -11,36 +11,35 @@ import type { RobotPermission } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    RobotPermissionCreateInput,
-    RobotPermissionResponse,
-    RobotPermissionUpdateInput,
+    RobotPermissionCreatePayload,
+    RobotPermissionUpdatePayload,
 } from './types';
 
 export class RobotPermissionAPI extends BaseAPI implements EntityAPI<RobotPermission> {
-    async getMany(data?: BuildInput<RobotPermission>) : Promise<EntityCollectionResponse<RobotPermissionResponse>> {
+    async getMany(data?: BuildInput<RobotPermission>) : Promise<EntityCollectionResponse<RobotPermission>> {
         const response = await this.client.get(`robot-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: RobotPermission['id'], data?: BuildInput<RobotPermission>) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
+    async getOne(id: RobotPermission['id'], data?: BuildInput<RobotPermission>) : Promise<EntityRecordResponse<RobotPermission>> {
         const response = await this.client.get(`robot-permissions/${id}${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async delete(id: RobotPermission['id']) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
+    async delete(id: RobotPermission['id']) : Promise<EntityRecordResponse<RobotPermission>> {
         const response = await this.client.delete(`robot-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: RobotPermissionCreateInput) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
+    async create(data: RobotPermissionCreatePayload) : Promise<EntityRecordResponse<RobotPermission>> {
         const response = await this.client.post('robot-permissions', data);
 
         return response.data;
     }
 
-    async update(id: RobotPermission['id'], data: RobotPermissionUpdateInput) : Promise<EntityRecordResponse<RobotPermissionResponse>> {
+    async update(id: RobotPermission['id'], data: RobotPermissionUpdatePayload) : Promise<EntityRecordResponse<RobotPermission>> {
         const response = await this.client.post(`robot-permissions/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { RobotPermission } from '@authup/core-kit';
+
+export type RobotPermissionCreateInput = Partial<RobotPermission>;
+export type RobotPermissionUpdateInput = Partial<RobotPermission>;
+export type RobotPermissionResponse = RobotPermission;

--- a/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
@@ -7,5 +7,7 @@
 
 import type { RobotPermission } from '@authup/core-kit';
 
-export type RobotPermissionCreatePayload = Partial<RobotPermission>;
-export type RobotPermissionUpdatePayload = Partial<RobotPermission>;
+// Mirrors `RobotPermissionValidator` mounts in @authup/core-kit.
+export type RobotPermissionCreatePayload =    & Pick<RobotPermission, 'robot_id' | 'permission_id'> &
+    Partial<Pick<RobotPermission, 'policy_id'>>;
+export type RobotPermissionUpdatePayload = Partial<RobotPermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
@@ -8,6 +8,6 @@
 import type { RobotPermission } from '@authup/core-kit';
 
 // Mirrors `RobotPermissionValidator` mounts in @authup/core-kit.
-export type RobotPermissionCreatePayload =    & Pick<RobotPermission, 'robot_id' | 'permission_id'> &
+export type RobotPermissionCreatePayload = Pick<RobotPermission, 'robot_id' | 'permission_id'> &
     Partial<Pick<RobotPermission, 'policy_id'>>;
 export type RobotPermissionUpdatePayload = Partial<RobotPermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-permission/types.ts
@@ -7,6 +7,5 @@
 
 import type { RobotPermission } from '@authup/core-kit';
 
-export type RobotPermissionCreateInput = Partial<RobotPermission>;
-export type RobotPermissionUpdateInput = Partial<RobotPermission>;
-export type RobotPermissionResponse = RobotPermission;
+export type RobotPermissionCreatePayload = Partial<RobotPermission>;
+export type RobotPermissionUpdatePayload = Partial<RobotPermission>;

--- a/packages/core-http-kit/src/domains/entities/robot-role/index.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-role/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/robot-role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-role/module.ts
@@ -10,28 +10,28 @@ import { buildQuery } from 'rapiq';
 import type { RobotRole } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-import type { RobotRoleCreateInput, RobotRoleResponse } from './types';
+import type { RobotRoleCreatePayload } from './types';
 
 export class RobotRoleAPI extends BaseAPI implements EntityAPISlim<RobotRole> {
-    async getMany(data: BuildInput<RobotRole> = {}): Promise<EntityCollectionResponse<RobotRoleResponse>> {
+    async getMany(data: BuildInput<RobotRole> = {}): Promise<EntityCollectionResponse<RobotRole>> {
         const response = await this.client.get(`robot-roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRoleResponse>> {
+    async getOne(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRole>> {
         const response = await this.client.get(`robot-roles/${id}`);
 
         return response.data;
     }
 
-    async delete(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRoleResponse>> {
+    async delete(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRole>> {
         const response = await this.client.delete(`robot-roles/${id}`);
 
         return response.data;
     }
 
-    async create(data: RobotRoleCreateInput): Promise<EntityRecordResponse<RobotRoleResponse>> {
+    async create(data: RobotRoleCreatePayload): Promise<EntityRecordResponse<RobotRole>> {
         const response = await this.client.post('robot-roles', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/robot-role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-role/module.ts
@@ -10,27 +10,28 @@ import { buildQuery } from 'rapiq';
 import type { RobotRole } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type { RobotRoleCreateInput, RobotRoleResponse } from './types';
 
 export class RobotRoleAPI extends BaseAPI implements EntityAPISlim<RobotRole> {
-    async getMany(data: BuildInput<RobotRole> = {}): Promise<EntityCollectionResponse<RobotRole>> {
+    async getMany(data: BuildInput<RobotRole> = {}): Promise<EntityCollectionResponse<RobotRoleResponse>> {
         const response = await this.client.get(`robot-roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRole>> {
+    async getOne(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRoleResponse>> {
         const response = await this.client.get(`robot-roles/${id}`);
 
         return response.data;
     }
 
-    async delete(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRole>> {
+    async delete(id: RobotRole['id']): Promise<EntityRecordResponse<RobotRoleResponse>> {
         const response = await this.client.delete(`robot-roles/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<RobotRole>): Promise<EntityRecordResponse<RobotRole>> {
+    async create(data: RobotRoleCreateInput): Promise<EntityRecordResponse<RobotRoleResponse>> {
         const response = await this.client.post('robot-roles', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/robot-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-role/types.ts
@@ -7,4 +7,5 @@
 
 import type { RobotRole } from '@authup/core-kit';
 
-export type RobotRoleCreatePayload = Partial<RobotRole>;
+// Mirrors `RobotRoleValidator` mounts in @authup/core-kit.
+export type RobotRoleCreatePayload = Pick<RobotRole, 'robot_id' | 'role_id'>;

--- a/packages/core-http-kit/src/domains/entities/robot-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-role/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { RobotRole } from '@authup/core-kit';
+
+export type RobotRoleCreateInput = Partial<RobotRole>;
+export type RobotRoleResponse = RobotRole;

--- a/packages/core-http-kit/src/domains/entities/robot-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot-role/types.ts
@@ -7,5 +7,4 @@
 
 import type { RobotRole } from '@authup/core-kit';
 
-export type RobotRoleCreateInput = Partial<RobotRole>;
-export type RobotRoleResponse = RobotRole;
+export type RobotRoleCreatePayload = Partial<RobotRole>;

--- a/packages/core-http-kit/src/domains/entities/robot/index.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/robot/module.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/module.ts
@@ -11,11 +11,17 @@ import type { Robot } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    RobotCreateInput,
+    RobotResponse,
+    RobotSaveInput,
+    RobotUpdateInput,
+} from './types';
 
 export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
     async getMany(
         options?: BuildInput<Robot>,
-    ): Promise<EntityCollectionResponse<Robot>> {
+    ): Promise<EntityCollectionResponse<RobotResponse>> {
         const response = await this.client
             .get(`robots${buildQuery(options)}`);
 
@@ -25,7 +31,7 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
     async getOne(
         id: Robot['id'],
         options?: BuildInput<Robot>,
-    ): Promise<EntityRecordResponse<Robot>> {
+    ): Promise<EntityRecordResponse<RobotResponse>> {
         const response = await this.client
             .get(`robots/${id}${buildQuery(options)}`);
 
@@ -34,7 +40,7 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async delete(
         id: Robot['id'],
-    ): Promise<EntityRecordResponse<Robot>> {
+    ): Promise<EntityRecordResponse<RobotResponse>> {
         const response = await this.client
             .delete(`robots/${id}`);
 
@@ -42,8 +48,8 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
     }
 
     async create(
-        data: Partial<Robot>,
-    ): Promise<EntityRecordResponse<Robot>> {
+        data: RobotCreateInput,
+    ): Promise<EntityRecordResponse<RobotResponse>> {
         const response = await this.client
             .post('robots', nullifyEmptyObjectProperties(data));
 
@@ -52,8 +58,8 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async update(
         id: Robot['id'],
-        data: Partial<Robot>,
-    ): Promise<EntityRecordResponse<Robot>> {
+        data: RobotUpdateInput,
+    ): Promise<EntityRecordResponse<RobotResponse>> {
         const response = await this.client.post(`robots/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -61,8 +67,8 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<Robot>,
-    ): Promise<EntityRecordResponse<Robot>> {
+        data: RobotSaveInput,
+    ): Promise<EntityRecordResponse<RobotResponse>> {
         const response = await this.client.put(`robots/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -70,7 +76,7 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async integrity(
         id: Robot['id'] | Robot['name'],
-    ): Promise<EntityRecordResponse<Robot>> {
+    ): Promise<EntityRecordResponse<RobotResponse>> {
         const { data: response } = await this.client
             .get(`robots/${id}/integrity`);
 

--- a/packages/core-http-kit/src/domains/entities/robot/module.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/module.ts
@@ -12,16 +12,15 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    RobotCreateInput,
-    RobotResponse,
-    RobotSaveInput,
-    RobotUpdateInput,
+    RobotCreatePayload,
+    RobotSavePayload,
+    RobotUpdatePayload,
 } from './types';
 
 export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
     async getMany(
         options?: BuildInput<Robot>,
-    ): Promise<EntityCollectionResponse<RobotResponse>> {
+    ): Promise<EntityCollectionResponse<Robot>> {
         const response = await this.client
             .get(`robots${buildQuery(options)}`);
 
@@ -31,7 +30,7 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
     async getOne(
         id: Robot['id'],
         options?: BuildInput<Robot>,
-    ): Promise<EntityRecordResponse<RobotResponse>> {
+    ): Promise<EntityRecordResponse<Robot>> {
         const response = await this.client
             .get(`robots/${id}${buildQuery(options)}`);
 
@@ -40,7 +39,7 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async delete(
         id: Robot['id'],
-    ): Promise<EntityRecordResponse<RobotResponse>> {
+    ): Promise<EntityRecordResponse<Robot>> {
         const response = await this.client
             .delete(`robots/${id}`);
 
@@ -48,8 +47,8 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
     }
 
     async create(
-        data: RobotCreateInput,
-    ): Promise<EntityRecordResponse<RobotResponse>> {
+        data: RobotCreatePayload,
+    ): Promise<EntityRecordResponse<Robot>> {
         const response = await this.client
             .post('robots', nullifyEmptyObjectProperties(data));
 
@@ -58,8 +57,8 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async update(
         id: Robot['id'],
-        data: RobotUpdateInput,
-    ): Promise<EntityRecordResponse<RobotResponse>> {
+        data: RobotUpdatePayload,
+    ): Promise<EntityRecordResponse<Robot>> {
         const response = await this.client.post(`robots/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -67,8 +66,8 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async createOrUpdate(
         idOrName: string,
-        data: RobotSaveInput,
-    ): Promise<EntityRecordResponse<RobotResponse>> {
+        data: RobotSavePayload,
+    ): Promise<EntityRecordResponse<Robot>> {
         const response = await this.client.put(`robots/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -76,7 +75,7 @@ export class RobotAPI extends BaseAPI implements EntityAPI<Robot> {
 
     async integrity(
         id: Robot['id'] | Robot['name'],
-    ): Promise<EntityRecordResponse<RobotResponse>> {
+    ): Promise<EntityRecordResponse<Robot>> {
         const { data: response } = await this.client
             .get(`robots/${id}/integrity`);
 

--- a/packages/core-http-kit/src/domains/entities/robot/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Robot } from '@authup/core-kit';
+
+export type RobotCreateInput = Partial<Robot>;
+export type RobotUpdateInput = Partial<Robot>;
+export type RobotSaveInput = Partial<Robot>;
+export type RobotResponse = Robot;

--- a/packages/core-http-kit/src/domains/entities/robot/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/types.ts
@@ -7,7 +7,6 @@
 
 import type { Robot } from '@authup/core-kit';
 
-export type RobotCreateInput = Partial<Robot>;
-export type RobotUpdateInput = Partial<Robot>;
-export type RobotSaveInput = Partial<Robot>;
-export type RobotResponse = Robot;
+export type RobotCreatePayload = Partial<Robot>;
+export type RobotUpdatePayload = Partial<Robot>;
+export type RobotSavePayload = Partial<Robot>;

--- a/packages/core-http-kit/src/domains/entities/robot/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/types.ts
@@ -7,6 +7,13 @@
 
 import type { Robot } from '@authup/core-kit';
 
-export type RobotCreatePayload = Partial<Robot>;
-export type RobotUpdatePayload = Partial<Robot>;
-export type RobotSavePayload = Partial<Robot>;
+// Mirrors `RobotValidator` mounts in @authup/core-kit.
+export type RobotCreatePayload =    & Pick<Robot, 'name'> &
+    Partial<Pick<Robot, 'secret' |
+        'active' |
+        'display_name' |
+        'description' |
+        'user_id' |
+        'realm_id'>>;
+export type RobotUpdatePayload = Partial<RobotCreatePayload>;
+export type RobotSavePayload = RobotCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/robot/types.ts
+++ b/packages/core-http-kit/src/domains/entities/robot/types.ts
@@ -8,7 +8,7 @@
 import type { Robot } from '@authup/core-kit';
 
 // Mirrors `RobotValidator` mounts in @authup/core-kit.
-export type RobotCreatePayload =    & Pick<Robot, 'name'> &
+export type RobotCreatePayload = Pick<Robot, 'name'> &
     Partial<Pick<Robot, 'secret' |
         'active' |
         'display_name' |

--- a/packages/core-http-kit/src/domains/entities/role-attribute/index.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/role-attribute/module.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/module.ts
@@ -11,33 +11,38 @@ import type { RoleAttribute } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    RoleAttributeCreateInput,
+    RoleAttributeResponse,
+    RoleAttributeUpdateInput,
+} from './types';
 
 export class RoleAttributeAPI extends BaseAPI implements EntityAPI<RoleAttribute> {
-    async getMany(data?: BuildInput<RoleAttribute>): Promise<EntityCollectionResponse<RoleAttribute>> {
+    async getMany(data?: BuildInput<RoleAttribute>): Promise<EntityCollectionResponse<RoleAttributeResponse>> {
         const response = await this.client.get(`role-attributes${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttribute>> {
+    async getOne(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttributeResponse>> {
         const response = await this.client.get(`role-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async delete(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttribute>> {
+    async delete(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttributeResponse>> {
         const response = await this.client.delete(`role-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async create(data: Partial<RoleAttribute>): Promise<EntityRecordResponse<RoleAttribute>> {
+    async create(data: RoleAttributeCreateInput): Promise<EntityRecordResponse<RoleAttributeResponse>> {
         const response = await this.client.post('role-attributes', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: RoleAttribute['id'], data: Partial<RoleAttribute>): Promise<EntityRecordResponse<RoleAttribute>> {
+    async update(id: RoleAttribute['id'], data: RoleAttributeUpdateInput): Promise<EntityRecordResponse<RoleAttributeResponse>> {
         const response = await this.client.post(`role-attributes/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/role-attribute/module.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/module.ts
@@ -12,37 +12,36 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    RoleAttributeCreateInput,
-    RoleAttributeResponse,
-    RoleAttributeUpdateInput,
+    RoleAttributeCreatePayload,
+    RoleAttributeUpdatePayload,
 } from './types';
 
 export class RoleAttributeAPI extends BaseAPI implements EntityAPI<RoleAttribute> {
-    async getMany(data?: BuildInput<RoleAttribute>): Promise<EntityCollectionResponse<RoleAttributeResponse>> {
+    async getMany(data?: BuildInput<RoleAttribute>): Promise<EntityCollectionResponse<RoleAttribute>> {
         const response = await this.client.get(`role-attributes${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttributeResponse>> {
+    async getOne(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttribute>> {
         const response = await this.client.get(`role-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async delete(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttributeResponse>> {
+    async delete(roleId: RoleAttribute['id']): Promise<EntityRecordResponse<RoleAttribute>> {
         const response = await this.client.delete(`role-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async create(data: RoleAttributeCreateInput): Promise<EntityRecordResponse<RoleAttributeResponse>> {
+    async create(data: RoleAttributeCreatePayload): Promise<EntityRecordResponse<RoleAttribute>> {
         const response = await this.client.post('role-attributes', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: RoleAttribute['id'], data: RoleAttributeUpdateInput): Promise<EntityRecordResponse<RoleAttributeResponse>> {
+    async update(id: RoleAttribute['id'], data: RoleAttributeUpdatePayload): Promise<EntityRecordResponse<RoleAttribute>> {
         const response = await this.client.post(`role-attributes/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
@@ -7,7 +7,6 @@
 
 import type { RoleAttribute } from '@authup/core-kit';
 
-export type RoleAttributeCreateInput = Partial<RoleAttribute>;
-export type RoleAttributeUpdateInput = Partial<RoleAttribute>;
-export type RoleAttributeSaveInput = Partial<RoleAttribute>;
-export type RoleAttributeResponse = RoleAttribute;
+export type RoleAttributeCreatePayload = Partial<RoleAttribute>;
+export type RoleAttributeUpdatePayload = Partial<RoleAttribute>;
+export type RoleAttributeSavePayload = Partial<RoleAttribute>;

--- a/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
@@ -8,8 +8,10 @@
 import type { RoleAttribute } from '@authup/core-kit';
 
 // `RoleAttribute` has no dedicated validator class — `RoleAttributeService` validates
-// inline and accepts `name`, `value`, and `role_id` (or a populated `role` relation).
-export type RoleAttributeCreatePayload =    & Pick<RoleAttribute, 'name'> &
-    Partial<Pick<RoleAttribute, 'value' | 'role_id'>>;
+// inline. `role_id` is required at runtime: the service sets
+// `data.realm_id = data.role.realm_id` after `validateJoinColumns` populates `data.role`
+// from the `role_id` FK, so omitting `role_id` causes a TypeError.
+export type RoleAttributeCreatePayload =    & Pick<RoleAttribute, 'name' | 'role_id'> &
+    Partial<Pick<RoleAttribute, 'value'>>;
 export type RoleAttributeUpdatePayload = Partial<RoleAttributeCreatePayload>;
 export type RoleAttributeSavePayload = RoleAttributeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
@@ -11,7 +11,7 @@ import type { RoleAttribute } from '@authup/core-kit';
 // inline. `role_id` is required at runtime: the service sets
 // `data.realm_id = data.role.realm_id` after `validateJoinColumns` populates `data.role`
 // from the `role_id` FK, so omitting `role_id` causes a TypeError.
-export type RoleAttributeCreatePayload =    & Pick<RoleAttribute, 'name' | 'role_id'> &
+export type RoleAttributeCreatePayload = Pick<RoleAttribute, 'name' | 'role_id'> &
     Partial<Pick<RoleAttribute, 'value'>>;
 export type RoleAttributeUpdatePayload = Partial<RoleAttributeCreatePayload>;
 export type RoleAttributeSavePayload = RoleAttributeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
@@ -7,6 +7,9 @@
 
 import type { RoleAttribute } from '@authup/core-kit';
 
-export type RoleAttributeCreatePayload = Partial<RoleAttribute>;
-export type RoleAttributeUpdatePayload = Partial<RoleAttribute>;
-export type RoleAttributeSavePayload = Partial<RoleAttribute>;
+// `RoleAttribute` has no dedicated validator class — `RoleAttributeService` validates
+// inline and accepts `name`, `value`, and `role_id` (or a populated `role` relation).
+export type RoleAttributeCreatePayload =    & Pick<RoleAttribute, 'name'> &
+    Partial<Pick<RoleAttribute, 'value' | 'role_id'>>;
+export type RoleAttributeUpdatePayload = Partial<RoleAttributeCreatePayload>;
+export type RoleAttributeSavePayload = RoleAttributeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-attribute/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { RoleAttribute } from '@authup/core-kit';
+
+export type RoleAttributeCreateInput = Partial<RoleAttribute>;
+export type RoleAttributeUpdateInput = Partial<RoleAttribute>;
+export type RoleAttributeSaveInput = Partial<RoleAttribute>;
+export type RoleAttributeResponse = RoleAttribute;

--- a/packages/core-http-kit/src/domains/entities/role-permission/index.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/role-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/module.ts
@@ -10,32 +10,37 @@ import { buildQuery } from 'rapiq';
 import type { RolePermission } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    RolePermissionCreateInput,
+    RolePermissionResponse,
+    RolePermissionUpdateInput,
+} from './types';
 
 export class RolePermissionAPI extends BaseAPI implements EntityAPI<RolePermission> {
-    async getMany(data?: BuildInput<RolePermission>) : Promise<EntityCollectionResponse<RolePermission>> {
+    async getMany(data?: BuildInput<RolePermission>) : Promise<EntityCollectionResponse<RolePermissionResponse>> {
         const response = await this.client.get(`role-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermission>> {
+    async getOne(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermissionResponse>> {
         const response = await this.client.get(`role-permissions/${id}`);
 
         return response.data;
     }
 
-    async delete(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermission>> {
+    async delete(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermissionResponse>> {
         const response = await this.client.delete(`role-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<RolePermission>) : Promise<EntityRecordResponse<RolePermission>> {
+    async create(data: RolePermissionCreateInput) : Promise<EntityRecordResponse<RolePermissionResponse>> {
         const response = await this.client.post('role-permissions', data);
 
         return response.data;
     }
 
-    async update(id: RolePermission['id'], data: Partial<RolePermission>) : Promise<EntityRecordResponse<RolePermission>> {
+    async update(id: RolePermission['id'], data: RolePermissionUpdateInput) : Promise<EntityRecordResponse<RolePermissionResponse>> {
         const response = await this.client.post(`role-permissions/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/role-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/module.ts
@@ -11,36 +11,35 @@ import type { RolePermission } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    RolePermissionCreateInput,
-    RolePermissionResponse,
-    RolePermissionUpdateInput,
+    RolePermissionCreatePayload,
+    RolePermissionUpdatePayload,
 } from './types';
 
 export class RolePermissionAPI extends BaseAPI implements EntityAPI<RolePermission> {
-    async getMany(data?: BuildInput<RolePermission>) : Promise<EntityCollectionResponse<RolePermissionResponse>> {
+    async getMany(data?: BuildInput<RolePermission>) : Promise<EntityCollectionResponse<RolePermission>> {
         const response = await this.client.get(`role-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermissionResponse>> {
+    async getOne(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermission>> {
         const response = await this.client.get(`role-permissions/${id}`);
 
         return response.data;
     }
 
-    async delete(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermissionResponse>> {
+    async delete(id: RolePermission['id']) : Promise<EntityRecordResponse<RolePermission>> {
         const response = await this.client.delete(`role-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: RolePermissionCreateInput) : Promise<EntityRecordResponse<RolePermissionResponse>> {
+    async create(data: RolePermissionCreatePayload) : Promise<EntityRecordResponse<RolePermission>> {
         const response = await this.client.post('role-permissions', data);
 
         return response.data;
     }
 
-    async update(id: RolePermission['id'], data: RolePermissionUpdateInput) : Promise<EntityRecordResponse<RolePermissionResponse>> {
+    async update(id: RolePermission['id'], data: RolePermissionUpdatePayload) : Promise<EntityRecordResponse<RolePermission>> {
         const response = await this.client.post(`role-permissions/${id}`, data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/role-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/types.ts
@@ -7,6 +7,5 @@
 
 import type { RolePermission } from '@authup/core-kit';
 
-export type RolePermissionCreateInput = Partial<RolePermission>;
-export type RolePermissionUpdateInput = Partial<RolePermission>;
-export type RolePermissionResponse = RolePermission;
+export type RolePermissionCreatePayload = Partial<RolePermission>;
+export type RolePermissionUpdatePayload = Partial<RolePermission>;

--- a/packages/core-http-kit/src/domains/entities/role-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/types.ts
@@ -7,5 +7,7 @@
 
 import type { RolePermission } from '@authup/core-kit';
 
-export type RolePermissionCreatePayload = Partial<RolePermission>;
-export type RolePermissionUpdatePayload = Partial<RolePermission>;
+// Mirrors `RolePermissionValidator` mounts in @authup/core-kit.
+export type RolePermissionCreatePayload =    & Pick<RolePermission, 'role_id' | 'permission_id'> &
+    Partial<Pick<RolePermission, 'policy_id'>>;
+export type RolePermissionUpdatePayload = Partial<RolePermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/role-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { RolePermission } from '@authup/core-kit';
+
+export type RolePermissionCreateInput = Partial<RolePermission>;
+export type RolePermissionUpdateInput = Partial<RolePermission>;
+export type RolePermissionResponse = RolePermission;

--- a/packages/core-http-kit/src/domains/entities/role-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role-permission/types.ts
@@ -8,6 +8,6 @@
 import type { RolePermission } from '@authup/core-kit';
 
 // Mirrors `RolePermissionValidator` mounts in @authup/core-kit.
-export type RolePermissionCreatePayload =    & Pick<RolePermission, 'role_id' | 'permission_id'> &
+export type RolePermissionCreatePayload = Pick<RolePermission, 'role_id' | 'permission_id'> &
     Partial<Pick<RolePermission, 'policy_id'>>;
 export type RolePermissionUpdatePayload = Partial<RolePermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/role/index.ts
+++ b/packages/core-http-kit/src/domains/entities/role/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/role/module.ts
@@ -12,38 +12,37 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    RoleCreateInput,
-    RoleResponse,
-    RoleSaveInput,
-    RoleUpdateInput,
+    RoleCreatePayload,
+    RoleSavePayload,
+    RoleUpdatePayload,
 } from './types';
 
 export class RoleAPI extends BaseAPI implements EntityAPI<Role> {
-    async getMany(data?: BuildInput<Role>): Promise<EntityCollectionResponse<RoleResponse>> {
+    async getMany(data?: BuildInput<Role>): Promise<EntityCollectionResponse<Role>> {
         const response = await this.client.get(`roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(roleId: Role['id']): Promise<EntityRecordResponse<RoleResponse>> {
+    async getOne(roleId: Role['id']): Promise<EntityRecordResponse<Role>> {
         const response = await this.client.get(`roles/${roleId}`);
 
         return response.data;
     }
 
-    async delete(roleId: Role['id']): Promise<EntityRecordResponse<RoleResponse>> {
+    async delete(roleId: Role['id']): Promise<EntityRecordResponse<Role>> {
         const response = await this.client.delete(`roles/${roleId}`);
 
         return response.data;
     }
 
-    async create(data: RoleCreateInput): Promise<EntityRecordResponse<RoleResponse>> {
+    async create(data: RoleCreatePayload): Promise<EntityRecordResponse<Role>> {
         const response = await this.client.post('roles', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: Role['id'], data: RoleUpdateInput): Promise<EntityRecordResponse<RoleResponse>> {
+    async update(id: Role['id'], data: RoleUpdatePayload): Promise<EntityRecordResponse<Role>> {
         const response = await this.client.post(`roles/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -51,8 +50,8 @@ export class RoleAPI extends BaseAPI implements EntityAPI<Role> {
 
     async createOrUpdate(
         idOrName: string,
-        data: RoleSaveInput,
-    ): Promise<EntityRecordResponse<RoleResponse>> {
+        data: RoleSavePayload,
+    ): Promise<EntityRecordResponse<Role>> {
         const response = await this.client.put(`roles/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/role/module.ts
@@ -11,33 +11,39 @@ import type { Role } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    RoleCreateInput,
+    RoleResponse,
+    RoleSaveInput,
+    RoleUpdateInput,
+} from './types';
 
 export class RoleAPI extends BaseAPI implements EntityAPI<Role> {
-    async getMany(data?: BuildInput<Role>): Promise<EntityCollectionResponse<Role>> {
+    async getMany(data?: BuildInput<Role>): Promise<EntityCollectionResponse<RoleResponse>> {
         const response = await this.client.get(`roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(roleId: Role['id']): Promise<EntityRecordResponse<Role>> {
+    async getOne(roleId: Role['id']): Promise<EntityRecordResponse<RoleResponse>> {
         const response = await this.client.get(`roles/${roleId}`);
 
         return response.data;
     }
 
-    async delete(roleId: Role['id']): Promise<EntityRecordResponse<Role>> {
+    async delete(roleId: Role['id']): Promise<EntityRecordResponse<RoleResponse>> {
         const response = await this.client.delete(`roles/${roleId}`);
 
         return response.data;
     }
 
-    async create(data: Partial<Role>): Promise<EntityRecordResponse<Role>> {
+    async create(data: RoleCreateInput): Promise<EntityRecordResponse<RoleResponse>> {
         const response = await this.client.post('roles', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: Role['id'], data: Partial<Role>): Promise<EntityRecordResponse<Role>> {
+    async update(id: Role['id'], data: RoleUpdateInput): Promise<EntityRecordResponse<RoleResponse>> {
         const response = await this.client.post(`roles/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -45,8 +51,8 @@ export class RoleAPI extends BaseAPI implements EntityAPI<Role> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<Role>,
-    ): Promise<EntityRecordResponse<Role>> {
+        data: RoleSaveInput,
+    ): Promise<EntityRecordResponse<RoleResponse>> {
         const response = await this.client.put(`roles/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role/types.ts
@@ -7,6 +7,8 @@
 
 import type { Role } from '@authup/core-kit';
 
-export type RoleCreatePayload = Partial<Role>;
-export type RoleUpdatePayload = Partial<Role>;
-export type RoleSavePayload = Partial<Role>;
+// Mirrors `RoleValidator` mounts in @authup/core-kit.
+export type RoleCreatePayload =    & Pick<Role, 'name'> &
+    Partial<Pick<Role, 'display_name' | 'description' | 'client_id' | 'realm_id'>>;
+export type RoleUpdatePayload = Partial<RoleCreatePayload>;
+export type RoleSavePayload = RoleCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Role } from '@authup/core-kit';
+
+export type RoleCreateInput = Partial<Role>;
+export type RoleUpdateInput = Partial<Role>;
+export type RoleSaveInput = Partial<Role>;
+export type RoleResponse = Role;

--- a/packages/core-http-kit/src/domains/entities/role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role/types.ts
@@ -8,7 +8,7 @@
 import type { Role } from '@authup/core-kit';
 
 // Mirrors `RoleValidator` mounts in @authup/core-kit.
-export type RoleCreatePayload =    & Pick<Role, 'name'> &
+export type RoleCreatePayload = Pick<Role, 'name'> &
     Partial<Pick<Role, 'display_name' | 'description' | 'client_id' | 'realm_id'>>;
 export type RoleUpdatePayload = Partial<RoleCreatePayload>;
 export type RoleSavePayload = RoleCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/role/types.ts
@@ -7,7 +7,6 @@
 
 import type { Role } from '@authup/core-kit';
 
-export type RoleCreateInput = Partial<Role>;
-export type RoleUpdateInput = Partial<Role>;
-export type RoleSaveInput = Partial<Role>;
-export type RoleResponse = Role;
+export type RoleCreatePayload = Partial<Role>;
+export type RoleUpdatePayload = Partial<Role>;
+export type RoleSavePayload = Partial<Role>;

--- a/packages/core-http-kit/src/domains/entities/scope/index.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/scope/module.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/module.ts
@@ -12,38 +12,37 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    ScopeCreateInput,
-    ScopeResponse,
-    ScopeSaveInput,
-    ScopeUpdateInput,
+    ScopeCreatePayload,
+    ScopeSavePayload,
+    ScopeUpdatePayload,
 } from './types';
 
 export class ScopeAPI extends BaseAPI implements EntityAPI<Scope> {
-    async getMany(data?: BuildInput<Scope>): Promise<EntityCollectionResponse<ScopeResponse>> {
+    async getMany(data?: BuildInput<Scope>): Promise<EntityCollectionResponse<Scope>> {
         const response = await this.client.get(`scopes${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: Scope['id']): Promise<EntityRecordResponse<ScopeResponse>> {
+    async getOne(id: Scope['id']): Promise<EntityRecordResponse<Scope>> {
         const response = await this.client.get(`scopes/${id}`);
 
         return response.data;
     }
 
-    async delete(id: Scope['id']): Promise<EntityRecordResponse<ScopeResponse>> {
+    async delete(id: Scope['id']): Promise<EntityRecordResponse<Scope>> {
         const response = await this.client.delete(`scopes/${id}`);
 
         return response.data;
     }
 
-    async create(data: ScopeCreateInput): Promise<EntityRecordResponse<ScopeResponse>> {
+    async create(data: ScopeCreatePayload): Promise<EntityRecordResponse<Scope>> {
         const response = await this.client.post('scopes', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: Scope['id'], data: ScopeUpdateInput): Promise<EntityRecordResponse<ScopeResponse>> {
+    async update(id: Scope['id'], data: ScopeUpdatePayload): Promise<EntityRecordResponse<Scope>> {
         const response = await this.client.post(`scopes/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -51,8 +50,8 @@ export class ScopeAPI extends BaseAPI implements EntityAPI<Scope> {
 
     async createOrUpdate(
         idOrName: string,
-        data: ScopeSaveInput,
-    ): Promise<EntityRecordResponse<ScopeResponse>> {
+        data: ScopeSavePayload,
+    ): Promise<EntityRecordResponse<Scope>> {
         const response = await this.client.put(`scopes/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/scope/module.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/module.ts
@@ -11,33 +11,39 @@ import type { Scope } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    ScopeCreateInput,
+    ScopeResponse,
+    ScopeSaveInput,
+    ScopeUpdateInput,
+} from './types';
 
 export class ScopeAPI extends BaseAPI implements EntityAPI<Scope> {
-    async getMany(data?: BuildInput<Scope>): Promise<EntityCollectionResponse<Scope>> {
+    async getMany(data?: BuildInput<Scope>): Promise<EntityCollectionResponse<ScopeResponse>> {
         const response = await this.client.get(`scopes${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: Scope['id']): Promise<EntityRecordResponse<Scope>> {
+    async getOne(id: Scope['id']): Promise<EntityRecordResponse<ScopeResponse>> {
         const response = await this.client.get(`scopes/${id}`);
 
         return response.data;
     }
 
-    async delete(id: Scope['id']): Promise<EntityRecordResponse<Scope>> {
+    async delete(id: Scope['id']): Promise<EntityRecordResponse<ScopeResponse>> {
         const response = await this.client.delete(`scopes/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<Scope>): Promise<EntityRecordResponse<Scope>> {
+    async create(data: ScopeCreateInput): Promise<EntityRecordResponse<ScopeResponse>> {
         const response = await this.client.post('scopes', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: Scope['id'], data: Partial<Scope>): Promise<EntityRecordResponse<Scope>> {
+    async update(id: Scope['id'], data: ScopeUpdateInput): Promise<EntityRecordResponse<ScopeResponse>> {
         const response = await this.client.post(`scopes/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -45,8 +51,8 @@ export class ScopeAPI extends BaseAPI implements EntityAPI<Scope> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<Scope>,
-    ): Promise<EntityRecordResponse<Scope>> {
+        data: ScopeSaveInput,
+    ): Promise<EntityRecordResponse<ScopeResponse>> {
         const response = await this.client.put(`scopes/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Scope } from '@authup/core-kit';
+
+export type ScopeCreateInput = Partial<Scope>;
+export type ScopeUpdateInput = Partial<Scope>;
+export type ScopeSaveInput = Partial<Scope>;
+export type ScopeResponse = Scope;

--- a/packages/core-http-kit/src/domains/entities/scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/types.ts
@@ -8,7 +8,7 @@
 import type { Scope } from '@authup/core-kit';
 
 // Mirrors `ScopeValidator` mounts in @authup/core-kit.
-export type ScopeCreatePayload =    & Pick<Scope, 'name'> &
+export type ScopeCreatePayload = Pick<Scope, 'name'> &
     Partial<Pick<Scope, 'display_name' | 'description' | 'realm_id'>>;
 export type ScopeUpdatePayload = Partial<ScopeCreatePayload>;
 export type ScopeSavePayload = ScopeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/types.ts
@@ -7,6 +7,8 @@
 
 import type { Scope } from '@authup/core-kit';
 
-export type ScopeCreatePayload = Partial<Scope>;
-export type ScopeUpdatePayload = Partial<Scope>;
-export type ScopeSavePayload = Partial<Scope>;
+// Mirrors `ScopeValidator` mounts in @authup/core-kit.
+export type ScopeCreatePayload =    & Pick<Scope, 'name'> &
+    Partial<Pick<Scope, 'display_name' | 'description' | 'realm_id'>>;
+export type ScopeUpdatePayload = Partial<ScopeCreatePayload>;
+export type ScopeSavePayload = ScopeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/scope/types.ts
+++ b/packages/core-http-kit/src/domains/entities/scope/types.ts
@@ -7,7 +7,6 @@
 
 import type { Scope } from '@authup/core-kit';
 
-export type ScopeCreateInput = Partial<Scope>;
-export type ScopeUpdateInput = Partial<Scope>;
-export type ScopeSaveInput = Partial<Scope>;
-export type ScopeResponse = Scope;
+export type ScopeCreatePayload = Partial<Scope>;
+export type ScopeUpdatePayload = Partial<Scope>;
+export type ScopeSavePayload = Partial<Scope>;

--- a/packages/core-http-kit/src/domains/entities/user-attribute/index.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/user-attribute/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/module.ts
@@ -11,33 +11,38 @@ import type { UserAttribute } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    UserAttributeCreateInput,
+    UserAttributeResponse,
+    UserAttributeUpdateInput,
+} from './types';
 
 export class UserAttributeAPI extends BaseAPI implements EntityAPI<UserAttribute> {
-    async getMany(data?: BuildInput<UserAttribute>): Promise<EntityCollectionResponse<UserAttribute>> {
+    async getMany(data?: BuildInput<UserAttribute>): Promise<EntityCollectionResponse<UserAttributeResponse>> {
         const response = await this.client.get(`user-attributes${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttribute>> {
+    async getOne(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttributeResponse>> {
         const response = await this.client.get(`user-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async delete(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttribute>> {
+    async delete(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttributeResponse>> {
         const response = await this.client.delete(`user-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async create(data: Partial<UserAttribute>): Promise<EntityRecordResponse<UserAttribute>> {
+    async create(data: UserAttributeCreateInput): Promise<EntityRecordResponse<UserAttributeResponse>> {
         const response = await this.client.post('user-attributes', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: UserAttribute['id'], data: Partial<UserAttribute>): Promise<EntityRecordResponse<UserAttribute>> {
+    async update(id: UserAttribute['id'], data: UserAttributeUpdateInput): Promise<EntityRecordResponse<UserAttributeResponse>> {
         const response = await this.client.post(`user-attributes/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/user-attribute/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/module.ts
@@ -12,37 +12,36 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    UserAttributeCreateInput,
-    UserAttributeResponse,
-    UserAttributeUpdateInput,
+    UserAttributeCreatePayload,
+    UserAttributeUpdatePayload,
 } from './types';
 
 export class UserAttributeAPI extends BaseAPI implements EntityAPI<UserAttribute> {
-    async getMany(data?: BuildInput<UserAttribute>): Promise<EntityCollectionResponse<UserAttributeResponse>> {
+    async getMany(data?: BuildInput<UserAttribute>): Promise<EntityCollectionResponse<UserAttribute>> {
         const response = await this.client.get(`user-attributes${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttributeResponse>> {
+    async getOne(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttribute>> {
         const response = await this.client.get(`user-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async delete(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttributeResponse>> {
+    async delete(roleId: UserAttribute['id']): Promise<EntityRecordResponse<UserAttribute>> {
         const response = await this.client.delete(`user-attributes/${roleId}`);
 
         return response.data;
     }
 
-    async create(data: UserAttributeCreateInput): Promise<EntityRecordResponse<UserAttributeResponse>> {
+    async create(data: UserAttributeCreatePayload): Promise<EntityRecordResponse<UserAttribute>> {
         const response = await this.client.post('user-attributes', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: UserAttribute['id'], data: UserAttributeUpdateInput): Promise<EntityRecordResponse<UserAttributeResponse>> {
+    async update(id: UserAttribute['id'], data: UserAttributeUpdatePayload): Promise<EntityRecordResponse<UserAttribute>> {
         const response = await this.client.post(`user-attributes/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
@@ -9,7 +9,7 @@ import type { UserAttribute } from '@authup/core-kit';
 
 // `UserAttribute` has no dedicated validator class — `UserAttributeService` validates
 // inline and accepts `name`, `value`, and `user_id` (defaulted to the actor on self-edit).
-export type UserAttributeCreatePayload =    & Pick<UserAttribute, 'name'> &
+export type UserAttributeCreatePayload = Pick<UserAttribute, 'name'> &
     Partial<Pick<UserAttribute, 'value' | 'user_id'>>;
 export type UserAttributeUpdatePayload = Partial<UserAttributeCreatePayload>;
 export type UserAttributeSavePayload = UserAttributeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { UserAttribute } from '@authup/core-kit';
+
+export type UserAttributeCreateInput = Partial<UserAttribute>;
+export type UserAttributeUpdateInput = Partial<UserAttribute>;
+export type UserAttributeSaveInput = Partial<UserAttribute>;
+export type UserAttributeResponse = UserAttribute;

--- a/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
@@ -7,7 +7,6 @@
 
 import type { UserAttribute } from '@authup/core-kit';
 
-export type UserAttributeCreateInput = Partial<UserAttribute>;
-export type UserAttributeUpdateInput = Partial<UserAttribute>;
-export type UserAttributeSaveInput = Partial<UserAttribute>;
-export type UserAttributeResponse = UserAttribute;
+export type UserAttributeCreatePayload = Partial<UserAttribute>;
+export type UserAttributeUpdatePayload = Partial<UserAttribute>;
+export type UserAttributeSavePayload = Partial<UserAttribute>;

--- a/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-attribute/types.ts
@@ -7,6 +7,9 @@
 
 import type { UserAttribute } from '@authup/core-kit';
 
-export type UserAttributeCreatePayload = Partial<UserAttribute>;
-export type UserAttributeUpdatePayload = Partial<UserAttribute>;
-export type UserAttributeSavePayload = Partial<UserAttribute>;
+// `UserAttribute` has no dedicated validator class — `UserAttributeService` validates
+// inline and accepts `name`, `value`, and `user_id` (defaulted to the actor on self-edit).
+export type UserAttributeCreatePayload =    & Pick<UserAttribute, 'name'> &
+    Partial<Pick<UserAttribute, 'value' | 'user_id'>>;
+export type UserAttributeUpdatePayload = Partial<UserAttributeCreatePayload>;
+export type UserAttributeSavePayload = UserAttributeCreatePayload;

--- a/packages/core-http-kit/src/domains/entities/user-permission/index.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/user-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/module.ts
@@ -12,36 +12,35 @@ import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
-    UserPermissionCreateInput,
-    UserPermissionResponse,
-    UserPermissionUpdateInput,
+    UserPermissionCreatePayload,
+    UserPermissionUpdatePayload,
 } from './types';
 
 export class UserPermissionAPI extends BaseAPI implements EntityAPI<UserPermission> {
-    async getMany(data?: BuildInput<UserPermission>) : Promise<EntityCollectionResponse<UserPermissionResponse>> {
+    async getMany(data?: BuildInput<UserPermission>) : Promise<EntityCollectionResponse<UserPermission>> {
         const response = await this.client.get(`user-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermissionResponse>> {
+    async getOne(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermission>> {
         const response = await this.client.get(`user-permissions/${id}`);
 
         return response.data;
     }
 
-    async delete(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermissionResponse>> {
+    async delete(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermission>> {
         const response = await this.client.delete(`user-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: UserPermissionCreateInput) : Promise<EntityRecordResponse<UserPermissionResponse>> {
+    async create(data: UserPermissionCreatePayload) : Promise<EntityRecordResponse<UserPermission>> {
         const response = await this.client.post('user-permissions', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: UserPermission['id'], data: UserPermissionUpdateInput) : Promise<EntityRecordResponse<UserPermissionResponse>> {
+    async update(id: UserPermission['id'], data: UserPermissionUpdatePayload) : Promise<EntityRecordResponse<UserPermission>> {
         const response = await this.client.post(`user-permissions/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/user-permission/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/module.ts
@@ -11,32 +11,37 @@ import type { UserPermission } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type {
+    UserPermissionCreateInput,
+    UserPermissionResponse,
+    UserPermissionUpdateInput,
+} from './types';
 
 export class UserPermissionAPI extends BaseAPI implements EntityAPI<UserPermission> {
-    async getMany(data?: BuildInput<UserPermission>) : Promise<EntityCollectionResponse<UserPermission>> {
+    async getMany(data?: BuildInput<UserPermission>) : Promise<EntityCollectionResponse<UserPermissionResponse>> {
         const response = await this.client.get(`user-permissions${buildQuery(data)}`);
         return response.data;
     }
 
-    async getOne(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermission>> {
+    async getOne(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermissionResponse>> {
         const response = await this.client.get(`user-permissions/${id}`);
 
         return response.data;
     }
 
-    async delete(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermission>> {
+    async delete(id: UserPermission['id']) : Promise<EntityRecordResponse<UserPermissionResponse>> {
         const response = await this.client.delete(`user-permissions/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<UserPermission>) : Promise<EntityRecordResponse<UserPermission>> {
+    async create(data: UserPermissionCreateInput) : Promise<EntityRecordResponse<UserPermissionResponse>> {
         const response = await this.client.post('user-permissions', nullifyEmptyObjectProperties(data));
 
         return response.data;
     }
 
-    async update(id: UserPermission['id'], data: Partial<UserPermission>) : Promise<EntityRecordResponse<UserPermission>> {
+    async update(id: UserPermission['id'], data: UserPermissionUpdateInput) : Promise<EntityRecordResponse<UserPermissionResponse>> {
         const response = await this.client.post(`user-permissions/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/user-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { UserPermission } from '@authup/core-kit';
+
+export type UserPermissionCreateInput = Partial<UserPermission>;
+export type UserPermissionUpdateInput = Partial<UserPermission>;
+export type UserPermissionResponse = UserPermission;

--- a/packages/core-http-kit/src/domains/entities/user-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/types.ts
@@ -7,5 +7,7 @@
 
 import type { UserPermission } from '@authup/core-kit';
 
-export type UserPermissionCreatePayload = Partial<UserPermission>;
-export type UserPermissionUpdatePayload = Partial<UserPermission>;
+// Mirrors `UserPermissionValidator` mounts in @authup/core-kit.
+export type UserPermissionCreatePayload =    & Pick<UserPermission, 'user_id' | 'permission_id'> &
+    Partial<Pick<UserPermission, 'policy_id'>>;
+export type UserPermissionUpdatePayload = Partial<UserPermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/user-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/types.ts
@@ -8,6 +8,6 @@
 import type { UserPermission } from '@authup/core-kit';
 
 // Mirrors `UserPermissionValidator` mounts in @authup/core-kit.
-export type UserPermissionCreatePayload =    & Pick<UserPermission, 'user_id' | 'permission_id'> &
+export type UserPermissionCreatePayload = Pick<UserPermission, 'user_id' | 'permission_id'> &
     Partial<Pick<UserPermission, 'policy_id'>>;
 export type UserPermissionUpdatePayload = Partial<UserPermissionCreatePayload>;

--- a/packages/core-http-kit/src/domains/entities/user-permission/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-permission/types.ts
@@ -7,6 +7,5 @@
 
 import type { UserPermission } from '@authup/core-kit';
 
-export type UserPermissionCreateInput = Partial<UserPermission>;
-export type UserPermissionUpdateInput = Partial<UserPermission>;
-export type UserPermissionResponse = UserPermission;
+export type UserPermissionCreatePayload = Partial<UserPermission>;
+export type UserPermissionUpdatePayload = Partial<UserPermission>;

--- a/packages/core-http-kit/src/domains/entities/user-role/index.ts
+++ b/packages/core-http-kit/src/domains/entities/user-role/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/user-role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user-role/module.ts
@@ -10,27 +10,28 @@ import { buildQuery } from 'rapiq';
 import type { UserRole } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type { UserRoleCreateInput, UserRoleResponse } from './types';
 
 export class UserRoleAPI extends BaseAPI implements EntityAPISlim<UserRole> {
-    async getMany(data: BuildInput<UserRole> = {}): Promise<EntityCollectionResponse<UserRole>> {
+    async getMany(data: BuildInput<UserRole> = {}): Promise<EntityCollectionResponse<UserRoleResponse>> {
         const response = await this.client.get(`user-roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: UserRole['id']): Promise<EntityRecordResponse<UserRole>> {
+    async getOne(id: UserRole['id']): Promise<EntityRecordResponse<UserRoleResponse>> {
         const response = await this.client.get(`user-roles/${id}`);
 
         return response.data;
     }
 
-    async delete(id: UserRole['id']): Promise<EntityRecordResponse<UserRole>> {
+    async delete(id: UserRole['id']): Promise<EntityRecordResponse<UserRoleResponse>> {
         const response = await this.client.delete(`user-roles/${id}`);
 
         return response.data;
     }
 
-    async create(data: Partial<UserRole>): Promise<EntityRecordResponse<UserRole>> {
+    async create(data: UserRoleCreateInput): Promise<EntityRecordResponse<UserRoleResponse>> {
         const response = await this.client.post('user-roles', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/user-role/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user-role/module.ts
@@ -10,28 +10,28 @@ import { buildQuery } from 'rapiq';
 import type { UserRole } from '@authup/core-kit';
 import { BaseAPI } from '../../base';
 import type { EntityAPISlim, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-import type { UserRoleCreateInput, UserRoleResponse } from './types';
+import type { UserRoleCreatePayload } from './types';
 
 export class UserRoleAPI extends BaseAPI implements EntityAPISlim<UserRole> {
-    async getMany(data: BuildInput<UserRole> = {}): Promise<EntityCollectionResponse<UserRoleResponse>> {
+    async getMany(data: BuildInput<UserRole> = {}): Promise<EntityCollectionResponse<UserRole>> {
         const response = await this.client.get(`user-roles${buildQuery(data)}`);
 
         return response.data;
     }
 
-    async getOne(id: UserRole['id']): Promise<EntityRecordResponse<UserRoleResponse>> {
+    async getOne(id: UserRole['id']): Promise<EntityRecordResponse<UserRole>> {
         const response = await this.client.get(`user-roles/${id}`);
 
         return response.data;
     }
 
-    async delete(id: UserRole['id']): Promise<EntityRecordResponse<UserRoleResponse>> {
+    async delete(id: UserRole['id']): Promise<EntityRecordResponse<UserRole>> {
         const response = await this.client.delete(`user-roles/${id}`);
 
         return response.data;
     }
 
-    async create(data: UserRoleCreateInput): Promise<EntityRecordResponse<UserRoleResponse>> {
+    async create(data: UserRoleCreatePayload): Promise<EntityRecordResponse<UserRole>> {
         const response = await this.client.post('user-roles', data);
 
         return response.data;

--- a/packages/core-http-kit/src/domains/entities/user-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-role/types.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { UserRole } from '@authup/core-kit';
+
+export type UserRoleCreateInput = Partial<UserRole>;
+export type UserRoleResponse = UserRole;

--- a/packages/core-http-kit/src/domains/entities/user-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-role/types.ts
@@ -7,5 +7,4 @@
 
 import type { UserRole } from '@authup/core-kit';
 
-export type UserRoleCreateInput = Partial<UserRole>;
-export type UserRoleResponse = UserRole;
+export type UserRoleCreatePayload = Partial<UserRole>;

--- a/packages/core-http-kit/src/domains/entities/user-role/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-role/types.ts
@@ -7,4 +7,5 @@
 
 import type { UserRole } from '@authup/core-kit';
 
-export type UserRoleCreatePayload = Partial<UserRole>;
+// Mirrors `UserRoleValidator` mounts in @authup/core-kit.
+export type UserRoleCreatePayload = Pick<UserRole, 'user_id' | 'role_id'>;

--- a/packages/core-http-kit/src/domains/entities/user/index.ts
+++ b/packages/core-http-kit/src/domains/entities/user/index.ts
@@ -6,3 +6,5 @@
  */
 
 export * from './module';
+
+export * from './types';

--- a/packages/core-http-kit/src/domains/entities/user/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user/module.ts
@@ -13,22 +13,21 @@ import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
 import type {
     ActivateResponse,
-    PasswordForgotInput,
+    PasswordForgotPayload,
     PasswordForgotResponse,
-    PasswordResetInput,
+    PasswordResetPayload,
     PasswordResetResponse,
-    RegisterInput,
+    RegisterPayload,
     RegisterResponse,
-    UserCreateInput,
-    UserResponse,
-    UserSaveInput,
-    UserUpdateInput,
+    UserCreatePayload,
+    UserSavePayload,
+    UserUpdatePayload,
 } from './types';
 
 export class UserAPI extends BaseAPI implements EntityAPI<User> {
     async getMany(
         options?: BuildInput<User>,
-    ): Promise<EntityCollectionResponse<UserResponse>> {
+    ): Promise<EntityCollectionResponse<User>> {
         const response = await this.client
             .get(`users${buildQuery(options)}`);
 
@@ -38,7 +37,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     async getOne(
         id: User['id'],
         options?: BuildInput<User>,
-    ): Promise<EntityRecordResponse<UserResponse>> {
+    ): Promise<EntityRecordResponse<User>> {
         const response = await this.client
             .get(`users/${id}${buildQuery(options)}`);
 
@@ -47,7 +46,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async delete(
         id: User['id'],
-    ): Promise<EntityRecordResponse<UserResponse>> {
+    ): Promise<EntityRecordResponse<User>> {
         const response = await this.client
             .delete(`users/${id}`);
 
@@ -55,8 +54,8 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async create(
-        data: UserCreateInput,
-    ): Promise<EntityRecordResponse<UserResponse>> {
+        data: UserCreatePayload,
+    ): Promise<EntityRecordResponse<User>> {
         const response = await this.client
             .post('users', nullifyEmptyObjectProperties(data));
 
@@ -65,8 +64,8 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async update(
         id: User['id'],
-        data: UserUpdateInput,
-    ): Promise<EntityRecordResponse<UserResponse>> {
+        data: UserUpdatePayload,
+    ): Promise<EntityRecordResponse<User>> {
         const response = await this.client.post(`users/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -74,8 +73,8 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async createOrUpdate(
         idOrName: string,
-        data: UserSaveInput,
-    ): Promise<EntityRecordResponse<UserResponse>> {
+        data: UserSavePayload,
+    ): Promise<EntityRecordResponse<User>> {
         const response = await this.client.put(`users/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -92,7 +91,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async register(
-        data: RegisterInput,
+        data: RegisterPayload,
     ): Promise<RegisterResponse> {
         const response = await this.client.post('register', nullifyEmptyObjectProperties(data));
 
@@ -100,7 +99,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async passwordForgot(
-        data: PasswordForgotInput,
+        data: PasswordForgotPayload,
     ) : Promise<PasswordForgotResponse> {
         const response = await this.client.post('password-forgot', nullifyEmptyObjectProperties(data));
 
@@ -108,7 +107,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async passwordReset(
-        data: PasswordResetInput,
+        data: PasswordResetPayload,
     ) : Promise<PasswordResetResponse> {
         const response = await this.client.post('password-reset', nullifyEmptyObjectProperties(data));
 

--- a/packages/core-http-kit/src/domains/entities/user/module.ts
+++ b/packages/core-http-kit/src/domains/entities/user/module.ts
@@ -11,23 +11,24 @@ import type { User } from '@authup/core-kit';
 import { nullifyEmptyObjectProperties } from '../../../utils';
 import { BaseAPI } from '../../base';
 import type { EntityAPI, EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
-
-export type PasswordForgotResponse = {
-    reset_expires: string;
-};
-
-export type PasswordResetResponse = {
-    reset_at: string;
-};
-
-export type RegisterResponse = {
-    active: boolean
-};
+import type {
+    ActivateResponse,
+    PasswordForgotInput,
+    PasswordForgotResponse,
+    PasswordResetInput,
+    PasswordResetResponse,
+    RegisterInput,
+    RegisterResponse,
+    UserCreateInput,
+    UserResponse,
+    UserSaveInput,
+    UserUpdateInput,
+} from './types';
 
 export class UserAPI extends BaseAPI implements EntityAPI<User> {
     async getMany(
         options?: BuildInput<User>,
-    ): Promise<EntityCollectionResponse<User>> {
+    ): Promise<EntityCollectionResponse<UserResponse>> {
         const response = await this.client
             .get(`users${buildQuery(options)}`);
 
@@ -37,7 +38,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     async getOne(
         id: User['id'],
         options?: BuildInput<User>,
-    ): Promise<EntityRecordResponse<User>> {
+    ): Promise<EntityRecordResponse<UserResponse>> {
         const response = await this.client
             .get(`users/${id}${buildQuery(options)}`);
 
@@ -46,7 +47,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async delete(
         id: User['id'],
-    ): Promise<EntityRecordResponse<User>> {
+    ): Promise<EntityRecordResponse<UserResponse>> {
         const response = await this.client
             .delete(`users/${id}`);
 
@@ -54,8 +55,8 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async create(
-        data: Partial<User>,
-    ): Promise<EntityRecordResponse<User>> {
+        data: UserCreateInput,
+    ): Promise<EntityRecordResponse<UserResponse>> {
         const response = await this.client
             .post('users', nullifyEmptyObjectProperties(data));
 
@@ -64,8 +65,8 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async update(
         id: User['id'],
-        data: Partial<User> & { password_repeat?: User['password'] },
-    ): Promise<EntityRecordResponse<User>> {
+        data: UserUpdateInput,
+    ): Promise<EntityRecordResponse<UserResponse>> {
         const response = await this.client.post(`users/${id}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -73,8 +74,8 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async createOrUpdate(
         idOrName: string,
-        data: Partial<User> & { password_repeat?: User['password'] },
-    ): Promise<EntityRecordResponse<User>> {
+        data: UserSaveInput,
+    ): Promise<EntityRecordResponse<UserResponse>> {
         const response = await this.client.put(`users/${idOrName}`, nullifyEmptyObjectProperties(data));
 
         return response.data;
@@ -84,14 +85,14 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
 
     async activate(
         token: string,
-    ): Promise<User> {
+    ): Promise<ActivateResponse> {
         const response = await this.client.post('activate', { token });
 
         return response.data;
     }
 
     async register(
-        data: Partial<Pick<User, 'email' | 'name' | 'password' | 'realm_id'>>,
+        data: RegisterInput,
     ): Promise<RegisterResponse> {
         const response = await this.client.post('register', nullifyEmptyObjectProperties(data));
 
@@ -99,7 +100,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async passwordForgot(
-        data: Partial<Pick<User, 'email' | 'name' | 'realm_id'>>,
+        data: PasswordForgotInput,
     ) : Promise<PasswordForgotResponse> {
         const response = await this.client.post('password-forgot', nullifyEmptyObjectProperties(data));
 
@@ -107,11 +108,7 @@ export class UserAPI extends BaseAPI implements EntityAPI<User> {
     }
 
     async passwordReset(
-        data: Partial<Pick<User, 'email' | 'name' | 'realm_id'>> &
-        {
-            token: string,
-            password: string 
-        },
+        data: PasswordResetInput,
     ) : Promise<PasswordResetResponse> {
         const response = await this.client.post('password-reset', nullifyEmptyObjectProperties(data));
 

--- a/packages/core-http-kit/src/domains/entities/user/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user/types.ts
@@ -7,27 +7,26 @@
 
 import type { User } from '@authup/core-kit';
 
-export type UserCreateInput = Partial<User>;
-export type UserUpdateInput = Partial<User> & { password_repeat?: User['password'] };
-export type UserSaveInput = Partial<User> & { password_repeat?: User['password'] };
-export type UserResponse = User;
+export type UserCreatePayload = Partial<User>;
+export type UserUpdatePayload = Partial<User> & { password_repeat?: User['password'] };
+export type UserSavePayload = Partial<User> & { password_repeat?: User['password'] };
 
-export type RegisterInput = Partial<Pick<User, 'email' | 'name' | 'password' | 'realm_id'>>;
+export type RegisterPayload = Partial<Pick<User, 'email' | 'name' | 'password' | 'realm_id'>>;
 export type RegisterResponse = {
     active: boolean,
 };
 
-export type ActivateInput = {
+export type ActivatePayload = {
     token: string,
 };
 export type ActivateResponse = null;
 
-export type PasswordForgotInput = Partial<Pick<User, 'email' | 'name' | 'realm_id'>>;
+export type PasswordForgotPayload = Partial<Pick<User, 'email' | 'name' | 'realm_id'>>;
 export type PasswordForgotResponse = {
     reset_expires: string,
 };
 
-export type PasswordResetInput = Partial<Pick<User, 'email' | 'name' | 'realm_id'>> & {
+export type PasswordResetPayload = Partial<Pick<User, 'email' | 'name' | 'realm_id'>> & {
     token: string,
     password: string,
 };

--- a/packages/core-http-kit/src/domains/entities/user/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user/types.ts
@@ -7,9 +7,24 @@
 
 import type { User } from '@authup/core-kit';
 
-export type UserCreatePayload = Partial<User>;
-export type UserUpdatePayload = Partial<User> & { password_repeat?: User['password'] };
-export type UserSavePayload = Partial<User> & { password_repeat?: User['password'] };
+// Mirrors `UserValidator` mounts in @authup/core-kit.
+// `password_repeat` is NOT validator-mounted but is accepted by the controller for password
+// confirmation; it is only carried on update/save shapes.
+type UserOptionalFields = Pick<User, 'name_locked' |
+    'first_name' |
+    'last_name' |
+    'display_name' |
+    'password' |
+    'active' |
+    'realm_id' |
+    'status' |
+    'status_message'>;
+
+export type UserCreatePayload =    & Pick<User, 'name' | 'email'> &
+    Partial<UserOptionalFields>;
+
+export type UserUpdatePayload = Partial<UserCreatePayload> & { password_repeat?: User['password'] };
+export type UserSavePayload = UserCreatePayload & { password_repeat?: User['password'] };
 
 export type RegisterPayload = Partial<Pick<User, 'email' | 'name' | 'password' | 'realm_id'>>;
 export type RegisterResponse = {

--- a/packages/core-http-kit/src/domains/entities/user/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user/types.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { User } from '@authup/core-kit';
+
+export type UserCreateInput = Partial<User>;
+export type UserUpdateInput = Partial<User> & { password_repeat?: User['password'] };
+export type UserSaveInput = Partial<User> & { password_repeat?: User['password'] };
+export type UserResponse = User;
+
+export type RegisterInput = Partial<Pick<User, 'email' | 'name' | 'password' | 'realm_id'>>;
+export type RegisterResponse = {
+    active: boolean,
+};
+
+export type ActivateInput = {
+    token: string,
+};
+export type ActivateResponse = null;
+
+export type PasswordForgotInput = Partial<Pick<User, 'email' | 'name' | 'realm_id'>>;
+export type PasswordForgotResponse = {
+    reset_expires: string,
+};
+
+export type PasswordResetInput = Partial<Pick<User, 'email' | 'name' | 'realm_id'>> & {
+    token: string,
+    password: string,
+};
+export type PasswordResetResponse = {
+    reset_at: string,
+};

--- a/packages/core-http-kit/src/domains/entities/user/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user/types.ts
@@ -20,7 +20,7 @@ type UserOptionalFields = Pick<User, 'name_locked' |
     'status' |
     'status_message'>;
 
-export type UserCreatePayload =    & Pick<User, 'name' | 'email'> &
+export type UserCreatePayload = Pick<User, 'name' | 'email'> &
     Partial<UserOptionalFields>;
 
 export type UserUpdatePayload = Partial<UserCreatePayload> & { password_repeat?: User['password'] };

--- a/packages/core-http-kit/src/domains/types-base.ts
+++ b/packages/core-http-kit/src/domains/types-base.ts
@@ -13,8 +13,8 @@ export type EntityRecordResponse<R> = R;
 export type EntityCollectionResponse<R> = {
     data: R[],
     meta: {
-        limit: number,
-        offset: number,
+        limit?: number,
+        offset?: number,
         total: number
     }
 };

--- a/packages/specs/src/oauth2/types.ts
+++ b/packages/specs/src/oauth2/types.ts
@@ -113,18 +113,18 @@ export type OAuth2TokenIntrospectionResponse = OAuth2TokenPayload & {
 export type OAuth2JsonWebKey = {
     alg: string,
     kid: string,
-    crv?: string | undefined;
-    d?: string | undefined;
-    dp?: string | undefined;
-    dq?: string | undefined;
-    e: string | undefined;
-    k?: string | undefined;
-    kty: string | undefined;
-    n: string | undefined;
-    p?: string | undefined;
-    q?: string | undefined;
-    qi?: string | undefined;
-    x?: string | undefined;
-    y?: string | undefined;
+    crv?: string;
+    d?: string;
+    dp?: string;
+    dq?: string;
+    e?: string;
+    k?: string;
+    kty?: string;
+    n?: string;
+    p?: string;
+    q?: string;
+    qi?: string;
+    x?: string;
+    y?: string;
     [key: string]: unknown;
 };


### PR DESCRIPTION
…or trapi schema generation

Defines named `<Entity>CreateInput`, `<Entity>UpdateInput`, `<Entity>SaveInput`, and `<Entity>Response` aliases per entity in `@authup/core-http-kit` (one shared contract for the typed Client, server controllers, and `@trapi/swagger` schema extraction). Workflow request/response types (`RegisterInput`, `ActivateInput`, `ActivateResponse`, `PasswordForgotInput`, `PasswordResetInput`) are co-located in the user types module.

All 21 entity controllers and the remaining workflow controllers (`activate`, `authorize`, `jwks`, `register`, `password-forgot`, `password-reset`, `token`) now use the typed aliases on `@DBody()` parameters and `Promise<...>` return signatures. The trapi-generated `dist/swagger.json` now ships 156 component schemas (50 inputs, 52 responses) instead of paths-only.

Adjacent fixes surfaced during the migration:
- `EntityCollectionResponse.meta.{limit,offset}` are now optional, matching what `applyQuery` actually emits.
- `Client.getJwks()` typed as `Promise<{ keys: OAuth2JsonWebKey[] }>` (not `OAuth2JsonWebKey[]`); `RealmController.getCerts` aligned to the same shape — the previous types disagreed with the runtime payload.
- `getJwksRouteHandler` / `getJwkRouteHandler` return types tightened from `Promise<any>` to the concrete OAuth2 shapes (with casts where the upstream JWK type is looser than `OAuth2JsonWebKey`).
- `ActivateResponse` corrected to `null` (the controller returns `null`, not `User`).

`.agents/architecture.md`: controller-pattern example updated to typed signatures, and the "always `Promise<any>`" rule replaced with a "use core-http-kit-sourced request/response types" rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Strengthened and standardized API/SDK request & response contracts across controllers and client libraries; collection responses and status behaviors preserved.
* **Documentation**
  * Added a Thin Controller Pattern to standardize HTTP controller conventions.
* **Bug Fix / Behavior**
  * JWKS endpoints now return a structured object with a keys array.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->