### PR TITLE
ci: exercise migrations against MySQL and PostgreSQL

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -191,3 +191,26 @@ Integration tests use Docker services defined in `docker-compose.yml`:
 | Redis      | 6379      |
 | Vault      | 8090      |
 | LDAP       | 389 / 636 |
+
+## Migration Tests
+
+The `tests-server-core` CI job runs the integration suite against MySQL and PostgreSQL, but the schema is built via `dataSource.synchronize()` (see `apps/server-core/test/app/database.ts`) — migrations in `apps/server-core/src/adapters/database/migrations/{mysql,postgres}/` are NOT exercised by that suite.
+
+A separate `tests-migrations` CI job runs the migration CLI end-to-end against a fresh MySQL and PostgreSQL container:
+
+1. `migration run` — applies all migrations forward
+2. `migration revert` × N — undoes every migration in reverse order (verifies every `down()` works)
+3. `migration run` — re-applies the full chain (verifies idempotency)
+
+This catches SQL syntax errors, cross-DB type mismatches, and `down()` regressions across every migration. It does **not** catch data-correctness bugs in `UPDATE`/`INSERT` migrations against pre-existing rows — those still require manual smoke-testing against a populated database.
+
+The job pre-flights with a sanity check that the compiled migrations exist under `apps/server-core/dist/adapters/database/migrations/{mysql,postgres}/` — without this guard, running the CLI from the wrong working directory results in typeorm silently reporting "No migrations are pending" with exit code 0, masking the failure.
+
+Locally, run the same flow with a running compose stack:
+
+```bash
+DB_TYPE=mysql DB_HOST=127.0.0.1 DB_PORT=3306 DB_USERNAME=root DB_PASSWORD=start123 DB_DATABASE=app \
+    node apps/server-core/dist/cli/index.mjs migration run
+```
+
+The CLI auto-creates the target database if it does not exist.

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,3 +129,77 @@ jobs:
                     DB_TYPE: ${{ matrix.db }}
                 run: |
                     npm run test --workspace=apps/server-core
+
+    tests-migrations:
+        name: Test Migrations
+        needs: [build]
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                include:
+                    -   db: mysql
+                        port: 3306
+                        user: root
+                    -   db: postgres
+                        port: 5432
+                        user: postgres
+
+        env:
+            DB_TYPE: ${{ matrix.db }}
+            DB_HOST: 127.0.0.1
+            DB_PORT: ${{ matrix.port }}
+            DB_USERNAME: ${{ matrix.user }}
+            DB_PASSWORD: start123
+            DB_DATABASE: app
+
+        steps:
+            -   name: Checkout
+                uses: actions/checkout@v6
+
+            -   name: Install
+                uses: ./.github/actions/install
+                with:
+                    node-version: ${{ env.NODE_VERSION }}
+                    node-registry: ${{ env.NODE_REGISTRY }}
+
+            -   name: Build
+                uses: ./.github/actions/build
+
+            -   name: Verify compiled migrations exist
+                working-directory: apps/server-core
+                run: |
+                    count=$(ls dist/adapters/database/migrations/${{ matrix.db }}/*.mjs 2>/dev/null | wc -l | tr -d ' ')
+                    if [ "$count" = "0" ]; then
+                        echo "ERROR: no compiled migrations in dist/adapters/database/migrations/${{ matrix.db }}/"
+                        exit 1
+                    fi
+                    echo "Found $count migration(s)"
+                    echo "MIGRATION_COUNT=$count" >> "$GITHUB_ENV"
+
+            -   name: Start ${{ matrix.db }}
+                run: docker compose up -d ${{ matrix.db }}
+
+            -   name: Wait for ${{ matrix.db }} to be ready
+                run: |
+                    if [ "${{ matrix.db }}" = "mysql" ]; then
+                        timeout 120 bash -c 'until docker compose exec -T mysql mysqladmin ping -h127.0.0.1 --silent; do sleep 2; done'
+                    else
+                        timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
+                    fi
+
+            -   name: Run migrations forward
+                working-directory: apps/server-core
+                run: node dist/cli/index.mjs migration run
+
+            -   name: Revert all migrations
+                working-directory: apps/server-core
+                run: |
+                    for ((i = 1; i <= MIGRATION_COUNT; i++)); do
+                        node dist/cli/index.mjs migration revert
+                    done
+
+            -   name: Re-apply all migrations (idempotency)
+                working-directory: apps/server-core
+                run: node dist/cli/index.mjs migration run

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -170,7 +170,9 @@ jobs:
             -   name: Verify compiled migrations exist
                 working-directory: apps/server-core
                 run: |
-                    count=$(ls dist/adapters/database/migrations/${{ matrix.db }}/*.mjs 2>/dev/null | wc -l | tr -d ' ')
+                    shopt -s nullglob
+                    files=(dist/adapters/database/migrations/${{ matrix.db }}/*.mjs)
+                    count=${#files[@]}
                     if [ "$count" = "0" ]; then
                         echo "ERROR: no compiled migrations in dist/adapters/database/migrations/${{ matrix.db }}/"
                         exit 1
@@ -184,7 +186,7 @@ jobs:
             -   name: Wait for ${{ matrix.db }} to be ready
                 run: |
                     if [ "${{ matrix.db }}" = "mysql" ]; then
-                        timeout 120 bash -c 'until docker compose exec -T mysql mysqladmin ping -h127.0.0.1 --silent; do sleep 2; done'
+                        timeout 120 bash -c 'until docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" mysql mysqladmin ping -h127.0.0.1 -uroot --silent; do sleep 2; done'
                     else
                         timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
                     fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@
 version: '3.9'
 services:
     mysql:
-        image: mysql:latest
+        image: mysql:9
         restart: always
         environment:
             MYSQL_ROOT_PASSWORD: start123
         ports:
             - '3306:3306'
     postgres:
-        image: postgres
+        image: postgres:18
         restart: always
         environment:
             POSTGRES_PASSWORD: start123


### PR DESCRIPTION
## Summary

- New `tests-migrations` CI job runs the migration CLI end-to-end against fresh MySQL and PostgreSQL containers: `migration run` → revert all in reverse order → `migration run` (idempotency replay). Every `up()`/`down()` gets exercised, not just the latest migration.
- Pre-flight step counts compiled migrations in `dist/adapters/database/migrations/<db>/` and fails loudly if zero. Without this guard, typeorm silently reports "No migrations are pending" with exit 0 when the CLI runs from the wrong working directory — the same failure mode this issue exists to fix.
- Pin `docker-compose.yml` images to `mysql:9` and `postgres:18` to match the versions used by `apps/server-core/test/setup.ts`, eliminating drift between the migration job and the rest of the test suite.

Closes #3067.

## What it catches

- SQL syntax errors in either DB
- Cross-DB type / quoting mismatches
- `down()` regressions in **any** migration (not just the latest)
- Idempotency: re-applying the full chain after a full revert

## What it still doesn't catch

- Data-correctness bugs in `UPDATE` / `INSERT` migrations against pre-existing rows (the migrations run against an empty DB). This is the scenario that caused the MySQL `BINARY` bug in #3066 and is listed as a stretch goal in #3067 — not addressed here.

## Test plan

- [ ] CI: `tests-migrations (mysql)` and `tests-migrations (postgres)` both green
- [ ] Verify the pre-flight sanity check fails clearly if `dist/adapters/database/migrations/<db>/` is empty (e.g. break the build cache, confirm the step prints `ERROR: no compiled migrations…`)
- [ ] Spot-check job logs for the expected `8 migrations were found in the source code` line on first `migration run`, eight `Migration … has been reverted successfully` lines during the revert loop, and `8 migrations are new migrations must be executed` on the idempotency replay

Local verification (already done): full run → revert-all → re-apply cycle against the docker-compose MySQL and PostgreSQL containers — all eight migrations applied, all eight reverted in reverse order, all eight re-applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration testing documentation.

* **Chores**
  * Enhanced database migration testing in CI for MySQL and Postgres.
  * Updated database service versions in development environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/authup/authup/pull/3068?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->