### PR TITLE
feat(client-web-theme): mode-aware chrome for header, sidebar & footer

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1032,13 +1032,22 @@ new `@authup/client-web-theme` package.
     genuinely dark in dark mode so the light `--vc-color-fg` keeps
     contrast — the predecessor `var(--vc-color-neutral-400/500)` was a
     light-mid grey (light-on-light, ~1.7:1, unreadable).
-  - **Chrome slate ramp** (`--authup-slate-900…300`) — **constant across
-    both modes** (the brand signature). Header / sidebar / footer /
-    navbar-dropdown stay dark slate even in light mode; only their text is
-    light. The `--authup-chrome-*` tokens the chrome stylesheets read are
-    aliased onto the slate ramp (`chrome-bg ← slate-800`,
-    `chrome-bg-elevated ← slate-700`, `chrome-fg = #e8e6e2`,
-    `chrome-fg-muted ← slate-400`), so the chrome CSS files need no edits.
+  - **Chrome tokens** (`--authup-chrome-*` — what header / sidebar /
+    footer / navbar-dropdown CSS reads) — **flip with the mode** (mirrors
+    hub's chrome model, PrivateAIM/hub#1668). Light-mode `:root` defaults
+    alias the vuecs semantic tokens (`chrome-bg ← --vc-color-bg-elevated`,
+    `chrome-bg-elevated ← -bg-muted`, `chrome-fg ← -fg`,
+    `chrome-fg-muted ← -fg-muted`, `chrome-border ← -border`) so the
+    chrome is a light raised surface; `.dark` pins them onto the **slate
+    ramp** (`--authup-slate-900…300`, the dark chrome palette:
+    `chrome-bg ← slate-800`, `chrome-bg-elevated ← slate-700`,
+    `chrome-fg = #e8e6e2`, `chrome-fg-muted ← slate-400`) so dark mode
+    keeps authup's recognizable dark-slate chrome. The chrome/content
+    edges are tokens too — `--authup-chrome-edge-shadow-{bottom,top,right}`:
+    soft drop shadows in light mode, the historical recessed inset band
+    (and a shadow-free sidebar right edge) in dark mode. The header sits
+    at `z-index: 2`, the sidebar at `position: relative; z-index: 1`, so
+    the light-mode shadows paint over the page content.
   - **Brand accents** — `--authup-periwinkle #6d7fcc` (primary accent —
     active pill / nav-link background; also drives the
     `--vc-color-primary-*` scale via color-mix, rebound to

--- a/packages/client-web-theme/assets/css/index.css
+++ b/packages/client-web-theme/assets/css/index.css
@@ -48,12 +48,18 @@
      *      `<VC*>` component AND authup's own content CSS resolve to them
      *      from one source of truth.
      *
-     *   2. CHROME slate ramp (`--authup-slate-*`) is CONSTANT across modes —
-     *      the brand signature. Header / sidebar / footer / navbar-dropdown
-     *      stay dark slate in BOTH light and dark mode; only their text is
-     *      light. The `--authup-chrome-*` tokens the chrome stylesheets read
-     *      are aliased onto the slate ramp (names kept so header/sidebar/
-     *      footer/navbar CSS needs no edits).
+     *   2. CHROME (`--authup-chrome-*` — header / sidebar / footer /
+     *      navbar-dropdown) FLIPS with the mode. Light-mode defaults alias
+     *      the vuecs semantic tokens (`--vc-color-bg-elevated` / `-fg` /
+     *      `-border`, themselves bridged onto the surface group) so the
+     *      chrome reads as a light raised surface distinct from the
+     *      page-content bg; the `.dark` block below pins the chrome onto
+     *      the slate ramp (`--authup-slate-*`) so dark mode keeps authup's
+     *      recognizable dark-slate chrome. The chrome edge against the
+     *      content is a token too (`--authup-chrome-edge-shadow-*`): a
+     *      soft drop shadow in light mode (the dark inset band would be a
+     *      muddy grey stripe on a light surface), the historical recessed
+     *      band in dark mode.
      *
      *   3. Brand ACCENTS (periwinkle / rose / salmon / green) carry the
      *      authup identity, hard-coded and constant across modes. Periwinkle
@@ -79,7 +85,8 @@
         --authup-auth-accent-alt:           var(--authup-rose);
         --authup-auth-logo-background:      var(--authup-slate-800);
 
-        /* Chrome slate ramp — constant across themes (brand signature) */
+        /* Slate ramp — the dark chrome palette (applied under `.dark`);
+           slate-800 also anchors mode-stable accents like the auth logo */
         --authup-slate-900:                 #30373e;  /* body text, pagination active */
         --authup-slate-800:                 #34353a;  /* header / sidebar / footer chrome */
         --authup-slate-700:                 #40434e;  /* navbar dropdown menu */
@@ -87,12 +94,23 @@
         --authup-slate-400:                 #aeb2b7;  /* chrome muted text */
         --authup-slate-300:                 #949da5;  /* link default */
 
-        /* Chrome semantic aliases — what header/sidebar/footer/navbar read */
-        --authup-chrome-bg:                 var(--authup-slate-800);
-        --authup-chrome-bg-elevated:        var(--authup-slate-700);
-        --authup-chrome-fg:                 #e8e6e2;
-        --authup-chrome-fg-muted:           var(--authup-slate-400);
-        --authup-chrome-border:             var(--authup-slate-700);
+        /* Chrome semantic aliases — what header/sidebar/footer/navbar read.
+           Light-mode defaults: alias the vuecs semantic tokens so the chrome
+           is a light raised surface over the page content; the `.dark` block
+           below re-pins them onto the slate ramp. */
+        --authup-chrome-bg:                 var(--vc-color-bg-elevated);
+        --authup-chrome-bg-elevated:        var(--vc-color-bg-muted);
+        --authup-chrome-fg:                 var(--vc-color-fg);
+        --authup-chrome-fg-muted:           var(--vc-color-fg-muted);
+        --authup-chrome-border:             var(--vc-color-border);
+
+        /* Chrome edge where it meets the content — `-bottom` for top chrome
+           (header / sidebar-header), `-top` for bottom chrome (footer),
+           `-right` for the sidebar's content edge. Light mode: a soft drop
+           shadow so the chrome reads as raised above the content. */
+        --authup-chrome-edge-shadow-bottom: 0 2px 8px 0 rgba(0, 0, 0, 0.06);
+        --authup-chrome-edge-shadow-top:    0 -2px 8px 0 rgba(0, 0, 0, 0.06);
+        --authup-chrome-edge-shadow-right:  2px 0 8px 0 rgba(0, 0, 0, 0.06);
 
         /* Themeable surfaces — light */
         --authup-surface-app:               #d5d8da;
@@ -146,15 +164,23 @@
     }
 
     /*
-     * Dark mode — flip ONLY the themeable surfaces. The chrome slate ramp
-     * and brand accents are constant (defined in `:root`), and the
-     * `--vc-color-*` bridge + primary palette resolve per-element, so they
-     * pick up these dark surface values automatically with no further
-     * overrides.
+     * Dark mode — two moves:
      *
-     * Surfaces stay genuinely dark so the light dark-mode `--vc-color-fg`
-     * (`--authup-on-surface` = #e8e6e2) keeps high contrast — the ramp
-     * climbs app < content < card < raised < active.
+     *   a) Flip the themeable surfaces. The `--vc-color-*` bridge +
+     *      primary palette resolve per-element, so they pick up these
+     *      dark surface values automatically with no further overrides.
+     *      Surfaces stay genuinely dark so the light dark-mode
+     *      `--vc-color-fg` (`--authup-on-surface` = #e8e6e2) keeps high
+     *      contrast — the ramp climbs app < content < card < raised <
+     *      active.
+     *
+     *   b) Pin the chrome onto the slate ramp — authup's recognizable
+     *      dark-slate header/sidebar/footer. Without this pin the chrome
+     *      would alias the flipped surface tokens and blend into the
+     *      page-content bg. The edge shadows switch from the light-mode
+     *      drop shadow to the historical recessed inset band; the
+     *      sidebar's right edge goes shadow-free — the chrome/content
+     *      tonal step carries the separation in dark mode.
      *
      * Works from inside `@layer base` because `@vuecs/design` 1.0.1+ wraps
      * its `.dark` token defaults in `@layer vuecs`, positioned earlier than
@@ -162,6 +188,15 @@
      * `@layer theme, vuecs, base, components, utilities;` declaration.
      */
     .dark {
+        --authup-chrome-bg:                 var(--authup-slate-800);
+        --authup-chrome-bg-elevated:        var(--authup-slate-700);
+        --authup-chrome-fg:                 #e8e6e2;
+        --authup-chrome-fg-muted:           var(--authup-slate-400);
+        --authup-chrome-border:             var(--authup-slate-700);
+        --authup-chrome-edge-shadow-bottom: 0 -6px 0 0 rgba(0, 0, 0, 0.3) inset;
+        --authup-chrome-edge-shadow-top:    0 6px 0 0 rgba(0, 0, 0, 0.3) inset;
+        --authup-chrome-edge-shadow-right:  none;
+
         --authup-surface-app:               #16171a;
         --authup-surface-content:           #1f2024;
         --authup-surface-card:              #26272c;

--- a/packages/client-web-theme/assets/css/styles/core/footer.css
+++ b/packages/client-web-theme/assets/css/styles/core/footer.css
@@ -6,7 +6,7 @@
  */
 
 .page-footer {
-    box-shadow: 0px 6px 0px 0px rgba(0, 0, 0, 0.3) inset;
+    box-shadow: var(--authup-chrome-edge-shadow-top);
     background-color: var(--authup-chrome-bg);
     padding: 10px 0px 4px 0px;
     position: relative;

--- a/packages/client-web-theme/assets/css/styles/core/header.css
+++ b/packages/client-web-theme/assets/css/styles/core/header.css
@@ -12,10 +12,12 @@
     top:0;
     display: flex;
     align-items: center;
-    box-shadow: 0px -6px 0px rgba(0, 0, 0, 0.3) inset;
+    box-shadow: var(--authup-chrome-edge-shadow-bottom);
     background-color: var(--authup-chrome-bg);
     padding-bottom: 6px;
-    z-index: 1;
+    /* Above the sidebar (z-index: 1) so the chrome edges layer correctly
+       where header and sidebar meet. */
+    z-index: 2;
 }
 
 .page-header .header-title {
@@ -41,7 +43,6 @@
     border-radius: .25rem;
     margin: 0 10px;
     padding: 10px;
-    box-shadow: 0 4px 25px 0 rgba(0, 0, 0, .4);
 }
 
 .page-header .toggle-box .toggle-trigger .icon-bar {

--- a/packages/client-web-theme/assets/css/styles/core/navbar.css
+++ b/packages/client-web-theme/assets/css/styles/core/navbar.css
@@ -56,18 +56,10 @@
 }
 
 /*
- * Center every gadget control on the row's cross axis. The gadgets
- * <ul> is a flex row; its default `align-items: stretch` makes each
- * <li> grow to the tallest sibling, but the `.vc-nav-link` inside is
- * not full-height — it sits at the TOP of its stretched <li> and
- * centers its icon within its OWN box. A <button> nav-link (color-mode
- * toggle, language dropdown-toggle) and an <a> nav-link (settings,
- * logout) differ by a fraction of a pixel in intrinsic height (residual
- * UA button metrics that survive Tailwind preflight), so their icon
- * centers land at slightly different Y — the items read as off-axis.
- * Switching the row to `align-items: center` collapses every <li> to
- * its natural height and centers it, so each control's center coincides
- * with the row center regardless of the button/anchor height delta.
+ * `align-items: center` centers each gadget <li> on the row's cross
+ * axis (the default `stretch` would grow each <li> to the tallest
+ * sibling while its link stays top-anchored). Box-height EQUALITY is
+ * handled on the links themselves — see the `inline-flex` note below.
  */
 .page-navbar .navbar-content .navbar-gadgets {
     margin-left: auto;
@@ -78,7 +70,33 @@
     padding-right: 0.25rem;
 }
 
+/*
+ * `inline-flex` normalizes the three gadget control types onto ONE box
+ * model. They are different element types, so without it the same
+ * padding/line-height rules yield three different heights:
+ *
+ *   - <a> (settings, logout) is `display: inline` — vertical padding
+ *     paints but does NOT expand the line box, so the box collapses to
+ *     bare font-metric height (~20.8px) and the icon sits on the text
+ *     baseline.
+ *   - <button> with text (language dropdown-toggle) is inline-block —
+ *     padding counts: 16px line + 8px padding = 24px.
+ *   - <button> with an svg icon (color-mode toggle) is inline-block,
+ *     but the icon's `vertical-align: -0.125em` baseline shift extends
+ *     the line box ~2px past the text strut → 26px.
+ *
+ * As a flex container, padding counts on all of them, `vertical-align`
+ * no longer applies (flex items aren't inline-level), and
+ * `align-items: center` puts every glyph on the same axis: a uniform
+ * 24px box (16px content + 2×4px padding) for anchors and buttons,
+ * icon and text alike. The VCNavItems-rendered links in the top nav
+ * already get `flex items-center` utilities from theme-tailwind's
+ * element class map; this gives the hand-written gadget links the
+ * same treatment.
+ */
 .page-navbar .navbar-content .vc-nav-link {
+    display: inline-flex;
+    align-items: center;
     padding: 0.25rem 0.5rem;
     font-weight: 500;
     letter-spacing: 1px;

--- a/packages/client-web-theme/assets/css/styles/core/sidebar.css
+++ b/packages/client-web-theme/assets/css/styles/core/sidebar.css
@@ -10,11 +10,20 @@
     width:240px;
     background-color: var(--authup-chrome-bg);
     color: var(--authup-chrome-fg);
-    transition: all 0.3s;
+    /* `width` covers the mobile collapse; avoid `all` so mode flips
+       don't animate layout properties. */
+    transition: width 0.3s, background-color 0.3s, box-shadow 0.3s;
     display: flex;
     flex-direction: column;
     font-size: 1rem;
     overflow: scroll;
+    /* Soften the edge against the page content (light mode; `none` in
+       dark). `.page-content` is a later sibling with its own background,
+       which would paint over an in-flow sidebar's outset shadow — lift
+       the sidebar one stacking step (below the header's z-index: 2). */
+    box-shadow: var(--authup-chrome-edge-shadow-right);
+    position: relative;
+    z-index: 1;
 
     -ms-overflow-style: none;  /* Internet Explorer 10+ */
     scrollbar-width: none;
@@ -26,8 +35,7 @@
 
 .page-sidebar .sidebar-header {
     padding: 20px;
-    -webkit-box-shadow: 0px -6px 0px rgba(0, 0, 0, 0.3) inset;
-    box-shadow: 0px -6px 0px rgba(0, 0, 0, 0.3) inset;
+    box-shadow: var(--authup-chrome-edge-shadow-bottom);
 }
 
 @media only screen and (max-width: 768px) {

--- a/packages/client-web-theme/assets/css/styles/navigation.css
+++ b/packages/client-web-theme/assets/css/styles/navigation.css
@@ -204,12 +204,13 @@ button.vc-nav-link {
 /*
  * Line color uses `--authup-chrome-fg-muted` (with opacity) rather
  * than `--authup-chrome-bg-elevated`: in light mode, chrome-bg
- * (neutral-100) and chrome-bg-elevated (neutral-50) are only ~1.5%
- * lightness apart, below the perceptual threshold against a near-
- * white surface — the lines disappear. The fg-muted token is a
- * mid-tone in both modes (neutral-500 in light, ~neutral-300 in
- * dark) and ALWAYS contrasts against chrome-bg, so the same opacity
- * gives a consistent subtle weight regardless of mode.
+ * (surface-card #ffffff) and chrome-bg-elevated (surface-raised
+ * #ececec) are only a few % lightness apart, below the perceptual
+ * threshold against a near-white surface — the lines disappear. The
+ * fg-muted token is a mid-tone in both modes (on-surface-muted in
+ * light, slate-400 in dark) and ALWAYS contrasts against chrome-bg,
+ * so the same opacity gives a consistent subtle weight regardless
+ * of mode.
  */
 .vc-nav-items .vc-nav-separator:before,
 .vc-nav-items .vc-nav-separator:after {
@@ -222,8 +223,8 @@ button.vc-nav-link {
 
 /*
  * Same contrast trap as `.vc-nav-separator` had:
- * `--authup-chrome-bg-elevated` is only ~1.5% L apart from chrome-bg
- * in light mode (neutral-50 vs neutral-100), so the border-left
+ * `--authup-chrome-bg-elevated` is only a few % L apart from chrome-bg
+ * in light mode (#ececec vs #ffffff), so the border-left
  * disappears against the light chrome surface. Mix
  * `--authup-chrome-fg-muted` to 30% alpha — the mid-tone token has
  * consistent visibility on chrome-bg in both modes, and `color-mix`


### PR DESCRIPTION
## Summary

Light mode previously kept the dark slate chrome (header / sidebar / footer / navbar-dropdown), which clashed with the light content surfaces. This replays hub's chrome model (PrivateAIM/hub#1668, commit `daa909b2b`) onto authup:

- **Chrome tokens flip with the mode.** `:root` defaults alias the vuecs semantic surface tokens (`chrome-bg ← --vc-color-bg-elevated`, `chrome-bg-elevated ← -bg-muted`, `chrome-fg ← -fg`, `chrome-fg-muted ← -fg-muted`, `chrome-border ← -border`), so light mode renders the chrome as a light raised surface. `.dark` pins them back onto the slate ramp (`slate-800` / `slate-700` / `#e8e6e2` / `slate-400`) — dark mode is visually unchanged.
- **Mode-aware edge shadows.** The three hard-coded `rgba(0,0,0,0.3) inset` bands (header bottom, sidebar-header bottom, footer top) become `--authup-chrome-edge-shadow-{bottom,top,right}` tokens: soft drop shadows in light mode (a dark inset band reads as a muddy grey stripe on a light surface), the historical recessed band in dark mode.
- **Sidebar edge + stacking.** The sidebar gains a right-edge shadow against the content (light mode only; `none` in dark, where the chrome/content tonal step carries the separation) plus `position: relative; z-index: 1` under the header's `z-index: 2` so the shadows paint over the page content. Its `transition: all` is narrowed to `width / background-color / box-shadow` so mode flips don't animate layout.
- Dropped the heavy `rgba(0,0,0,.4)` blur on the mobile nav toggle — it only worked on dark chrome.

`navigation.css` needed no functional changes: the active pill (white-on-periwinkle pinned in both modes) and the separator / nested-border rules (`chrome-fg-muted` at 30% alpha) were already written mode-aware; only their comments' stale value references were corrected. Brand accents (periwinkle wordmark/pill, salmon dropdown hover, rose/green footer credits) and the self-contained dark-badge logo read fine on both chrome surfaces.

`.agents/architecture.md`'s theme-token section is updated to describe the flipping contract.

## Verification

- `npm run build -w packages/client-web-theme` ✅
- `npm run build -w apps/server-core` (compiles the embedded UI through Tailwind v4) ✅
- Dark mode resolves to the exact same values as before (slate pins + inset bands)

🤖 Generated with [Claude Code](https://claude.com/claude-code)