### PR TITLE
feat(server-core): mount entity controllers under /realms/:realmId

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -529,7 +529,7 @@ This applies to the six controllers that read realm context: `client`, `robot`, 
 
 **Permission model is unchanged**. `system.realm-match` still evaluates against the resolved `entity.realm_id`. Mounting `/realms/:realmId/users` does not grant cross-realm write access; an admin-in-master cannot create users in another realm regardless of which prefix is used. The dual mount is a routing convenience, not an authorization shortcut.
 
-**`RealmController` overlap**: `RealmController` itself is mounted flat at `/realms` with routes like `/realms/:id`, `/realms/:id/.well-known/openid-configuration`. The realm-resolver middleware also fires on these URLs (prefix match) — it sets `event.params.realmId` independently, while the controller reads `event.params.id`. No conflict, but one extra `realmRepository.resolve()` call per realm-CRUD request — acceptable given realm count is small.
+**`RealmController` is unaffected**: the middleware is mounted at `/realms/:realmId/:nested` (not just `/realms/:realmId`) so it only fires when there's at least one path segment after `:realmId`. Bare realm CRUD routes (`GET/POST/PUT/DELETE /realms/:id`) and sub-resource routes that belong to `RealmController` itself (`/realms/:id/.well-known/openid-configuration`, `/realms/:id/jwks`, `/realms/:id/jwks/:keyId`) are not intercepted. This is important for `PUT /realms/:id` upsert semantics — an unknown realm name in the path is a valid "create" intent, not a lookup miss.
 
 ## Policy-Permission Model (n:m)
 

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -350,6 +350,7 @@ Controller conventions:
 - Read query via `useRequestQuery(event)` from `@routup/basic/query`
 - Read path params via `@DPath('id') id: string` or `event.params.id`
 - Build actor via `buildActorContext(event)`
+- For realm-scoped writes (create / update / save) on controllers that are dual-mounted at `/realms/:realmId/<entity>`, call `applyRouteRealmIDToBody(event, data)` before delegating — route realm wins silently over body realm. For realm-scoped reads, pass `getRequestRealmID(event)` as the realm key argument. See *Realm Scoping Model → Nested Route Mounting*.
 - Delegate all work to `this.service.*()` methods
 - For non-200 statuses, set `event.response.status = 201/202` and return the value — never use `sendCreated`/`sendAccepted` because they erase the typed return value that trapi extracts.
 
@@ -445,9 +446,15 @@ adapters/http/controllers/workflows/
 
 adapters/http/request/helpers/
   actor.ts                          — buildActorContext(req) bridge function
+  realm-id.ts                       — getRequestRealmID / applyRouteRealmIDToBody / setRequestRealmID
+
+adapters/http/middleware/built-in/
+  realm-resolver/module.ts          — RealmResolverMiddleware resolves :realmId (UUID or name) → UUID
+  realm-resolver/factory.ts         — createRealmResolverMiddleware(ctx)
 
 app/modules/http/modules/
   controller.ts                     — Factory methods: creates repositories, services, and controllers
+  middleware.ts                     — HTTPMiddlewareModule (mountRealmResolver wires realm-resolver at /realms/:realmId)
 
 core/provisioning/
   entities/{entity}/types.ts        — Provisioning entity types and validators
@@ -500,6 +507,29 @@ There is no special "master realm" bypass. Access control is entirely policy-dri
 |------|-------|-----------------|
 | `admin` | All permissions, no restrictions | None |
 | `realm_admin` | All permissions except `realm_create`, `realm_update`, `realm_delete` | `system.realm-bound` on each role-permission entry |
+
+### Nested Route Mounting
+
+Realm-scoped controllers are dual-mounted via `@routup/decorators` array paths:
+
+```typescript
+@DController(['/users', '/realms/:realmId/users'])
+export class UserController { ... }
+```
+
+This applies to the six controllers that read realm context: `client`, `robot`, `user`, `permission`, `policy`, `identity-provider`. Junction controllers (e.g. `client-role`, `user-permission`) are mounted flat — their realm is implicit via the parent entity's joins.
+
+**Request flow**:
+
+1. `RealmResolverMiddleware` (mounted at `router.use('/realms/:realmId', middleware)` in `HTTPMiddlewareModule.mountRealmResolver`) fires on any URL whose first segment is `/realms/<key>`. It accepts either a UUID or a realm name, resolves via `IRealmRepository.resolve()`, and stashes the resolved UUID on `event.store[sym]` via `setRequestRealmID(event, uuid)`. Unknown realm key → `EntityNotFoundError` → 404.
+2. The decorator-mounted route subsequently re-extracts `:realmId` from the URL into `event.params.realmId`, clobbering the raw URL value with itself — this is why the resolved UUID is stored on `event.store`, not `event.params`.
+3. Controllers read the realm via `getRequestRealmID(event)` (helper in `adapters/http/request/helpers/realm-id.ts`), which prefers the stashed UUID and falls back to `event.params.realmId` for cases where the middleware didn't run.
+
+**Route-realm precedence (writes)**: controllers call `applyRouteRealmIDToBody(event, data)` at the top of `add`/`edit`/`put` (and inside `IdentityProviderController.write()`). When the route has `:realmId`, the helper overwrites `data.realm_id` with the route value — *route wins silently over body* (no `BadRequestError` for mismatch; the body value is simply discarded).
+
+**Permission model is unchanged**. `system.realm-match` still evaluates against the resolved `entity.realm_id`. Mounting `/realms/:realmId/users` does not grant cross-realm write access; an admin-in-master cannot create users in another realm regardless of which prefix is used. The dual mount is a routing convenience, not an authorization shortcut.
+
+**`RealmController` overlap**: `RealmController` itself is mounted flat at `/realms` with routes like `/realms/:id`, `/realms/:id/.well-known/openid-configuration`. The realm-resolver middleware also fires on these URLs (prefix match) — it sets `event.params.realmId` independently, while the controller reads `event.params.id`. No conflict, but one extra `realmRepository.resolve()` call per realm-CRUD request — acceptable given realm count is small.
 
 ## Policy-Permission Model (n:m)
 

--- a/apps/server-core/package.json
+++ b/apps/server-core/package.json
@@ -79,7 +79,7 @@
         "@routup/assets": "^4.1.0",
         "@routup/basic": "^2.1.0",
         "@routup/cors": "^1.0.1",
-        "@routup/decorators": "^4.1.0",
+        "@routup/decorators": "^4.2.0",
         "@routup/logger": "^1.0.0",
         "@routup/prometheus": "^3.1.0",
         "@routup/rate-limit": "^3.1.0",

--- a/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/client/module.ts
@@ -32,7 +32,9 @@ import type { IClientRepository, IClientService } from '../../../../../core/inde
 import { OAuth2ScopeAttributesResolver } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
+    applyRouteRealmIDToBody,
     buildActorContext,
+    getRequestRealmID,
     useRequestIdentity,
     useRequestScopes,
 } from '../../../request/index.ts';
@@ -43,7 +45,7 @@ export type ClientControllerContext = {
 };
 
 @DTags('oauth2')
-@DController('/clients')
+@DController(['/clients', '/realms/:realmId/clients'])
 export class ClientController {
     protected service: IClientService;
 
@@ -91,7 +93,7 @@ export class ClientController {
 
             const entity = await this.repository.findOneByIdOrName(
                 identity!.id,
-                event.params.realmId,
+                getRequestRealmID(event),
             );
 
             if (!entity) {
@@ -116,7 +118,7 @@ export class ClientController {
             id,
             actor,
             useRequestQuery(event),
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         return entity;
@@ -127,6 +129,7 @@ export class ClientController {
         @DBody() data: ClientCreatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Client> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -141,6 +144,7 @@ export class ClientController {
         @DBody() data: ClientUpdatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Client> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.update(id, data, actor);
 
@@ -155,6 +159,7 @@ export class ClientController {
         @DBody() data: ClientSavePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Client> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const {
             entity,

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -61,8 +61,10 @@ import {
     createIdentityProviderOAuth2Authenticator,
 } from '../../../../../core/index.ts';
 import {
+    applyRouteRealmIDToBody,
     getBodyRealmID,
     getRequestParamID,
+    getRequestRealmID,
     useRequestIdentityOrFail,
     useRequestParamID,
     useRequestPermissionEvaluator,
@@ -71,7 +73,7 @@ import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import type { IdentityProviderControllerContext, IdentityProviderControllerOptions } from './types.ts';
 
 @DTags('identity')
-@DController('/identity-providers')
+@DController(['/identity-providers', '/realms/:realmId/identity-providers'])
 export class IdentityProviderController {
     protected options: IdentityProviderControllerOptions;
 
@@ -146,7 +148,7 @@ export class IdentityProviderController {
 
         const entity = await this.repository.findOneByIdOrName(
             paramId,
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         if (!entity) {
@@ -360,7 +362,8 @@ export class IdentityProviderController {
         let group: string;
         const id = getRequestParamID(event, { isUUID: false });
         const body = await readRequestBody(event);
-        const realmId = getBodyRealmID(body);
+        applyRouteRealmIDToBody(event, body);
+        const realmId = getRequestRealmID(event) ?? getBodyRealmID(body);
 
         let entity: IdentityProvider | null | undefined;
         if (id) {

--- a/apps/server-core/src/adapters/http/controllers/entities/permission/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/permission/module.ts
@@ -32,7 +32,11 @@ import type {
     IPermissionService,
 } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
-import { buildActorContext } from '../../../request/index.ts';
+import {
+    applyRouteRealmIDToBody,
+    buildActorContext,
+    getRequestRealmID,
+} from '../../../request/index.ts';
 
 export type PermissionControllerContext = {
     service: IPermissionService,
@@ -40,7 +44,7 @@ export type PermissionControllerContext = {
 };
 
 @DTags('permission')
-@DController('/permissions')
+@DController(['/permissions', '/realms/:realmId/permissions'])
 export class PermissionController {
     protected service: IPermissionService;
 
@@ -72,6 +76,7 @@ export class PermissionController {
         @DBody() data: PermissionCreatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Permission> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -90,7 +95,7 @@ export class PermissionController {
             event.params.id,
             data,
             actor,
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         event.response.status = 202;
@@ -113,7 +118,7 @@ export class PermissionController {
         const entity = await this.service.getOne(
             id,
             actor,
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         return entity;
@@ -125,6 +130,7 @@ export class PermissionController {
         @DBody() data: PermissionUpdatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Permission> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -143,6 +149,7 @@ export class PermissionController {
         @DBody() data: PermissionSavePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Permission> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const {
             entity,

--- a/apps/server-core/src/adapters/http/controllers/entities/policy/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/policy/module.ts
@@ -32,7 +32,11 @@ import type {
     IPolicyService,
 } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
-import { buildActorContext } from '../../../request/index.ts';
+import {
+    applyRouteRealmIDToBody,
+    buildActorContext,
+    getRequestRealmID,
+} from '../../../request/index.ts';
 
 export type PolicyControllerContext = {
     service: IPolicyService,
@@ -40,7 +44,7 @@ export type PolicyControllerContext = {
 };
 
 @DTags('policy')
-@DController('/policies')
+@DController(['/policies', '/realms/:realmId/policies'])
 export class PolicyController {
     protected service: IPolicyService;
 
@@ -86,7 +90,7 @@ export class PolicyController {
         const entity = await this.service.getOne(
             id,
             actor,
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         return entity;
@@ -103,7 +107,7 @@ export class PolicyController {
             id,
             data,
             actor,
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         event.response.status = 202;
@@ -123,6 +127,7 @@ export class PolicyController {
         @DBody() data: PolicyUpdatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PolicyResponse> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -141,6 +146,7 @@ export class PolicyController {
         @DBody() data: PolicySavePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PolicyResponse> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
 
         const {
@@ -174,6 +180,7 @@ export class PolicyController {
         @DBody() data: PolicyCreatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<PolicyResponse> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/robot/module.ts
@@ -35,7 +35,9 @@ import { OAuth2ScopeAttributesResolver } from '../../../../../core/index.ts';
 import { RobotEntity } from '../../../../database/domains/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import {
+    applyRouteRealmIDToBody,
     buildActorContext,
+    getRequestRealmID,
     useRequestIdentity,
     useRequestScopes,
 } from '../../../request/index.ts';
@@ -48,7 +50,7 @@ export type RobotControllerContext = {
 };
 
 @DTags('robot')
-@DController('/robots')
+@DController(['/robots', '/realms/:realmId/robots'])
 export class RobotController {
     protected service: IRobotService;
 
@@ -86,6 +88,7 @@ export class RobotController {
         @DBody() data: RobotCreatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Robot> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const { entity } = await this.service.save(undefined, data, actor);
 
@@ -120,7 +123,7 @@ export class RobotController {
             identity &&
             identity.type === 'robot'
         ) {
-            const realm = await this.realmRepository.resolve(event.params.realmId, true);
+            const realm = await this.realmRepository.resolve(getRequestRealmID(event), true);
             if (
                 identity.realmId === realm.id &&
                 identity.data &&
@@ -139,7 +142,7 @@ export class RobotController {
             const resolvedId = isSelfToken(id) ? identity!.id : id;
             entity = await this.repository.findOneByIdOrName(
                 resolvedId,
-                event.params.realmId,
+                getRequestRealmID(event),
             );
 
             if (entity) {
@@ -163,7 +166,7 @@ export class RobotController {
                 id,
                 actor,
                 useRequestQuery(event),
-                event.params.realmId,
+                getRequestRealmID(event),
             );
 
             return entity;
@@ -182,6 +185,7 @@ export class RobotController {
         @DBody() data: RobotUpdatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Robot> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const { entity } = await this.service.save(
             id,
@@ -201,6 +205,7 @@ export class RobotController {
         @DBody() data: RobotSavePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<Robot> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const {
             entity,

--- a/apps/server-core/src/adapters/http/controllers/entities/user/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user/module.ts
@@ -27,7 +27,11 @@ import type {
 import type { User } from '@authup/core-kit';
 import type { IUserService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
-import { buildActorContext } from '../../../request/index.ts';
+import {
+    applyRouteRealmIDToBody,
+    buildActorContext,
+    getRequestRealmID,
+} from '../../../request/index.ts';
 import { isSelfToken } from '../../../../../utils/index.ts';
 
 export type UserControllerContext = {
@@ -35,7 +39,7 @@ export type UserControllerContext = {
 };
 
 @DTags('user')
-@DController('/users')
+@DController(['/users', '/realms/:realmId/users'])
 export class UserController {
     protected service: IUserService;
 
@@ -79,7 +83,7 @@ export class UserController {
             paramId,
             actor,
             useRequestQuery(event),
-            event.params.realmId,
+            getRequestRealmID(event),
         );
 
         return entity;
@@ -90,6 +94,7 @@ export class UserController {
         @DBody() data: UserCreatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<User> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.create(data, actor);
 
@@ -104,6 +109,7 @@ export class UserController {
         @DBody() data: UserUpdatePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<User> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const entity = await this.service.update(
             id,
@@ -122,6 +128,7 @@ export class UserController {
         @DBody() data: UserSavePayload,
         @DContext() event: IRoutupEvent,
     ): Promise<User> {
+        applyRouteRealmIDToBody(event, data);
         const actor = buildActorContext(event);
         const {
             entity,

--- a/apps/server-core/src/adapters/http/middleware/built-in/index.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/index.ts
@@ -7,6 +7,7 @@
 
 export * from './authorization/index.ts';
 export * from './loggedin/index.ts';
+export * from './realm-resolver/index.ts';
 
 export * from './assets.ts';
 export * from './basic.ts';

--- a/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/factory.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/factory.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { defineCoreHandler } from 'routup';
+import type { Handler } from 'routup';
+import { RealmResolverMiddleware } from './module.ts';
+import type { RealmResolverMiddlewareContext } from './types.ts';
+
+export function createRealmResolverMiddleware(ctx: RealmResolverMiddlewareContext): Handler {
+    const middleware = new RealmResolverMiddleware(ctx);
+
+    return defineCoreHandler(async (event) => {
+        await middleware.run(event);
+        return event.next();
+    });
+}

--- a/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/index.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module.ts';
+export * from './factory.ts';
+export * from './types.ts';

--- a/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/module.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/module.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isUUID } from '@authup/kit';
+import { EntityNotFoundError } from '@authup/errors';
+import type { IRoutupEvent } from 'routup';
+import type { IRealmRepository } from '../../../../../core/index.ts';
+import { setRequestRealmID } from '../../../request/index.ts';
+import type { RealmResolverMiddlewareContext } from './types.ts';
+
+export class RealmResolverMiddleware {
+    protected realmRepository: IRealmRepository;
+
+    constructor(ctx: RealmResolverMiddlewareContext) {
+        this.realmRepository = ctx.realmRepository;
+    }
+
+    async run(event: IRoutupEvent) {
+        const value = event.params.realmId;
+        if (typeof value !== 'string' || !value) {
+            return;
+        }
+
+        if (isUUID(value)) {
+            setRequestRealmID(event, value);
+            return;
+        }
+
+        const realm = await this.realmRepository.resolve(value);
+        if (!realm) {
+            throw new EntityNotFoundError(`realm '${value}' not found`);
+        }
+
+        setRequestRealmID(event, realm.id);
+    }
+}

--- a/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/types.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/types.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IRealmRepository } from '../../../../../core/index.ts';
+
+export type RealmResolverMiddlewareContext = {
+    realmRepository: IRealmRepository,
+};

--- a/apps/server-core/src/adapters/http/request/helpers/index.ts
+++ b/apps/server-core/src/adapters/http/request/helpers/index.ts
@@ -10,5 +10,6 @@ export * from './body-realm-id.ts';
 export * from './identity.ts';
 export * from './locations.ts';
 export * from './param-id.ts';
+export * from './realm-id.ts';
 export * from './scopes.ts';
 export * from './token.ts';

--- a/apps/server-core/src/adapters/http/request/helpers/realm-id.ts
+++ b/apps/server-core/src/adapters/http/request/helpers/realm-id.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IRoutupEvent } from 'routup';
+import { getRequestStringParam } from './param-id.ts';
+
+const sym = Symbol('RRealmID');
+
+export function setRequestRealmID(event: IRoutupEvent, id: string): void {
+    event.store[sym] = id;
+}
+
+export function getRequestRealmID(event: IRoutupEvent): string | undefined {
+    const stored = event.store[sym] as string | undefined;
+    if (stored) {
+        return stored;
+    }
+    return getRequestStringParam(event, 'realmId');
+}
+
+export function applyRouteRealmIDToBody(event: IRoutupEvent, data: Record<string, any>): void {
+    const routeRealmId = getRequestRealmID(event);
+    if (routeRealmId) {
+        data.realm_id = routeRealmId;
+    }
+}

--- a/apps/server-core/src/app/modules/http/modules/middleware.ts
+++ b/apps/server-core/src/app/modules/http/modules/middleware.ts
@@ -120,7 +120,12 @@ export class HTTPMiddlewareModule {
         const realmRepository = container.resolve<Repository<Realm>>(RealmEntity);
         const middleware = createRealmResolverMiddleware({ realmRepository: new RealmRepositoryAdapter(realmRepository) });
 
-        router.use('/realms/:realmId', middleware);
+        // Mounted at /realms/:realmId/:nested so the middleware only fires on
+        // nested-resource URLs (e.g. /realms/master/users/...). Bare
+        // /realms/:id routes belong to RealmController (CRUD, openid-config,
+        // jwks) and would otherwise 404 on PUT upserts where the realm
+        // doesn't exist yet.
+        router.use('/realms/:realmId/:nested', middleware);
     }
 
     async mountAuthorization(router: Router, container: IContainer): Promise<void> {

--- a/apps/server-core/src/app/modules/http/modules/middleware.ts
+++ b/apps/server-core/src/app/modules/http/modules/middleware.ts
@@ -8,9 +8,12 @@
 import type { Router } from 'routup';
 import path from 'node:path';
 import type { IContainer } from 'eldin';
+import type { Repository } from 'typeorm';
+import type { Realm } from '@authup/core-kit';
 import {
     createAuthorizationMiddleware,
     createLoggerMiddleware,
+    createRealmResolverMiddleware,
     createSwaggerMiddleware,
     registerAssetsMiddleware,
     registerBasicMiddleware,
@@ -24,6 +27,8 @@ import { AuthenticationInjectionKey } from '../../authentication/index.ts';
 import { ConfigInjectionKey } from '../../config/index.ts';
 import { IdentityInjectionKey } from '../../identity/index.ts';
 import { OAuth2InjectionToken } from '../../oauth2/index.ts';
+import { RealmEntity } from '../../../../adapters/database/domains/index.ts';
+import { RealmRepositoryAdapter } from '../../database/repositories/index.ts';
 import {
     DatabaseInjectionKey,
     PermissionDatabaseProvider,
@@ -43,6 +48,7 @@ export class HTTPMiddlewareModule {
 
         await this.mountSwagger(router, container);
         await this.mountAuthorization(router, container);
+        await this.mountRealmResolver(router, container);
     }
 
      
@@ -108,6 +114,13 @@ export class HTTPMiddlewareModule {
         });
 
         router.use('/docs', middleware);
+    }
+
+    async mountRealmResolver(router: Router, container: IContainer): Promise<void> {
+        const realmRepository = container.resolve<Repository<Realm>>(RealmEntity);
+        const middleware = createRealmResolverMiddleware({ realmRepository: new RealmRepositoryAdapter(realmRepository) });
+
+        router.use('/realms/:realmId', middleware);
     }
 
     async mountAuthorization(router: Router, container: IContainer): Promise<void> {

--- a/apps/server-core/test/unit/http/controllers/entities/realm-scoped.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-scoped.spec.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { Realm } from '@authup/core-kit';
+import {
+    createFakeRealm,
+    createFakeUser,
+    httpRequest,
+} from '../../../../utils/index.ts';
+import { createTestApplication } from '../../../../app/index.ts';
+
+describe('src/http/controllers/realm-scoped', () => {
+    const suite = createTestApplication();
+    const basicAuth = `Basic ${Buffer.from('admin:start123').toString('base64')}`;
+
+    let masterRealm: Realm;
+    let scopedRealm: Realm;
+
+    beforeAll(async () => {
+        await suite.setup();
+        masterRealm = await suite.client.realm.getOne('master');
+        scopedRealm = await suite.client.realm.create(createFakeRealm());
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    describe('user', () => {
+        it('should list users via /realms/<name>/users', async () => {
+            const response = await httpRequest(suite, 'GET', '/realms/master/users', { headers: { Authorization: basicAuth } });
+
+            expect(response.status).toEqual(200);
+            const body = await response.json();
+            expect(body.data).toBeDefined();
+            expect(Array.isArray(body.data)).toBe(true);
+        });
+
+        it('should list users via /realms/<uuid>/users', async () => {
+            const response = await httpRequest(suite, 'GET', `/realms/${masterRealm.id}/users`, { headers: { Authorization: basicAuth } });
+
+            expect(response.status).toEqual(200);
+        });
+
+        it('should 404 on unknown realm key in path', async () => {
+            const response = await httpRequest(suite, 'GET', '/realms/this-realm-does-not-exist/users', { headers: { Authorization: basicAuth } });
+
+            expect(response.status).toEqual(404);
+        });
+
+        it('should create user under route realm, overriding body realm_id', async () => {
+            // body points at scopedRealm (a realm the admin can't write to);
+            // route says master. If the override works, the user lands in
+            // master and the permission check passes (admin is in master).
+            // If body won instead, the request would 403.
+            const payload = { ...createFakeUser(), realm_id: scopedRealm.id };
+
+            const response = await httpRequest(suite, 'POST', `/realms/${masterRealm.id}/users`, {
+                headers: { Authorization: basicAuth, 'Content-Type': 'application/json' },
+                body: JSON.stringify(payload),
+            });
+
+            expect(response.status).toEqual(201);
+            const body = await response.json();
+            expect(body.realm_id).toEqual(masterRealm.id);
+            expect(body.realm_id).not.toEqual(scopedRealm.id);
+        });
+    });
+
+    describe.each([
+        ['clients'],
+        ['robots'],
+        ['permissions'],
+        ['policies'],
+        ['identity-providers'],
+    ])('nested mount smoke test: %s', (entity) => {
+        it(`should expose GET /realms/master/${entity}`, async () => {
+            const response = await httpRequest(suite, 'GET', `/realms/master/${entity}`, { headers: { Authorization: basicAuth } });
+
+            expect(response.status).toEqual(200);
+        });
+    });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,7 +184,7 @@
                 "@routup/assets": "^4.1.0",
                 "@routup/basic": "^2.1.0",
                 "@routup/cors": "^1.0.1",
-                "@routup/decorators": "^4.1.0",
+                "@routup/decorators": "^4.2.0",
                 "@routup/logger": "^1.0.0",
                 "@routup/prometheus": "^3.1.0",
                 "@routup/rate-limit": "^3.1.0",
@@ -225,6 +225,7 @@
             },
             "devDependencies": {
                 "@authup/client-web-kit": "^1.0.0-beta.41",
+                "@authup/server-test-kit": "^1.0.0-beta.41",
                 "@faker-js/faker": "^10.4.0",
                 "@fortawesome/fontawesome-free": "^7.2.0",
                 "@trapi/cli": "^0.1.2-beta.3",
@@ -256,6 +257,26 @@
             },
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0"
+            }
+        },
+        "apps/server-core/node_modules/@routup/decorators": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@routup/decorators/-/decorators-4.2.0.tgz",
+            "integrity": "sha512-Foju3Xtq1xBRPU+P+FEGHhZ1gDD+nJ4jQhzn4VC1b5cRt4AzZKUJ6oQym5RY7QlAzegYCr9/cNqwPZOWevvTYQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@routup/body": "^3.2.0",
+                "@routup/cookie": "^3.2.0",
+                "@routup/query": "^3.2.0"
+            },
+            "peerDependencies": {
+                "@trapi/core": "^2.0.0",
+                "routup": "^5.2.0"
+            },
+            "peerDependenciesMeta": {
+                "@trapi/core": {
+                    "optional": true
+                }
             }
         },
         "apps/server-core/node_modules/dotenv": {
@@ -8018,24 +8039,24 @@
             }
         },
         "node_modules/@routup/body": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@routup/body/-/body-3.1.0.tgz",
-            "integrity": "sha512-WBZd4hZWS92KHyZuPkbHakfKC3Ws2EYoFBrPwBvtdDuZ1yRI+AbpTwJ0mgg6uLJwpiciMirGb7B2tD4BP1eiCQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@routup/body/-/body-3.2.0.tgz",
+            "integrity": "sha512-1zNqQb59wKPoA+MC4eXo8pgWPx78y18+8+YCSekir1q8AQh+QN09VGwvh+h3FAsML3hblcG9vARdqrdsgxKS7w==",
             "license": "MIT",
             "peerDependencies": {
-                "routup": "^5.0.1"
+                "routup": "^5.2.0"
             }
         },
         "node_modules/@routup/cookie": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@routup/cookie/-/cookie-3.1.0.tgz",
-            "integrity": "sha512-Qcc8VmAdYwfARDz8+yuvabx1x73ZvOqJHtbZLMqigKSdctadshXHBDhfpV3pZOVOxBJ3RB6BcYx6D3g1yG7/Gg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@routup/cookie/-/cookie-3.2.0.tgz",
+            "integrity": "sha512-G8OSiAITxKWFiIaDCCT9apvMwjhk+pEh4CyA3ORCXgkaCgCfkiS62aSuIaArj0it7nQ652Lkbc9OO2AsyICY4A==",
             "license": "MIT",
             "dependencies": {
                 "cookie-es": "^3.1.1"
             },
             "peerDependencies": {
-                "routup": "^5.0.1"
+                "routup": "^5.2.0"
             }
         },
         "node_modules/@routup/cookie/node_modules/cookie-es": {
@@ -8051,26 +8072,6 @@
             "license": "MIT",
             "peerDependencies": {
                 "routup": "^5.0.1"
-            }
-        },
-        "node_modules/@routup/decorators": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/@routup/decorators/-/decorators-4.1.0.tgz",
-            "integrity": "sha512-ga9in539UW4WMIf7YKnBnae/FjwMMIWpnmgiEw1qS+q8U+trJ7htPYMM+l5YOvVPIWaMBJ2wQSu+eADE2kBeew==",
-            "license": "MIT",
-            "dependencies": {
-                "@routup/body": "^3.1.0",
-                "@routup/cookie": "^3.1.0",
-                "@routup/query": "^3.1.0"
-            },
-            "peerDependencies": {
-                "@trapi/core": ">=2.0.0-beta.3 <3.0.0",
-                "routup": "^5.0.1"
-            },
-            "peerDependenciesMeta": {
-                "@trapi/core": {
-                    "optional": true
-                }
             }
         },
         "node_modules/@routup/logger": {
@@ -8093,16 +8094,16 @@
             }
         },
         "node_modules/@routup/query": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@routup/query/-/query-3.1.0.tgz",
-            "integrity": "sha512-+uCUhqgB27OvPSQmM+RlRlTaBEZDjeWTNaMouwf7sNnZQwhknb+tA7S8MmKGT3of+XAltjr9YkYqWXZIJI8Q8w==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@routup/query/-/query-3.2.0.tgz",
+            "integrity": "sha512-/gdnBPTqIcoyjStLpXttmxhjs8O1q79K1lrsRKy1ZE3EWi1+ADFbFnzFoz3emL7nknn0Nd0NoL2lFGni6wMW+g==",
             "license": "MIT",
             "dependencies": {
-                "@types/qs": "^6.14.0",
+                "@types/qs": "^6.15.1",
                 "qs": "^6.15.1"
             },
             "peerDependencies": {
-                "routup": "^5.0.1"
+                "routup": "^5.2.0"
             }
         },
         "node_modules/@routup/rate-limit": {
@@ -9068,9 +9069,9 @@
             }
         },
         "node_modules/@types/qs": {
-            "version": "6.15.0",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
-            "integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
+            "version": "6.15.1",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+            "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
             "license": "MIT"
         },
         "node_modules/@types/resolve": {
@@ -22483,9 +22484,9 @@
             "license": "MIT"
         },
         "node_modules/routup": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/routup/-/routup-5.1.1.tgz",
-            "integrity": "sha512-cU3ZP8FA3ybBc0qOMMKfpaDe5RpOIjH5s2FjK5U4m7NaSq1PQYSAcd7t/KauroWaf5/3fPtU9zQtQk1+vBGInQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/routup/-/routup-5.2.0.tgz",
+            "integrity": "sha512-TjG5WsZE2PMtkaYWTQwYLG+pl4fLUUtyX5pz/V5tyaLMbVvRAuCiH3nDfABNNoZ/3nXovuNVsw63hczf3Y36aQ==",
             "license": "MIT",
             "workspaces": [
                 "docs"


### PR DESCRIPTION
## Summary

- Dual-mount the six realm-aware controllers (client, robot, user, permission, policy, identity-provider) via `@routup/decorators` array paths at both `/<entity>` and `/realms/:realmId/<entity>`. Bumps `@routup/decorators` to `^4.2.0` for the `DController(url: string | string[])` overload.
- New `RealmResolverMiddleware` mounted at `/realms/:realmId` resolves the path segment (UUID or realm name) to a canonical UUID via `IRealmRepository` and stashes it on `event.store`. Two helpers in `adapters/http/request/helpers/realm-id.ts` (`getRequestRealmID`, `applyRouteRealmIDToBody`) let controllers read the realm and override `data.realm_id` on write — route realm wins silently over body realm.
- Permission policy semantics are **unchanged**. `system.realm-match` still gates cross-realm writes; the route prefix is a routing convenience, not an authorization shortcut.

Resolves the long-standing precedence bug originally flagged on `IdentityProviderController.write()` in PR #3030 review: lookups and creates no longer ignore the route's `:realmId` in favour of body or actor-identity realm.

Closes #3031

## Test plan

- [x] `npm run build -w apps/server-core` clean
- [x] `npm run test -w apps/server-core -- test/unit/http/controllers/entities/realm-scoped.spec.ts` — 9/9 pass (user list by name/UUID/404, route-wins-over-body create, smoke GET for the other 5 nested entities)
- [ ] `npm run test -w apps/server-core` — full HTTP suite green (existing tests should be unaffected — non-nested routes get a no-op middleware path)
- [ ] Manual smoke: hit `GET /realms/master/users` and `GET /realms/<unknown>/users` against a dev server

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity endpoints (clients, identity providers, permissions, policies, robots, users) now support realm-scoped access via /realms/:realmId/ routes alongside global endpoints.
  * Added request helpers and a realm-resolver middleware that resolve and apply route realm IDs to requests; middleware is mounted early in HTTP pipeline.

* **Documentation**
  * Architecture docs updated with realm scoping behavior, HTTP wiring, and nested route mounting patterns.

* **Chores**
  * Dependency bump for routing decorators.

* **Tests**
  * Added tests covering realm-scoped controller behavior and nested mount scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/authup/authup/pull/3049)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->