### PR TITLE
feat: sub-path deployment support for backend-served auth workflow UI

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -378,6 +378,21 @@ not by client-web:
   restores the authorize request. `sanitizeRelativeRedirect()` in
   `adapters/http/ui/render.ts` rejects absolute / protocol-relative URLs
   (open-redirect guard).
+- **Sub-path deployment**: the SSR UI works behind a prefix-stripping
+  reverse proxy (e.g. `https://example.com/auth/* → authup /*`) with no
+  extra config — the prefix is derived from `publicUrl`'s pathname
+  (`getURLBasePath` in `@authup/kit`). The vite build keeps its fixed
+  `base: '/public/'`; `renderUIPage` rebases emitted asset URLs onto the
+  prefix per request (`rebasePublicAssetURLs` in
+  `adapters/http/ui/base-path.ts`, so the prebuilt dist stays
+  deployment-agnostic). Inside the UI app the same prefix feeds the
+  vue-router history base (`ui/src/app.ts`) and the `useBasePath()`
+  composable (`ui/src/base-path.ts`) that pages use for inter-page hrefs
+  and rendered `redirect` values — `redirect`/`requestPath` params stay
+  server-local (prefix-free); the prefix is applied only when a path is
+  rendered as an href. Server-side `Location` redirects are unaffected
+  (built from full `publicUrl`). A true subdomain (no pathname) yields an
+  empty prefix and identical behavior to before.
 - **Kit form components** (`@authup/client-web-kit`,
   `src/components/workflows/`): `ALoginForm` (renamed from `ALogin`,
   deprecated alias kept; optional `registerLink` / `passwordForgotLink`
@@ -586,6 +601,7 @@ adapters/http/controllers/workflows/
 
 adapters/http/ui/
   render.ts                         — renderUIPage(event, {url, payload}) shared SSR plumbing + sanitizeRelativeRedirect()
+  base-path.ts                      — rebasePublicAssetURLs(html, basePath) sub-path asset rewrite (prefix from publicUrl pathname)
 
 adapters/http/request/helpers/
   actor.ts                          — buildActorContext(req) bridge function

--- a/apps/server-core/src/adapters/http/ui/base-path.ts
+++ b/apps/server-core/src/adapters/http/ui/base-path.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Rewrite root-absolute /public/ asset references (script/link/preload tags
+ * emitted with the fixed vite base) so they carry the path prefix under which
+ * authup is publicly served (e.g. /auth/public/...). The reverse proxy is
+ * expected to strip the prefix before the request reaches authup, so the
+ * assets middleware keeps serving at /public.
+ */
+export function rebasePublicAssetURLs(html: string, basePath: string) : string {
+    if (!basePath) {
+        return html;
+    }
+
+    return html.replace(/(src|href)="\/public\//g, `$1="${basePath}/public/`);
+}

--- a/apps/server-core/src/adapters/http/ui/index.ts
+++ b/apps/server-core/src/adapters/http/ui/index.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './base-path.ts';
 export * from './render.ts';
 export * from './serve.ts';
 export * from './types.ts';

--- a/apps/server-core/src/adapters/http/ui/render.ts
+++ b/apps/server-core/src/adapters/http/ui/render.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { getURLBasePath } from '@authup/kit';
 import { useRequestCookie } from '@routup/basic/cookie';
 import { load } from 'locter';
 import fs from 'node:fs';
@@ -15,6 +16,7 @@ import { CodeTransformation, isCodeTransformation } from 'typeorm-extension';
 import { UI_DIST_PATH, UI_SOURCE_PATH } from '../../../path.ts';
 import { VITE_SERVER_STORE_KEY } from '../middleware/index.ts';
 import { LOCALE_COOKIE } from '../request/helpers/locale.ts';
+import { rebasePublicAssetURLs } from './base-path.ts';
 import type { UIRenderContext } from './types.ts';
 
 const COLOR_MODE_COOKIE = 'vc-color-mode';
@@ -88,6 +90,11 @@ export async function renderUIPage(event: IAppEvent, ctx: UIRenderContext): Prom
     // so a reformatted tag / dev-mode transformIndexHtml rewrite still gets
     // the lang + color-mode attributes (no silent FOUC).
     body = body.replace(/<html\b[^>]*>/i, `<html ${htmlAttrs}>`);
+
+    // When authup is publicly served under a sub-path (publicUrl carries a
+    // pathname, e.g. https://example.com/auth), the fixed /public/ vite base
+    // would bypass the proxy mapping — rebase asset URLs onto the prefix.
+    body = rebasePublicAssetURLs(body, getURLBasePath(ctx.payload.config.baseURL));
 
     event.response.headers.set('content-type', 'text/html; charset=utf-8');
     return body;

--- a/apps/server-core/test/unit/adapters/http/ui/base-path.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/base-path.spec.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { rebasePublicAssetURLs } from '../../../../../src/adapters/http/ui/base-path.ts';
+
+const HTML = `<!doctype html>
+<html lang="en">
+<head>
+    <link rel="modulepreload" crossorigin href="/public/assets/chunk-abc.js">
+    <link rel="stylesheet" crossorigin href="/public/assets/index-def.css">
+    <link rel="preload" href="/public/assets/nunito-300-normal.woff2" as="font" type="font/woff2" crossorigin>
+    <script type="module" crossorigin src="/public/assets/index-ghi.js"></script>
+</head>
+<body>
+    <div id="app"></div>
+    <script>window.__PAYLOAD__ = {"config":{"baseURL":"https://example.com/auth"},"data":{"redirect":"/authorize?response_type=code"}}</script>
+</body>
+</html>`;
+
+describe('rebasePublicAssetURLs', () => {
+    it('prefixes script, stylesheet and preload references with the base path', () => {
+        const result = rebasePublicAssetURLs(HTML, '/auth');
+
+        expect(result).toContain('href="/auth/public/assets/chunk-abc.js"');
+        expect(result).toContain('href="/auth/public/assets/index-def.css"');
+        expect(result).toContain('href="/auth/public/assets/nunito-300-normal.woff2"');
+        expect(result).toContain('src="/auth/public/assets/index-ghi.js"');
+        expect(result).not.toContain('"/public/');
+    });
+
+    it('does not touch the hydration payload', () => {
+        const result = rebasePublicAssetURLs(HTML, '/auth');
+
+        expect(result).toContain('"redirect":"/authorize?response_type=code"');
+        expect(result).toContain('"baseURL":"https://example.com/auth"');
+    });
+
+    it('returns the input unchanged for an empty base path', () => {
+        expect(rebasePublicAssetURLs(HTML, '')).toBe(HTML);
+    });
+});

--- a/apps/server-core/ui/src/app.ts
+++ b/apps/server-core/ui/src/app.ts
@@ -12,7 +12,7 @@ import {
     syncTranslatorLocaleFromManager,
 } from '@authup/client-web-kit';
 import { matchLocale } from '@authup/i18n';
-import { omitRecord } from '@authup/kit';
+import { getURLBasePath, omitRecord } from '@authup/kit';
 import { createPinia } from 'pinia';
 import type { App } from 'vue';
 import { createSSRApp, ref } from 'vue';
@@ -57,10 +57,15 @@ export function createApp(payload: HydrationPayload) : {
 
     const isClient = typeof window !== 'undefined';
 
+    // When authup is publicly served under a sub-path (baseURL carries a
+    // pathname), the browser location includes the prefix — the router base
+    // strips it so route matching keeps working on hydration.
+    const basePath = getURLBasePath(payload?.config?.baseURL);
+
     const router = createRouter({
         history: isClient ?
-            createWebHistory() :
-            createMemoryHistory(),
+            createWebHistory(basePath) :
+            createMemoryHistory(basePath),
         routes: [
             {
                 component: Authorize,

--- a/apps/server-core/ui/src/base-path.ts
+++ b/apps/server-core/ui/src/base-path.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { getURLBasePath } from '@authup/kit';
+import { injectPayload } from './di';
+
+/**
+ * Prefix a server-local path (e.g. /register, or a sanitized redirect like
+ * /authorize?...) with the sub-path authup is publicly served under, derived
+ * from the hydration payload's baseURL. Identity when served at the root.
+ */
+export function useBasePath() : (path: string) => string {
+    const payload = injectPayload();
+    const basePath = getURLBasePath(payload?.config?.baseURL);
+
+    return (path: string) => (
+        basePath && path.startsWith('/') ? `${basePath}${path}` : path
+    );
+}

--- a/apps/server-core/ui/src/pages/activate.vue
+++ b/apps/server-core/ui/src/pages/activate.vue
@@ -9,6 +9,7 @@ import { AActivateForm, AAuthShell, useTranslations } from '@authup/client-web-k
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { defineComponent } from 'vue';
+import { useBasePath } from '../base-path';
 import { injectPayload } from '../di';
 
 export default defineComponent({
@@ -31,9 +32,12 @@ export default defineComponent({
             },
         ]);
 
+        const withBasePath = useBasePath();
+
         return {
             data: payload.data,
             translations,
+            withBasePath,
         };
     },
 });
@@ -59,7 +63,7 @@ export default defineComponent({
             v-if="data.redirect"
             class="text-center"
         >
-            <a :href="data.redirect">{{ translations.backToLogin }}</a>
+            <a :href="withBasePath(data.redirect)">{{ translations.backToLogin }}</a>
         </div>
     </AAuthShell>
 </template>

--- a/apps/server-core/ui/src/pages/authorize.vue
+++ b/apps/server-core/ui/src/pages/authorize.vue
@@ -10,6 +10,7 @@ import type { Client, OAuth2AuthorizationCodeRequest, Scope } from '@authup/core
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import type { LinkProperties } from '@vuecs/link';
 import { computed, defineComponent } from 'vue';
+import { useBasePath } from '../base-path';
 import { injectPayload } from '../di';
 
 export default defineComponent({
@@ -24,6 +25,8 @@ export default defineComponent({
             requestPath: string | undefined
         }>();
 
+        const withBasePath = useBasePath();
+
         const buildWorkflowLink = (path: string) : LinkProperties => {
             const params = new URLSearchParams();
             if (app.data.codeRequest && app.data.codeRequest.realm_id) {
@@ -34,7 +37,7 @@ export default defineComponent({
             }
 
             const qs = params.toString();
-            return { href: `${path}${qs ? `?${qs}` : ''}` };
+            return { href: withBasePath(`${path}${qs ? `?${qs}` : ''}`) };
         };
 
         const registerLink = computed(() => (

--- a/apps/server-core/ui/src/pages/password-forgot.vue
+++ b/apps/server-core/ui/src/pages/password-forgot.vue
@@ -9,6 +9,7 @@ import { AAuthShell, APasswordForgotForm, useTranslations } from '@authup/client
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { defineComponent } from 'vue';
+import { useBasePath } from '../base-path';
 import { injectPayload } from '../di';
 
 export default defineComponent({
@@ -31,6 +32,8 @@ export default defineComponent({
             },
         ]);
 
+        const withBasePath = useBasePath();
+
         const resetPath = (() => {
             const params = new URLSearchParams();
             if (payload.data.realmId) {
@@ -40,13 +43,14 @@ export default defineComponent({
                 params.set('redirect', payload.data.redirect);
             }
             const qs = params.toString();
-            return `/password-reset${qs ? `?${qs}` : ''}`;
+            return withBasePath(`/password-reset${qs ? `?${qs}` : ''}`);
         })();
 
         return {
             data: payload.data,
             translations,
             resetPath,
+            withBasePath,
         };
     },
 });
@@ -56,7 +60,7 @@ export default defineComponent({
         <template v-if="data.features && data.features.passwordRecovery">
             <APasswordForgotForm
                 :realm-id="data.realmId"
-                :back-link="data.redirect ? { href: data.redirect } : undefined"
+                :back-link="data.redirect ? { href: withBasePath(data.redirect) } : undefined"
             />
 
             <div class="text-center">

--- a/apps/server-core/ui/src/pages/password-reset.vue
+++ b/apps/server-core/ui/src/pages/password-reset.vue
@@ -9,6 +9,7 @@ import { AAuthShell, APasswordResetForm, useTranslations } from '@authup/client-
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { defineComponent } from 'vue';
+import { useBasePath } from '../base-path';
 import { injectPayload } from '../di';
 
 export default defineComponent({
@@ -32,9 +33,12 @@ export default defineComponent({
             },
         ]);
 
+        const withBasePath = useBasePath();
+
         return {
             data: payload.data,
             translations,
+            withBasePath,
         };
     },
 });
@@ -57,7 +61,7 @@ export default defineComponent({
             v-if="data.redirect"
             class="text-center"
         >
-            <a :href="data.redirect">{{ translations.backToLogin }}</a>
+            <a :href="withBasePath(data.redirect)">{{ translations.backToLogin }}</a>
         </div>
     </AAuthShell>
 </template>

--- a/apps/server-core/ui/src/pages/register.vue
+++ b/apps/server-core/ui/src/pages/register.vue
@@ -9,6 +9,7 @@ import { AAuthShell, ARegisterForm, useTranslations } from '@authup/client-web-k
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { defineComponent } from 'vue';
+import { useBasePath } from '../base-path';
 import { injectPayload } from '../di';
 
 export default defineComponent({
@@ -27,9 +28,12 @@ export default defineComponent({
             },
         ]);
 
+        const withBasePath = useBasePath();
+
         return {
             data: payload.data,
             translations,
+            withBasePath,
         };
     },
 });
@@ -39,7 +43,7 @@ export default defineComponent({
         <ARegisterForm
             v-if="data.features && data.features.registration"
             :realm-id="data.realmId"
-            :back-link="data.redirect ? { href: data.redirect } : undefined"
+            :back-link="data.redirect ? { href: withBasePath(data.redirect) } : undefined"
         />
         <div
             v-else

--- a/apps/server-core/ui/src/types.ts
+++ b/apps/server-core/ui/src/types.ts
@@ -7,7 +7,7 @@
 
 export type HydrationPayload<T extends Record<string, any> = Record<string, any>> = {
     config: {
-        publicURL: string,
+        baseURL?: string,
         [key: string]: any
     },
     data: T

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -34,6 +34,10 @@ export default {
     
     /**
      * API base URL.
+     * May include a path prefix (e.g. https://example.com/auth) when the
+     * server runs behind a reverse proxy that strips the prefix — asset
+     * URLs and links of the built-in auth pages are rebased onto it
+     * automatically.
      * default: http://localhost:3001
      */
     publicUrl: 'http://localhost:3001',

--- a/packages/kit/src/url.ts
+++ b/packages/kit/src/url.ts
@@ -8,3 +8,23 @@
 export function makeURLPublicAccessible(url: string) {
     return url.replace('0.0.0.0', '127.0.0.1');
 }
+
+export function getURLBasePath(url?: string) : string {
+    if (!url) {
+        return '';
+    }
+
+    let pathname : string;
+    try {
+        pathname = new URL(url).pathname;
+    } catch {
+        return '';
+    }
+
+    const normalized = pathname.replace(/\/+$/, '');
+    if (normalized === '' || normalized === '/') {
+        return '';
+    }
+
+    return normalized;
+}

--- a/packages/kit/src/url.ts
+++ b/packages/kit/src/url.ts
@@ -21,7 +21,9 @@ export function getURLBasePath(url?: string) : string {
         return '';
     }
 
-    const normalized = pathname.replace(/\/+$/, '');
+    const normalized = pathname
+        .replace(/\/+$/, '')
+        .replace(/^\/{2,}/, '/');
     if (normalized === '' || normalized === '/') {
         return '';
     }

--- a/packages/kit/test/unit/url.spec.ts
+++ b/packages/kit/test/unit/url.spec.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getURLBasePath } from '../../src';
+
+describe('getURLBasePath', () => {
+    it('extracts the path prefix of a sub-path URL', () => {
+        expect(getURLBasePath('https://example.com/auth')).toBe('/auth');
+        expect(getURLBasePath('https://example.com/foo/bar')).toBe('/foo/bar');
+    });
+
+    it('strips trailing slashes', () => {
+        expect(getURLBasePath('https://example.com/auth/')).toBe('/auth');
+        expect(getURLBasePath('https://example.com/auth///')).toBe('/auth');
+    });
+
+    it('returns an empty string for root-level URLs', () => {
+        expect(getURLBasePath('https://example.com')).toBe('');
+        expect(getURLBasePath('https://example.com/')).toBe('');
+    });
+
+    it('returns an empty string for missing or invalid input', () => {
+        expect(getURLBasePath()).toBe('');
+        expect(getURLBasePath('')).toBe('');
+        expect(getURLBasePath('not a url')).toBe('');
+    });
+
+    it('ignores query and hash', () => {
+        expect(getURLBasePath('https://example.com/auth?foo=bar#baz')).toBe('/auth');
+    });
+});

--- a/packages/kit/test/unit/url.spec.ts
+++ b/packages/kit/test/unit/url.spec.ts
@@ -19,6 +19,12 @@ describe('getURLBasePath', () => {
         expect(getURLBasePath('https://example.com/auth///')).toBe('/auth');
     });
 
+    it('collapses duplicated leading slashes', () => {
+        expect(getURLBasePath('https://example.com//auth')).toBe('/auth');
+        expect(getURLBasePath('https://example.com///auth/')).toBe('/auth');
+        expect(getURLBasePath('https://example.com//')).toBe('');
+    });
+
     it('returns an empty string for root-level URLs', () => {
         expect(getURLBasePath('https://example.com')).toBe('');
         expect(getURLBasePath('https://example.com/')).toBe('');


### PR DESCRIPTION
## Summary

The embedded SSR auth pages (`/authorize`, `/register`, `/activate`, `/password-forgot`, `/password-reset`) now work when authup is served under a path prefix behind a prefix-stripping reverse proxy (e.g. `https://example.com/auth/* → authup /*`). The prefix is derived from `publicUrl`'s pathname — no new config option.

Previously, asset URLs were emitted root-absolute (`/public/assets/...` from the fixed vite `base: '/public/'`), so the browser requested them outside the proxy mapping → 404; vue-router route matching also broke on hydration, and inter-page links pointed at the site root.

## Changes

- **`@authup/kit`**: new `getURLBasePath(url)` — normalized pathname prefix of a URL (`https://example.com/auth/` → `/auth`; root/invalid → `''`).
- **server-core, `adapters/http/ui`**: new `rebasePublicAssetURLs(html, basePath)`; `renderUIPage` applies it per request using the payload's `baseURL`, rewriting `src`/`href` `/public/...` references (script/stylesheet/modulepreload/font-preload, prod + JIT). The prebuilt `dist/ui` stays deployment-agnostic; the vite base is untouched. The attribute-syntax regex never touches the hydration payload JSON (test asserts this).
- **server-core, `ui/` app**: the vue-router history gets the base path (hydration route matching under the prefix); new `useBasePath()` composable used by all five pages to prefix inter-page hrefs and rendered `redirect` back-links. `redirect`/`requestPath` query values stay server-local — the prefix is applied only when a path is rendered as an href. Also fixed the dead `publicURL` field in `HydrationPayload` to the `baseURL` everything actually sets.
- Unaffected by design (verified): API calls (kit client uses full `publicUrl`), OAuth2/IdP `Location` redirects (built from full `publicUrl`), `AuthorizeForm`'s `window.location` targets (absolute URLs). Subdomain deployments yield an empty prefix → behavior identical to before.
- Docs: `.agents/architecture.md` (Auth Workflow UI section + file map), `docs/src/guide/deployment/configuration-server-core.md` (`publicUrl` note).

## Tests

- `packages/kit`: new `url.spec.ts` (suite: 20 passed)
- `apps/server-core`: new `test/unit/adapters/http/ui/base-path.spec.ts`; adapters tree 31 passed; embedded UI vite build green; ESLint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support for deploying the authentication UI behind a reverse proxy that strips path prefixes from requests
  * Asset URLs and navigation links now automatically adjust when the application is deployed at sub-paths
  
* **Documentation**
  * Updated deployment configuration guide to clarify how sub-path deployments are handled and explain the automatic path rebasing behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->