### PR TITLE
fix(access,server-core)!: compare policy content in isSuperset/grantDominates (#3159)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -904,31 +904,29 @@ expressed via a `policy_id` `ATTRIBUTES` policy. See
 
 ### Superset Check
 
-When assigning a role to an identity or identity-provider (user-role, client-role, robot-role, identity-provider-role-mapping), the service verifies the actor owns all permissions in the target role. The check is **policy-aware**:
+When assigning a role to an identity or identity-provider (user-role, client-role, robot-role, identity-provider-role-mapping), `IdentityPermissionProvider.isSuperset(parent, child)` verifies the actor (`parent`) owns at least what the target role (`child`) confers. It is **disjunction-aware and policy-aware** — there is no lossy collapse (the old `mergePermissionBindings` AFFIRMATIVE fold was removed in #3158):
 
-1. Merge actor's bindings per permission (using `mergePermissionBindings` with AFFIRMATIVE strategy)
-2. Merge target's bindings per permission
-3. For each target permission: if actor's merged binding has policies but target's doesn't → fail (actor is more restricted)
+1. `aggregatePermissionPolicyBindings` groups each side's raw bindings into per-permission **grant disjunctions** (`{ realm_scope, policy }[]`).
+2. For each target permission (matched by `name + realm_id + client_id`): if the actor holds no grant for it → fail.
+3. For each target **grant**, require that **some** actor grant **dominates** it (`grantDominates`). Because access is the OR over grants, child-access ⊆ actor-access iff every child grant is covered by some actor grant.
 
-An actor with both `admin` (unrestricted) and `realm_admin` (restricted) roles gets unrestricted access — the merge uses AFFIRMATIVE (least restrictive wins).
+**`grantDominates(parent, child)`** (`@authup/access`, `permission/helpers/grant.ts`) — a parent grant covers a child grant iff:
+
+- **Reach:** `compareRealmScope(parent.realm_scope, child.realm_scope) >= 0` (ordered `none < own < ownOrNull < any`), AND
+- **Policy** (`policyDominates`): an unrestricted parent covers any child; a restricted parent never covers an *unrestricted* child (it cannot confer the wider policy-free reach it lacks); two restricted grants cover one another **only when their policies are provably the same** (`isPolicyEquivalent`), never by evaluated effect. Provably-same means **either** the same persisted row (equal primary-key `id`) **or** structurally-identical configuration — a value-compare (`smob` `isEqual`) over the policy after `normalizePolicyForEquality` strips the non-evaluation-affecting columns (`id, built_in, name, display_name, description, parent_id, parent, realm_id, realm, created_at, updated_at`) recursively through `children`. So two *distinct rows with identical config* (same predicate) dominate, but a genuinely **different** configuration does not. A shared `type` is **not** equivalence (two `attributes` policies are both `type: attributes`, but `{department:X}` ≠ `{department:Y}`). Deciding `child ⊆ parent` for *different* trees is undecidable (a policy is a predicate over `PolicyData`), so we accept only provable identity/equality and treat anything else as distinct (#3159 — the predecessor treated any two policy-bound grants as mutually dominating: a latent over-permit across disjoint policy scopes, e.g. a `department=X` actor conferring a `department=Y` grant). Fail-closed; may under-permit only when the two equal predicates are not provably equal (e.g. composite children in different order). **Security invariant:** every key in `NON_SEMANTIC_POLICY_KEYS` must stay non-evaluation-affecting — adding an evaluation-relevant field there would widen equivalence into an over-permit (new *config* fields need not be added; they are compared by default).
+
+An actor with both `admin` (unrestricted) and `realm_admin` (restricted) grants for a permission gets the union: the unrestricted grant dominates anything, so the disjunction stays permissive without any "least-restrictive-wins" fold.
 
 ### Junction Policy Propagation
 
 When creating any permission-binding junction (role-permission, user-permission, client-permission, robot-permission):
 
-1. The service calls `this.identityPermissionProvider.resolveJunctionPolicy(identity, { name, realm_id, client_id })`
-2. This loads and merges the actor's bindings for that permission
-3. If the merged result has policies, the first policy is set as `policy_id` on the new junction entry
-4. If `data.policy_id` is already set explicitly, propagation is skipped
+1. The service calls `this.identityPermissionProvider.resolveJunctionGrant(identity, { name, realmId, clientId })`.
+2. It aggregates the actor's grants for that permission and selects the **ceiling** = the actor's most-permissive single grant (`selectCeilingGrant`: highest `realm_scope`, policy-free preferred on a tie).
+3. The new junction is capped to that ceiling: `realm_scope = min(requested, ceiling.realm_scope)`, and the ceiling's **own** `policy` (its `id`) is propagated as `policy_id` — never the target's. (If the ceiling is policy-restricted but its policy is not a propagatable `Policy` — e.g. an id-less composite — it fails closed to `realm_scope: none`.)
+4. If `data.policy_id` is already set explicitly, propagation is skipped.
 
-This prevents privilege escalation: a `realm_admin` cannot create unrestricted permission bindings.
-
-### mergePermissionBindings
-
-When merging duplicate permission bindings (same `name + client_id + realm_id`):
-
-- If **any** binding has no policies → merged result has **no policies** (unrestricted)
-- If all bindings have policies → each binding's policies are wrapped in a composite with that binding's `decision_strategy` (defaulting to `UNANIMOUS` when `null`/`undefined`), then all composites are combined under an outer AFFIRMATIVE composite (any-one-passes)
+This prevents privilege escalation: a `realm_admin` cannot create unrestricted permission bindings. Because the actor only ever propagates its *own* policy (not the target's), this path needs no policy-content comparison — the asymmetry with the superset check, which must compare against fixed target grants.
 
 ## Self-Edit Pattern (declarative field denylists)
 

--- a/apps/server-core/src/core/identity/permission/module.ts
+++ b/apps/server-core/src/core/identity/permission/module.ts
@@ -14,6 +14,7 @@ import {
     RealmScope,
     aggregatePermissionPolicyBindings,
     compareRealmScope,
+    grantDominates,
     isPermissionPolicyBindingEqual,
 } from '@authup/access';
 import type { Policy } from '@authup/core-kit';
@@ -63,9 +64,10 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
             }
 
             // Disjunction-aware superset: EVERY child grant must be dominated by SOME parent
-            // grant (the parent reaches at least as far AND is no more policy-restricted). A
-            // child grant the parent cannot match (e.g. an unconditional `any` the parent only
-            // holds policy-gated) fails the check — the actor cannot assign more than it holds.
+            // grant (reach >= AND the parent's policy provably covers the child's — see
+            // grantDominates). A child grant the parent cannot match — an unconditional `any`
+            // the parent only holds policy-gated, or a policy the parent does not itself hold
+            // (#3159) — fails the check; the actor cannot assign more than it holds.
             for (const childGrant of childItem.grants) {
                 const dominated = parentItem.grants.some(
                     (parentGrant) => grantDominates(parentGrant, childGrant),
@@ -215,24 +217,6 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
 
         return bindings.filter((binding) => binding.permission.client_id === identity.clientId);
     }
-}
-
-/**
- * Whether `parent` grant covers `child` grant: it reaches at least as far (ordered
- * none < own < ownOrNull < any) AND is not more policy-restricted (a policy-bound parent
- * cannot cover an unrestricted child). Policy *content* is not compared — same conservative
- * approximation the collapsed superset used, now applied per grant.
- */
-function grantDominates(parent: PermissionGrant, child: PermissionGrant): boolean {
-    if (compareRealmScope(parent.realm_scope, child.realm_scope) < 0) {
-        return false;
-    }
-
-    if (parent.policy && !child.policy) {
-        return false;
-    }
-
-    return true;
 }
 
 /**

--- a/apps/server-core/test/unit/core/identity/permission/provider.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/provider.spec.ts
@@ -31,6 +31,7 @@ function createProvider(bindingsById: Record<string, PermissionPolicyBinding[]>)
 }
 
 const policy = { id: 'policy-1', type: BuiltInPolicyType.IDENTITY } as any;
+const policyOther = { id: 'policy-2', type: BuiltInPolicyType.ATTRIBUTES } as any;
 
 describe('core/identity/permission — IdentityPermissionProvider disjunction (#3155)', () => {
     describe('isSuperset', () => {
@@ -90,6 +91,52 @@ describe('core/identity/permission — IdentityPermissionProvider disjunction (#
 
             const result = await provider.isSuperset({ type: 'role', id: 'parent' }, { type: 'role', id: 'child' });
             expect(result).toBe(false);
+        });
+
+        // #3159: policy content is compared — a differently-CONFIGURED policy must not dominate.
+        it('blocks an actor restricted by one policy from assigning a role restricted by another', async () => {
+            const provider = createProvider({
+                parent: [{ permission: { name: 'user_update' }, policies: [policy] }],
+                child: [{ permission: { name: 'user_update' }, policies: [policyOther] }],
+            });
+
+            const result = await provider.isSuperset({ type: 'role', id: 'parent' }, { type: 'role', id: 'child' });
+            expect(result).toBe(false);
+        });
+
+        it('allows assigning a role restricted by the SAME policy the actor holds', async () => {
+            const provider = createProvider({
+                parent: [{ permission: { name: 'user_update' }, policies: [policy] }],
+                child: [{ permission: { name: 'user_update' }, policies: [policy] }],
+            });
+
+            const result = await provider.isSuperset({ type: 'role', id: 'parent' }, { type: 'role', id: 'child' });
+            expect(result).toBe(true);
+        });
+
+        it('allows assigning a role restricted by a distinct policy row with identical config', async () => {
+            // Different persisted id, same configuration => same predicate => the actor holds it.
+            const provider = createProvider({
+                parent: [{
+                    permission: { name: 'user_update' },
+                    policies: [{
+                        id: 'row-1', 
+                        type: BuiltInPolicyType.IDENTITY, 
+                        types: ['user'], 
+                    } as any], 
+                }],
+                child: [{
+                    permission: { name: 'user_update' },
+                    policies: [{
+                        id: 'row-2', 
+                        type: BuiltInPolicyType.IDENTITY, 
+                        types: ['user'], 
+                    } as any], 
+                }],
+            });
+
+            const result = await provider.isSuperset({ type: 'role', id: 'parent' }, { type: 'role', id: 'child' });
+            expect(result).toBe(true);
         });
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29358,6 +29358,7 @@
                 "@ucast/mongo2js": "^2.0.0",
                 "@validup/zod": "^0.3.3",
                 "pathtrace": "^2.2.0",
+                "smob": "^1.6.1",
                 "validup": "^0.5.1",
                 "zod": "^4.4.3"
             },

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -55,6 +55,7 @@
     "dependencies": {
         "@ucast/mongo2js": "^2.0.0",
         "pathtrace": "^2.2.0",
+        "smob": "^1.6.1",
         "validup": "^0.5.1",
         "zod": "^4.4.3",
         "@validup/zod": "^0.3.3"

--- a/packages/access/src/permission/helpers/grant.ts
+++ b/packages/access/src/permission/helpers/grant.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isEqual } from 'smob';
+import type { BasePolicy } from '../../policy';
+import { compareRealmScope } from '../realm-scope';
+import type { PermissionGrant } from '../types';
+
+/**
+ * Policy fields that do NOT affect evaluation — persisted identity, audit and label columns plus
+ * the loaded `parent` / `realm` relation objects. They are stripped before the structural compare
+ * in isPolicyEquivalent so two DISTINCT rows with identical configuration still match. Verified
+ * against every built-in evaluator, which read only `type`, `invert`, `decision_strategy`,
+ * `children` and the type-specific config (query / names / types / start / end / interval /
+ * day_of_* / attribute_name* / scope). `parent` is additionally a circular back-reference and
+ * `realm` a nested object with its own id, so leaving either in would break the deep compare.
+ *
+ * SECURITY INVARIANT: every key here MUST stay non-evaluation-affecting. Adding an
+ * evaluation-relevant field would silently widen equivalence into an over-permit. New *config*
+ * fields need NOT be added — they are compared by default, which is the fail-closed direction.
+ */
+const NON_SEMANTIC_POLICY_KEYS = new Set<string>([
+    'id',
+    'built_in',
+    'name',
+    'display_name',
+    'description',
+    'parent_id',
+    'parent',
+    'realm_id',
+    'realm',
+    'created_at',
+    'updated_at',
+]);
+
+/**
+ * Project a policy node onto its evaluation-relevant configuration: drop the non-semantic keys
+ * and recurse through `children` (the only field that carries nested policy nodes). Config values
+ * (e.g. an `attributes` `query`) are left untouched, so a semantic `id` / `name` key *inside* a
+ * query is never mistaken for the policy's own identity column.
+ */
+function normalizePolicyForEquality(policy: BasePolicy): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(policy)) {
+        if (NON_SEMANTIC_POLICY_KEYS.has(key)) {
+            continue;
+        }
+
+        const value = (policy as Record<string, unknown>)[key];
+        if (
+            key === 'children' &&
+            Array.isArray(value)
+        ) {
+            result[key] = value.map((child) => normalizePolicyForEquality(child as BasePolicy));
+            continue;
+        }
+
+        result[key] = value;
+    }
+
+    return result;
+}
+
+/**
+ * Whether two restriction policies are provably the SAME policy for domination purposes — by
+ * persisted identity OR by identical configuration, never by evaluated effect. Fast path: equal
+ * primary-key `id` means the same persisted row (the `typeof … === 'string'` guards keep an
+ * id-less / missing-id policy out of it — never `undefined === undefined`). Otherwise fall back to
+ * a structural value-compare of the configuration (`normalizePolicyForEquality` strips the
+ * non-semantic identity / audit / relation columns, `isEqual` deep-compares the rest), so two
+ * distinct rows with identical config — the same predicate — still dominate. Comparing by
+ * *effect* is undecidable (a policy is a predicate over PolicyData), so we accept ONLY provable
+ * identity or provable structural equality; a genuinely different configuration is treated as
+ * distinct (fail-closed) — isSuperset must never assume one restriction covers a different one.
+ */
+function isPolicyEquivalent(parent: BasePolicy, child: BasePolicy): boolean {
+    const parentId = (parent as { id?: unknown }).id;
+    const childId = (child as { id?: unknown }).id;
+
+    if (
+        typeof parentId === 'string' &&
+        typeof childId === 'string' &&
+        parentId === childId
+    ) {
+        return true;
+    }
+
+    return isEqual(normalizePolicyForEquality(parent), normalizePolicyForEquality(child));
+}
+
+/**
+ * Whether the actor's `parent` policy provably covers the target's `child` policy on a shared
+ * permission. Conservative / fail-closed:
+ *  - an unrestricted parent (no policy) covers any child;
+ *  - a restricted parent NEVER covers an unrestricted child — it cannot confer the wider,
+ *    policy-free reach it does not itself hold;
+ *  - two restricted grants cover one another only when their policies are provably equivalent.
+ *    A DIFFERENT policy is NOT assumed to be a subset (#3159: the predecessor treated any two
+ *    policy-bound grants as mutually dominating, a latent over-permit across disjoint policy
+ *    scopes — e.g. an actor restricted to `department=X` conferring a `department=Y` grant).
+ */
+function policyDominates(parent?: BasePolicy, child?: BasePolicy): boolean {
+    if (!parent) {
+        return true;
+    }
+
+    if (!child) {
+        return false;
+    }
+
+    return isPolicyEquivalent(parent, child);
+}
+
+/**
+ * Whether the actor's `parent` grant covers the target's `child` grant: it reaches at least as
+ * far (ordered none < own < ownOrNull < any) AND its policy provably covers the child's
+ * (see `policyDominates`). Used per grant by `isSuperset` over the aggregated disjunction —
+ * every child grant must be dominated by SOME parent grant.
+ */
+export function grantDominates(parent: PermissionGrant, child: PermissionGrant): boolean {
+    if (compareRealmScope(parent.realm_scope, child.realm_scope) < 0) {
+        return false;
+    }
+
+    return policyDominates(parent.policy, child.policy);
+}

--- a/packages/access/src/permission/helpers/index.ts
+++ b/packages/access/src/permission/helpers/index.ts
@@ -7,4 +7,5 @@
 
 export * from './aggregate';
 export * from './equal';
+export * from './grant';
 export * from './key';

--- a/packages/access/test/unit/permission/escalation.spec.ts
+++ b/packages/access/test/unit/permission/escalation.spec.ts
@@ -6,17 +6,18 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import type { PermissionPolicyBinding } from '../../../src';
+import type { PermissionGrant, PermissionPolicyBinding } from '../../../src';
 import {
     BuiltInPolicyType,
     RealmScope,
     aggregatePermissionPolicyBindings,
-    compareRealmScope,
+    grantDominates,
     isPermissionPolicyBindingEqual,
 } from '../../../src';
 
 // Mirrors IdentityPermissionProvider.isSuperset over the aggregated disjunction: every child
-// grant must be dominated by some parent grant (reach >= AND not more policy-restricted).
+// grant must be dominated by some parent grant (reach >= AND policy provably covered). Uses the
+// shared `grantDominates` so the test cannot drift from production domination semantics.
 function isSupersetPolicyAware(
     parentBindings: PermissionPolicyBinding[],
     childBindings: PermissionPolicyBinding[],
@@ -32,10 +33,9 @@ function isSupersetPolicyAware(
         }
 
         for (const childGrant of childItem.grants) {
-            const dominated = parentItem.grants.some((parentGrant) => (
-                compareRealmScope(parentGrant.realm_scope, childGrant.realm_scope) >= 0 &&
-                !(parentGrant.policy && !childGrant.policy)
-            ));
+            const dominated = parentItem.grants.some(
+                (parentGrant) => grantDominates(parentGrant, childGrant),
+            );
 
             if (!dominated) {
                 return false;
@@ -50,6 +50,19 @@ describe('escalation prevention', () => {
     const realmBoundPolicy = {
         type: BuiltInPolicyType.ATTRIBUTES,
         id: 'realm-bound-id',
+    };
+
+    // Two genuinely different restrictions (disjoint `attributes` queries). "Different policy"
+    // means different CONFIGURATION, not merely a different id — the value-compare strips id.
+    const policyDeptX = {
+        type: BuiltInPolicyType.ATTRIBUTES,
+        id: 'policy-department-x',
+        query: { department: 'x' },
+    };
+    const policyDeptY = {
+        type: BuiltInPolicyType.ATTRIBUTES,
+        id: 'policy-department-y',
+        query: { department: 'y' },
     };
 
     it('should allow: unrestricted actor assigning unrestricted role', () => {
@@ -102,6 +115,114 @@ describe('escalation prevention', () => {
             {
                 permission: { name: 'user_read' },
                 policies: [realmBoundPolicy],
+            },
+        ];
+
+        expect(isSupersetPolicyAware(parent, child)).toBe(true);
+    });
+
+    it('should allow: same policy by id even as distinct objects (identity, not reference)', () => {
+        const parent: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_read' },
+                policies: [{ type: BuiltInPolicyType.ATTRIBUTES, id: 'realm-bound-id' }],
+            },
+        ];
+        const child: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_read' },
+                policies: [{ type: BuiltInPolicyType.ATTRIBUTES, id: 'realm-bound-id' }],
+            },
+        ];
+
+        expect(isSupersetPolicyAware(parent, child)).toBe(true);
+    });
+
+    // --- #3159: policy CONTENT matters — two differently-configured grants must not dominate ---
+
+    it('should block: restricted actor assigning a role restricted by a DIFFERENT policy', () => {
+        // Actor reaches only `department=X`; target confers `department=Y`. Both are policy-bound,
+        // but on disjoint scopes — the actor must NOT be able to confer reach it does not hold.
+        const parent: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptX],
+            },
+        ];
+        const child: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptY],
+            },
+        ];
+
+        expect(isSupersetPolicyAware(parent, child)).toBe(false);
+    });
+
+    it('should block: differing policies even when the actor reaches further (any vs own)', () => {
+        // Wider realm reach does not excuse a non-matching policy — domination needs BOTH.
+        const parent: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptX],
+                realm_scope: RealmScope.ANY,
+            },
+        ];
+        const child: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptY],
+                realm_scope: RealmScope.OWN,
+            },
+        ];
+
+        expect(isSupersetPolicyAware(parent, child)).toBe(false);
+    });
+
+    it('should allow: distinct policy rows with identical configuration (value-compare, different id)', () => {
+        // Two SEPARATE policy rows (different id) encoding the same restriction = same predicate,
+        // so the actor genuinely holds what it confers. id differs; structural config is identical.
+        const parent: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [{
+                    type: BuiltInPolicyType.ATTRIBUTES, 
+                    id: 'row-1', 
+                    query: { department: 'x' }, 
+                }],
+            },
+        ];
+        const child: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [{
+                    type: BuiltInPolicyType.ATTRIBUTES, 
+                    id: 'row-2', 
+                    query: { department: 'x' }, 
+                }],
+            },
+        ];
+
+        expect(isSupersetPolicyAware(parent, child)).toBe(true);
+    });
+
+    it('should allow: a matching policy grant dominates even when another actor grant differs', () => {
+        // Disjunction: the actor holds department=X AND department=Y on user_update; assigning a
+        // department=Y role is fine because the department=Y grant dominates it (X need not).
+        const parent: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptX],
+            },
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptY],
+            },
+        ];
+        const child: PermissionPolicyBinding[] = [
+            {
+                permission: { name: 'user_update' },
+                policies: [policyDeptY],
             },
         ];
 
@@ -279,5 +400,99 @@ describe('escalation prevention', () => {
         ];
 
         expect(isSupersetPolicyAware(parent, child)).toBe(false);
+    });
+});
+
+// Direct contract of the per-grant domination primitive used by isSuperset. realm_scope is held
+// equal so each case isolates the policy-content decision (the #3159 crux), except where noted.
+describe('grantDominates', () => {
+    const own = RealmScope.OWN;
+    // Two differently-CONFIGURED attributes policies (disjoint queries), not just different ids.
+    const policyA: PermissionGrant['policy'] = {
+        type: BuiltInPolicyType.ATTRIBUTES, 
+        id: 'a', 
+        query: { department: 'x' }, 
+    } as any;
+    const policyB: PermissionGrant['policy'] = {
+        type: BuiltInPolicyType.ATTRIBUTES, 
+        id: 'b', 
+        query: { department: 'y' }, 
+    } as any;
+
+    it('dominates when both grants are unrestricted at equal reach', () => {
+        expect(grantDominates({ realm_scope: own }, { realm_scope: own })).toBe(true);
+    });
+
+    it('an unrestricted parent dominates a restricted child', () => {
+        expect(grantDominates({ realm_scope: own }, { realm_scope: own, policy: policyA })).toBe(true);
+    });
+
+    it('a restricted parent does NOT dominate an unrestricted child', () => {
+        expect(grantDominates({ realm_scope: own, policy: policyA }, { realm_scope: own })).toBe(false);
+    });
+
+    it('dominates when both reference the same persisted policy (same id)', () => {
+        expect(grantDominates(
+            { realm_scope: own, policy: { type: BuiltInPolicyType.ATTRIBUTES, id: 'a' } as any },
+            { realm_scope: own, policy: { type: BuiltInPolicyType.ATTRIBUTES, id: 'a' } as any },
+        )).toBe(true);
+    });
+
+    it('dominates two distinct rows (different id) with identical config (value-compare)', () => {
+        expect(grantDominates(
+            {
+                realm_scope: own,
+                policy: {
+                    type: BuiltInPolicyType.ATTRIBUTES, 
+                    id: 'r1', 
+                    query: { department: 'x' }, 
+                } as any, 
+            },
+            {
+                realm_scope: own,
+                policy: {
+                    type: BuiltInPolicyType.ATTRIBUTES, 
+                    id: 'r2', 
+                    query: { department: 'x' }, 
+                } as any, 
+            },
+        )).toBe(true);
+    });
+
+    it('does NOT dominate two policies with different configuration', () => {
+        // Same type, disjoint queries — a shared type is not equivalence (department=X vs =Y).
+        expect(grantDominates({ realm_scope: own, policy: policyA }, { realm_scope: own, policy: policyB })).toBe(false);
+    });
+
+    it('dominates id-less policies with identical config (value-compare handles missing id)', () => {
+        expect(grantDominates(
+            { realm_scope: own, policy: { type: BuiltInPolicyType.COMPOSITE, children: [policyA] } as any },
+            { realm_scope: own, policy: { type: BuiltInPolicyType.COMPOSITE, children: [policyA] } as any },
+        )).toBe(true);
+    });
+
+    it('does NOT dominate id-less policies whose config differs (fail closed)', () => {
+        expect(grantDominates(
+            { realm_scope: own, policy: { type: BuiltInPolicyType.COMPOSITE, children: [policyA] } as any },
+            { realm_scope: own, policy: { type: BuiltInPolicyType.COMPOSITE, children: [policyB] } as any },
+        )).toBe(false);
+    });
+
+    it('does NOT dominate when the parent reaches less far, even for the same policy', () => {
+        expect(grantDominates(
+            { realm_scope: own, policy: policyA },
+            { realm_scope: RealmScope.ANY, policy: policyA },
+        )).toBe(false);
+    });
+
+    it('a wider ownOrNull parent dominates an own child; the reverse does not (ordered reach)', () => {
+        expect(grantDominates(
+            { realm_scope: RealmScope.OWN_OR_NULL },
+            { realm_scope: own },
+        )).toBe(true);
+        expect(grantDominates(
+            { realm_scope: own },
+            { realm_scope: RealmScope.OWN_OR_NULL },
+        )).toBe(false);
     });
 });


### PR DESCRIPTION
## Summary

Fixes #3159 — `IdentityPermissionProvider.isSuperset` / `grantDominates` gated role/identity
assignment by comparing realm reach but **never the policy content**. Any two policy-bound grants
were treated as mutually dominating, so a restricted actor could confer a permission gated by a
*different* policy than it holds (e.g. an actor scoped to `department=X` assigning a role scoped
to `department=Y`) — a fail-open **privilege escalation across disjoint policy scopes**.

## Fix

`grantDominates` now requires the child's policy to be **provably covered** by the parent's. Two
restricted grants dominate only when their policies are provably the **same**:

- **same persisted row** — equal primary-key `id`, or
- **identical configuration** — a structural value-compare (`smob` `isEqual`) over
  `normalizePolicyForEquality`, which recursively strips the non-evaluation-affecting
  identity/audit/relation columns (`id, built_in, name, display_name, description, parent_id,
  parent, realm_id, realm, created_at, updated_at`) and deep-compares the rest.

A policy is a predicate over `PolicyData`, so deciding `child ⊆ parent` for *different* trees is
undecidable — we therefore accept only provable identity/equality and treat anything else as
**distinct (fail-closed)**. The strip-list is a denylist, so a future new *config* field is
compared by default (never silently over-permitted); every stripped key was verified
non-evaluation-affecting against all built-in evaluators (**security invariant** documented in
code).

Net behavior:

| case | before | after |
|---|---|---|
| same persisted policy | dominated | dominated |
| **different config** (`dept=X` vs `dept=Y`) | **dominated (escalation)** | **not dominated** ✅ |
| distinct rows, identical config | dominated | dominated (recovers under-permit) |
| restricted parent, unrestricted child | not dominated | not dominated |

`grantDominates` was also **extracted into `@authup/access`** so production and the escalation
test share one implementation instead of duplicating the predicate (the issue's drift concern).
Adds `smob` to `@authup/access`.

## Acceptance criteria (from #3159)

- ✅ A target grant whose policy is not provably a subset of the actor's is **not** dominated (fail closed).
- ✅ Existing escalation-prevention tests pass; added cases for differing policy-bound grants in
  `packages/access/test/unit/permission/escalation.spec.ts` and
  `apps/server-core/test/unit/core/identity/permission/provider.spec.ts`.

## Testing

- `@authup/access` suite: **87 pass** (incl. new `grantDominates` direct + value-compare cases)
- `apps/server-core` suite: **933 pass**
- Builds + ESLint clean.

## Notes

- **Breaking** (`!`): tightens role-assignment authorization — cross-policy assignments that were
  wrongly permitted are now blocked. Admin / unrestricted actors are unaffected
  (`policyDominates(undefined, x) === true`).
- The `resolveJunctionGrant` propagation path is intentionally untouched: it propagates the
  actor's *own* policy, so it needs no content comparison.
- `.agents/architecture.md` (Superset Check / Junction Policy Propagation) updated to the current
  per-grant disjunction + `grantDominates` model.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission checks now better handle multiple grants, including policy-based and scope-based coverage, for more accurate role assignment.

* **Bug Fixes**
  * Fixed cases where users could be incorrectly blocked or allowed when permissions were tied to equivalent policies with different records.
  * Improved escalation prevention so permission reach and policy matching are validated more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->