### PR TITLE
refactor: retire bootstrap-compat badge/nav/form shims (plan 017-A)

### DIFF
--- a/apps/client-web/components/sidebar.vue
+++ b/apps/client-web/components/sidebar.vue
@@ -92,18 +92,14 @@ export default defineNuxtComponent({
             </div>
 
             <!--
-                Use Bootstrap's `.nav .flex-col` instead of
-                `.navbar-nav`: navbar-nav zeroes
-                `--bs-nav-link-padding-x` (correct for the header bar,
-                wrong for a sidebar). Bare `.nav` provides the CSS-var
-                scope `.nav-link` reads its padding from
-                (`--bs-nav-link-padding-x: 1rem; --bs-nav-link-padding-y:
-                0.5rem;`); `.flex-col` keeps the layout vertical
-                (`.nav` alone is `display: flex; flex-wrap: wrap;`, which
-                would lay items out horizontally).
+                Vertical flex column for the side nav. (Previously
+                Bootstrap's `.nav .flex-col` shim; `.nav` is retired —
+                VCNavItems is already a flex column via theme-tailwind,
+                and `flex flex-wrap flex-col` mirrors the old `.nav` for
+                the hand-rolled API-docs list below.)
             -->
             <VCNavItems
-                class="sidebar-menu nav flex-col"
+                class="sidebar-menu flex flex-wrap flex-col"
                 :data="sideItems"
                 :watch="sideItemsWatch"
             />
@@ -132,10 +128,10 @@ export default defineNuxtComponent({
                     </small>
                 </div>
 
-                <ul class="sidebar-menu vc-nav-items nav flex-col">
+                <ul class="sidebar-menu vc-nav-items flex flex-wrap flex-col">
                     <li class="vc-nav-item">
                         <a
-                            class="vc-nav-link nav-link flex items-center gap-2 text-sm"
+                            class="vc-nav-link flex items-center gap-2 text-sm px-3"
                             :href="docsUrl"
                             target="_blank"
                         >

--- a/packages/client-web-kit/src/components/entities/policy/APolicyInlineInfo.vue
+++ b/packages/client-web-kit/src/components/entities/policy/APolicyInlineInfo.vue
@@ -9,6 +9,7 @@
 import type { Policy } from '@authup/core-kit';
 import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
+import { VCBadge } from '@vuecs/elements';
 import {
     TranslatorTranslationCommonKey,
     TranslatorTranslationNamespace,
@@ -18,7 +19,11 @@ import APolicyTypeBadge from './APolicyTypeBadge.vue';
 import APolicyDetailNav from './APolicyDetailNav.vue';
 
 export default defineComponent({
-    components: { APolicyTypeBadge, APolicyDetailNav },
+    components: {
+        APolicyTypeBadge, 
+        APolicyDetailNav, 
+        VCBadge, 
+    },
     props: {
         entity: {
             type: Object as PropType<Policy>,
@@ -44,10 +49,13 @@ export default defineComponent({
 </script>
 <template>
     <APolicyTypeBadge :type="entity.type" />
-    <span
+    <VCBadge
         v-if="entity.invert"
-        class="badge bg-warning-500"
-    >{{ translations.inverted }}</span>
+        color="warning"
+        variant="solid"
+    >
+        {{ translations.inverted }}
+    </VCBadge>
     <APolicyDetailNav
         :policy-id="entity.id"
         @click="handleDetail"

--- a/packages/client-web-kit/src/components/entities/policy/APolicySummary.vue
+++ b/packages/client-web-kit/src/components/entities/policy/APolicySummary.vue
@@ -9,6 +9,7 @@
 import type { Policy } from '@authup/core-kit';
 import type { PropType } from 'vue';
 import { defineComponent } from 'vue';
+import { VCBadge } from '@vuecs/elements';
 import {
     TranslatorTranslationCommonKey,
     TranslatorTranslationFieldKey,
@@ -18,7 +19,7 @@ import { useTranslations } from '../../../core';
 import APolicyTypeBadge from './APolicyTypeBadge.vue';
 
 export default defineComponent({
-    components: { APolicyTypeBadge },
+    components: { APolicyTypeBadge, VCBadge },
     props: {
         entity: {
             type: Object as PropType<Policy>,
@@ -93,7 +94,12 @@ export default defineComponent({
         >
             <strong style="min-width: 120px">{{ translations.invert }}</strong>
             <div>
-                <span class="badge bg-warning-500">{{ translations.yes }}</span>
+                <VCBadge
+                    color="warning"
+                    variant="solid"
+                >
+                    {{ translations.yes }}
+                </VCBadge>
             </div>
         </div>
         <div
@@ -102,7 +108,12 @@ export default defineComponent({
         >
             <strong style="min-width: 120px">{{ translations.builtIn }}</strong>
             <div>
-                <span class="badge bg-bg-elevated">{{ translations.yes }}</span>
+                <VCBadge
+                    color="neutral"
+                    variant="soft"
+                >
+                    {{ translations.yes }}
+                </VCBadge>
             </div>
         </div>
     </div>

--- a/packages/client-web-kit/src/components/entities/policy/APolicyTypeBadge.vue
+++ b/packages/client-web-kit/src/components/entities/policy/APolicyTypeBadge.vue
@@ -7,6 +7,7 @@
 
 <script lang="ts">
 import { computed, defineComponent } from 'vue';
+import { VCBadge } from '@vuecs/elements';
 import {
     TranslatorTranslationClientKey,
     TranslatorTranslationNamespace,
@@ -15,6 +16,7 @@ import { useTranslationsForNamespace } from '../../../core';
 import { POLICY_TYPE_TRANSLATION_KEYS } from './policy-type';
 
 export default defineComponent({
+    components: { VCBadge },
     props: {
         type: {
             type: String,
@@ -50,5 +52,10 @@ export default defineComponent({
 });
 </script>
 <template>
-    <span class="badge bg-info-500">{{ label }}</span>
+    <VCBadge
+        color="info"
+        variant="solid"
+    >
+        {{ label }}
+    </VCBadge>
 </template>

--- a/packages/client-web-theme/assets/css/index.css
+++ b/packages/client-web-theme/assets/css/index.css
@@ -349,17 +349,7 @@
     .alert-danger  { @apply border-error-200   bg-error-50   text-error-700; }
     .alert-info    { @apply border-info-200    bg-info-50    text-info-700; }
 
-    /* Badges --------------------------------------------------------- */
-    .badge {
-        @apply inline-flex items-center rounded-full px-2 py-0.5
-               text-xs font-medium;
-    }
-
-    /* Nav / navbar — bootstrap's nav components ---------------------- */
-    .nav             { @apply flex flex-wrap; }
-    .nav-item        { @apply list-none; }
-    .nav-link        { @apply block px-3 py-2 text-fg hover:text-primary-600 no-underline; }
-    .nav-link.active { @apply text-primary-600; }
+    /* Navbar — bootstrap's navbar components ------------------------- */
     .navbar          { @apply flex flex-wrap items-center justify-between; }
     .navbar-nav      { @apply flex flex-col list-none; }
     .navbar-brand    { @apply mr-4 inline-block py-2 text-lg whitespace-nowrap; }
@@ -391,10 +381,6 @@
     .navbar-expand-md .navbar-collapse { @apply md:flex!; }
     .navbar-expand-md .navbar-nav      { @apply md:flex-row!; }
     .navbar-expand-md                  { @apply md:flex-nowrap md:justify-start; }
-
-    /* Forms — minimal shims (vuecs SFCs own the real form styles) ---- */
-    .form-group   { @apply mb-3; }
-    .form-switch  { @apply inline-flex items-center gap-2; }
 
     /* Pagination — override theme-tailwind's per-button rounded-md to a
        joined-tab look (only first / last buttons get rounded outer

--- a/packages/client-web-theme/assets/css/styles/navigation.css
+++ b/packages/client-web-theme/assets/css/styles/navigation.css
@@ -11,15 +11,12 @@
 }
 
 /*
- * Bump the sidebar's nav-link vertical padding. The sidebar's
- * VCNavItems renders `.vc-nav-link` (vuecs prefix), so target that;
- * the legacy "API Docs" anchor at the bottom of the sidebar still
- * uses plain `.nav-link`, so cover both. Replaces the pre-Tailwind
- * `--bs-nav-link-padding-y` CSS-variable bump that lived inside the
- * Bootstrap `.nav` scope.
+ * Bump the sidebar's nav-link vertical padding. Both the VCNavItems
+ * links and the hand-rolled "API Docs" anchor carry `.vc-nav-link`.
+ * Replaces the pre-Tailwind `--bs-nav-link-padding-y` CSS-variable
+ * bump that lived inside the Bootstrap `.nav` scope.
  */
-.page-sidebar .vc-nav-link,
-.page-sidebar .nav-link {
+.page-sidebar .vc-nav-link {
     padding-top: 1rem;
     padding-bottom: 1rem;
 }


### PR DESCRIPTION
## Summary

Continues the **plan 017-A** phase-out of the transitional Bootstrap-compat `@layer components` block in `@authup/client-web-theme`. Removes three rule families whose only remaining call sites were migrated to native vuecs / Tailwind, with no behavior change.

Removed compat rules:
- `.badge`
- `.nav` / `.nav-item` / `.nav-link` (+ `.nav-link.active`)
- `.form-group` / `.form-switch` (already dead — vuecs SFCs own form styling)

## Changes

- **3 policy components** (`APolicyTypeBadge`, `APolicyInlineInfo`, `APolicySummary`) → `<VCBadge :color :variant>` (info / warning → `solid`, `bg-elevated` → `neutral` `soft`).
- **`sidebar.vue`** — `.nav flex-col` → `flex flex-wrap flex-col`; the hand-rolled API-docs anchor moves off `.nav-link` onto `px-3` utilities.
- **`navigation.css`** — the sidebar nav-link padding selector now targets only `.vc-nav-link` (the legacy `.nav-link` fallback is gone).
- **`client-web-theme/index.css`** — the three rule families deleted from the compat layer; `.navbar*` / `.alert*` / `.btn*` / `.row`/`.col*` / pagination shims remain (tracked under plan 017-A for later families).

## Verification

- `npx eslint --fix` clean on the 4 changed `.vue` files.
- `npm run build -w packages/client-web-kit` passes (tsdown + `vue-tsc` declaration emit).
- UI eyeballed in light + dark mode — badges, sidebar nav, and API-docs link render correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sidebar and navigation styling for improved visual consistency.
  * Refined policy badge appearance and presentation across components.

* **Refactor**
  * Consolidated badge rendering to use standardized badge components throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->