### PR TITLE
fix(server-core): decouple CORS from app-origin allowlist

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -580,9 +580,11 @@ endpoint — the `/authorize` verifier already resolves clients via
 - **App origins** come from `getAppOrigins(config)` = `[publicUrl, ...additionalDomains]`
   reduced to bare origins. `ADDITIONAL_DOMAINS` (env, comma-separated) is
   **security-sensitive**: the `web` client is `built_in` (auto-consent) + `global`
-  scope, so any allowlisted origin can obtain a full-permission user token. The
-  same origin list also drives the CORS `origin` allowlist
-  (`mountCors` in `app/modules/http/modules/middleware.ts`). In non-production,
+  scope, so any allowlisted origin can obtain a full-permission user token.
+  The origin list does NOT drive CORS — CORS reflects any origin by default
+  (auth is header-based only, and OAuth2 clients are registered at runtime on
+  domains unknown at startup; an explicit allowlist can be set via the
+  `middlewareCors` config options). In non-production,
   `http://localhost:3000` is dev-seeded so client-web works on first run.
 - **Provisioning (`WebClientProvisioner.ensureForRealm`)** is the single upsert
   mechanism, run two ways and sharing the same factory so they can't drift:

--- a/apps/server-core/src/adapters/http/middleware/built-in/cors.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/cors.ts
@@ -11,9 +11,13 @@ import type { App } from 'routup';
 
 export function registerCorsMiddleware(router: App, input?: CorsOptions) {
     router.use(cors({
-        // @routup/cors reflects the matched origin when given an array (and
-        // still honours credentials: true). Callers pass the trusted
-        // appOrigins allowlist; falls back to reflect-all only if unset.
+        // Reflect any origin by default: OAuth2 clients (and their UIs) are
+        // registered at runtime on arbitrary domains, so a startup-time
+        // allowlist cannot know them. All authentication is header-based
+        // (Bearer/Basic) — no cookie-authenticated endpoint exists — so an
+        // origin allowlist would add no security, only break dynamically
+        // registered browser clients. Operators can still pass an explicit
+        // `origin` via the middlewareCors config options.
         origin: true,
         credentials: true,
         // `credentials: true` is incompatible with the `*` wildcard for

--- a/apps/server-core/src/app/modules/http/modules/middleware.ts
+++ b/apps/server-core/src/app/modules/http/modules/middleware.ts
@@ -26,7 +26,7 @@ import {
 import { HTTPInjectionKey } from '../constants.ts';
 import { DIST_PATH } from '../../../../path.ts';
 import { AuthenticationInjectionKey } from '../../authentication/index.ts';
-import { ConfigInjectionKey, getAppOrigins } from '../../config/index.ts';
+import { ConfigInjectionKey } from '../../config/index.ts';
 import { LoggerInjectionKey } from '../../logger/index.ts';
 import { IdentityInjectionKey } from '../../identity/index.ts';
 import { OAuth2InjectionToken } from '../../oauth2/index.ts';
@@ -69,13 +69,6 @@ export class HTTPMiddlewareModule {
         }
 
         const options = this.transformBoolToEmptyObject(config.middlewareCors) ?? {};
-
-        // Restrict CORS to the trusted application origins (publicUrl +
-        // additionalDomains) unless the operator explicitly configured an
-        // origin via the middlewareCors options object.
-        if (typeof options.origin === 'undefined') {
-            options.origin = getAppOrigins(config);
-        }
 
         registerCorsMiddleware(router, options);
     }

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -44,8 +44,8 @@ export default {
 
     /**
      * Additional trusted origins (bare origins, e.g. https://app.example.com).
-     * Each origin is added to the CORS allowlist and to the redirect-URI
-     * allowlist of the per-realm public `web` client (as `<origin>/**`).
+     * Each origin is added to the redirect-URI allowlist of the per-realm
+     * public `web` client (as `<origin>/**`).
      * The origin of `publicUrl` is always trusted implicitly.
      *
      * Security: the `web` client is built-in with global scope, so any

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -38,7 +38,10 @@ attempting to create or rename a client to it returns a `400 Bad Request`.
 The `redirect_uri` allowlist is derived from the set of trusted app origins:
 the origin of `publicUrl` plus every entry in `additionalDomains`
 (`ADDITIONAL_DOMAINS`). Each origin contributes one `<origin>/**` redirect
-pattern and is added to the CORS allowlist.
+pattern. (CORS is independent of this list — the API reflects any origin by
+default, since OAuth2 clients are registered at runtime on domains unknown at
+startup; an explicit allowlist can be configured via the `middlewareCors`
+options.)
 
 ::: danger Security
 The `web` client is built-in with the `global` scope, so **any** allowlisted


### PR DESCRIPTION
## Motivation

The `getAppOrigins(config)` CORS origin default (introduced with the per-realm `web`-client work, #3104) couples browser API reachability to a startup-time config list. But OAuth2 clients — and the UIs they belong to — are registered at **runtime** on domains unknown at startup: a legitimately registered SPA client passes `/authorize`, obtains tokens via PKCE, and then fails every API call on CORS preflight unless the operator also mirrored its domain into `ADDITIONAL_DOMAINS`. That's a hidden coupling between two mechanisms that should be independent.

## Why this is safe

- All authentication is header-based (`Authorization: Bearer/Basic`) — no endpoint is cookie-authenticated (the only cookies the server reads are `vc-locale` / `vc-color-mode`). A CORS allowlist only adds security against ambient-credential (cookie) attacks, so it adds none here: a malicious origin doesn't hold the victim's token.
- This matches the OAuth Browser-Based Apps BCP: the token endpoint should be CORS-open to any origin; the real security boundary for browser flows is `redirect_uri` binding + PKCE, which authup enforces.
- `ADDITIONAL_DOMAINS` keeps its genuinely security-sensitive job: which origins get the built-in `web` client's `<origin>/**` redirect wildcard (auto-consent + global scope). That stays explicit startup config.

## Changes

- `mountCors` no longer defaults `origin` to `getAppOrigins(config)` — `registerCorsMiddleware`'s reflect-any-origin default applies again (pre-#3104 behavior). An explicit allowlist remains configurable via the `middlewareCors` config options.
- Updated the rationale comment in `cors.ts` and the `ADDITIONAL_DOMAINS` docs (`.agents/architecture.md`, deployment configuration + provisioning guides) to stop claiming the origin list drives CORS.

## Verification

- `npm run build -w apps/server-core` clean
- Full server-core suite: **89 files / 868 tests passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)