### PR TITLE
refactor(oauth2): drop dead Date branch from OIDC updated_at claim handlers

### DIFF
--- a/apps/server-core/src/core/oauth2/openid/claims.ts
+++ b/apps/server-core/src/core/oauth2/openid/claims.ts
@@ -37,10 +37,6 @@ export class OAuth2OpenIDClaimsBuilder {
                     return Math.floor(new Date(value).getTime() / 1000);
                 }
 
-                if (value instanceof Date) {
-                    return Math.floor(value.getTime() / 1000);
-                }
-
                 return value;
             },
         ],
@@ -55,10 +51,6 @@ export class OAuth2OpenIDClaimsBuilder {
             (value: unknown) => {
                 if (typeof value === 'string') {
                     return Math.floor(new Date(value).getTime() / 1000);
-                }
-
-                if (value instanceof Date) {
-                    return Math.floor(value.getTime() / 1000);
                 }
 
                 return value;
@@ -77,10 +69,6 @@ export class OAuth2OpenIDClaimsBuilder {
             (value: unknown) => {
                 if (typeof value === 'string') {
                     return Math.floor(new Date(value).getTime() / 1000);
-                }
-
-                if (value instanceof Date) {
-                    return Math.floor(value.getTime() / 1000);
                 }
 
                 return value;

--- a/apps/server-core/test/unit/core/oauth2/openid/claims.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/openid/claims.spec.ts
@@ -55,22 +55,12 @@ describe('OAuth2OpenIDClaimsBuilder', () => {
             expect(result.preferred_username).toBe('my-client');
         });
 
-        it('should transform Date updated_at to unix timestamp in seconds per OIDC §5.1', () => {
-            const date = new Date('2025-01-15T12:00:00Z');
-            const client = {
-                name: 'c',
-                updated_at: date, 
-            } as Client;
-            const result = builder.fromClient(client);
-            expect(result.updated_at).toBe(Math.floor(date.getTime() / 1000));
-        });
-
         it('should transform string updated_at to unix timestamp in seconds per OIDC §5.1', () => {
             const dateStr = '2025-01-15T12:00:00Z';
             const client = {
                 name: 'c',
-                updated_at: dateStr, 
-            } as unknown as Client;
+                updated_at: dateStr,
+            } as Client;
             const result = builder.fromClient(client);
             expect(result.updated_at).toBe(Math.floor(new Date(dateStr).getTime() / 1000));
         });
@@ -92,14 +82,14 @@ describe('OAuth2OpenIDClaimsBuilder', () => {
             expect(result.preferred_username).toBe('my-robot');
         });
 
-        it('should transform Date updated_at to unix timestamp in seconds per OIDC §5.1', () => {
-            const date = new Date('2025-06-01T00:00:00Z');
+        it('should transform string updated_at to unix timestamp in seconds per OIDC §5.1', () => {
+            const dateStr = '2025-06-01T00:00:00Z';
             const robot = {
                 name: 'r',
-                updated_at: date, 
+                updated_at: dateStr,
             } as Robot;
             const result = builder.fromRobot(robot);
-            expect(result.updated_at).toBe(Math.floor(date.getTime() / 1000));
+            expect(result.updated_at).toBe(Math.floor(new Date(dateStr).getTime() / 1000));
         });
 
         it('should not have email or family_name', () => {
@@ -132,17 +122,17 @@ describe('OAuth2OpenIDClaimsBuilder', () => {
             expect(result.email_verified).toBe(true);
         });
 
-        it('should transform Date updated_at to unix timestamp in seconds per OIDC §5.1', () => {
-            const date = new Date('2025-03-01T10:30:00Z');
+        it('should transform string updated_at to unix timestamp in seconds per OIDC §5.1', () => {
+            const dateStr = '2025-03-01T10:30:00Z';
             const user = {
                 name: 'u',
-                updated_at: date, 
+                updated_at: dateStr,
             } as User;
             const result = builder.fromUser(user);
-            expect(result.updated_at).toBe(Math.floor(date.getTime() / 1000));
+            expect(result.updated_at).toBe(Math.floor(new Date(dateStr).getTime() / 1000));
         });
 
-        it('should pass through non-Date non-string updated_at', () => {
+        it('should pass through non-string updated_at', () => {
             const user = {
                 name: 'u',
                 updated_at: 1234567890, 


### PR DESCRIPTION
## Summary

Follow-up cleanup to #3147 (the ISO-8601 timestamp migration, closing #3143).

That PR typed every entity `created_at` / `updated_at` as a `string` and added a runtime read-transformer (`dateToISOStringTransformer`) to every `@CreateDateColumn` / `@UpdateDateColumn`, so `Client` / `Robot` / `User` `updated_at` is now guaranteed to be an ISO-8601 **string** in-process — not just at the JSON boundary.

#3147 deliberately left the OIDC claims builder's defensive `value instanceof Date` branch untouched (it classed it as *dehydration*, out of scope for acceptance criterion 3). With the runtime invariant now in place, that branch is genuinely unreachable on the normal repository path. This PR removes it.

## Changes

- **`core/oauth2/openid/claims.ts`** — drop the `value instanceof Date` branch from all three `updated_at` handlers (`clientMap`, `robotMap`, `userMap`). Each now does just the `string → epoch-seconds` conversion (per OIDC §5.1), keeping the `return value` pass-through fallback.
- **`test/unit/core/oauth2/openid/claims.spec.ts`** — the three "transform **Date** updated_at" cases fed dead input; converted to "transform **string** updated_at" (the real runtime shape). Renamed the user pass-through test to "pass through non-string updated_at". The redundant client Date test was dropped (client already had a string test).

Scope intentionally minimal — the three now-identical handlers are **not** deduplicated here; that's a separate optional refactor.

## Testing

- `server-core` build clean, eslint clean on both files.
- `claims.spec.ts` — 13/13.
- Dependent token-issuer specs (`open-id/module.spec.ts`, `access/module.spec.ts`) — 22/22.
