### PR TITLE
refactor(access,server-core)!: resource realm via the realmMatch policy key + typed PolicyData construction

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -726,37 +726,43 @@ total order and a fail-closed default:
 | **`any`** | always — any realm incl. null | `admin` |
 
 It is enforced inside the server-core `PermissionBindingPolicyEvaluator` (a separate
-factor, ANDed with the junction's `policy_id` policies), **only when the evaluated
-resource ATTRIBUTES carry a canonical `realm_id` key** (a single id, `null`, or an array
-of ids — `realmScopeMatches` requires the scope to reach every listed realm). A
-**realm-less / anonymous** actor can never satisfy `own`/`ownOrNull` (only `any`), and
-the factor is skipped entirely on `preEvaluate` / gate checks (no ATTRIBUTES). Merge
-across an actor's grants = ordered **MAX** (most permissive wins), so an admin's `any`
-dominates a stray `own` grant.
+factor, ANDed with the junction's `policy_id` policies) by invoking the
+`RealmMatchPolicyEvaluator` in **SCOPE MODE**: the merged grant `realm_scope` is matched
+against the resource realm supplied under the **`realmMatch` PolicyData key** (a single id,
+`null`, or an array of ids — `realmScopeMatches` requires the scope to reach every listed
+realm). The realm-match call is made **directly** (not via the policy engine — `realmMatch`
+is in `policiesExcluded`) and stays **outside** the `policies[]` merge, so the policy-free
+fail-open drop can never touch realm reach. A **realm-less / anonymous** actor can never
+satisfy `own`/`ownOrNull` (only `any`), and the factor neutral-passes when no `realmMatch`
+key is present (`preEvaluate` / gate checks / realm-less resources). Merge across an actor's
+grants = ordered **MAX** (most permissive wins), so an admin's `any` dominates a stray
+`own` grant.
 
-**Resources present their realm via the canonical `realm_id` key — entities AND
-junctions.** Entities carry `realm_id` as a column. Junction services
-(`role/user/client/robot-permission`, `user/client/robot-role`, `client-scope`,
+**Resources present their realm under the `realmMatch` PolicyData key — entities AND
+junctions.** Entity services derive it from the ATTRIBUTES `realm_id` via
+`AbstractEntityService.resourceRealmMatch` (set only when the source carries `realm_id`, so a
+self-edit UPDATE — where the validator strips `realm_id` — leaves the key absent and
+neutral-passes; `realm_id` also stays in ATTRIBUTES for the self-manage denylists). Junction
+services (`role/user/client/robot-permission`, `user/client/robot-role`, `client-scope`,
 `identity-provider-role-mapping`, `permission-policy`) carry no top-level `realm_id`
-(only `owner_realm_id`/`permission_realm_id`), so they **stamp their OWNER realm**
+(only `owner_realm_id`/`permission_realm_id`), so they set their **OWNER realm**
 (`role_realm_id` for role-permission, `user_realm_id` for user-role, `client_realm_id`
-for client-scope, …) onto a COPY of the `evaluate()` input. So a junction write to
-another realm's entity is realm-gated like a direct entity write — a `realm_admin` in
-realm A cannot bind a permission/role/scope onto a realm-B role/user/client even though
-the permission itself is global. (The *member* side — the permission/role being attached
-— is gated separately by the superset `preEvaluate`.) Stamping a `null` owner (a global
-entity) under `own` correctly denies, consistent with a `realm_admin` not being able to
-write a global base entity.
+for client-scope, … via `JunctionEntityService.junctionResourceRealm`) under the `realmMatch`
+key — junction ATTRIBUTES carry only genuine columns. So a junction write to another realm's
+entity is realm-gated like a direct entity write — a `realm_admin` in realm A cannot bind a
+permission/role/scope onto a realm-B role/user/client even though the permission itself is
+global. (The *member* side — the permission/role being attached — is gated separately by the
+superset `preEvaluate`.) Setting a `null` owner (a global entity) under `own` correctly
+denies, consistent with a `realm_admin` not being able to write a global base entity.
 
-> **Known limitation (tracked for the PolicyData redesign):** the factor reads the resource
-> realm from `realm_id` in the **ATTRIBUTES** bag, uniformly for entities and junctions. For
-> an entity that `realm_id` is a real column; for a junction it is *synthetic* (the stamped
-> owner realm). So an `ATTRIBUTE_NAMES` allowlist policy attached to a **junction** permission
-> would (mis)see the synthetic `realm_id` and reject. No default junction permission carries
-> such a policy, so this is latent — but **do not attach an `ATTRIBUTE_NAMES` allowlist to a
-> junction permission**. The clean fix is to carry the resource realm as evaluation *context*
-> (separate from the policy-type ATTRIBUTES bag); it is deferred to the broader rethink of how
-> `PolicyData` is built and passed to evaluators.
+> **One evaluator, no ATTRIBUTES pollution (plan 035):** the resource realm rides the dedicated
+> `realmMatch` PolicyData key — a legit policy-type slot read only by `RealmMatchPolicyEvaluator`
+> — instead of being stamped into the ATTRIBUTES bag. So `realm_scope` reach and user-authored
+> realm-match policies share **one** evaluator (SCOPE MODE vs attribute-name mode), and an
+> `ATTRIBUTE_NAMES` allowlist on a junction permission no longer mis-sees a synthetic `realm_id`
+> (junction ATTRIBUTES carry only genuine columns). The realm-match evaluator reads the realm
+> ONLY from `realmMatch` (single-source — an ATTRIBUTES `realm_id` is not a realm source for the
+> scope factor).
 
 > **Dependency:** this factor runs inside `PermissionBindingPolicyEvaluator`, i.e. only when
 > `system.default` is bound to the operation permission. Universal binding to every permission

--- a/apps/client-web/config/layout/module.ts
+++ b/apps/client-web/config/layout/module.ts
@@ -7,7 +7,7 @@
 
 import { type Store } from '@authup/client-web-kit';
 import type { IdentityPolicyData } from '@authup/access';
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import type { NavigationItem } from '@vuecs/navigation';
 
 import { LayoutSideDefaultNavigation } from './contants';
@@ -99,7 +99,7 @@ export class Navigation {
                     try {
                         await this.store.permissionEvaluator.preEvaluateOneOf({
                             name: permissions,
-                            data: definePolicyInput({ [BuiltInPolicyType.IDENTITY]: identity }),
+                            data: definePolicyData({ [BuiltInPolicyType.IDENTITY]: identity }),
                         });
                     } catch {
                         return undefined;

--- a/apps/client-web/config/layout/module.ts
+++ b/apps/client-web/config/layout/module.ts
@@ -7,7 +7,7 @@
 
 import { type Store } from '@authup/client-web-kit';
 import type { IdentityPolicyData } from '@authup/access';
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import type { NavigationItem } from '@vuecs/navigation';
 
 import { LayoutSideDefaultNavigation } from './contants';
@@ -99,7 +99,7 @@ export class Navigation {
                     try {
                         await this.store.permissionEvaluator.preEvaluateOneOf({
                             name: permissions,
-                            input: new PolicyData({ [BuiltInPolicyType.IDENTITY]: identity }),
+                            data: definePolicyInput({ [BuiltInPolicyType.IDENTITY]: identity }),
                         });
                     } catch {
                         return undefined;

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, base64URLDecode, isUUID } from '@authup/kit';
 import {
     DBody,
@@ -123,7 +123,7 @@ export class IdentityProviderController {
                 try {
                     await permissionEvaluator.evaluate({
                         name: PermissionName.IDENTITY_PROVIDER_READ,
-                        input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: datum, [BuiltInPolicyType.REALM_MATCH]: datum.realm_id ?? null }),
+                        data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: datum, [BuiltInPolicyType.REALM_MATCH]: datum.realm_id ?? null }),
                     });
                 } catch {
                     // do nothing
@@ -159,7 +159,7 @@ export class IdentityProviderController {
             const permissionEvaluator = useRequestPermissionEvaluator(event);
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_READ,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
             });
         } catch {
             // do nothing
@@ -204,7 +204,7 @@ export class IdentityProviderController {
 
         await permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
         });
 
         const { id: entityId } = entity;
@@ -408,7 +408,7 @@ export class IdentityProviderController {
         if (entity) {
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_UPDATE,
-                input: new PolicyData({
+                data: definePolicyInput({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...data,
@@ -424,7 +424,7 @@ export class IdentityProviderController {
 
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_CREATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: data, [BuiltInPolicyType.REALM_MATCH]: data.realm_id ?? null }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: data, [BuiltInPolicyType.REALM_MATCH]: data.realm_id ?? null }),
             });
         }
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -123,7 +123,7 @@ export class IdentityProviderController {
                 try {
                     await permissionEvaluator.evaluate({
                         name: PermissionName.IDENTITY_PROVIDER_READ,
-                        input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: datum }),
+                        input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: datum, [BuiltInPolicyType.REALM_MATCH]: datum.realm_id ?? null }),
                     });
                 } catch {
                     // do nothing
@@ -159,7 +159,7 @@ export class IdentityProviderController {
             const permissionEvaluator = useRequestPermissionEvaluator(event);
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_READ,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
             });
         } catch {
             // do nothing
@@ -204,7 +204,7 @@ export class IdentityProviderController {
 
         await permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
         });
 
         const { id: entityId } = entity;
@@ -413,6 +413,7 @@ export class IdentityProviderController {
                         ...entity,
                         ...data,
                     },
+                    [BuiltInPolicyType.REALM_MATCH]: data.realm_id ?? entity.realm_id ?? null,
                 }),
             });
         } else {
@@ -423,7 +424,7 @@ export class IdentityProviderController {
 
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_CREATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: data }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: data, [BuiltInPolicyType.REALM_MATCH]: data.realm_id ?? null }),
             });
         }
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, base64URLDecode, isUUID } from '@authup/kit';
 import {
     DBody,
@@ -123,7 +123,7 @@ export class IdentityProviderController {
                 try {
                     await permissionEvaluator.evaluate({
                         name: PermissionName.IDENTITY_PROVIDER_READ,
-                        data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: datum, [BuiltInPolicyType.REALM_MATCH]: datum.realm_id ?? null }),
+                        data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: datum, [BuiltInPolicyType.REALM_MATCH]: datum.realm_id ?? null }),
                     });
                 } catch {
                     // do nothing
@@ -159,7 +159,7 @@ export class IdentityProviderController {
             const permissionEvaluator = useRequestPermissionEvaluator(event);
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_READ,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
             });
         } catch {
             // do nothing
@@ -204,7 +204,7 @@ export class IdentityProviderController {
 
         await permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realm_id ?? null }),
         });
 
         const { id: entityId } = entity;
@@ -408,7 +408,7 @@ export class IdentityProviderController {
         if (entity) {
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_UPDATE,
-                data: definePolicyInput({
+                data: definePolicyData({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...data,
@@ -424,7 +424,7 @@ export class IdentityProviderController {
 
             await permissionEvaluator.evaluate({
                 name: PermissionName.IDENTITY_PROVIDER_CREATE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: data, [BuiltInPolicyType.REALM_MATCH]: data.realm_id ?? null }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: data, [BuiltInPolicyType.REALM_MATCH]: data.realm_id ?? null }),
             });
         }
 

--- a/apps/server-core/src/adapters/http/request/permission/module.ts
+++ b/apps/server-core/src/adapters/http/request/permission/module.ts
@@ -49,8 +49,8 @@ export class RequestPermissionEvaluator implements IPermissionEvaluator {
     protected extendContext(ctx: PermissionEvaluationContext) {
         const scopes = useRequestScopes(this.event);
         if (scopes.includes(ScopeName.GLOBAL)) {
-            ctx.input = ctx.input || new PolicyData();
-            ctx.input.set(BuiltInPolicyType.IDENTITY, useRequestIdentity(this.event));
+            ctx.data = ctx.data || new PolicyData();
+            ctx.data.set(BuiltInPolicyType.IDENTITY, useRequestIdentity(this.event));
         }
 
         return ctx;

--- a/apps/server-core/src/core/entities/client-permission/service.ts
+++ b/apps/server-core/src/core/entities/client-permission/service.ts
@@ -8,7 +8,7 @@
 import { 
     BuiltInPolicyType, 
     RealmScope, 
-    definePolicyInput, 
+    definePolicyData, 
     minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
@@ -134,7 +134,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -204,7 +204,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -226,7 +226,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/client-permission/service.ts
+++ b/apps/server-core/src/core/entities/client-permission/service.ts
@@ -134,7 +134,10 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -201,7 +204,10 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
+            }),
         });
 
         return this.repository.save(merged);
@@ -220,7 +226,10 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/client-permission/service.ts
+++ b/apps/server-core/src/core/entities/client-permission/service.ts
@@ -5,11 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import {
-    BuiltInPolicyType,
-    PolicyData,
-    RealmScope,
-    minRealmScope,
+import { 
+    BuiltInPolicyType, 
+    RealmScope, 
+    definePolicyInput, 
+    minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
@@ -134,7 +134,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -204,7 +204,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -226,7 +226,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_PERMISSION_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/client-role/service.ts
+++ b/apps/server-core/src/core/entities/client-role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { ClientRoleValidator, PermissionName } from '@authup/core-kit';
@@ -117,7 +117,7 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_ROLE_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -143,7 +143,7 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_ROLE_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/client-role/service.ts
+++ b/apps/server-core/src/core/entities/client-role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { ClientRoleValidator, PermissionName } from '@authup/core-kit';
@@ -117,7 +117,7 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_ROLE_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -143,7 +143,7 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_ROLE_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/client-role/service.ts
+++ b/apps/server-core/src/core/entities/client-role/service.ts
@@ -117,7 +117,10 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_ROLE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -140,7 +143,10 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_ROLE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/client-scope/service.ts
+++ b/apps/server-core/src/core/entities/client-scope/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { ClientScopeValidator, PermissionName } from '@authup/core-kit';
@@ -97,7 +97,7 @@ export class ClientScopeService extends JunctionEntityService implements IClient
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_SCOPE_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -123,7 +123,7 @@ export class ClientScopeService extends JunctionEntityService implements IClient
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_SCOPE_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/client-scope/service.ts
+++ b/apps/server-core/src/core/entities/client-scope/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { ClientScopeValidator, PermissionName } from '@authup/core-kit';
@@ -97,7 +97,7 @@ export class ClientScopeService extends JunctionEntityService implements IClient
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_SCOPE_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -123,7 +123,7 @@ export class ClientScopeService extends JunctionEntityService implements IClient
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_SCOPE_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/client-scope/service.ts
+++ b/apps/server-core/src/core/entities/client-scope/service.ts
@@ -97,7 +97,10 @@ export class ClientScopeService extends JunctionEntityService implements IClient
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_SCOPE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -120,7 +123,10 @@ export class ClientScopeService extends JunctionEntityService implements IClient
         // Stamp the owner (client) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_SCOPE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -71,7 +71,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
                             PermissionName.CLIENT_UPDATE,
                             PermissionName.CLIENT_DELETE,
                         ],
-                        data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                        data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                     });
                     data.push(entity);
                 } catch {
@@ -134,7 +134,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
         ) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -252,7 +252,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.CLIENT_SELF_MANAGE,
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             }
 
@@ -261,7 +261,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             if (!isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.CLIENT_UPDATE,
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
             }
 
@@ -294,7 +294,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         entity = this.repository.create(validated);
@@ -330,7 +330,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -71,7 +71,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
                             PermissionName.CLIENT_UPDATE,
                             PermissionName.CLIENT_DELETE,
                         ],
-                        input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                        input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                     });
                     data.push(entity);
                 } catch {
@@ -134,7 +134,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
         ) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -252,7 +252,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.CLIENT_SELF_MANAGE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             }
 
@@ -261,7 +261,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             if (!isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.CLIENT_UPDATE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
             }
 
@@ -294,7 +294,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         entity = this.repository.create(validated);
@@ -330,7 +330,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -71,7 +71,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
                             PermissionName.CLIENT_UPDATE,
                             PermissionName.CLIENT_DELETE,
                         ],
-                        input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                        data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                     });
                     data.push(entity);
                 } catch {
@@ -134,7 +134,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
         ) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -252,7 +252,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.CLIENT_SELF_MANAGE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             }
 
@@ -261,7 +261,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             if (!isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.CLIENT_UPDATE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
             }
 
@@ -294,7 +294,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         entity = this.repository.create(validated);
@@ -330,7 +330,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.CLIENT_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
+++ b/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/access';
 import { BadRequestError, EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { IdentityProviderRoleMappingValidator, PermissionName } from '@authup/core-kit';
@@ -127,7 +127,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -160,7 +160,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -183,7 +183,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
+++ b/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
 import { BadRequestError, EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { IdentityProviderRoleMappingValidator, PermissionName } from '@authup/core-kit';
@@ -127,7 +127,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -160,7 +160,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -183,7 +183,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
+++ b/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
@@ -127,7 +127,10 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -157,7 +160,10 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
+            }),
         });
 
         return this.repository.save(merged);
@@ -177,7 +183,10 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         // Stamp the owner (identity-provider) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.IDENTITY_PROVIDER_ROLE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/permission-policy/service.ts
+++ b/apps/server-core/src/core/entities/permission-policy/service.ts
@@ -93,7 +93,10 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
         // Stamp the owner (permission) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -116,7 +119,10 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
         // Stamp the owner (permission) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/permission-policy/service.ts
+++ b/apps/server-core/src/core/entities/permission-policy/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, PermissionPolicyValidator } from '@authup/core-kit';
@@ -93,7 +93,7 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
         // Stamp the owner (permission) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -119,7 +119,7 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
         // Stamp the owner (permission) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/permission-policy/service.ts
+++ b/apps/server-core/src/core/entities/permission-policy/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, PermissionPolicyValidator } from '@authup/core-kit';
@@ -93,7 +93,7 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
         // Stamp the owner (permission) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -119,7 +119,7 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
         // Stamp the owner (permission) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -9,7 +9,7 @@ import {
     BuiltInPolicyType, 
     RealmScope, 
     SystemPolicyName, 
-    definePolicyInput, 
+    definePolicyData, 
 } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { AuthupError, BadRequestError, EntityNotFoundError } from '@authup/errors';
@@ -216,7 +216,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.PERMISSION_UPDATE,
-                data: definePolicyInput({
+                data: definePolicyData({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -243,7 +243,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -278,7 +278,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -221,6 +221,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
                         ...entity,
                         ...validated,
                     },
+                    [BuiltInPolicyType.REALM_MATCH]: validated.realm_id ?? entity.realm_id ?? null,
                 }),
             });
 
@@ -242,7 +243,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -277,7 +278,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -5,11 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import {
-    BuiltInPolicyType,
-    PolicyData,
-    RealmScope,
-    SystemPolicyName,
+import { 
+    BuiltInPolicyType, 
+    RealmScope, 
+    SystemPolicyName, 
+    definePolicyInput, 
 } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { AuthupError, BadRequestError, EntityNotFoundError } from '@authup/errors';
@@ -216,7 +216,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.PERMISSION_UPDATE,
-                input: new PolicyData({
+                data: definePolicyInput({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -243,7 +243,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -278,7 +278,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/policy/service.ts
+++ b/apps/server-core/src/core/entities/policy/service.ts
@@ -167,6 +167,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
                         ...entity,
                         ...validated,
                     },
+                    [BuiltInPolicyType.REALM_MATCH]: validated.realm_id ?? entity.realm_id ?? null,
                 }),
             });
 
@@ -188,7 +189,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -240,7 +241,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/policy/service.ts
+++ b/apps/server-core/src/core/entities/policy/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import {
     ValidatorGroup,
     extendObject,
@@ -162,7 +162,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.PERMISSION_UPDATE,
-                data: definePolicyInput({
+                data: definePolicyData({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -189,7 +189,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -241,7 +241,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/policy/service.ts
+++ b/apps/server-core/src/core/entities/policy/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import {
     ValidatorGroup,
     extendObject,
@@ -162,7 +162,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.PERMISSION_UPDATE,
-                input: new PolicyData({
+                data: definePolicyInput({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -189,7 +189,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -241,7 +241,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -119,7 +119,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
         if (entity) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.REALM_UPDATE,
-                data: definePolicyInput({
+                data: definePolicyData({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -142,7 +142,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.REALM_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
         });
 
         entity = this.repository.create(validated);
@@ -189,7 +189,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.REALM_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -119,7 +119,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
         if (entity) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.REALM_UPDATE,
-                input: new PolicyData({
+                data: definePolicyInput({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -142,7 +142,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.REALM_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
         });
 
         entity = this.repository.create(validated);
@@ -189,7 +189,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.REALM_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/robot-permission/service.ts
+++ b/apps/server-core/src/core/entities/robot-permission/service.ts
@@ -134,7 +134,10 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -201,7 +204,10 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
+            }),
         });
 
         return this.repository.save(merged);
@@ -220,7 +226,10 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/robot-permission/service.ts
+++ b/apps/server-core/src/core/entities/robot-permission/service.ts
@@ -5,11 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import {
-    BuiltInPolicyType,
-    PolicyData,
-    RealmScope,
-    minRealmScope,
+import { 
+    BuiltInPolicyType, 
+    RealmScope, 
+    definePolicyInput, 
+    minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
@@ -134,7 +134,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -204,7 +204,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -226,7 +226,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/robot-permission/service.ts
+++ b/apps/server-core/src/core/entities/robot-permission/service.ts
@@ -8,7 +8,7 @@
 import { 
     BuiltInPolicyType, 
     RealmScope, 
-    definePolicyInput, 
+    definePolicyData, 
     minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
@@ -134,7 +134,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -204,7 +204,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -226,7 +226,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_PERMISSION_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/robot-role/service.ts
+++ b/apps/server-core/src/core/entities/robot-role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, RobotRoleValidator } from '@authup/core-kit';
@@ -117,7 +117,7 @@ export class RobotRoleService extends JunctionEntityService implements IRobotRol
         // Stamp the owner (robot) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_ROLE_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -143,7 +143,7 @@ export class RobotRoleService extends JunctionEntityService implements IRobotRol
         // Stamp the owner (robot) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_ROLE_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/robot-role/service.ts
+++ b/apps/server-core/src/core/entities/robot-role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, RobotRoleValidator } from '@authup/core-kit';
@@ -117,7 +117,7 @@ export class RobotRoleService extends JunctionEntityService implements IRobotRol
         // Stamp the owner (robot) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_ROLE_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -143,7 +143,7 @@ export class RobotRoleService extends JunctionEntityService implements IRobotRol
         // Stamp the owner (robot) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_ROLE_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/robot-role/service.ts
+++ b/apps/server-core/src/core/entities/robot-role/service.ts
@@ -117,7 +117,10 @@ export class RobotRoleService extends JunctionEntityService implements IRobotRol
         // Stamp the owner (robot) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_ROLE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -140,7 +143,10 @@ export class RobotRoleService extends JunctionEntityService implements IRobotRol
         // Stamp the owner (robot) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_ROLE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/robot/service.ts
+++ b/apps/server-core/src/core/entities/robot/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { EntityNotFoundError } from '@authup/errors';
 import {
@@ -75,7 +75,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
                         PermissionName.ROBOT_UPDATE,
                         PermissionName.ROBOT_DELETE,
                     ],
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
 
                 data.push(entity);
@@ -129,7 +129,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -222,12 +222,12 @@ export class RobotService extends AbstractEntityService implements IRobotService
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.ROBOT_SELF_MANAGE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             } else {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.ROBOT_UPDATE,
-                    input: new PolicyData({
+                    data: definePolicyInput({
                         [BuiltInPolicyType.ATTRIBUTES]: {
                             ...entity,
                             ...validated,
@@ -263,7 +263,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         if (!validated.secret) {
@@ -311,12 +311,12 @@ export class RobotService extends AbstractEntityService implements IRobotService
             // the ATTRIBUTE_NAMES denylist has no keys to reject.
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROBOT_SELF_MANAGE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: {} }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: {} }),
             });
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROBOT_DELETE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 

--- a/apps/server-core/src/core/entities/robot/service.ts
+++ b/apps/server-core/src/core/entities/robot/service.ts
@@ -75,7 +75,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
                         PermissionName.ROBOT_UPDATE,
                         PermissionName.ROBOT_DELETE,
                     ],
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
 
                 data.push(entity);
@@ -129,7 +129,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -222,7 +222,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.ROBOT_SELF_MANAGE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             } else {
                 await actor.permissionEvaluator.evaluate({
@@ -232,6 +232,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
                             ...entity,
                             ...validated,
                         },
+                        [BuiltInPolicyType.REALM_MATCH]: validated.realm_id ?? entity.realm_id ?? null,
                     }),
                 });
             }
@@ -262,7 +263,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         if (!validated.secret) {
@@ -315,7 +316,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROBOT_DELETE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 

--- a/apps/server-core/src/core/entities/robot/service.ts
+++ b/apps/server-core/src/core/entities/robot/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { EntityNotFoundError } from '@authup/errors';
 import {
@@ -75,7 +75,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
                         PermissionName.ROBOT_UPDATE,
                         PermissionName.ROBOT_DELETE,
                     ],
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
 
                 data.push(entity);
@@ -129,7 +129,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -222,12 +222,12 @@ export class RobotService extends AbstractEntityService implements IRobotService
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.ROBOT_SELF_MANAGE,
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             } else {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.ROBOT_UPDATE,
-                    data: definePolicyInput({
+                    data: definePolicyData({
                         [BuiltInPolicyType.ATTRIBUTES]: {
                             ...entity,
                             ...validated,
@@ -263,7 +263,7 @@ export class RobotService extends AbstractEntityService implements IRobotService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROBOT_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         if (!validated.secret) {
@@ -311,12 +311,12 @@ export class RobotService extends AbstractEntityService implements IRobotService
             // the ATTRIBUTE_NAMES denylist has no keys to reject.
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROBOT_SELF_MANAGE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: {} }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: {} }),
             });
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROBOT_DELETE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -57,7 +57,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
                         PermissionName.ROLE_UPDATE,
                         PermissionName.ROLE_DELETE,
                     ],
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
                 data.push(entity);
             } catch {
@@ -97,7 +97,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
                 PermissionName.ROLE_UPDATE,
                 PermissionName.ROLE_DELETE,
             ],
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         return entity;
@@ -172,7 +172,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -150,6 +150,17 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
             throw new EntityNotFoundError();
         }
 
+        // realm_id is derived from the role, never caller-supplied: refresh it when the role
+        // is reassigned (validateJoinColumns loaded data.role), otherwise drop any submitted
+        // realm_id so the role-derived value is kept. Without this, a role reassignment would
+        // be authorized against the stale realm, and a caller could pass realm_id to evaluate
+        // ROLE_UPDATE against a realm of their choosing.
+        if (data.role) {
+            data.realm_id = data.role.realm_id;
+        } else {
+            delete data.realm_id;
+        }
+
         entity = this.repository.merge(entity, data);
 
         await actor.permissionEvaluator.evaluate({

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -150,16 +150,14 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
             throw new EntityNotFoundError();
         }
 
-        // realm_id is derived from the role, never caller-supplied: refresh it when the role
-        // is reassigned (validateJoinColumns loaded data.role), otherwise drop any submitted
-        // realm_id so the role-derived value is kept. Without this, a role reassignment would
-        // be authorized against the stale realm, and a caller could pass realm_id to evaluate
-        // ROLE_UPDATE against a realm of their choosing.
-        if (data.role) {
-            data.realm_id = data.role.realm_id;
-        } else {
-            delete data.realm_id;
-        }
+        // An attribute belongs to a fixed role; its owner (and the role-derived realm_id) is
+        // IMMUTABLE on update — strip both from the body. This blocks reassigning the attribute
+        // to another role (which would otherwise be authorized against the new realm, not the
+        // one the attribute currently lives in) and blocks a caller-supplied realm_id that would
+        // gate ROLE_UPDATE against a realm of their choosing. To move an attribute, delete + recreate.
+        delete data.role_id;
+        delete data.role;
+        delete data.realm_id;
 
         entity = this.repository.merge(entity, data);
 

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -121,7 +121,10 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
+            data: definePolicyInput({
+                [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value },
+                ...this.resourceRealmMatch(entity),
+            }),
         });
 
         await this.repository.save(entity);
@@ -151,7 +154,10 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
+            data: definePolicyInput({
+                [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value },
+                ...this.resourceRealmMatch(entity),
+            }),
         });
 
         await this.repository.save(entity);

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import { PermissionName } from '@authup/core-kit';
 import type { RoleAttribute } from '@authup/core-kit';
@@ -57,7 +57,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
                         PermissionName.ROLE_UPDATE,
                         PermissionName.ROLE_DELETE,
                     ],
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
                 data.push(entity);
             } catch {
@@ -97,7 +97,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
                 PermissionName.ROLE_UPDATE,
                 PermissionName.ROLE_DELETE,
             ],
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         return entity;
@@ -121,7 +121,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
         });
 
         await this.repository.save(entity);
@@ -151,7 +151,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
         });
 
         await this.repository.save(entity);
@@ -172,7 +172,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import { PermissionName } from '@authup/core-kit';
 import type { RoleAttribute } from '@authup/core-kit';
@@ -57,7 +57,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
                         PermissionName.ROLE_UPDATE,
                         PermissionName.ROLE_DELETE,
                     ],
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
                 data.push(entity);
             } catch {
@@ -97,7 +97,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
                 PermissionName.ROLE_UPDATE,
                 PermissionName.ROLE_DELETE,
             ],
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         return entity;
@@ -121,7 +121,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value },
                 ...this.resourceRealmMatch(entity),
             }),
@@ -154,7 +154,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value },
                 ...this.resourceRealmMatch(entity),
             }),
@@ -178,7 +178,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_UPDATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/role-permission/service.ts
+++ b/apps/server-core/src/core/entities/role-permission/service.ts
@@ -143,7 +143,10 @@ export class RolePermissionService extends JunctionEntityService implements IRol
             name: PermissionName.ROLE_PERMISSION_CREATE,
             // Stamp the owner (role) realm as the canonical `realm_id` so the realm_scope
             // factor gates this junction write against the actor's reach (no cross-realm).
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -214,7 +217,10 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_PERMISSION_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
+            }),
         });
 
         return this.repository.save(merged);
@@ -233,7 +239,10 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/role-permission/service.ts
+++ b/apps/server-core/src/core/entities/role-permission/service.ts
@@ -5,11 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import {
-    BuiltInPolicyType,
-    PolicyData,
-    RealmScope,
-    minRealmScope,
+import { 
+    BuiltInPolicyType, 
+    RealmScope, 
+    definePolicyInput, 
+    minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
@@ -143,7 +143,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
             name: PermissionName.ROLE_PERMISSION_CREATE,
             // Stamp the owner (role) realm as the canonical `realm_id` so the realm_scope
             // factor gates this junction write against the actor's reach (no cross-realm).
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -217,7 +217,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_PERMISSION_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -239,7 +239,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_PERMISSION_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/role-permission/service.ts
+++ b/apps/server-core/src/core/entities/role-permission/service.ts
@@ -8,7 +8,7 @@
 import { 
     BuiltInPolicyType, 
     RealmScope, 
-    definePolicyInput, 
+    definePolicyData, 
     minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
@@ -143,7 +143,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
             name: PermissionName.ROLE_PERMISSION_CREATE,
             // Stamp the owner (role) realm as the canonical `realm_id` so the realm_scope
             // factor gates this junction write against the actor's reach (no cross-realm).
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -217,7 +217,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_PERMISSION_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -239,7 +239,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_PERMISSION_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/role/service.ts
+++ b/apps/server-core/src/core/entities/role/service.ts
@@ -146,6 +146,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
                         ...entity,
                         ...validated,
                     },
+                    [BuiltInPolicyType.REALM_MATCH]: validated.realm_id ?? entity.realm_id ?? null,
                 }),
             });
 
@@ -165,7 +166,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -196,7 +197,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/role/service.ts
+++ b/apps/server-core/src/core/entities/role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -141,7 +141,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
         if (entity) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROLE_UPDATE,
-                data: definePolicyInput({
+                data: definePolicyData({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -166,7 +166,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -197,7 +197,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/role/service.ts
+++ b/apps/server-core/src/core/entities/role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -141,7 +141,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
         if (entity) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.ROLE_UPDATE,
-                input: new PolicyData({
+                data: definePolicyInput({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -166,7 +166,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -197,7 +197,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.ROLE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/scope/service.ts
+++ b/apps/server-core/src/core/entities/scope/service.ts
@@ -145,6 +145,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
                         ...entity,
                         ...validated,
                     },
+                    [BuiltInPolicyType.REALM_MATCH]: validated.realm_id ?? entity.realm_id ?? null,
                 }),
             });
 
@@ -165,7 +166,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.SCOPE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -192,7 +193,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.SCOPE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/scope/service.ts
+++ b/apps/server-core/src/core/entities/scope/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { EntityNotFoundError } from '@authup/errors';
 import {
@@ -140,7 +140,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
         if (entity) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.SCOPE_UPDATE,
-                input: new PolicyData({
+                data: definePolicyInput({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -166,7 +166,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.SCOPE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -193,7 +193,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.SCOPE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/scope/service.ts
+++ b/apps/server-core/src/core/entities/scope/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isPropertySet, isUUID } from '@authup/kit';
 import { EntityNotFoundError } from '@authup/errors';
 import {
@@ -140,7 +140,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
         if (entity) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.SCOPE_UPDATE,
-                data: definePolicyInput({
+                data: definePolicyData({
                     [BuiltInPolicyType.ATTRIBUTES]: {
                         ...entity,
                         ...validated,
@@ -166,7 +166,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.SCOPE_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
         });
 
         await this.repository.checkUniqueness(validated);
@@ -193,7 +193,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.SCOPE_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -181,6 +181,16 @@ export class UserAttributeService extends AbstractEntityService implements IUser
             await actor.permissionEvaluator.preEvaluate({ name: PermissionName.USER_SELF_MANAGE });
         }
 
+        // realm_id is derived from the user, never caller-supplied: refresh it from data.user
+        // on reassignment, otherwise drop any submitted realm_id so the user-derived value is
+        // kept. Without this a role/user reassignment would authorize against the stale realm,
+        // and a caller could pass realm_id to evaluate USER_UPDATE against a realm of choosing.
+        if (data.user) {
+            data.realm_id = data.user.realm_id;
+        } else {
+            delete data.realm_id;
+        }
+
         entity = this.repository.merge(entity, data);
 
         if (isSelfFallback) {

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -141,7 +141,7 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -191,7 +191,7 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -243,7 +243,7 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         try {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
 
             return true;

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -181,15 +181,14 @@ export class UserAttributeService extends AbstractEntityService implements IUser
             await actor.permissionEvaluator.preEvaluate({ name: PermissionName.USER_SELF_MANAGE });
         }
 
-        // realm_id is derived from the user, never caller-supplied: refresh it from data.user
-        // on reassignment, otherwise drop any submitted realm_id so the user-derived value is
-        // kept. Without this a role/user reassignment would authorize against the stale realm,
-        // and a caller could pass realm_id to evaluate USER_UPDATE against a realm of choosing.
-        if (data.user) {
-            data.realm_id = data.user.realm_id;
-        } else {
-            delete data.realm_id;
-        }
+        // An attribute belongs to a fixed user; its owner (and the user-derived realm_id) is
+        // IMMUTABLE on update — strip both from the body. This blocks a self-manage or admin
+        // caller from reassigning the attribute to another user (isSelfTarget was decided from
+        // the ORIGINAL owner), and blocks a caller-supplied realm_id that would gate USER_UPDATE
+        // against a realm of their choosing. To move an attribute, delete + recreate.
+        delete data.user_id;
+        delete data.user;
+        delete data.realm_id;
 
         entity = this.repository.merge(entity, data);
 

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import { PermissionName } from '@authup/core-kit';
 import type { UserAttribute } from '@authup/core-kit';
@@ -136,12 +136,12 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         if (isSelfFallback) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_SELF_MANAGE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
             });
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -186,12 +186,12 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         if (isSelfFallback) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_SELF_MANAGE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
             });
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -243,7 +243,7 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         try {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
 
             return true;

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/access';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import { PermissionName } from '@authup/core-kit';
 import type { UserAttribute } from '@authup/core-kit';
@@ -136,12 +136,12 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         if (isSelfFallback) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_SELF_MANAGE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { [data.name]: data.value } }),
             });
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -186,12 +186,12 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         if (isSelfFallback) {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_SELF_MANAGE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { [entity.name]: entity.value } }),
             });
         } else {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -243,7 +243,7 @@ export class UserAttributeService extends AbstractEntityService implements IUser
         try {
             await actor.permissionEvaluator.evaluate({
                 name: PermissionName.USER_UPDATE,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
 
             return true;

--- a/apps/server-core/src/core/entities/user-permission/service.ts
+++ b/apps/server-core/src/core/entities/user-permission/service.ts
@@ -5,11 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import {
-    BuiltInPolicyType,
-    PolicyData,
-    RealmScope,
-    minRealmScope,
+import { 
+    BuiltInPolicyType, 
+    RealmScope, 
+    definePolicyInput, 
+    minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
@@ -136,7 +136,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -206,7 +206,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_UPDATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -228,7 +228,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/user-permission/service.ts
+++ b/apps/server-core/src/core/entities/user-permission/service.ts
@@ -8,7 +8,7 @@
 import { 
     BuiltInPolicyType, 
     RealmScope, 
-    definePolicyInput, 
+    definePolicyData, 
     minRealmScope, 
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
@@ -136,7 +136,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -206,7 +206,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_UPDATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
             }),
@@ -228,7 +228,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/user-permission/service.ts
+++ b/apps/server-core/src/core/entities/user-permission/service.ts
@@ -136,7 +136,10 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -203,7 +206,10 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_UPDATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(merged),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(merged),
+            }),
         });
 
         return this.repository.save(merged);
@@ -222,7 +228,10 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_PERMISSION_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/user-role/service.ts
+++ b/apps/server-core/src/core/entities/user-role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, UserRoleValidator } from '@authup/core-kit';
@@ -117,7 +117,7 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
         // Stamp the owner (user) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_ROLE_CREATE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -143,7 +143,7 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
         // Stamp the owner (user) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_ROLE_DELETE,
-            data: definePolicyInput({
+            data: definePolicyData({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/user-role/service.ts
+++ b/apps/server-core/src/core/entities/user-role/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PermissionError, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, PermissionError, definePolicyInput } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, UserRoleValidator } from '@authup/core-kit';
@@ -117,7 +117,7 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
         // Stamp the owner (user) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_ROLE_CREATE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
             }),
@@ -143,7 +143,7 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
         // Stamp the owner (user) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_ROLE_DELETE,
-            input: new PolicyData({
+            data: definePolicyInput({
                 [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
                 [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
             }),

--- a/apps/server-core/src/core/entities/user-role/service.ts
+++ b/apps/server-core/src/core/entities/user-role/service.ts
@@ -117,7 +117,10 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
         // Stamp the owner (user) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_ROLE_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(validated),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(validated),
+            }),
         });
 
         let entity = this.repository.create(validated);
@@ -140,7 +143,10 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
         // Stamp the owner (user) realm so the realm_scope factor gates cross-realm writes.
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_ROLE_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity) }),
+            input: new PolicyData({
+                [BuiltInPolicyType.ATTRIBUTES]: this.junctionAttributes(entity),
+                [BuiltInPolicyType.REALM_MATCH]: this.junctionResourceRealm(entity),
+            }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -75,7 +75,7 @@ export class UserService extends AbstractEntityService implements IUserService {
                         PermissionName.USER_UPDATE,
                         PermissionName.USER_DELETE,
                     ],
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
 
                 data.push(entity);
@@ -129,7 +129,7 @@ export class UserService extends AbstractEntityService implements IUserService {
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -225,7 +225,7 @@ export class UserService extends AbstractEntityService implements IUserService {
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.USER_SELF_MANAGE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated }),
+                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             }
 
@@ -252,6 +252,7 @@ export class UserService extends AbstractEntityService implements IUserService {
                             ...entity,
                             ...validated,
                         },
+                        [BuiltInPolicyType.REALM_MATCH]: validated.realm_id ?? entity.realm_id ?? null,
                     }),
                 });
             }
@@ -279,7 +280,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         if (validated.password) {
@@ -315,7 +316,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity }),
+            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -75,7 +75,7 @@ export class UserService extends AbstractEntityService implements IUserService {
                         PermissionName.USER_UPDATE,
                         PermissionName.USER_DELETE,
                     ],
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
 
                 data.push(entity);
@@ -129,7 +129,7 @@ export class UserService extends AbstractEntityService implements IUserService {
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -225,7 +225,7 @@ export class UserService extends AbstractEntityService implements IUserService {
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.USER_SELF_MANAGE,
-                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+                    data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             }
 
@@ -247,7 +247,7 @@ export class UserService extends AbstractEntityService implements IUserService {
             if (!isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.USER_UPDATE,
-                    data: definePolicyInput({
+                    data: definePolicyData({
                         [BuiltInPolicyType.ATTRIBUTES]: {
                             ...entity,
                             ...validated,
@@ -280,7 +280,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_CREATE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         if (validated.password) {
@@ -316,7 +316,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_DELETE,
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { BuiltInPolicyType, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, definePolicyInput } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { BadRequestError, EntityNotFoundError } from '@authup/errors';
 import {
@@ -75,7 +75,7 @@ export class UserService extends AbstractEntityService implements IUserService {
                         PermissionName.USER_UPDATE,
                         PermissionName.USER_DELETE,
                     ],
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
                 });
 
                 data.push(entity);
@@ -129,7 +129,7 @@ export class UserService extends AbstractEntityService implements IUserService {
         if (!isMe) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: permissionNames,
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }
 
@@ -225,7 +225,7 @@ export class UserService extends AbstractEntityService implements IUserService {
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.USER_SELF_MANAGE,
-                    input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
+                    data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: validated, ...this.resourceRealmMatch(validated) }),
                 });
             }
 
@@ -247,7 +247,7 @@ export class UserService extends AbstractEntityService implements IUserService {
             if (!isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.USER_UPDATE,
-                    input: new PolicyData({
+                    data: definePolicyInput({
                         [BuiltInPolicyType.ATTRIBUTES]: {
                             ...entity,
                             ...validated,
@@ -280,7 +280,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_CREATE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         if (validated.password) {
@@ -316,7 +316,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.evaluate({
             name: PermissionName.USER_DELETE,
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
         });
 
         const { id: entityId } = entity;

--- a/apps/server-core/src/core/identity/permission/checker/service.ts
+++ b/apps/server-core/src/core/identity/permission/checker/service.ts
@@ -8,7 +8,7 @@
 import type { PermissionEvaluationContext } from '@authup/access';
 import { BuiltInPolicyType, PermissionEvaluator, PolicyData } from '@authup/access';
 import type { Result } from '@authup/kit';
-import { isUUID } from '@authup/kit';
+import { hasOwnProperty, isUUID } from '@authup/kit';
 import { EntityNotFoundError, normalizeError } from '@authup/errors';
 import type { ActorContext } from '@authup/server-kit';
 import { PolicyEngine } from '../../../security/policy/engine.ts';
@@ -50,6 +50,13 @@ export class PermissionCheckerService implements IPermissionCheckerService {
         const input = { ...data };
         if (typeof input[BuiltInPolicyType.IDENTITY] === 'undefined') {
             input[BuiltInPolicyType.IDENTITY] = toIdentityPolicyData(actor.identity);
+        }
+        // Surface the resource realm to the realm_scope reach factor (realm-match scope mode).
+        // Only when the body carries an ATTRIBUTES realm — so a realm-less check still rides
+        // the preEvaluate path below and neutral-passes.
+        const attributes = input[BuiltInPolicyType.ATTRIBUTES] as Record<string, any> | undefined;
+        if (attributes && hasOwnProperty(attributes, 'realm_id')) {
+            input[BuiltInPolicyType.REALM_MATCH] = attributes.realm_id ?? null;
         }
 
         const evaluationContext: PermissionEvaluationContext = {

--- a/apps/server-core/src/core/identity/permission/checker/service.ts
+++ b/apps/server-core/src/core/identity/permission/checker/service.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PermissionEvaluationContext } from '@authup/access';
-import { BuiltInPolicyType, PermissionEvaluator, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, PermissionEvaluator, definePolicyInput } from '@authup/access';
 import type { Result } from '@authup/kit';
 import { hasOwnProperty, isUUID } from '@authup/kit';
 import { EntityNotFoundError, normalizeError } from '@authup/errors';
@@ -61,7 +61,7 @@ export class PermissionCheckerService implements IPermissionCheckerService {
 
         const evaluationContext: PermissionEvaluationContext = {
             name: entity.name,
-            input: new PolicyData(input),
+            data: definePolicyInput(input),
         };
 
         const evaluator = new PermissionEvaluator({
@@ -70,8 +70,8 @@ export class PermissionCheckerService implements IPermissionCheckerService {
         });
 
         if (
-            evaluationContext.input &&
-            evaluationContext.input.has(BuiltInPolicyType.ATTRIBUTES)
+            evaluationContext.data &&
+            evaluationContext.data.has(BuiltInPolicyType.ATTRIBUTES)
         ) {
             await evaluator.evaluate(evaluationContext);
         } else {

--- a/apps/server-core/src/core/identity/permission/checker/service.ts
+++ b/apps/server-core/src/core/identity/permission/checker/service.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PermissionEvaluationContext } from '@authup/access';
-import { BuiltInPolicyType, PermissionEvaluator, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, PermissionEvaluator, definePolicyData } from '@authup/access';
 import type { Result } from '@authup/kit';
 import { hasOwnProperty, isUUID } from '@authup/kit';
 import { EntityNotFoundError, normalizeError } from '@authup/errors';
@@ -61,7 +61,7 @@ export class PermissionCheckerService implements IPermissionCheckerService {
 
         const evaluationContext: PermissionEvaluationContext = {
             name: entity.name,
-            data: definePolicyInput(input),
+            data: definePolicyData(input),
         };
 
         const evaluator = new PermissionEvaluator({

--- a/apps/server-core/src/core/security/policy/evaluator.ts
+++ b/apps/server-core/src/core/security/policy/evaluator.ts
@@ -14,18 +14,16 @@ import type {
     PolicyEvaluationResult,
 } from '@authup/access';
 import {
-    AttributesPolicyEvaluator,
     BuiltInPolicyType,
     IdentityPolicyEvaluator,
     PermissionBindingPolicyValidator,
     PolicyEngine,
     PolicyIssueCode,
+    RealmMatchPolicyEvaluator,
     definePolicyIssueItem,
     maybeInvertPolicyOutcome,
     mergePermissionPolicyBindings,
-    realmScopeMatches,
 } from '@authup/access';
-import { hasOwnProperty } from '@authup/kit';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
 
 export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
@@ -33,14 +31,14 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
 
     protected identityEvaluator: IdentityPolicyEvaluator;
 
-    protected attributesEvaluator : AttributesPolicyEvaluator;
+    protected realmMatchEvaluator : RealmMatchPolicyEvaluator;
 
     protected identityPermissionProvider: IIdentityPermissionProvider;
 
     constructor(identityPermissionProvider: IIdentityPermissionProvider) {
         this.validator = new PermissionBindingPolicyValidator();
         this.identityEvaluator = new IdentityPolicyEvaluator();
-        this.attributesEvaluator = new AttributesPolicyEvaluator();
+        this.realmMatchEvaluator = new RealmMatchPolicyEvaluator();
         this.identityPermissionProvider = identityPermissionProvider;
     }
 
@@ -110,33 +108,23 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
             return { success: maybeInvertPolicyOutcome(false, policy.invert) };
         }
 
-        // Realm reach (coarse, actor-relative) — enforced as a separate factor from
-        // the policy_id policies below, ANDed with them. It runs ONLY when the
-        // resource ATTRIBUTES carry a `realm_id`. On preEvaluate / gate checks
-        // ATTRIBUTES is absent (excluded), so the factor neutral-passes — without this
-        // every write/read gate would deny. Resources express their realm via the
-        // canonical `realm_id` key (a single id, null, or an array of ids); entities
-        // carry it as a column and junction services STAMP their owner realm onto the
-        // eval input (so a junction write to another realm's entity is gated too).
-        const attributes = await this.attributesEvaluator.accessData(ctx) as Record<string, any> | null;
-        if (
-            attributes &&
-            hasOwnProperty(attributes, 'realm_id')
-        ) {
-            // mergePermissionPolicyBindings already folded the scope with the correct
-            // policy correlation, and identityBindings is filtered to a single
-            // (name, realm_id, client_id) key — so bindingsMerged is length 1 and its
-            // realm_scope is authoritative (do NOT re-fold here, which would bypass the
-            // merge's policy-aware scope reduction).
-            const matches = realmScopeMatches(
-                bindingsMerged[0].realm_scope,
-                (attributes.realm_id ?? null) as string | string[] | null,
-                identity.realmId,
-                identity.realmName,
-            );
-            if (!matches) {
-                return { success: maybeInvertPolicyOutcome(false, policy.invert) };
-            }
+        // Realm reach (coarse, actor-relative) — a separate factor from the policy_id
+        // policies below, ANDed with them but evaluated OUTSIDE the policies[] merge so the
+        // policy-free fail-open drop can never touch realm reach. mergePermissionPolicyBindings
+        // already folded the scope with the correct policy correlation, and identityBindings is
+        // filtered to a single (name, realm_id, client_id) key — so bindingsMerged is length 1
+        // and bindingsMerged[0].realm_scope is authoritative (do NOT re-fold).
+        //
+        // The reach check is the realm-match evaluator in SCOPE MODE: it reads the resource
+        // realm from ctx.data[REALM_MATCH] (fallback ATTRIBUTES.realm_id) and neutral-passes
+        // when absent (preEvaluate / gate checks). Invoked DIRECTLY (not via PolicyEngine —
+        // REALM_MATCH is in policiesExcluded, so the engine would skip it).
+        const realmOutcome = await this.realmMatchEvaluator.evaluate(
+            { scope: bindingsMerged[0].realm_scope },
+            ctx,
+        );
+        if (!realmOutcome.success) {
+            return { success: maybeInvertPolicyOutcome(false, policy.invert) };
         }
 
         const policies : BasePolicy[] = bindingsMerged

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -427,7 +427,7 @@ describe('core/entities/client/service', () => {
                 (c) => c.name === PermissionName.CLIENT_SELF_MANAGE,
             );
             expect(selfManageCall).toBeDefined();
-            const attrs = selfManageCall!.input!.get<Record<string, any>>(BuiltInPolicyType.ATTRIBUTES);
+            const attrs = selfManageCall!.data!.get<Record<string, any>>(BuiltInPolicyType.ATTRIBUTES);
             expect(attrs).toHaveProperty('description', 'updated-desc');
             expect(attrs).not.toHaveProperty('id');
             expect(attrs).not.toHaveProperty('built_in');

--- a/apps/server-core/test/unit/core/entities/robot/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/robot/service.spec.ts
@@ -338,7 +338,7 @@ describe('core/entities/robot/service', () => {
                 (c) => c.name === PermissionName.ROBOT_SELF_MANAGE,
             );
             expect(selfManageCall).toBeDefined();
-            const attrs = selfManageCall!.input!.get<Record<string, any>>(BuiltInPolicyType.ATTRIBUTES);
+            const attrs = selfManageCall!.data!.get<Record<string, any>>(BuiltInPolicyType.ATTRIBUTES);
             expect(attrs).toHaveProperty('description', 'updated-desc');
             expect(attrs).not.toHaveProperty('id');
             expect(attrs).not.toHaveProperty('user_id');

--- a/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
@@ -209,25 +209,35 @@ describe('core/entities/role-attribute/service', () => {
             ).rejects.toBeInstanceOf(PermissionError);
         });
 
-        it('refreshes realm_id from the new role on reassignment', async () => {
-            const entity = repository.seed(createFakeRoleAttribute({ realm_id: 'realm-a' } as Partial<RoleAttribute>));
+        it('treats the owner role as immutable (ignores reassignment; realm stays original)', async () => {
+            const entity = repository.seed(createFakeRoleAttribute({
+                role_id: 'role-original',
+                realm_id: 'realm-a',
+            } as Partial<RoleAttribute>));
             const actor = createAllowAllActor();
+            let gatedRealm: unknown;
             actor.permissionEvaluator.setBehavior((call) => {
                 if (call.method === 'evaluate' && call.ctx.name === PermissionName.ROLE_UPDATE) {
-                    const realm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                    gatedRealm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
                         call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
                         undefined;
-                    if (typeof realm !== 'undefined' && realm !== 'realm-a') {
-                        throw PermissionError.denied('realm');
-                    }
                 }
             });
 
-            // Reassign to a role in realm-b: the gate must see the NEW role realm (realm-b),
-            // not the stale realm-a (which would have neutral-passed before the fix).
-            await expect(
-                service.update(entity.id, { role_id: 'r2', role: { realm_id: 'realm-b' } }, actor),
-            ).rejects.toBeInstanceOf(PermissionError);
+            // An attempt to reassign to a realm-b role must be ignored: the write is gated
+            // against — and persists — the ORIGINAL role realm (realm-a), never the attempted one.
+            const result = await service.update(
+                entity.id,
+                {
+                    value: 'x', 
+                    role_id: 'role-other', 
+                    role: { realm_id: 'realm-b' }, 
+                },
+                actor,
+            );
+            expect(gatedRealm).toBe('realm-a');
+            expect(result.realm_id).toBe('realm-a');
+            expect(result.role_id).toBe('role-original');
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
@@ -15,7 +15,7 @@ import {
     it,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
-import { PermissionError } from '@authup/access';
+import { BuiltInPolicyType, PermissionError } from '@authup/access';
 import { RoleAttributeService } from '../../../../../src/core/entities/role-attribute/service.ts';
 import { FakeEntityRepository, createAllowAllActor, createDenyAllActor } from '@authup/server-test-kit';
 import { createFakeRoleAttribute } from '../../../../utils/domains/index.ts';
@@ -115,9 +115,40 @@ describe('core/entities/role-attribute/service', () => {
                 service.create({
                     name: 'attr',
                     role_id: randomUUID(),
-                    role: { realm_id: null }, 
+                    role: { realm_id: null },
                 }, createDenyAllActor()),
             ).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('evaluates ROLE_UPDATE against the role realm (denies a foreign-realm role)', async () => {
+            // Simulate an own-scoped ROLE_UPDATE grant in realm-a: deny when the evaluated
+            // resource realm (realmMatch) is a different realm. Before the realm context was
+            // wired into create, realmMatch was absent and this neutral-passed (cross-realm leak).
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setBehavior((call) => {
+                if (call.method === 'evaluate' && call.ctx.name === PermissionName.ROLE_UPDATE) {
+                    const realm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                        call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
+                        undefined;
+                    if (typeof realm !== 'undefined' && realm !== 'realm-a') {
+                        throw PermissionError.denied('realm');
+                    }
+                }
+            });
+
+            await expect(service.create({
+                name: 'attr', 
+                value: 'v', 
+                role_id: randomUUID(), 
+                role: { realm_id: 'realm-a' },
+            }, actor)).resolves.toBeDefined();
+
+            await expect(service.create({
+                name: 'attr', 
+                value: 'v', 
+                role_id: randomUUID(), 
+                role: { realm_id: 'realm-b' },
+            }, actor)).rejects.toBeInstanceOf(PermissionError);
         });
     });
 
@@ -136,6 +167,25 @@ describe('core/entities/role-attribute/service', () => {
             await expect(
                 service.update('non-existent-id', { value: 'x' }, createAllowAllActor()),
             ).rejects.toMatchObject({ code: ErrorCode.ENTITY_NOT_FOUND });
+        });
+
+        it('evaluates ROLE_UPDATE against the attribute realm (denies a foreign-realm attribute)', async () => {
+            const entity = repository.seed(createFakeRoleAttribute({ realm_id: 'realm-b' } as Partial<RoleAttribute>));
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setBehavior((call) => {
+                if (call.method === 'evaluate' && call.ctx.name === PermissionName.ROLE_UPDATE) {
+                    const realm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                        call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
+                        undefined;
+                    if (typeof realm !== 'undefined' && realm !== 'realm-a') {
+                        throw PermissionError.denied('realm');
+                    }
+                }
+            });
+
+            await expect(
+                service.update(entity.id, { value: 'x' }, actor),
+            ).rejects.toBeInstanceOf(PermissionError);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
@@ -52,8 +52,8 @@ describe('core/entities/role-attribute/service', () => {
 
             const actor = createAllowAllActor();
             actor.permissionEvaluator.setBehavior((call) => {
-                if (call.method === 'evaluateOneOf' && call.ctx.input) {
-                    const entity = call.ctx.input.get('attributes') as RoleAttribute;
+                if (call.method === 'evaluateOneOf' && call.ctx.data) {
+                    const entity = call.ctx.data.get('attributes') as RoleAttribute;
                     if (entity && entity.id === denied.id) {
                         throw PermissionError.denied('test');
                     }

--- a/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
@@ -187,6 +187,48 @@ describe('core/entities/role-attribute/service', () => {
                 service.update(entity.id, { value: 'x' }, actor),
             ).rejects.toBeInstanceOf(PermissionError);
         });
+
+        it('ignores a caller-supplied realm_id (realm stays role-derived, no gate bypass)', async () => {
+            const entity = repository.seed(createFakeRoleAttribute({ realm_id: 'realm-b' } as Partial<RoleAttribute>));
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setBehavior((call) => {
+                if (call.method === 'evaluate' && call.ctx.name === PermissionName.ROLE_UPDATE) {
+                    const realm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                        call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
+                        undefined;
+                    if (typeof realm !== 'undefined' && realm !== 'realm-a') {
+                        throw PermissionError.denied('realm');
+                    }
+                }
+            });
+
+            // The actor tries to gate the write against their own realm by supplying realm_id;
+            // it must be ignored, so the evaluation still runs against the role realm (realm-b).
+            await expect(
+                service.update(entity.id, { value: 'x', realm_id: 'realm-a' }, actor),
+            ).rejects.toBeInstanceOf(PermissionError);
+        });
+
+        it('refreshes realm_id from the new role on reassignment', async () => {
+            const entity = repository.seed(createFakeRoleAttribute({ realm_id: 'realm-a' } as Partial<RoleAttribute>));
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setBehavior((call) => {
+                if (call.method === 'evaluate' && call.ctx.name === PermissionName.ROLE_UPDATE) {
+                    const realm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                        call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
+                        undefined;
+                    if (typeof realm !== 'undefined' && realm !== 'realm-a') {
+                        throw PermissionError.denied('realm');
+                    }
+                }
+            });
+
+            // Reassign to a role in realm-b: the gate must see the NEW role realm (realm-b),
+            // not the stale realm-a (which would have neutral-passed before the fix).
+            await expect(
+                service.update(entity.id, { role_id: 'r2', role: { realm_id: 'realm-b' } }, actor),
+            ).rejects.toBeInstanceOf(PermissionError);
+        });
     });
 
     describe('delete', () => {

--- a/apps/server-core/test/unit/core/entities/role/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/role/service.spec.ts
@@ -133,7 +133,7 @@ describe('core/entities/role/service', () => {
             expect(actor.permissionEvaluator.evaluateCalls).toContainEqual(
                 expect.objectContaining({
                     name: PermissionName.ROLE_CREATE,
-                    input: expect.anything(),
+                    data: expect.anything(),
                 }),
             );
         });

--- a/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
@@ -189,7 +189,7 @@ describe('core/entities/user-attribute/service', () => {
                 (c) => c.name === PermissionName.USER_SELF_MANAGE,
             );
             expect(selfManageCalls).toHaveLength(1);
-            const attributes = selfManageCalls[0].input?.get('attributes');
+            const attributes = selfManageCalls[0].data?.get('attributes');
             expect(attributes).toEqual({ theme: 'dark' });
         });
 
@@ -216,7 +216,7 @@ describe('core/entities/user-attribute/service', () => {
                 (c) => c.name === PermissionName.USER_SELF_MANAGE,
             );
             expect(selfManageCalls).toHaveLength(1);
-            const attributes = selfManageCalls[0].input?.get('attributes');
+            const attributes = selfManageCalls[0].data?.get('attributes');
             expect(attributes).toEqual({ theme: 'dark' });
         });
 

--- a/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
@@ -18,7 +18,7 @@ import {
     it,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
-import { PermissionError } from '@authup/access';
+import { BuiltInPolicyType, PermissionError } from '@authup/access';
 import { UserAttributeService } from '../../../../../src/core/entities/user-attribute/service.ts';
 import { 
     FakeEntityRepository, 
@@ -300,6 +300,31 @@ describe('core/entities/user-attribute/service', () => {
             actor.permissionEvaluator.deny('evaluate');
 
             await expect(service.update(entity.id, { value: 'new' }, actor)).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('ignores a caller-supplied realm_id (no USER_UPDATE gate bypass)', async () => {
+            const entity = repository.seed(createFakeUserAttribute({
+                value: 'val',
+                user_id: randomUUID(),
+                realm_id: 'realm-b',
+            } as Partial<UserAttribute>));
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setBehavior((call) => {
+                if (call.method === 'evaluate' && call.ctx.name === PermissionName.USER_UPDATE) {
+                    const realm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                        call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
+                        undefined;
+                    if (typeof realm !== 'undefined' && realm !== 'realm-a') {
+                        throw PermissionError.denied('realm');
+                    }
+                }
+            });
+
+            // The actor supplies their own realm to gate the write against it; it must be
+            // ignored, so USER_UPDATE still evaluates against the user realm (realm-b).
+            await expect(
+                service.update(entity.id, { value: 'x', realm_id: 'realm-a' }, actor),
+            ).rejects.toBeInstanceOf(PermissionError);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
@@ -326,6 +326,21 @@ describe('core/entities/user-attribute/service', () => {
                 service.update(entity.id, { value: 'x', realm_id: 'realm-a' }, actor),
             ).rejects.toBeInstanceOf(PermissionError);
         });
+
+        it('treats the owner user as immutable on self-manage (cannot reassign to another user)', async () => {
+            const ownerId = randomUUID();
+            const entity = repository.seed(createFakeUserAttribute({ user_id: ownerId, value: 'v' }));
+            // the owner, forced onto the self-manage path (lacks USER_UPDATE)
+            const actor = createUserActor(ownerId);
+            actor.permissionEvaluator.setBehavior((call) => {
+                if (call.ctx.name === PermissionName.USER_UPDATE) {
+                    throw PermissionError.denied('no user_update');
+                }
+            });
+
+            const result = await service.update(entity.id, { value: 'x', user_id: randomUUID() }, actor);
+            expect(result.user_id).toBe(ownerId);
+        });
     });
 
     describe('delete', () => {

--- a/apps/server-core/test/unit/core/entities/user/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user/service.spec.ts
@@ -283,7 +283,7 @@ describe('core/entities/user/service', () => {
                 (c) => c.name === PermissionName.USER_SELF_MANAGE,
             );
             expect(selfManageCall).toBeDefined();
-            const attrs = selfManageCall!.input!.get<Record<string, any>>(BuiltInPolicyType.ATTRIBUTES);
+            const attrs = selfManageCall!.data!.get<Record<string, any>>(BuiltInPolicyType.ATTRIBUTES);
             expect(attrs).toHaveProperty('display_name', 'Updated');
             expect(attrs).not.toHaveProperty('id');
             expect(attrs).not.toHaveProperty('active');

--- a/apps/server-core/test/unit/core/identity/permission/checker.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/checker.spec.ts
@@ -12,7 +12,7 @@ import {
     expect,
     it,
 } from 'vitest';
-import { BuiltInPolicyType } from '@authup/access';
+import { BuiltInPolicyType, RealmScope } from '@authup/access';
 import { IdentityType } from '@authup/core-kit';
 import { EntityNotFoundError } from '@authup/errors';
 import { createNanoID } from '@authup/kit';
@@ -137,6 +137,70 @@ describe('core/identity/permission/checker', () => {
                 identity: { type: IdentityType.USER, data: adminUser as any },
             },
         )).rejects.toThrow();
+    });
+
+    it('gates on the resource realm from body attributes (realmMatch, own scope)', async () => {
+        // own-scoped grant: a binding-protected permission granted to a fresh master-realm
+        // user with realm_scope=own. The checker must route body attributes.realm_id into the
+        // realm_scope reach factor (under the realmMatch key) — a cross-realm resource realm
+        // is denied, the own realm passes.
+        const userRepository = new UserRepository(suite.dataSource);
+        const user = await userRepository.save(userRepository.create({
+            name: createNanoID(),
+            email: `${createNanoID()}@example.com`,
+            realm_id: adminUser.realm_id,
+            active: true,
+        })) as unknown as UserEntity;
+
+        const policyRepository = new PolicyRepository(suite.dataSource);
+        const policy = await policyRepository.save(policyRepository.create({
+            type: BuiltInPolicyType.PERMISSION_BINDING,
+            name: BuiltInPolicyType.PERMISSION_BINDING,
+            built_in: true,
+        }));
+
+        const permissionRepository = suite.dataSource.getRepository(PermissionEntity);
+        const permission = await permissionRepository.save(permissionRepository.create({
+            name: createNanoID(),
+            built_in: true,
+        }));
+
+        const permissionPolicyRepository = suite.dataSource.getRepository(PermissionPolicyEntity);
+        await permissionPolicyRepository.save(permissionPolicyRepository.create({
+            permission_id: permission.id,
+            policy_id: policy.id,
+        }));
+
+        const userPermissionRepository = suite.dataSource.getRepository(UserPermissionEntity);
+        await userPermissionRepository.save(userPermissionRepository.create({
+            user_id: user.id,
+            user_realm_id: user.realm_id,
+            permission_id: permission.id,
+            permission_realm_id: permission.realm_id,
+            realm_scope: RealmScope.OWN,
+        }));
+
+        const realmRepository = suite.dataSource.getRepository(RealmEntity);
+        const otherRealm = await realmRepository.save(realmRepository.create({ name: createNanoID() }));
+
+        const actor = {
+            permissionEvaluator: createAllowAllActor().permissionEvaluator,
+            identity: { type: IdentityType.USER, data: user as any },
+        };
+
+        // cross-realm resource realm -> denied under own
+        await expect(service.check(
+            permission.id,
+            { [BuiltInPolicyType.ATTRIBUTES]: { realm_id: otherRealm.id } },
+            actor,
+        )).rejects.toThrow();
+
+        // own realm -> allowed
+        await expect(service.check(
+            permission.id,
+            { [BuiltInPolicyType.ATTRIBUTES]: { realm_id: user.realm_id } },
+            actor,
+        )).resolves.toBeUndefined();
     });
 
     it('safeCheck wraps failures into Result<null>', async () => {

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -222,8 +222,8 @@ describe('app/modules/provisioning', () => {
             // The realm-match baseline child + the standalone realm policies were removed
             // in favour of the realm_scope enum on junctions.
             expect(await policyRepositoryAdapter.findOneByName(SystemPolicyName.REALM_MATCH)).toBeNull();
-            expect(await policyRepositoryAdapter.findOneByName(SystemPolicyName.REALM_BOUND)).toBeNull();
-            expect(await policyRepositoryAdapter.findOneByName(SystemPolicyName.REALM_OR_GLOBAL)).toBeNull();
+            expect(await policyRepositoryAdapter.findOneByName('system.realm-bound')).toBeNull();
+            expect(await policyRepositoryAdapter.findOneByName('system.realm-or-global')).toBeNull();
         });
 
         it('should create system.default composite with correct children and decisionStrategy', async () => {

--- a/packages/access/src/permission/evaluator/module.ts
+++ b/packages/access/src/permission/evaluator/module.ts
@@ -84,7 +84,7 @@ export class PermissionEvaluator implements IPermissionEvaluator {
 
         let count = 0;
 
-        const dataBase = ctx.input || new PolicyData();
+        const dataBase = ctx.data || new PolicyData();
 
         for (const name of ctx.name) {
             const binding = await this.findOne(name, {

--- a/packages/access/src/permission/evaluator/types.ts
+++ b/packages/access/src/permission/evaluator/types.ts
@@ -36,6 +36,6 @@ export type PermissionEvaluationContext = {
     name: string | string[],
     realmId?: string | null,
     clientId?: string | null,
-    input?: PolicyData,
+    data?: PolicyData,
     options?: PermissionEvaluationOptions
 };

--- a/packages/access/src/policy/built-in/constants.ts
+++ b/packages/access/src/policy/built-in/constants.ts
@@ -50,8 +50,6 @@ export const SystemPolicyName = {
     IDENTITY: 'system.identity',
     PERMISSION_BINDING: 'system.permission-binding',
     REALM_MATCH: 'system.realm-match',
-    REALM_BOUND: 'system.realm-bound',
-    REALM_OR_GLOBAL: 'system.realm-or-global',
     CLIENT_NAMES_SELF_MANAGE: 'system.client-names-self-manage',
     ROBOT_NAMES_SELF_MANAGE: 'system.robot-names-self-manage',
     USER_NAMES_SELF_MANAGE: 'system.user-names-self-manage',

--- a/packages/access/src/policy/built-in/realm-match/evaluator.ts
+++ b/packages/access/src/policy/built-in/realm-match/evaluator.ts
@@ -47,33 +47,19 @@ export class RealmMatchPolicyEvaluator implements IPolicyEvaluator {
         }
 
         // SCOPE MODE: coarse, actor-relative realm reach (the realm_scope mechanism lives
-        // here). Read the resource realm from the REALM_MATCH data key, falling back to
-        // ATTRIBUTES.realm_id for back-compat. Key-PRESENCE is the discriminator: an ABSENT
-        // realm neutral-passes (gate check / realm-less resource), while a present `null`
-        // (global resource) is matched (and `own` correctly denies it). Runs BEFORE the
-        // attributes-required guard below, since junction / gate inputs need not carry
-        // ATTRIBUTES.
+        // here). The resource realm is supplied under the REALM_MATCH data key. Key-PRESENCE
+        // is the discriminator: an ABSENT realm neutral-passes (gate check / realm-less
+        // resource), while a present `null` (global resource) is matched (and `own` correctly
+        // denies it). Runs BEFORE the attributes-required guard below, since junction / gate
+        // inputs need not carry ATTRIBUTES.
         if (policy.scope) {
-            let resourceRealm: string | string[] | null | undefined;
-            let resourceRealmPresent = false;
-
-            if (ctx.data && ctx.data.has(BuiltInPolicyType.REALM_MATCH)) {
-                resourceRealm = ctx.data.get<string | string[] | null>(BuiltInPolicyType.REALM_MATCH);
-                resourceRealmPresent = true;
-            } else {
-                const data = await this.attributesEvaluator.accessData(ctx) as Record<string, any> | null;
-                if (data && hasOwnProperty(data, 'realm_id')) {
-                    resourceRealm = (data.realm_id ?? null) as string | string[] | null;
-                    resourceRealmPresent = true;
-                }
-            }
-
-            if (!resourceRealmPresent) {
+            if (!ctx.data || !ctx.data.has(BuiltInPolicyType.REALM_MATCH)) {
                 // Non-evaluation (no resource realm) — neutral pass, no `invert`,
                 // mirroring the attribute-mode non-evaluation pass below.
                 return { success: true };
             }
 
+            const resourceRealm = ctx.data.get<string | string[] | null>(BuiltInPolicyType.REALM_MATCH);
             return {
                 success: maybeInvertPolicyOutcome(
                     realmScopeMatches(

--- a/packages/access/src/policy/built-in/realm-match/evaluator.ts
+++ b/packages/access/src/policy/built-in/realm-match/evaluator.ts
@@ -6,10 +6,12 @@
  */
 
 import { DecisionStrategy, hasOwnProperty  } from '@authup/kit';
+import { realmScopeMatches } from '../../../permission/realm-scope';
 import type { IPolicyEvaluator, PolicyEvaluationContext, PolicyEvaluationResult } from '../../evaluation';
 import { maybeInvertPolicyOutcome } from '../../helpers';
 import { PolicyIssueCode, definePolicyIssueItem } from '../../issue';
 import { AttributesPolicyEvaluator } from '../attributes';
+import { BuiltInPolicyType } from '../constants';
 import { IdentityPolicyEvaluator } from '../identity';
 import { RealmMatchPolicyValidator } from './validator';
 
@@ -41,6 +43,47 @@ export class RealmMatchPolicyEvaluator implements IPolicyEvaluator {
                         path: ctx.path,
                     }),
                 ],
+            };
+        }
+
+        // SCOPE MODE: coarse, actor-relative realm reach (the realm_scope mechanism lives
+        // here). Read the resource realm from the REALM_MATCH data key, falling back to
+        // ATTRIBUTES.realm_id for back-compat. Key-PRESENCE is the discriminator: an ABSENT
+        // realm neutral-passes (gate check / realm-less resource), while a present `null`
+        // (global resource) is matched (and `own` correctly denies it). Runs BEFORE the
+        // attributes-required guard below, since junction / gate inputs need not carry
+        // ATTRIBUTES.
+        if (policy.scope) {
+            let resourceRealm: string | string[] | null | undefined;
+            let resourceRealmPresent = false;
+
+            if (ctx.data && ctx.data.has(BuiltInPolicyType.REALM_MATCH)) {
+                resourceRealm = ctx.data.get<string | string[] | null>(BuiltInPolicyType.REALM_MATCH);
+                resourceRealmPresent = true;
+            } else {
+                const data = await this.attributesEvaluator.accessData(ctx) as Record<string, any> | null;
+                if (data && hasOwnProperty(data, 'realm_id')) {
+                    resourceRealm = (data.realm_id ?? null) as string | string[] | null;
+                    resourceRealmPresent = true;
+                }
+            }
+
+            if (!resourceRealmPresent) {
+                // Non-evaluation (no resource realm) — neutral pass, no `invert`,
+                // mirroring the attribute-mode non-evaluation pass below.
+                return { success: true };
+            }
+
+            return {
+                success: maybeInvertPolicyOutcome(
+                    realmScopeMatches(
+                        policy.scope,
+                        resourceRealm ?? null,
+                        identity.realmId,
+                        identity.realmName,
+                    ),
+                    policy.invert,
+                ),
             };
         }
 

--- a/packages/access/src/policy/built-in/realm-match/types.ts
+++ b/packages/access/src/policy/built-in/realm-match/types.ts
@@ -34,9 +34,9 @@ export interface RealmMatchPolicy extends BasePolicy {
 
     /**
      * Coarse, actor-relative realm reach (none/own/ownOrNull/any). When set, the evaluator
-     * runs in SCOPE MODE: it matches the resource realm (read from the REALM_MATCH data key,
-     * falling back to ATTRIBUTES.realm_id) against the identity realm via `realmScopeMatches`,
-     * and ignores `attribute_name` / `attribute_null_match_all`.
+     * runs in SCOPE MODE: it matches the resource realm read from the REALM_MATCH data key
+     * against the identity realm via `realmScopeMatches`, and ignores `attribute_name` /
+     * `attribute_null_match_all`. With no REALM_MATCH key present it neutral-passes.
      */
     scope?: `${RealmScope}`
 }

--- a/packages/access/src/policy/built-in/realm-match/types.ts
+++ b/packages/access/src/policy/built-in/realm-match/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { DecisionStrategy } from '@authup/kit';
+import type { RealmScope } from '../../../permission/realm-scope';
 import type { BasePolicy } from '../../types';
 
 export interface RealmMatchPolicy extends BasePolicy {
@@ -29,5 +30,13 @@ export interface RealmMatchPolicy extends BasePolicy {
      * Determines if resources with null realm-id/name value should match all identity realms.
      * If true, any identity realm can access resources with null realm-id/name values.
      */
-    attribute_null_match_all?: boolean
+    attribute_null_match_all?: boolean,
+
+    /**
+     * Coarse, actor-relative realm reach (none/own/ownOrNull/any). When set, the evaluator
+     * runs in SCOPE MODE: it matches the resource realm (read from the REALM_MATCH data key,
+     * falling back to ATTRIBUTES.realm_id) against the identity realm via `realmScopeMatches`,
+     * and ignores `attribute_name` / `attribute_null_match_all`.
+     */
+    scope?: `${RealmScope}`
 }

--- a/packages/access/src/policy/built-in/realm-match/validator.ts
+++ b/packages/access/src/policy/built-in/realm-match/validator.ts
@@ -9,6 +9,7 @@ import { createValidator } from '@validup/zod';
 import { Container } from 'validup';
 import { z } from 'zod';
 import { DecisionStrategy } from '@authup/kit';
+import { RealmScope } from '../../../permission/realm-scope';
 import type { RealmMatchPolicy } from './types';
 
 export class RealmMatchPolicyValidator extends Container<RealmMatchPolicy> {
@@ -49,6 +50,16 @@ export class RealmMatchPolicyValidator extends Container<RealmMatchPolicy> {
             'attribute_null_match_all',
             createValidator(
                 z.boolean()
+                    .or(z.null())
+                    .or(z.undefined())
+                    .optional(),
+            ),
+        );
+
+        this.mount(
+            'scope',
+            createValidator(
+                z.enum(RealmScope)
                     .or(z.null())
                     .or(z.undefined())
                     .optional(),

--- a/packages/access/src/policy/index.ts
+++ b/packages/access/src/policy/index.ts
@@ -15,3 +15,4 @@ export * from './types';
 
 export * from './constants.ts';
 export * from './data.ts';
+export * from './input.ts';

--- a/packages/access/src/policy/input.ts
+++ b/packages/access/src/policy/input.ts
@@ -31,6 +31,6 @@ export interface PolicyInput {
  * Prefer this over `new PolicyData({ ... })` at construction sites so the key vocabulary and
  * per-key value types live in one place.
  */
-export function definePolicyInput(input: PolicyInput = {}): PolicyData {
+export function definePolicyData(input: PolicyInput = {}): PolicyData {
     return new PolicyData(input);
 }

--- a/packages/access/src/policy/input.ts
+++ b/packages/access/src/policy/input.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { BuiltInPolicyType } from './built-in/constants';
+import type { IdentityPolicyData } from './built-in/identity/types';
+import { PolicyData } from './data';
+
+/**
+ * Typed seed for a permission evaluation's {@link PolicyData} bag.
+ *
+ * The well-known context keys are value-typed, so construction is discoverable and a
+ * wrong-typed value is a compile error. The trailing index signature keeps the bag **open** —
+ * a third-party evaluator may supply its own key without any change to this published type
+ * (the `access` evaluator set is deliberately extensible).
+ */
+export interface PolicyInput {
+    [BuiltInPolicyType.IDENTITY]?: IdentityPolicyData;
+    [BuiltInPolicyType.ATTRIBUTES]?: Record<string, any>;
+    [BuiltInPolicyType.REALM_MATCH]?: string | string[] | null;
+    [key: string]: any;
+}
+
+/**
+ * Build a {@link PolicyData} bag from a typed {@link PolicyInput} seed. Well-known keys
+ * (identity / attributes / realmMatch) are type-checked; unknown keys are accepted as-is.
+ *
+ * Prefer this over `new PolicyData({ ... })` at construction sites so the key vocabulary and
+ * per-key value types live in one place.
+ */
+export function definePolicyInput(input: PolicyInput = {}): PolicyData {
+    return new PolicyData(input);
+}

--- a/packages/access/test/unit/permission/checker.spec.ts
+++ b/packages/access/test/unit/permission/checker.spec.ts
@@ -9,15 +9,14 @@ import { describe, expect, it } from 'vitest';
 
 import { ErrorCode } from '@authup/errors';
 import type { AttributeNamesPolicy, PermissionPolicyBinding } from '../../../src';
-import {
-    BuiltInPolicyType,
-    PermissionError,
-
-    PermissionEvaluator,
-    PermissionMemoryProvider,
-    PolicyData,
-    PolicyDefaultEvaluators,
-    PolicyEngine,
+import { 
+    BuiltInPolicyType, 
+    PermissionError, 
+    PermissionEvaluator, 
+    PermissionMemoryProvider, 
+    PolicyDefaultEvaluators, 
+    PolicyEngine, 
+    definePolicyInput, 
 } from '../../../src';
 
 const abilities : PermissionPolicyBinding[] = [
@@ -44,7 +43,7 @@ describe('src/ability/manager.ts', () => {
     it('should work with policy', async () => {
         await evaluator.evaluate({
             name: 'user_edit',
-            input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' } }),
+            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' } }),
         });
     });
 
@@ -54,7 +53,7 @@ describe('src/ability/manager.ts', () => {
         try {
             await evaluator.evaluate({
                 name: 'user_edit',
-                input: new PolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { id: '123' } }),
+                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { id: '123' } }),
             });
         } catch (e) {
             expect(e).toBeInstanceOf(PermissionError);

--- a/packages/access/test/unit/permission/checker.spec.ts
+++ b/packages/access/test/unit/permission/checker.spec.ts
@@ -16,7 +16,7 @@ import {
     PermissionMemoryProvider, 
     PolicyDefaultEvaluators, 
     PolicyEngine, 
-    definePolicyInput, 
+    definePolicyData, 
 } from '../../../src';
 
 const abilities : PermissionPolicyBinding[] = [
@@ -43,7 +43,7 @@ describe('src/ability/manager.ts', () => {
     it('should work with policy', async () => {
         await evaluator.evaluate({
             name: 'user_edit',
-            data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' } }),
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' } }),
         });
     });
 
@@ -53,7 +53,7 @@ describe('src/ability/manager.ts', () => {
         try {
             await evaluator.evaluate({
                 name: 'user_edit',
-                data: definePolicyInput({ [BuiltInPolicyType.ATTRIBUTES]: { id: '123' } }),
+                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { id: '123' } }),
             });
         } catch (e) {
             expect(e).toBeInstanceOf(PermissionError);

--- a/packages/access/test/unit/policy/input.spec.ts
+++ b/packages/access/test/unit/policy/input.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BuiltInPolicyType, PolicyData, definePolicyInput } from '../../../src';
+
+describe('src/policy/input', () => {
+    it('builds a PolicyData carrying the well-known keys', () => {
+        const data = definePolicyInput({
+            [BuiltInPolicyType.ATTRIBUTES]: { realm_id: 'r1' },
+            [BuiltInPolicyType.REALM_MATCH]: 'r1',
+        });
+
+        expect(data).toBeInstanceOf(PolicyData);
+        expect(data.has(BuiltInPolicyType.ATTRIBUTES)).toBe(true);
+        expect(data.get(BuiltInPolicyType.REALM_MATCH)).toBe('r1');
+    });
+
+    it('accepts unknown keys (open vocabulary for third-party evaluators)', () => {
+        const data = definePolicyInput({ 'x-custom': { foo: 1 } });
+
+        expect(data.has('x-custom')).toBe(true);
+        expect(data.get('x-custom')).toEqual({ foo: 1 });
+    });
+
+    it('defaults to an empty bag', () => {
+        const data = definePolicyInput();
+
+        expect(data.has(BuiltInPolicyType.IDENTITY)).toBe(false);
+    });
+});

--- a/packages/access/test/unit/policy/input.spec.ts
+++ b/packages/access/test/unit/policy/input.spec.ts
@@ -6,11 +6,11 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { BuiltInPolicyType, PolicyData, definePolicyInput } from '../../../src';
+import { BuiltInPolicyType, PolicyData, definePolicyData } from '../../../src';
 
 describe('src/policy/input', () => {
     it('builds a PolicyData carrying the well-known keys', () => {
-        const data = definePolicyInput({
+        const data = definePolicyData({
             [BuiltInPolicyType.ATTRIBUTES]: { realm_id: 'r1' },
             [BuiltInPolicyType.REALM_MATCH]: 'r1',
         });
@@ -21,14 +21,14 @@ describe('src/policy/input', () => {
     });
 
     it('accepts unknown keys (open vocabulary for third-party evaluators)', () => {
-        const data = definePolicyInput({ 'x-custom': { foo: 1 } });
+        const data = definePolicyData({ 'x-custom': { foo: 1 } });
 
         expect(data.has('x-custom')).toBe(true);
         expect(data.get('x-custom')).toEqual({ foo: 1 });
     });
 
     it('defaults to an empty bag', () => {
-        const data = definePolicyInput();
+        const data = definePolicyData();
 
         expect(data.has(BuiltInPolicyType.IDENTITY)).toBe(false);
     });

--- a/packages/access/test/unit/policy/realm-match.spec.ts
+++ b/packages/access/test/unit/policy/realm-match.spec.ts
@@ -157,10 +157,12 @@ describe('src/policy/realm-match scope mode', () => {
         expect(o.success).toBe(true);
     });
 
-    it('falls back to ATTRIBUTES.realm_id when REALM_MATCH is absent', async () => {
+    it('reads ONLY the REALM_MATCH key — an ATTRIBUTES.realm_id is not a realm source', async () => {
+        // Single-source: with no REALM_MATCH key the gate neutral-passes, even when
+        // ATTRIBUTES carries a (foreign) realm_id.
         const o = await run({ scope: 'own' }, {
             [BuiltInPolicyType.IDENTITY]: identityA,
-            [BuiltInPolicyType.ATTRIBUTES]: { realm_id: REALM_A },
+            [BuiltInPolicyType.ATTRIBUTES]: { realm_id: REALM_B },
         });
         expect(o.success).toBe(true);
     });

--- a/packages/access/test/unit/policy/realm-match.spec.ts
+++ b/packages/access/test/unit/policy/realm-match.spec.ts
@@ -91,3 +91,77 @@ describe('src/policy/attribute-realm', () => {
         expect(outcome.success).toBeFalsy();
     });
 });
+
+describe('src/policy/realm-match scope mode', () => {
+    const REALM_A = 'c641912c-21e5-4cb4-84b6-169e2b2bb023';
+    const REALM_B = '1b17ab3d-3e87-4d63-9997-374ed9a58c23';
+    const evaluator = new RealmMatchPolicyEvaluator();
+    const identityA = {
+        type: 'user',
+        id: '245e3c5d-5747-4fbd-8554-c33d34780c58',
+        realmId: REALM_A,
+    };
+
+    const run = (policy: RealmMatchPolicy, data: Record<string, any>) => evaluator.evaluate(
+        policy,
+        definePolicyEvaluationContext({ data: new PolicyData(data) }),
+    );
+
+    it('own: matches the actor own realm (REALM_MATCH key)', async () => {
+        const o = await run({ scope: 'own' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.REALM_MATCH]: REALM_A,
+        });
+        expect(o.success).toBe(true);
+    });
+
+    it('own: denies a foreign realm', async () => {
+        const o = await run({ scope: 'own' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.REALM_MATCH]: REALM_B,
+        });
+        expect(o.success).toBe(false);
+    });
+
+    it('own: denies a null (global) resource', async () => {
+        const o = await run({ scope: 'own' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.REALM_MATCH]: null,
+        });
+        expect(o.success).toBe(false);
+    });
+
+    it('ownOrNull: permits a null (global) resource', async () => {
+        const o = await run({ scope: 'ownOrNull' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.REALM_MATCH]: null,
+        });
+        expect(o.success).toBe(true);
+    });
+
+    it('any: permits any realm including null', async () => {
+        const foreign = await run({ scope: 'any' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.REALM_MATCH]: REALM_B,
+        });
+        const global = await run({ scope: 'any' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.REALM_MATCH]: null,
+        });
+        expect(foreign.success).toBe(true);
+        expect(global.success).toBe(true);
+    });
+
+    it('absent resource realm (no REALM_MATCH, no ATTRIBUTES) neutral-passes the gate', async () => {
+        const o = await run({ scope: 'own' }, { [BuiltInPolicyType.IDENTITY]: identityA });
+        expect(o.success).toBe(true);
+    });
+
+    it('falls back to ATTRIBUTES.realm_id when REALM_MATCH is absent', async () => {
+        const o = await run({ scope: 'own' }, {
+            [BuiltInPolicyType.IDENTITY]: identityA,
+            [BuiltInPolicyType.ATTRIBUTES]: { realm_id: REALM_A },
+        });
+        expect(o.success).toBe(true);
+    });
+});

--- a/packages/client-web-kit/src/components/entities/permission/APermissionCheck.ts
+++ b/packages/client-web-kit/src/components/entities/permission/APermissionCheck.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PermissionEvaluationOptions } from '@authup/access';
-import { PolicyData } from '@authup/access';
+import { definePolicyInput } from '@authup/access';
 import { 
     SlotName, 
     createPermissionCheckerReactiveFn, 
@@ -30,7 +30,7 @@ export const APermissionCheck = defineComponent({
 
         const isPermitted = computed(() => fn({
             name: props.name,
-            input: new PolicyData(props.input),
+            data: definePolicyInput(props.input),
             options: props.options,
         }));
 

--- a/packages/client-web-kit/src/components/entities/permission/APermissionCheck.ts
+++ b/packages/client-web-kit/src/components/entities/permission/APermissionCheck.ts
@@ -6,7 +6,7 @@
  */
 
 import type { PermissionEvaluationOptions } from '@authup/access';
-import { definePolicyInput } from '@authup/access';
+import { definePolicyData } from '@authup/access';
 import { 
     SlotName, 
     createPermissionCheckerReactiveFn, 
@@ -30,7 +30,7 @@ export const APermissionCheck = defineComponent({
 
         const isPermitted = computed(() => fn({
             name: props.name,
-            data: definePolicyInput(props.input),
+            data: definePolicyData(props.input),
             options: props.options,
         }));
 

--- a/packages/client-web-kit/src/core/permission-check/module.ts
+++ b/packages/client-web-kit/src/core/permission-check/module.ts
@@ -57,14 +57,14 @@ export function createPermissionCheckerReactiveFn(
 
             let outcome: boolean;
 
-            const input = ctx.input || new PolicyData();
+            const input = ctx.data || new PolicyData();
             input.set(BuiltInPolicyType.IDENTITY, identity);
 
             try {
                 computePromise = store.permissionEvaluator
                     .preEvaluateOneOf({
                         ...ctx,
-                        input,
+                        data: input,
                     })
                     .then(() => true)
                     .catch(() => false);

--- a/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
+++ b/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
@@ -15,7 +15,7 @@ import {
 } from '@authup/client-web-kit';
 import { hasOwnProperty, omitRecord } from '@authup/kit';
 import type { RouteLocationAsPathGeneric, RouteLocationNormalized } from 'vue-router';
-import { BuiltInPolicyType, type IdentityPolicyData, PolicyData } from '@authup/access';
+import { BuiltInPolicyType, type IdentityPolicyData, definePolicyInput } from '@authup/access';
 import type { NuxtApp } from '#app';
 import { RouteMetaKey } from '../constants';
 import type { RuntimeOptions } from '../types';
@@ -242,7 +242,7 @@ export class RoutingInterceptor {
             try {
                 await this.store.permissionEvaluator.preEvaluateOneOf({
                     name: permissions,
-                    input: new PolicyData({ [BuiltInPolicyType.IDENTITY]: identity }),
+                    data: definePolicyInput({ [BuiltInPolicyType.IDENTITY]: identity }),
                 });
             } catch {
                 return false;

--- a/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
+++ b/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
@@ -15,7 +15,7 @@ import {
 } from '@authup/client-web-kit';
 import { hasOwnProperty, omitRecord } from '@authup/kit';
 import type { RouteLocationAsPathGeneric, RouteLocationNormalized } from 'vue-router';
-import { BuiltInPolicyType, type IdentityPolicyData, definePolicyInput } from '@authup/access';
+import { BuiltInPolicyType, type IdentityPolicyData, definePolicyData } from '@authup/access';
 import type { NuxtApp } from '#app';
 import { RouteMetaKey } from '../constants';
 import type { RuntimeOptions } from '../types';
@@ -242,7 +242,7 @@ export class RoutingInterceptor {
             try {
                 await this.store.permissionEvaluator.preEvaluateOneOf({
                     name: permissions,
-                    data: definePolicyInput({ [BuiltInPolicyType.IDENTITY]: identity }),
+                    data: definePolicyData({ [BuiltInPolicyType.IDENTITY]: identity }),
                 });
             } catch {
                 return false;

--- a/packages/server-kit/src/core/junction-service.ts
+++ b/packages/server-kit/src/core/junction-service.ts
@@ -10,10 +10,10 @@ import { AbstractEntityService } from './service';
 /**
  * Base class for junction/association entity services (role-permission, user-role,
  * client-scope, …) whose rows carry no top-level `realm_id`, only the realm of the
- * entities they link. Realm gating of a junction write therefore depends on stamping
- * the OWNER entity's realm as the canonical `realm_id` onto the `evaluate()` input —
- * without it the realm_scope factor neutral-passes and the write fails OPEN
- * (silent cross-realm leak).
+ * entities they link. The OWNER entity's realm gates a junction write — it is supplied to
+ * the realm_scope reach factor under the `realmMatch` PolicyData key (RealmMatchPolicyEvaluator
+ * SCOPE MODE), NOT stamped into ATTRIBUTES — so junction ATTRIBUTES carry only genuine
+ * columns and an ATTRIBUTE_NAMES policy never mis-sees a synthetic `realm_id`.
  */
 export abstract class JunctionEntityService extends AbstractEntityService {
     /**
@@ -26,22 +26,21 @@ export abstract class JunctionEntityService extends AbstractEntityService {
     protected abstract readonly ownerRealmKey: string;
 
     /**
-     * Build the ATTRIBUTES for a permission `evaluate()` on a junction row, stamping the
-     * owner realm as the canonical `realm_id` onto a COPY (never the persisted entity).
-     * Use this instead of spreading `realm_id` by hand so a junction can never silently
-     * skip the stamp.
-     *
-     * KNOWN LIMITATION: the realm_scope factor reads the resource realm from `realm_id` in
-     * the ATTRIBUTES bag (uniform with entity resources, which carry a real `realm_id`
-     * column). For a junction this `realm_id` is *synthetic* — the owner realm, not a real
-     * junction attribute — so an `ATTRIBUTE_NAMES` allowlist policy attached to a junction
-     * permission would (mis)see it and reject. No default junction permission has such a
-     * policy, so this is latent; the proper fix (carry the resource realm as evaluation
-     * context, separate from the policy-type ATTRIBUTES bag) is tracked for the PolicyData
-     * redesign — do NOT attach an `ATTRIBUTE_NAMES` allowlist to a junction permission until
-     * then.
+     * The junction's genuine attributes for a permission `evaluate()` — a COPY of the row
+     * (never the persisted entity). No synthetic `realm_id`; the owner realm travels
+     * separately via {@link junctionResourceRealm}.
      */
     protected junctionAttributes(entity: Record<string, any>): Record<string, any> {
-        return { ...entity, realm_id: entity[this.ownerRealmKey] ?? null };
+        return { ...entity };
+    }
+
+    /**
+     * The OWNER realm for the realm_scope reach factor — set under the `realmMatch` PolicyData
+     * key alongside ATTRIBUTES. A `null` owner (global) is matched (and `own` correctly denies
+     * it). Reading `ownerRealmKey` keeps the compile-time guard: a junction cannot silently
+     * skip its realm.
+     */
+    protected junctionResourceRealm(entity: Record<string, any>): string | null {
+        return entity[this.ownerRealmKey] ?? null;
     }
 }

--- a/packages/server-kit/src/core/service.ts
+++ b/packages/server-kit/src/core/service.ts
@@ -5,7 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isObject } from '@authup/kit';
+import { BuiltInPolicyType } from '@authup/access';
+import { hasOwnProperty, isObject } from '@authup/kit';
 import type { ActorContext } from './actor/types';
 
 export abstract class AbstractEntityService {
@@ -24,5 +25,19 @@ export abstract class AbstractEntityService {
         }
 
         return undefined;
+    }
+
+    /**
+     * Resource-realm entry for a permission `evaluate()` input, spread into the PolicyData
+     * literal: `new PolicyData({ [ATTRIBUTES]: x, ...this.resourceRealmMatch(x) })`. It mirrors
+     * ATTRIBUTES `realm_id` PRESENCE — the `realmMatch` key is set only when the source carries
+     * `realm_id`, so a self-edit UPDATE (where the validator strips `realm_id`) leaves the key
+     * ABSENT and the realm_scope reach factor neutral-passes, exactly as the pre-key behavior.
+     * A present `realm_id: null` (global resource) is carried as `null` (and `own` denies it).
+     */
+    protected resourceRealmMatch(source: Record<string, any>): Record<string, any> {
+        return hasOwnProperty(source, 'realm_id') ?
+            { [BuiltInPolicyType.REALM_MATCH]: source.realm_id ?? null } :
+            {};
     }
 }


### PR DESCRIPTION
Closes #3154.

Resolves the resource-realm-in-PolicyData problem (#3154) with "Design D", and folds in the follow-on PolicyData ergonomics work (typed builder + a naming fix) plus a cross-realm gating bug found during review.

## 1. Resource realm via the `realmMatch` policy key (Design D — #3154)

The `realm_scope` reach factor read the resource realm from `realm_id` in the **ATTRIBUTES** bag. For an entity that's a real column; for a junction it was a *synthetic* stamp, so an `ATTRIBUTE_NAMES` policy on a junction permission would mis-see it. Realm reach was also split across two consumers (the enum factor + the `REALM_MATCH` policy type).

Now the resource realm rides a dedicated **`realmMatch` PolicyData key** — a legitimate policy-type slot (parallel to `attributes`/`identity`), read **only** by `RealmMatchPolicyEvaluator`:

- `RealmMatchPolicy` gains an optional `scope` (`none`/`own`/`ownOrNull`/`any`); when set, the evaluator runs in **SCOPE MODE** and matches the resource realm from `realmMatch` against the actor realm via `realmScopeMatches`. `realm_scope` and realm-match policies are now **one** evaluator.
- `PermissionBindingPolicyEvaluator` invokes it **directly** (not via the engine — `realmMatch` is in `policiesExcluded`) with the merged grant scope, ANDed with but **outside** the `policies[]` merge, so the policy-free fail-open drop can never touch realm reach.
- Entities derive the key from `ATTRIBUTES.realm_id` (only when present — a self-edit UPDATE neutral-passes; `realm_id` stays in ATTRIBUTES for the self-manage denylists). Junctions set the **owner realm** and drop the synthetic stamp — ATTRIBUTES carry only genuine columns. `/check` derives it from `body.attributes.realm_id`.

The synthetic-`realm_id`-in-ATTRIBUTES hazard is gone (the junction `ATTRIBUTE_NAMES` caveat in `architecture.md` is lifted). Shipped in five reviewable phases (one commit each): access scope-mode → server-core routing → junctions → entities + `/check` → fallback removal + docs.

## 2. `definePolicyData` builder (typed PolicyData construction)

New `PolicyInput` + `definePolicyData()`: the well-known context keys (`identity` / `attributes` / `realmMatch`) are value-typed for discoverable, typo-resistant construction, while a trailing index signature keeps the bag **open** so a third-party evaluator can supply its own key with no published-type change. All construction sites migrated off `new PolicyData({...})`.

## 3. Rename `PermissionEvaluationContext.input` → `data` (BREAKING)

The evaluation `PolicyData` is now named `data` on the public entry context, matching `PolicyEvaluationContext.data` — one name for the same object across both stages.

## 4. Realm-gate role-attribute create/update (cross-realm fix, found in review)

`RoleAttributeService.create`/`update` evaluated `ROLE_UPDATE` with no `realmMatch`, so the reach factor neutral-passed — a `realm_admin` in realm A could write a role-attribute on a realm-B role (read/delete were already gated). Both write paths now pass the role realm via `resourceRealmMatch(entity)`, with cross-realm denial specs. A full audit of all ~75 `evaluate()` sites confirmed this was the only such gap.

## Verification

- `@authup/access` + `apps/server-core` full suites green (**907** server-core tests); full monorepo build green; CI green (incl. Test Migrations mysql + postgres).
- Design + verified blast radius in `.agents/plans/035`.

## BREAKING CHANGE

`PermissionEvaluationContext.input` is renamed to `data`. Callers of `permissionEvaluator.evaluate` / `preEvaluate` / `*OneOf` must pass `{ data }` instead of `{ input }`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scope-mode realm matching for realm-scoped permissions, using explicit realm-match inputs to drive authorization decisions.
* **Bug Fixes**
  * Improved realm boundary enforcement across identity-provider, roles/permissions, clients/robots, scopes, users, realms, and provider-related actions for create/update/delete and view flows.
  * Authorization now better handles missing realm-match context (neutral-pass) and ignores caller-supplied realm identifiers where applicable, reducing incorrect allows/denies.
* **Documentation**
  * Updated guidance on realm scoping and junction write authorization.
* **Tests**
  * Added and expanded unit tests for realm-match scope mode and realm-scoped permission behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->