### PR TITLE
refactor: type entity timestamps as ISO-8601 string with runtime transformer

### DIFF
--- a/apps/server-core/src/adapters/database/domains/client-permission/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/client-permission/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Client,
     ClientPermission,
@@ -81,9 +82,9 @@ export class ClientPermissionEntity implements ClientPermission {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/client-role/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/client-role/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Client, 
     ClientRole, 
@@ -69,9 +70,9 @@ export class ClientRoleEntity implements ClientRole {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/client-scope/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/client-scope/entity.ts
@@ -15,6 +15,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Client,
     ClientScope,
@@ -39,11 +40,11 @@ export class ClientScopeEntity implements ClientScope {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/client/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/client/entity.ts
@@ -17,6 +17,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Client, Realm } from '@authup/core-kit';
 import { RealmEntity } from '../realm/index.ts';
 
@@ -128,10 +129,10 @@ export class ClientEntity implements Client {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/domains/identity-provider-account/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-account/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
  
     IdentityProvider, 
@@ -84,11 +85,11 @@ export class IdentityProviderAccountEntity implements IdentityProviderAccount {
     })
     expires_at: string | null;
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/identity-provider-attribute-mapping/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-attribute-mapping/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { IdentityProviderAttributeMapping, IdentityProviderMappingSyncMode, Realm } from '@authup/core-kit';
 import { IdentityProviderEntity } from '../identity-provider/index.ts';
 import { RealmEntity } from '../realm/index.ts';
@@ -65,11 +66,11 @@ export class IdentityProviderAttributeMappingEntity implements IdentityProviderA
     })
     target_value: string | null;
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/identity-provider-attribute/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-attribute/entity.ts
@@ -15,6 +15,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { IdentityProvider, IdentityProviderAttribute, Realm } from '@authup/core-kit';
 import {
     deserialize,
@@ -71,9 +72,9 @@ export class IdentityProviderAttributeEntity implements IdentityProviderAttribut
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/identity-provider-permission-mapping/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-permission-mapping/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     IdentityProviderMappingSyncMode, 
     IdentityProviderPermissionMapping,
@@ -58,11 +59,11 @@ export class IdentityProviderPermissionMappingEntity implements IdentityProvider
     })
     value_is_regex: boolean;
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/identity-provider-role-mapping/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-role-mapping/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     IdentityProviderMappingSyncMode, 
     IdentityProviderRoleMapping, 
@@ -58,11 +59,11 @@ export class IdentityProviderRoleMappingEntity implements IdentityProviderRoleMa
     })
     value_is_regex: boolean;
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/identity-provider/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider/entity.ts
@@ -16,6 +16,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     IdentityProvider,
     IdentityProviderPreset,
@@ -63,10 +64,10 @@ export class IdentityProviderEntity implements IdentityProvider {
     })
     enabled: boolean;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     @Index()

--- a/apps/server-core/src/adapters/database/domains/key/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/key/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn, 
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { JWKType } from '@authup/specs';
 import type {
     Key,
@@ -71,11 +72,11 @@ export class KeyEntity implements Key {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/permission-policy/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/permission-policy/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Permission, 
     PermissionPolicy, 
@@ -31,10 +32,10 @@ export class PermissionPolicyEntity implements PermissionPolicy {
     @PrimaryGeneratedColumn('uuid')
     id: string;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/domains/permission/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/permission/entity.ts
@@ -16,6 +16,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { DecisionStrategy } from '@authup/kit';
 import type { Client, Realm } from '@authup/core-kit';
 import { RealmEntity } from '../realm/index.ts';
@@ -88,9 +89,9 @@ export class PermissionEntity {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/policy-attribute/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/policy-attribute/entity.ts
@@ -15,6 +15,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Policy, PolicyAttribute, Realm } from '@authup/core-kit';
 import {
     deserialize,
@@ -72,9 +73,9 @@ export class PolicyAttributeEntity implements PolicyAttribute {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/policy/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/policy/entity.ts
@@ -19,6 +19,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Policy, Realm } from '@authup/core-kit';
 import { RealmEntity } from '../realm/index.ts';
 
@@ -91,9 +92,9 @@ export class PolicyEntity implements Policy {
     @JoinColumn({ name: 'realm_id' })
     realm: Realm | null;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/realm/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/realm/entity.ts
@@ -12,6 +12,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Realm } from '@authup/core-kit';
 
 @Entity({ name: 'auth_realms' })
@@ -46,9 +47,9 @@ export class RealmEntity implements Realm {
     })
     built_in: boolean;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/robot-permission/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/robot-permission/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Permission, 
     Policy, 
@@ -81,9 +82,9 @@ export class RobotPermissionEntity implements RobotPermission {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/robot-role/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/robot-role/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Realm, 
     Robot, 
@@ -69,9 +70,9 @@ export class RobotRoleEntity implements RobotRole {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/robot/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/robot/entity.ts
@@ -19,6 +19,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Client,
     Realm,
@@ -68,11 +69,11 @@ export class RobotEntity implements Robot {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/role-attribute/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/role-attribute/entity.ts
@@ -15,6 +15,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Realm, Role, RoleAttribute } from '@authup/core-kit';
 import {
     deserialize,
@@ -70,9 +71,9 @@ export class RoleAttributeEntity implements RoleAttribute {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/role-permission/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/role-permission/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Permission,
     Policy,
@@ -35,11 +36,11 @@ export class RolePermissionEntity implements RolePermission {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/role/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/role/entity.ts
@@ -17,6 +17,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import { RealmEntity } from '../realm/index.ts';
 
 @Entity({ name: 'auth_roles' })
@@ -85,9 +86,9 @@ export class RoleEntity implements Role {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/scope/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/scope/entity.ts
@@ -16,6 +16,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Realm, Scope } from '@authup/core-kit';
 import { RealmEntity } from '../realm/index.ts';
 
@@ -52,10 +53,10 @@ export class ScopeEntity implements Scope {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/domains/session/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/session/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn, 
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Client, 
     Realm, 
@@ -82,10 +83,10 @@ export class SessionEntity implements Session {
     })
     seen_at: string | null;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/adapters/database/domains/user-attribute/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/user-attribute/entity.ts
@@ -15,6 +15,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Realm, User, UserAttribute } from '@authup/core-kit';
 import { deserialize, serialize } from '@authup/kit';
 import { RealmEntity } from '../realm/index.ts';
@@ -64,9 +65,9 @@ export class UserAttributeEntity implements UserAttribute {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/user-permission/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/user-permission/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Permission,
     Policy,
@@ -35,11 +36,11 @@ export class UserPermissionEntity implements UserPermission {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/domains/user-role/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/user-role/entity.ts
@@ -15,6 +15,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type {
     Realm, 
     Role, 
@@ -69,9 +70,9 @@ export class UserRoleEntity implements UserRole {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
     created_at: string;
 
-    @UpdateDateColumn()
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
     updated_at: string;
 }

--- a/apps/server-core/src/adapters/database/domains/user/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/user/entity.ts
@@ -18,6 +18,7 @@ import {
     Unique,
     UpdateDateColumn,
 } from 'typeorm';
+import { dateToISOStringTransformer } from '../../helpers/index.ts';
 import type { Realm, User } from '@authup/core-kit';
 import { RealmEntity } from '../realm/index.ts';
 
@@ -160,11 +161,11 @@ export class UserEntity implements User {
 
     // ------------------------------------------------------------------
 
-    @CreateDateColumn()
-    created_at: Date;
+    @CreateDateColumn({ transformer: dateToISOStringTransformer })
+    created_at: string;
 
-    @UpdateDateColumn()
-    updated_at: Date;
+    @UpdateDateColumn({ transformer: dateToISOStringTransformer })
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/apps/server-core/src/adapters/database/helpers/date.ts
+++ b/apps/server-core/src/adapters/database/helpers/date.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+import type { ValueTransformer } from 'typeorm';
+
+/**
+ * Normalize datetime column reads to ISO-8601 strings.
+ *
+ * TypeORM hydrates @CreateDateColumn / @UpdateDateColumn / datetime columns to
+ * Date objects in-process (pg/mysql2 return Date natively; sqlite datetime
+ * strings are normalized to Date by the driver before this transformer runs).
+ * Without this transformer a string-typed timestamp field would still be a Date
+ * at runtime server-side. Applying it makes the runtime value match the declared
+ * `string` type, so there is a single timestamp representation across backend and
+ * frontend with no per-consumer re-hydration.
+ */
+export const dateToISOStringTransformer : ValueTransformer = {
+    to(value) {
+        return value;
+    },
+    from(value) {
+        return value instanceof Date ? value.toISOString() : value;
+    },
+};

--- a/apps/server-core/src/adapters/database/helpers/index.ts
+++ b/apps/server-core/src/adapters/database/helpers/index.ts
@@ -5,4 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './date.ts';
 export * from './is-supported.ts';

--- a/apps/server-core/test/unit/adapters/database/timestamp.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/timestamp.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { RealmEntity, UserEntity } from '../../../../src';
+import { createFakeRealm, createFakeUser } from '../../../utils/index.ts';
+import { createTestApplication } from '../../../app/index.ts';
+
+// Asserts the runtime matches the declared string type: @CreateDateColumn /
+// @UpdateDateColumn values are normalized to ISO-8601 strings on the read path
+// by dateToISOStringTransformer (in-process, before any JSON boundary).
+describe('adapters/database/timestamp', () => {
+    const suite = createTestApplication();
+
+    beforeAll(async () => {
+        await suite.setup();
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    const expectISOString = (value: unknown) => {
+        expect(typeof value).toBe('string');
+        expect(Number.isNaN(Date.parse(value as string))).toBe(false);
+        expect(new Date(value as string).toISOString()).toBe(value);
+    };
+
+    it('should hydrate realm timestamps as ISO strings', async () => {
+        const created = await suite.client.realm.create(createFakeRealm());
+
+        const entity = await suite.dataSource
+            .getRepository(RealmEntity)
+            .findOneByOrFail({ id: created.id });
+
+        expectISOString(entity.created_at);
+        expectISOString(entity.updated_at);
+    });
+
+    it('should hydrate user timestamps as ISO strings', async () => {
+        const created = await suite.client.user.create(createFakeUser());
+
+        const entity = await suite.dataSource
+            .getRepository(UserEntity)
+            .findOneByOrFail({ id: created.id });
+
+        expectISOString(entity.created_at);
+        expectISOString(entity.updated_at);
+    });
+});

--- a/packages/core-kit/src/domains/attempt-activation/entity.ts
+++ b/packages/core-kit/src/domains/attempt-activation/entity.ts
@@ -14,7 +14,7 @@ export interface AttemptActivation {
 
     token: string | null,
 
-    created_at: Date | string,
+    created_at: string,
 
-    updated_at: Date | string,
+    updated_at: string,
 }

--- a/packages/core-kit/src/domains/attempt-login/entity.ts
+++ b/packages/core-kit/src/domains/attempt-login/entity.ts
@@ -22,7 +22,7 @@ export interface AttemptLogin {
 
     user_id: User['id'],
 
-    created_at: Date | string,
+    created_at: string,
 
-    updated_at: Date | string,
+    updated_at: string,
 }

--- a/packages/core-kit/src/domains/attempt-reset/entity.ts
+++ b/packages/core-kit/src/domains/attempt-reset/entity.ts
@@ -16,7 +16,7 @@ export interface AttemptReset {
 
     token: string | null,
 
-    created_at: Date | string,
+    created_at: string,
 
-    updated_at: Date | string,
+    updated_at: string,
 }

--- a/packages/core-kit/src/domains/client-permission/entity.ts
+++ b/packages/core-kit/src/domains/client-permission/entity.ts
@@ -14,9 +14,9 @@ export interface ClientPermission extends PermissionRelation {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/identity-provider-account/entity.ts
+++ b/packages/core-kit/src/domains/identity-provider-account/entity.ts
@@ -18,9 +18,9 @@ export interface IdentityProviderAccount {
 
     provider_user_email: string;
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/packages/core-kit/src/domains/identity-provider-attribute-mapping/entity.ts
+++ b/packages/core-kit/src/domains/identity-provider-attribute-mapping/entity.ts
@@ -14,7 +14,7 @@ export interface IdentityProviderAttributeMapping extends IdentityProviderBaseMa
 
     target_value: string | null;
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/identity-provider-permission-mapping/entity.ts
+++ b/packages/core-kit/src/domains/identity-provider-permission-mapping/entity.ts
@@ -12,9 +12,9 @@ import type { Realm } from '../realm';
 export interface IdentityProviderPermissionMapping extends IdentityProviderBaseMapping {
     id: string;
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/packages/core-kit/src/domains/identity-provider-role-mapping/entity.ts
+++ b/packages/core-kit/src/domains/identity-provider-role-mapping/entity.ts
@@ -12,9 +12,9 @@ import type { Realm } from '../realm';
 export interface IdentityProviderRoleMapping extends IdentityProviderBaseMapping {
     id: string;
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // -----------------------------------------------
 

--- a/packages/core-kit/src/domains/key/type.ts
+++ b/packages/core-kit/src/domains/key/type.ts
@@ -38,9 +38,9 @@ export interface Key {
 
     // ------------------------------------------------------------------
 
-    created_at: Date | string,
+    created_at: string,
 
-    updated_at: Date | string,
+    updated_at: string,
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/policy-attribute/entity.ts
+++ b/packages/core-kit/src/domains/policy-attribute/entity.ts
@@ -29,7 +29,7 @@ export interface PolicyAttribute {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 }

--- a/packages/core-kit/src/domains/robot-permission/entity.ts
+++ b/packages/core-kit/src/domains/robot-permission/entity.ts
@@ -14,9 +14,9 @@ export interface RobotPermission extends PermissionRelation {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/robot/entity.ts
+++ b/packages/core-kit/src/domains/robot/entity.ts
@@ -24,9 +24,9 @@ export interface Robot {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/role-permission/entity.ts
+++ b/packages/core-kit/src/domains/role-permission/entity.ts
@@ -14,9 +14,9 @@ export interface RolePermission extends PermissionRelation {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/user-permission/entity.ts
+++ b/packages/core-kit/src/domains/user-permission/entity.ts
@@ -14,9 +14,9 @@ export interface UserPermission extends PermissionRelation {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 

--- a/packages/core-kit/src/domains/user/entity.ts
+++ b/packages/core-kit/src/domains/user/entity.ts
@@ -52,9 +52,9 @@ export interface User {
 
     // ------------------------------------------------------------------
 
-    created_at: Date;
+    created_at: string;
 
-    updated_at: Date;
+    updated_at: string;
 
     // ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Finishes migrating entity timestamp fields (`created_at`, `updated_at`) from `Date` to an ISO-8601 `string`, so the type matches the form these values take across every transport (JSON has no `Date`). Mirrors the FLAME Hub equivalent (PrivateAIM/hub#1722).

The migration has **two layers** — typing alone is not enough:

### 1. Type
Declared the remaining `@authup/core-kit` domain-entity timestamps as `string` (the other half were already migrated):

- `role-permission`, `client-permission`, `robot-permission`, `user-permission`
- `user`, `robot`, `key`, `policy-attribute`
- `identity-provider-account`, `identity-provider-{role,permission,attribute}-mapping`
- `attempt-login`, `attempt-activation`, `attempt-reset`

### 2. Runtime
Added a shared `dateToISOStringTransformer` (`adapters/database/helpers/date.ts`) and applied it to **every** `@CreateDateColumn` / `@UpdateDateColumn` across all 28 TypeORM entities.

TypeORM hydrates these columns to `Date` in-process (`pg`/`mysql2` return `Date` natively; sqlite datetime strings are normalized to `Date` by the driver *before* the column transformer runs). Without a transformer a `string`-typed field would still be a `Date` server-side — accurate only at the JSON boundary. The transformer normalizes the read value to an ISO string so the runtime genuinely matches the type: **one timestamp representation across backend and frontend, no per-consumer re-hydration.**

```ts
export const dateToISOStringTransformer: ValueTransformer = {
    to(value) { return value; },
    from(value) { return value instanceof Date ? value.toISOString() : value; },
};
```

### Re acceptance criterion 3 (drop redundant `Date` re-hydration)
No `new Date(entity.created_at)`-style re-hydration exists in the clients/adapters, so there was nothing to remove. The OIDC `claims.ts` `updated_at` handler intentionally stays defensive (accepts both `Date` and `string` → unix seconds, with explicit tests for both branches) and is left untouched — it is *dehydration*, not re-hydration.

## Testing
- New repository-level spec (`test/unit/adapters/database/timestamp.spec.ts`) asserts fetched `created_at` / `updated_at` are ISO strings that round-trip exactly through `new Date().toISOString()` — proving the in-process contract, not just the JSON wire shape.
- Verified green against **better-sqlite3** (default), **PostgreSQL**, and **MySQL**.
- Full `server-core` suite: 882 passed.
- Full monorepo build (22 projects) + lint clean.

Closes #3143

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized timestamp values across server entities and shared types to return ISO-formatted strings.
  * Added coverage to verify timestamp fields are consistently normalized when read from storage.

* **Bug Fixes**
  * Improved consistency for `created_at` and `updated_at` values across permissions, roles, users, robots, identity provider records, policies, sessions, and related data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->