### PR TITLE
refactor!: drop user.client_id, backfill canonical identifier columns

### DIFF
--- a/apps/server-core/src/adapters/database/domains/user/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/user/entity.ts
@@ -18,8 +18,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
-import type { Client, Realm, User } from '@authup/core-kit';
-import { ClientEntity } from '../client/index.ts';
+import type { Realm, User } from '@authup/core-kit';
 import { RealmEntity } from '../realm/index.ts';
 
 @Entity({ name: 'auth_users' })
@@ -176,19 +175,6 @@ export class UserEntity implements User {
     @ManyToOne(() => RealmEntity, { onDelete: 'CASCADE' })
     @JoinColumn({ name: 'realm_id' })
     realm: Realm;
-
-    // ------------------------------------------------------------------
-
-    @Index()
-    @Column({ nullable: true })
-    client_id: Client['id'] | null;
-
-    @ManyToOne(() => ClientEntity, {
-        onDelete: 'CASCADE',
-        nullable: true, 
-    })
-    @JoinColumn({ name: 'client_id' })
-    client: Client | null;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/migrations/mysql/1779267068441-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1779267068441-Default.ts
@@ -43,7 +43,7 @@ export class Default1779267068441 implements MigrationInterface {
             await queryRunner.query(`
                 UPDATE \`${table}\`
                 SET \`name\` = LOWER(TRIM(\`name\`))
-                WHERE \`name\` <> LOWER(TRIM(\`name\`))
+                WHERE BINARY \`name\` <> LOWER(TRIM(\`name\`))
             `);
         }
 
@@ -51,7 +51,7 @@ export class Default1779267068441 implements MigrationInterface {
             UPDATE \`auth_users\`
             SET \`email\` = LOWER(TRIM(\`email\`))
             WHERE \`email\` IS NOT NULL
-              AND \`email\` <> LOWER(TRIM(\`email\`))
+              AND BINARY \`email\` <> LOWER(TRIM(\`email\`))
         `);
 
         await queryRunner.query(`

--- a/apps/server-core/src/adapters/database/migrations/mysql/1779267068441-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1779267068441-Default.ts
@@ -3,6 +3,7 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 type CollisionCheck = {
     table: string,
     groupBy: string[],
+    where?: string,
 };
 
 const NAME_COLLISION_CHECKS: CollisionCheck[] = [
@@ -10,10 +11,26 @@ const NAME_COLLISION_CHECKS: CollisionCheck[] = [
     { table: 'auth_robots', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
     { table: 'auth_users', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
     { table: 'auth_realms', groupBy: ['LOWER(TRIM(name))'] },
-    { table: 'auth_roles', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
-    { table: 'auth_scopes', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
-    { table: 'auth_permissions', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
-    { table: 'auth_policies', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    {
+        table: 'auth_roles', 
+        groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'], 
+        where: 'client_id IS NOT NULL AND realm_id IS NOT NULL', 
+    },
+    {
+        table: 'auth_scopes', 
+        groupBy: ['LOWER(TRIM(name))', 'realm_id'], 
+        where: 'realm_id IS NOT NULL', 
+    },
+    {
+        table: 'auth_permissions', 
+        groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'], 
+        where: 'client_id IS NOT NULL AND realm_id IS NOT NULL', 
+    },
+    {
+        table: 'auth_policies', 
+        groupBy: ['LOWER(TRIM(name))', 'realm_id'], 
+        where: 'realm_id IS NOT NULL', 
+    },
     { table: 'auth_identity_providers', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
 ];
 
@@ -28,6 +45,7 @@ export class Default1779267068441 implements MigrationInterface {
             const rows = await queryRunner.query(`
                 SELECT ${groupBy}
                 FROM \`${check.table}\`
+                ${check.where ? `WHERE ${check.where}` : ''}
                 GROUP BY ${groupBy}
                 HAVING COUNT(*) > 1
             `);

--- a/apps/server-core/src/adapters/database/migrations/mysql/1779267068441-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1779267068441-Default.ts
@@ -1,0 +1,80 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+type CollisionCheck = {
+    table: string,
+    groupBy: string[],
+};
+
+const NAME_COLLISION_CHECKS: CollisionCheck[] = [
+    { table: 'auth_clients', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_robots', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_users', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_realms', groupBy: ['LOWER(TRIM(name))'] },
+    { table: 'auth_roles', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
+    { table: 'auth_scopes', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_permissions', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
+    { table: 'auth_policies', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_identity_providers', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+];
+
+const NAME_TABLES = NAME_COLLISION_CHECKS.map((c) => c.table);
+
+export class Default1779267068441 implements MigrationInterface {
+    name = 'Default1779267068441';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const check of NAME_COLLISION_CHECKS) {
+            const groupBy = check.groupBy.join(', ');
+            const rows = await queryRunner.query(`
+                SELECT ${groupBy}
+                FROM \`${check.table}\`
+                GROUP BY ${groupBy}
+                HAVING COUNT(*) > 1
+            `);
+            if (rows.length > 0) {
+                throw new Error(
+                    `Canonical-name migration aborted: \`${check.table}\` has ${rows.length} collision group(s) on ${groupBy}. ` +
+                    'Merge the conflicting rows manually before re-running.',
+                );
+            }
+        }
+
+        for (const table of NAME_TABLES) {
+            await queryRunner.query(`
+                UPDATE \`${table}\`
+                SET \`name\` = LOWER(TRIM(\`name\`))
+                WHERE \`name\` <> LOWER(TRIM(\`name\`))
+            `);
+        }
+
+        await queryRunner.query(`
+            UPDATE \`auth_users\`
+            SET \`email\` = LOWER(TRIM(\`email\`))
+            WHERE \`email\` IS NOT NULL
+              AND \`email\` <> LOWER(TRIM(\`email\`))
+        `);
+
+        await queryRunner.query(`
+            ALTER TABLE \`auth_users\` DROP FOREIGN KEY \`FK_b1797e07106b4af61280b8edac1\`
+        `);
+        await queryRunner.query(`
+            DROP INDEX \`IDX_b1797e07106b4af61280b8edac\` ON \`auth_users\`
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`auth_users\` DROP COLUMN \`client_id\`
+        `);
+    }
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`auth_users\`
+            ADD \`client_id\` varchar(255) NULL
+        `);
+        await queryRunner.query(`
+            CREATE INDEX \`IDX_b1797e07106b4af61280b8edac\` ON \`auth_users\` (\`client_id\`)
+        `);
+        await queryRunner.query(`
+            ALTER TABLE \`auth_users\`
+            ADD CONSTRAINT \`FK_b1797e07106b4af61280b8edac1\` FOREIGN KEY (\`client_id\`) REFERENCES \`auth_clients\`(\`id\`) ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1779267068441-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1779267068441-Default.ts
@@ -1,0 +1,80 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+type CollisionCheck = {
+    table: string,
+    groupBy: string[],
+};
+
+const NAME_COLLISION_CHECKS: CollisionCheck[] = [
+    { table: 'auth_clients', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_robots', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_users', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_realms', groupBy: ['LOWER(TRIM(name))'] },
+    { table: 'auth_roles', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
+    { table: 'auth_scopes', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_permissions', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
+    { table: 'auth_policies', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    { table: 'auth_identity_providers', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+];
+
+const NAME_TABLES = NAME_COLLISION_CHECKS.map((c) => c.table);
+
+export class Default1779267068441 implements MigrationInterface {
+    name = 'Default1779267068441';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const check of NAME_COLLISION_CHECKS) {
+            const groupBy = check.groupBy.join(', ');
+            const rows = await queryRunner.query(`
+                SELECT ${groupBy}
+                FROM "${check.table}"
+                GROUP BY ${groupBy}
+                HAVING COUNT(*) > 1
+            `);
+            if (rows.length > 0) {
+                throw new Error(
+                    `Canonical-name migration aborted: "${check.table}" has ${rows.length} collision group(s) on ${groupBy}. ` +
+                    'Merge the conflicting rows manually before re-running.',
+                );
+            }
+        }
+
+        for (const table of NAME_TABLES) {
+            await queryRunner.query(`
+                UPDATE "${table}"
+                SET "name" = LOWER(TRIM("name"))
+                WHERE "name" <> LOWER(TRIM("name"))
+            `);
+        }
+
+        await queryRunner.query(`
+            UPDATE "auth_users"
+            SET "email" = LOWER(TRIM("email"))
+            WHERE "email" IS NOT NULL
+              AND "email" <> LOWER(TRIM("email"))
+        `);
+
+        await queryRunner.query(`
+            ALTER TABLE "auth_users" DROP CONSTRAINT "FK_b1797e07106b4af61280b8edac1"
+        `);
+        await queryRunner.query(`
+            DROP INDEX "public"."IDX_b1797e07106b4af61280b8edac"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "auth_users" DROP COLUMN "client_id"
+        `);
+    }
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "auth_users"
+            ADD "client_id" uuid
+        `);
+        await queryRunner.query(`
+            CREATE INDEX "IDX_b1797e07106b4af61280b8edac" ON "auth_users" ("client_id")
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "auth_users"
+            ADD CONSTRAINT "FK_b1797e07106b4af61280b8edac1" FOREIGN KEY ("client_id") REFERENCES "auth_clients"("id") ON DELETE CASCADE ON UPDATE NO ACTION
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1779267068441-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1779267068441-Default.ts
@@ -3,6 +3,7 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
 type CollisionCheck = {
     table: string,
     groupBy: string[],
+    where?: string,
 };
 
 const NAME_COLLISION_CHECKS: CollisionCheck[] = [
@@ -10,10 +11,26 @@ const NAME_COLLISION_CHECKS: CollisionCheck[] = [
     { table: 'auth_robots', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
     { table: 'auth_users', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
     { table: 'auth_realms', groupBy: ['LOWER(TRIM(name))'] },
-    { table: 'auth_roles', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
-    { table: 'auth_scopes', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
-    { table: 'auth_permissions', groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'] },
-    { table: 'auth_policies', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
+    {
+        table: 'auth_roles', 
+        groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'], 
+        where: 'client_id IS NOT NULL AND realm_id IS NOT NULL', 
+    },
+    {
+        table: 'auth_scopes', 
+        groupBy: ['LOWER(TRIM(name))', 'realm_id'], 
+        where: 'realm_id IS NOT NULL', 
+    },
+    {
+        table: 'auth_permissions', 
+        groupBy: ['LOWER(TRIM(name))', 'client_id', 'realm_id'], 
+        where: 'client_id IS NOT NULL AND realm_id IS NOT NULL', 
+    },
+    {
+        table: 'auth_policies', 
+        groupBy: ['LOWER(TRIM(name))', 'realm_id'], 
+        where: 'realm_id IS NOT NULL', 
+    },
     { table: 'auth_identity_providers', groupBy: ['LOWER(TRIM(name))', 'realm_id'] },
 ];
 
@@ -28,6 +45,7 @@ export class Default1779267068441 implements MigrationInterface {
             const rows = await queryRunner.query(`
                 SELECT ${groupBy}
                 FROM "${check.table}"
+                ${check.where ? `WHERE ${check.where}` : ''}
                 GROUP BY ${groupBy}
                 HAVING COUNT(*) > 1
             `);

--- a/apps/server-core/src/core/provisioning/synchronizer/user/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/user/module.ts
@@ -64,7 +64,6 @@ export class UserProvisioningSynchronizer extends BaseProvisioningSynchronizer<U
         let attributes = await this.userRepository.findOneBy({
             name: input.attributes.name,
             realm_id: input.attributes.realm_id || null,
-            client_id: input.attributes.client_id || null,
         });
 
         if (strategy.type === ProvisioningEntityStrategyType.ABSENT) {

--- a/packages/core-kit/src/domains/user/entity.ts
+++ b/packages/core-kit/src/domains/user/entity.ts
@@ -5,7 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Client } from '../client';
 import type { Realm } from '../realm';
 
 export interface User {
@@ -56,12 +55,6 @@ export interface User {
     created_at: Date;
 
     updated_at: Date;
-
-    // ------------------------------------------------------------------
-
-    client_id: Client['id'] | null;
-
-    client: Client | null;
 
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Drops the unused `client_id` / `client` columns and relation from `User` / `UserEntity`. The column has been functionally dead since migration `1766830857009` deleted every row where it was non-null ("user client_id referenced wrong table"). The provisioning synchronizer drops the now-redundant `client_id` lookup key.
- Adds paired `postgres` + `mysql` migration `1779267068441-Default` that bundles:
  - **Canonical-name backfill** (consolidates plan 008): collision pre-check that aborts on any duplicate group after `LOWER(TRIM(name))`, then `UPDATE … = LOWER(TRIM(…))` across nine name tables (`auth_clients`, `auth_robots`, `auth_users`, `auth_realms`, `auth_roles`, `auth_scopes`, `auth_permissions`, `auth_policies`, `auth_identity_providers`) and `auth_users.email`. Pre-check `GROUP BY` mirrors each entity's `@Unique([...])` declaration.
  - **Column drop**: auto-generated DDL dropping the `auth_users.client_id` FK, index, and column.
- `down()` restores the column / index / FK only; canonical `UPDATE`s are not reversed (lossy by definition — original casing is not recoverable).

## Breaking change

`User.client_id` and `User.client` are removed from `@authup/core-kit`. Note the `[key: string]: any` escape hatch on the `User` interface means any consumer reading these fields still typechecks but returns `undefined` at runtime.

## Test plan

- [x] `npm run build --workspace=apps/server-core` — clean
- [x] `npm run test --workspace=apps/server-core` — 799/799 passed
- [x] `npx eslint --fix` on all changed files — clean
- [x] Smoke-tested migration `up` / `down` / re-`up` against fresh Postgres + MySQL containers — see below
- [x] Verified canonical UPDATE rewrites mixed-case rows correctly on both DBs
- [x] Verified collision pre-check aborts cleanly on a deliberately seeded duplicate

### Smoke-test details

- Postgres: fresh DB → migration run (8/8 applied) → `auth_users.client_id` confirmed dropped → revert → column restored with correct FK target (`auth_clients`, not the originally-buggy `auth_realms`) → re-apply → column dropped again. ✅
- MySQL: same cycle. ✅
- Canonical UPDATE on Postgres: seeded `'TestRealm'` + `'Foo@Bar.COM'`, ran migration → names and emails canonicalized to lowercase. ✅
- Collision detection on Postgres: seeded `'CollideMe'` + `'collideme'` (Postgres is case-sensitive, both rows persist) → migration aborted with actionable error: `Canonical-name migration aborted: "auth_realms" has 1 collision group(s) on LOWER(TRIM(name))`. ✅
- **Bug caught during MySQL smoke test** (fixed in `ec8972dfa`): MySQL's default `utf8mb4_0900_ai_ci` collation treats `'TestRealm' = 'testrealm'`, so the original `WHERE name <> LOWER(TRIM(name))` predicate was always false on mixed-case rows and the UPDATE silently no-op'd. Switched the WHERE clause to `WHERE BINARY name <> LOWER(TRIM(name))` (and same for `email`) to force byte-level comparison. Re-verified end-to-end. ✅

## Notes

- Migration bundles two unrelated changes (column drop + canonical backfill). Considered splitting; kept bundled because the canonical backfill was already ledger'd in plan 008 awaiting consolidation, and shipping both in one timestamp avoids a second migration run for operators.
- `down()` for canonical backfill is intentionally a no-op (cannot recover original casing); subsequent writes continue to canonicalize, so the schema stays consistent.
- ⚠️ **CI does not exercise migration files** — the test runner uses `dataSource.synchronize()` instead. The MySQL `BINARY` bug above was only caught by manual smoke testing. Opened #3067 to add a dedicated CI job that runs migrations end-to-end. Until that lands, every migration PR should be smoke-tested manually against both DBs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * User names and email addresses are now automatically normalized (converted to lowercase with whitespace trimmed) for improved data consistency.

* **Refactor**
  * Simplified user record structure by removing client associations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/authup/authup/pull/3066?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->