### PR TITLE
ci(migrations): use GHA services: blocks instead of docker compose

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -154,6 +154,31 @@ jobs:
             DB_PASSWORD: start123
             DB_DATABASE: app
 
+        services:
+            mysql:
+                image: mysql:9
+                env:
+                    MYSQL_ROOT_PASSWORD: start123
+                ports:
+                    - 3306:3306
+                options: >-
+                    --health-cmd="mysqladmin ping -h localhost -pstart123"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
+            postgres:
+                image: postgres:18
+                env:
+                    POSTGRES_PASSWORD: start123
+                ports:
+                    - 5432:5432
+                options: >-
+                    --health-cmd="pg_isready -U postgres"
+                    --health-interval=10s
+                    --health-timeout=5s
+                    --health-retries=5
+
         steps:
             -   name: Checkout
                 uses: actions/checkout@v6
@@ -179,17 +204,6 @@ jobs:
                     fi
                     echo "Found $count migration(s)"
                     echo "MIGRATION_COUNT=$count" >> "$GITHUB_ENV"
-
-            -   name: Start ${{ matrix.db }}
-                run: docker compose up -d ${{ matrix.db }}
-
-            -   name: Wait for ${{ matrix.db }} to be ready
-                run: |
-                    if [ "${{ matrix.db }}" = "mysql" ]; then
-                        timeout 120 bash -c 'until docker compose exec -T -e MYSQL_PWD="$DB_PASSWORD" mysql mysqladmin ping -h127.0.0.1 -uroot --silent; do sleep 2; done'
-                    else
-                        timeout 60 bash -c 'until docker compose exec -T postgres pg_isready -U postgres; do sleep 2; done'
-                    fi
 
             -   name: Run migrations forward
                 working-directory: apps/server-core


### PR DESCRIPTION
## Summary

Follow-up to #3068. Switches the `tests-migrations` job from `docker compose up` to native GHA `services:` blocks.

## Why

`docker compose up` + a manual `until ... ping` wait loop is doing work that GHA does for free. Native `services:` containers come with built-in health-check polling and automatic teardown.

Net result:
- Drops the **Start mysql/postgres** step
- Drops the **Wait for mysql/postgres to be ready** bash loop (incl. the `MYSQL_PWD` plumbing)
- Workflow is shorter and uses a feature most readers already know

`docker-compose.yml` stays in place for local development — `.agents/testing.md`'s local-repro instructions are unchanged.

## Trade-off

The DB image versions (`mysql:9` / `postgres:18`) now live in two places: the workflow services block and `docker-compose.yml`. Drift risk is real but bounded — there's only one canonical place to bump versions in CI (this workflow), and `docker-compose.yml` is for human use where minor drift is harmless.

## Test plan

- [ ] CI: `tests-migrations (mysql)` and `tests-migrations (postgres)` both green
- [ ] Logs show no `Wait for ... ready` step (GHA service health-check replaces it)