### PR TITLE
fix(server-core)!: select junction grant relative to requested reach (#3160)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -919,14 +919,14 @@ An actor with both `admin` (unrestricted) and `realm_admin` (restricted) grants 
 
 ### Junction Policy Propagation
 
-When creating any permission-binding junction (role-permission, user-permission, client-permission, robot-permission):
+When creating or updating any permission-binding junction (role-permission, user-permission, client-permission, robot-permission):
 
-1. The service calls `this.identityPermissionProvider.resolveJunctionGrant(identity, { name, realmId, clientId })`.
-2. It aggregates the actor's grants for that permission and selects the **ceiling** = the actor's most-permissive single grant (`selectCeilingGrant`: highest `realm_scope`, policy-free preferred on a tie).
-3. The new junction is capped to that ceiling: `realm_scope = min(requested, ceiling.realm_scope)`, and the ceiling's **own** `policy` (its `id`) is propagated as `policy_id` — never the target's. (If the ceiling is policy-restricted but its policy is not a propagatable `Policy` — e.g. an id-less composite — it fails closed to `realm_scope: none`.)
-4. If `data.policy_id` is already set explicitly, propagation is skipped.
+1. The service calls `this.identityPermissionProvider.resolveJunctionGrant(identity, { name, realmId, clientId, realmScope })`, passing the **requested** reach (`validated.realm_scope ?? own` on create; `data.realm_scope ?? entity.realm_scope` on update — the *resulting* junction reach, so a policy-only update can't silently widen).
+2. It aggregates the actor's grants for that permission and selects the grant **relative to the requested reach** (`selectGrantForRequest`, #3160): each grant is ranked by the reach it can confer *for this request* — its `realm_scope` capped to `realmScope` — so a lower-scoped policy-free grant beats a higher-scoped policy-bound grant when both cap to the same requested reach (highest *capped* reach, policy-free preferred on a tie). This is **not** a global "ceiling" — a mixed-grant actor (e.g. `own`+no-policy *and* `any`+policy) propagates its policy-free `own` grant for an `own` request instead of inheriting the wider grant's policy.
+3. The selected grant is returned **uncapped**; the new junction is then capped by the consumer: `realm_scope = min(requested, selected.realm_scope)`, and the selected grant's **own** `policy` (its `id`) is propagated as `policy_id` — never the target's. (If the selected grant is policy-restricted but its policy is not a propagatable `Policy` — e.g. an id-less composite — it fails closed to `realm_scope: none`. A clean lower-scoped grant covering the request avoids that fail-closed.)
+4. Returning the selected grant uncapped preserves the "only an unrestricted (`any`, policy-free) actor may set an explicit `policy_id`" rule: that check reads the selected grant's uncapped `realm_scope`/`policy`, so it still fires exactly when the actor genuinely holds an `any` policy-free grant.
 
-This prevents privilege escalation: a `realm_admin` cannot create unrestricted permission bindings. Because the actor only ever propagates its *own* policy (not the target's), this path needs no policy-content comparison — the asymmetry with the superset check, which must compare against fixed target grants.
+This prevents privilege escalation: a `realm_admin` cannot create unrestricted permission bindings, and (post-#3160) a mixed-grant actor neither under-propagates (spurious policy inheritance on a narrow request) nor over-propagates (riding a wider grant's reach with a narrower grant's policy). Because the actor only ever propagates its *own* policy (not the target's), this path needs no policy-content comparison — the asymmetry with the superset check, which must compare against fixed target grants.
 
 ## Self-Edit Pattern (declarative field denylists)
 

--- a/apps/server-core/src/core/entities/client-permission/service.ts
+++ b/apps/server-core/src/core/entities/client-permission/service.ts
@@ -120,6 +120,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
                     name: validated.permission.name,
                     realmId: validated.permission.realm_id,
                     clientId: validated.permission.client_id,
+                    realmScope: validated.realm_scope ?? RealmScope.OWN,
                 },
             );
 
@@ -171,6 +172,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
                         name: permission.name,
                         realmId: permission.realm_id,
                         clientId: permission.client_id,
+                        realmScope: data.realm_scope ?? entity.realm_scope,
                     },
                 );
                 actorScope = grant.realmScope as RealmScope;
@@ -181,8 +183,11 @@ export class ClientPermissionService extends JunctionEntityService implements IC
 
         const updateData: Record<string, any> = {};
 
+        const touchesScope = hasOwnProperty(data, 'realm_scope');
+        const touchesPolicy = hasOwnProperty(data, 'policy_id');
+
         // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (hasOwnProperty(data, 'realm_scope')) {
+        if (touchesScope) {
             updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
         }
 
@@ -191,11 +196,19 @@ export class ClientPermissionService extends JunctionEntityService implements IC
         // actor that touches the binding inherits its own grant's policy and cannot
         // detach or replace it to persist a binding broader than it holds.
         if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (hasOwnProperty(data, 'policy_id')) {
+            if (touchesPolicy) {
                 updateData.policy_id = data.policy_id;
             }
-        } else if (hasOwnProperty(data, 'realm_scope') || hasOwnProperty(data, 'policy_id')) {
+        } else if (touchesScope || touchesPolicy) {
             updateData.policy_id = actorPolicyId;
+
+            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
+            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
+            // realm_scope standing — that would persist a binding broader than any grant it
+            // holds (fail-OPEN otherwise).
+            if (!touchesScope) {
+                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
+            }
         }
 
         await this.repository.validateJoinColumns(updateData);

--- a/apps/server-core/src/core/entities/client-permission/service.ts
+++ b/apps/server-core/src/core/entities/client-permission/service.ts
@@ -5,17 +5,17 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { 
-    BuiltInPolicyType, 
-    RealmScope, 
-    definePolicyData, 
-    minRealmScope, 
+import {
+    BuiltInPolicyType,
+    RealmScope,
+    definePolicyData,
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
-import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
+import { ValidatorGroup } from '@authup/kit';
 import { ClientPermissionValidator, PermissionName } from '@authup/core-kit';
 import type { ClientPermission, Permission } from '@authup/core-kit';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
+import { applyJunctionCreateGrant, buildJunctionUpdateData } from '../../identity/permission/junction-grant.ts';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } from '@authup/server-kit';
 import { JunctionEntityService } from '@authup/server-kit';
 import type { IClientPermissionRepository, IClientPermissionService } from './types.ts';
@@ -124,13 +124,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
                 },
             );
 
-            // CAP the grant's realm scope to the actor's own ceiling; default `own`.
-            validated.realm_scope = minRealmScope([validated.realm_scope ?? RealmScope.OWN, grant.realmScope]);
-
-            // Only an unrestricted (`any`) actor may set policy_id explicitly.
-            if (grant.realmScope !== RealmScope.ANY || grant.policy) {
-                validated.policy_id = grant.policy ? grant.policy.id : null;
-            }
+            applyJunctionCreateGrant(validated, grant);
         }
 
         await actor.permissionEvaluator.evaluate({
@@ -159,57 +153,46 @@ export class ClientPermissionService extends JunctionEntityService implements IC
             throw new EntityNotFoundError();
         }
 
-        let actorScope: RealmScope = RealmScope.ANY;
+        const validated = await this.validator.run(data, { group: ValidatorGroup.UPDATE });
+
+        const permission = await this.permissionRepository.findOneById(entity.permission_id);
+        if (permission) {
+            // Member-permission gate: an actor may only modify a binding for a permission it
+            // holds (mirrors create()).
+            await actor.permissionEvaluator.preEvaluate({
+                name: permission.name,
+                realmId: permission.realm_id,
+                clientId: permission.client_id,
+            });
+        }
+
+        let actorScope: `${RealmScope}` = RealmScope.ANY;
         let actorPolicyFree = true;
         let actorPolicyId: string | null = null;
-        if (actor.identity) {
+        if (actor.identity && permission) {
+            const grant = await this.identityPermissionProvider.resolveJunctionGrant(
+                { type: actor.identity.type, id: actor.identity.data.id },
+                {
+                    name: permission.name,
+                    realmId: permission.realm_id,
+                    clientId: permission.client_id,
+                    realmScope: validated.realm_scope ?? entity.realm_scope,
+                },
+            );
+            actorScope = grant.realmScope;
+            actorPolicyFree = !grant.policy;
+            actorPolicyId = grant.policy ? grant.policy.id : null;
+        } else if (actor.identity) {
             actorScope = RealmScope.OWN;
-            const permission = await this.permissionRepository.findOneById(entity.permission_id);
-            if (permission) {
-                const grant = await this.identityPermissionProvider.resolveJunctionGrant(
-                    { type: actor.identity.type, id: actor.identity.data.id },
-                    {
-                        name: permission.name,
-                        realmId: permission.realm_id,
-                        clientId: permission.client_id,
-                        realmScope: data.realm_scope ?? entity.realm_scope,
-                    },
-                );
-                actorScope = grant.realmScope as RealmScope;
-                actorPolicyFree = !grant.policy;
-                actorPolicyId = grant.policy ? grant.policy.id : null;
-            }
         }
 
-        const updateData: Record<string, any> = {};
-
-        const touchesScope = hasOwnProperty(data, 'realm_scope');
-        const touchesPolicy = hasOwnProperty(data, 'policy_id');
-
-        // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (touchesScope) {
-            updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
-        }
-
-        // policy_id, capped to the actor's ceiling (mirrors create-time inheritance):
-        // an unrestricted actor may set/clear it explicitly; a restricted/policy-bound
-        // actor that touches the binding inherits its own grant's policy and cannot
-        // detach or replace it to persist a binding broader than it holds.
-        if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (touchesPolicy) {
-                updateData.policy_id = data.policy_id;
-            }
-        } else if (touchesScope || touchesPolicy) {
-            updateData.policy_id = actorPolicyId;
-
-            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
-            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
-            // realm_scope standing — that would persist a binding broader than any grant it
-            // holds (fail-OPEN otherwise).
-            if (!touchesScope) {
-                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
-            }
-        }
+        const updateData = buildJunctionUpdateData({
+            data: validated,
+            existingScope: entity.realm_scope,
+            actorScope,
+            actorPolicyFree,
+            actorPolicyId,
+        });
 
         await this.repository.validateJoinColumns(updateData);
 

--- a/apps/server-core/src/core/entities/robot-permission/service.ts
+++ b/apps/server-core/src/core/entities/robot-permission/service.ts
@@ -5,17 +5,17 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { 
-    BuiltInPolicyType, 
-    RealmScope, 
-    definePolicyData, 
-    minRealmScope, 
+import {
+    BuiltInPolicyType,
+    RealmScope,
+    definePolicyData,
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
-import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
+import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, RobotPermissionValidator } from '@authup/core-kit';
 import type { Permission, RobotPermission } from '@authup/core-kit';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
+import { applyJunctionCreateGrant, buildJunctionUpdateData } from '../../identity/permission/junction-grant.ts';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } from '@authup/server-kit';
 import { JunctionEntityService } from '@authup/server-kit';
 import type { IRobotPermissionRepository, IRobotPermissionService } from './types.ts';
@@ -124,13 +124,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
                 },
             );
 
-            // CAP the grant's realm scope to the actor's own ceiling; default `own`.
-            validated.realm_scope = minRealmScope([validated.realm_scope ?? RealmScope.OWN, grant.realmScope]);
-
-            // Only an unrestricted (`any`) actor may set policy_id explicitly.
-            if (grant.realmScope !== RealmScope.ANY || grant.policy) {
-                validated.policy_id = grant.policy ? grant.policy.id : null;
-            }
+            applyJunctionCreateGrant(validated, grant);
         }
 
         await actor.permissionEvaluator.evaluate({
@@ -159,57 +153,46 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
             throw new EntityNotFoundError();
         }
 
-        let actorScope: RealmScope = RealmScope.ANY;
+        const validated = await this.validator.run(data, { group: ValidatorGroup.UPDATE });
+
+        const permission = await this.permissionRepository.findOneById(entity.permission_id);
+        if (permission) {
+            // Member-permission gate: an actor may only modify a binding for a permission it
+            // holds (mirrors create()).
+            await actor.permissionEvaluator.preEvaluate({
+                name: permission.name,
+                realmId: permission.realm_id,
+                clientId: permission.client_id,
+            });
+        }
+
+        let actorScope: `${RealmScope}` = RealmScope.ANY;
         let actorPolicyFree = true;
         let actorPolicyId: string | null = null;
-        if (actor.identity) {
+        if (actor.identity && permission) {
+            const grant = await this.identityPermissionProvider.resolveJunctionGrant(
+                { type: actor.identity.type, id: actor.identity.data.id },
+                {
+                    name: permission.name,
+                    realmId: permission.realm_id,
+                    clientId: permission.client_id,
+                    realmScope: validated.realm_scope ?? entity.realm_scope,
+                },
+            );
+            actorScope = grant.realmScope;
+            actorPolicyFree = !grant.policy;
+            actorPolicyId = grant.policy ? grant.policy.id : null;
+        } else if (actor.identity) {
             actorScope = RealmScope.OWN;
-            const permission = await this.permissionRepository.findOneById(entity.permission_id);
-            if (permission) {
-                const grant = await this.identityPermissionProvider.resolveJunctionGrant(
-                    { type: actor.identity.type, id: actor.identity.data.id },
-                    {
-                        name: permission.name,
-                        realmId: permission.realm_id,
-                        clientId: permission.client_id,
-                        realmScope: data.realm_scope ?? entity.realm_scope,
-                    },
-                );
-                actorScope = grant.realmScope as RealmScope;
-                actorPolicyFree = !grant.policy;
-                actorPolicyId = grant.policy ? grant.policy.id : null;
-            }
         }
 
-        const updateData: Record<string, any> = {};
-
-        const touchesScope = hasOwnProperty(data, 'realm_scope');
-        const touchesPolicy = hasOwnProperty(data, 'policy_id');
-
-        // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (touchesScope) {
-            updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
-        }
-
-        // policy_id, capped to the actor's ceiling (mirrors create-time inheritance):
-        // an unrestricted actor may set/clear it explicitly; a restricted/policy-bound
-        // actor that touches the binding inherits its own grant's policy and cannot
-        // detach or replace it to persist a binding broader than it holds.
-        if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (touchesPolicy) {
-                updateData.policy_id = data.policy_id;
-            }
-        } else if (touchesScope || touchesPolicy) {
-            updateData.policy_id = actorPolicyId;
-
-            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
-            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
-            // realm_scope standing — that would persist a binding broader than any grant it
-            // holds (fail-OPEN otherwise).
-            if (!touchesScope) {
-                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
-            }
-        }
+        const updateData = buildJunctionUpdateData({
+            data: validated,
+            existingScope: entity.realm_scope,
+            actorScope,
+            actorPolicyFree,
+            actorPolicyId,
+        });
 
         await this.repository.validateJoinColumns(updateData);
 

--- a/apps/server-core/src/core/entities/robot-permission/service.ts
+++ b/apps/server-core/src/core/entities/robot-permission/service.ts
@@ -120,6 +120,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
                     name: validated.permission.name,
                     realmId: validated.permission.realm_id,
                     clientId: validated.permission.client_id,
+                    realmScope: validated.realm_scope ?? RealmScope.OWN,
                 },
             );
 
@@ -171,6 +172,7 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
                         name: permission.name,
                         realmId: permission.realm_id,
                         clientId: permission.client_id,
+                        realmScope: data.realm_scope ?? entity.realm_scope,
                     },
                 );
                 actorScope = grant.realmScope as RealmScope;
@@ -181,8 +183,11 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
 
         const updateData: Record<string, any> = {};
 
+        const touchesScope = hasOwnProperty(data, 'realm_scope');
+        const touchesPolicy = hasOwnProperty(data, 'policy_id');
+
         // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (hasOwnProperty(data, 'realm_scope')) {
+        if (touchesScope) {
             updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
         }
 
@@ -191,11 +196,19 @@ export class RobotPermissionService extends JunctionEntityService implements IRo
         // actor that touches the binding inherits its own grant's policy and cannot
         // detach or replace it to persist a binding broader than it holds.
         if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (hasOwnProperty(data, 'policy_id')) {
+            if (touchesPolicy) {
                 updateData.policy_id = data.policy_id;
             }
-        } else if (hasOwnProperty(data, 'realm_scope') || hasOwnProperty(data, 'policy_id')) {
+        } else if (touchesScope || touchesPolicy) {
             updateData.policy_id = actorPolicyId;
+
+            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
+            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
+            // realm_scope standing — that would persist a binding broader than any grant it
+            // holds (fail-OPEN otherwise).
+            if (!touchesScope) {
+                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
+            }
         }
 
         await this.repository.validateJoinColumns(updateData);

--- a/apps/server-core/src/core/entities/role-permission/service.ts
+++ b/apps/server-core/src/core/entities/role-permission/service.ts
@@ -124,6 +124,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
                     name: validated.permission.name,
                     realmId: validated.permission.realm_id,
                     clientId: validated.permission.client_id,
+                    realmScope: validated.realm_scope ?? RealmScope.OWN,
                 },
             );
 
@@ -184,6 +185,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
                         name: permission.name,
                         realmId: permission.realm_id,
                         clientId: permission.client_id,
+                        realmScope: data.realm_scope ?? entity.realm_scope,
                     },
                 );
                 actorScope = grant.realmScope as RealmScope;
@@ -194,8 +196,11 @@ export class RolePermissionService extends JunctionEntityService implements IRol
 
         const updateData: Record<string, any> = {};
 
+        const touchesScope = hasOwnProperty(data, 'realm_scope');
+        const touchesPolicy = hasOwnProperty(data, 'policy_id');
+
         // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (hasOwnProperty(data, 'realm_scope')) {
+        if (touchesScope) {
             updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
         }
 
@@ -204,11 +209,19 @@ export class RolePermissionService extends JunctionEntityService implements IRol
         // actor that touches the binding inherits its own grant's policy and cannot
         // detach or replace it to persist a binding broader than it holds.
         if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (hasOwnProperty(data, 'policy_id')) {
+            if (touchesPolicy) {
                 updateData.policy_id = data.policy_id;
             }
-        } else if (hasOwnProperty(data, 'realm_scope') || hasOwnProperty(data, 'policy_id')) {
+        } else if (touchesScope || touchesPolicy) {
             updateData.policy_id = actorPolicyId;
+
+            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
+            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
+            // realm_scope standing — that would persist a binding broader than any grant it
+            // holds (fail-OPEN otherwise).
+            if (!touchesScope) {
+                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
+            }
         }
 
         await this.repository.validateJoinColumns(updateData);

--- a/apps/server-core/src/core/entities/role-permission/service.ts
+++ b/apps/server-core/src/core/entities/role-permission/service.ts
@@ -5,20 +5,20 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { 
-    BuiltInPolicyType, 
-    RealmScope, 
-    definePolicyData, 
-    minRealmScope, 
+import {
+    BuiltInPolicyType,
+    RealmScope,
+    definePolicyData,
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
-import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
+import { ValidatorGroup } from '@authup/kit';
 import {
     PermissionName,
     RolePermissionValidator,
 } from '@authup/core-kit';
 import type { Permission, RolePermission } from '@authup/core-kit';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
+import { applyJunctionCreateGrant, buildJunctionUpdateData } from '../../identity/permission/junction-grant.ts';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } from '@authup/server-kit';
 import { JunctionEntityService } from '@authup/server-kit';
 import type { IRolePermissionRepository, IRolePermissionService } from './types.ts';
@@ -128,16 +128,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
                 },
             );
 
-            // CAP the grant's realm scope to the actor's own ceiling (a creator may not
-            // grant broader than it holds); default to the most restrictive `own`.
-            validated.realm_scope = minRealmScope([validated.realm_scope ?? RealmScope.OWN, grant.realmScope]);
-
-            // Only an unrestricted (`any`) actor may set policy_id explicitly; a
-            // restricted actor silently inherits its own grant's policy (cannot
-            // attach an unowned policy nor detach to widen).
-            if (grant.realmScope !== RealmScope.ANY || grant.policy) {
-                validated.policy_id = grant.policy ? grant.policy.id : null;
-            }
+            applyJunctionCreateGrant(validated, grant);
         }
 
         await actor.permissionEvaluator.evaluate({
@@ -168,61 +159,50 @@ export class RolePermissionService extends JunctionEntityService implements IRol
             throw new EntityNotFoundError();
         }
 
-        // Resolve the actor's ceiling for this junction's permission (the existing
-        // entity only carries scalar FKs — load the permission relation to derive it).
-        // No actor identity (system context) is not realm-gated here; the operation is
-        // still authorized by the evaluate() below.
-        let actorScope: RealmScope = RealmScope.ANY;
+        const validated = await this.validator.run(data, { group: ValidatorGroup.UPDATE });
+
+        // Resolve the actor's grant for this junction's permission (the existing entity only
+        // carries scalar FKs — load the permission relation to derive it).
+        const permission = await this.permissionRepository.findOneById(entity.permission_id);
+        if (permission) {
+            // Member-permission gate: an actor may only modify a binding for a permission it
+            // holds (mirrors create()).
+            await actor.permissionEvaluator.preEvaluate({
+                name: permission.name,
+                realmId: permission.realm_id,
+                clientId: permission.client_id,
+            });
+        }
+
+        // No actor identity (system context) is not realm-gated here; the operation is still
+        // authorized by the evaluate() below.
+        let actorScope: `${RealmScope}` = RealmScope.ANY;
         let actorPolicyFree = true;
         let actorPolicyId: string | null = null;
-        if (actor.identity) {
+        if (actor.identity && permission) {
+            const grant = await this.identityPermissionProvider.resolveJunctionGrant(
+                { type: actor.identity.type, id: actor.identity.data.id },
+                {
+                    name: permission.name,
+                    realmId: permission.realm_id,
+                    clientId: permission.client_id,
+                    realmScope: validated.realm_scope ?? entity.realm_scope,
+                },
+            );
+            actorScope = grant.realmScope;
+            actorPolicyFree = !grant.policy;
+            actorPolicyId = grant.policy ? grant.policy.id : null;
+        } else if (actor.identity) {
             actorScope = RealmScope.OWN;
-            const permission = await this.permissionRepository.findOneById(entity.permission_id);
-            if (permission) {
-                const grant = await this.identityPermissionProvider.resolveJunctionGrant(
-                    { type: actor.identity.type, id: actor.identity.data.id },
-                    {
-                        name: permission.name,
-                        realmId: permission.realm_id,
-                        clientId: permission.client_id,
-                        realmScope: data.realm_scope ?? entity.realm_scope,
-                    },
-                );
-                actorScope = grant.realmScope as RealmScope;
-                actorPolicyFree = !grant.policy;
-                actorPolicyId = grant.policy ? grant.policy.id : null;
-            }
         }
 
-        const updateData: Record<string, any> = {};
-
-        const touchesScope = hasOwnProperty(data, 'realm_scope');
-        const touchesPolicy = hasOwnProperty(data, 'policy_id');
-
-        // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (touchesScope) {
-            updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
-        }
-
-        // policy_id, capped to the actor's ceiling (mirrors create-time inheritance):
-        // an unrestricted actor may set/clear it explicitly; a restricted/policy-bound
-        // actor that touches the binding inherits its own grant's policy and cannot
-        // detach or replace it to persist a binding broader than it holds.
-        if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (touchesPolicy) {
-                updateData.policy_id = data.policy_id;
-            }
-        } else if (touchesScope || touchesPolicy) {
-            updateData.policy_id = actorPolicyId;
-
-            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
-            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
-            // realm_scope standing — that would persist a binding broader than any grant it
-            // holds (fail-OPEN otherwise).
-            if (!touchesScope) {
-                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
-            }
-        }
+        const updateData = buildJunctionUpdateData({
+            data: validated,
+            existingScope: entity.realm_scope,
+            actorScope,
+            actorPolicyFree,
+            actorPolicyId,
+        });
 
         await this.repository.validateJoinColumns(updateData);
 

--- a/apps/server-core/src/core/entities/user-permission/service.ts
+++ b/apps/server-core/src/core/entities/user-permission/service.ts
@@ -5,17 +5,17 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { 
-    BuiltInPolicyType, 
-    RealmScope, 
-    definePolicyData, 
-    minRealmScope, 
+import {
+    BuiltInPolicyType,
+    RealmScope,
+    definePolicyData,
 } from '@authup/access';
 import { EntityConflictError, EntityNotFoundError } from '@authup/errors';
-import { ValidatorGroup, hasOwnProperty } from '@authup/kit';
+import { ValidatorGroup } from '@authup/kit';
 import { PermissionName, UserPermissionValidator } from '@authup/core-kit';
 import type { Permission, UserPermission } from '@authup/core-kit';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
+import { applyJunctionCreateGrant, buildJunctionUpdateData } from '../../identity/permission/junction-grant.ts';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } from '@authup/server-kit';
 import { JunctionEntityService } from '@authup/server-kit';
 import type { IUserPermissionRepository, IUserPermissionService } from './types.ts';
@@ -126,13 +126,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
                 },
             );
 
-            // CAP the grant's realm scope to the actor's own ceiling; default `own`.
-            validated.realm_scope = minRealmScope([validated.realm_scope ?? RealmScope.OWN, grant.realmScope]);
-
-            // Only an unrestricted (`any`) actor may set policy_id explicitly.
-            if (grant.realmScope !== RealmScope.ANY || grant.policy) {
-                validated.policy_id = grant.policy ? grant.policy.id : null;
-            }
+            applyJunctionCreateGrant(validated, grant);
         }
 
         await actor.permissionEvaluator.evaluate({
@@ -161,57 +155,46 @@ export class UserPermissionService extends JunctionEntityService implements IUse
             throw new EntityNotFoundError();
         }
 
-        let actorScope: RealmScope = RealmScope.ANY;
+        const validated = await this.validator.run(data, { group: ValidatorGroup.UPDATE });
+
+        const permission = await this.permissionRepository.findOneById(entity.permission_id);
+        if (permission) {
+            // Member-permission gate: an actor may only modify a binding for a permission it
+            // holds (mirrors create()).
+            await actor.permissionEvaluator.preEvaluate({
+                name: permission.name,
+                realmId: permission.realm_id,
+                clientId: permission.client_id,
+            });
+        }
+
+        let actorScope: `${RealmScope}` = RealmScope.ANY;
         let actorPolicyFree = true;
         let actorPolicyId: string | null = null;
-        if (actor.identity) {
+        if (actor.identity && permission) {
+            const grant = await this.identityPermissionProvider.resolveJunctionGrant(
+                { type: actor.identity.type, id: actor.identity.data.id },
+                {
+                    name: permission.name,
+                    realmId: permission.realm_id,
+                    clientId: permission.client_id,
+                    realmScope: validated.realm_scope ?? entity.realm_scope,
+                },
+            );
+            actorScope = grant.realmScope;
+            actorPolicyFree = !grant.policy;
+            actorPolicyId = grant.policy ? grant.policy.id : null;
+        } else if (actor.identity) {
             actorScope = RealmScope.OWN;
-            const permission = await this.permissionRepository.findOneById(entity.permission_id);
-            if (permission) {
-                const grant = await this.identityPermissionProvider.resolveJunctionGrant(
-                    { type: actor.identity.type, id: actor.identity.data.id },
-                    {
-                        name: permission.name,
-                        realmId: permission.realm_id,
-                        clientId: permission.client_id,
-                        realmScope: data.realm_scope ?? entity.realm_scope,
-                    },
-                );
-                actorScope = grant.realmScope as RealmScope;
-                actorPolicyFree = !grant.policy;
-                actorPolicyId = grant.policy ? grant.policy.id : null;
-            }
         }
 
-        const updateData: Record<string, any> = {};
-
-        const touchesScope = hasOwnProperty(data, 'realm_scope');
-        const touchesPolicy = hasOwnProperty(data, 'policy_id');
-
-        // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (touchesScope) {
-            updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
-        }
-
-        // policy_id, capped to the actor's ceiling (mirrors create-time inheritance):
-        // an unrestricted actor may set/clear it explicitly; a restricted/policy-bound
-        // actor that touches the binding inherits its own grant's policy and cannot
-        // detach or replace it to persist a binding broader than it holds.
-        if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (touchesPolicy) {
-                updateData.policy_id = data.policy_id;
-            }
-        } else if (touchesScope || touchesPolicy) {
-            updateData.policy_id = actorPolicyId;
-
-            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
-            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
-            // realm_scope standing — that would persist a binding broader than any grant it
-            // holds (fail-OPEN otherwise).
-            if (!touchesScope) {
-                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
-            }
-        }
+        const updateData = buildJunctionUpdateData({
+            data: validated,
+            existingScope: entity.realm_scope,
+            actorScope,
+            actorPolicyFree,
+            actorPolicyId,
+        });
 
         await this.repository.validateJoinColumns(updateData);
 

--- a/apps/server-core/src/core/entities/user-permission/service.ts
+++ b/apps/server-core/src/core/entities/user-permission/service.ts
@@ -122,6 +122,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
                     name: validated.permission.name,
                     realmId: validated.permission.realm_id,
                     clientId: validated.permission.client_id,
+                    realmScope: validated.realm_scope ?? RealmScope.OWN,
                 },
             );
 
@@ -173,6 +174,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
                         name: permission.name,
                         realmId: permission.realm_id,
                         clientId: permission.client_id,
+                        realmScope: data.realm_scope ?? entity.realm_scope,
                     },
                 );
                 actorScope = grant.realmScope as RealmScope;
@@ -183,8 +185,11 @@ export class UserPermissionService extends JunctionEntityService implements IUse
 
         const updateData: Record<string, any> = {};
 
+        const touchesScope = hasOwnProperty(data, 'realm_scope');
+        const touchesPolicy = hasOwnProperty(data, 'policy_id');
+
         // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
-        if (hasOwnProperty(data, 'realm_scope')) {
+        if (touchesScope) {
             updateData.realm_scope = minRealmScope([data.realm_scope as RealmScope, actorScope]);
         }
 
@@ -193,11 +198,19 @@ export class UserPermissionService extends JunctionEntityService implements IUse
         // actor that touches the binding inherits its own grant's policy and cannot
         // detach or replace it to persist a binding broader than it holds.
         if (actorScope === RealmScope.ANY && actorPolicyFree) {
-            if (hasOwnProperty(data, 'policy_id')) {
+            if (touchesPolicy) {
                 updateData.policy_id = data.policy_id;
             }
-        } else if (hasOwnProperty(data, 'realm_scope') || hasOwnProperty(data, 'policy_id')) {
+        } else if (touchesScope || touchesPolicy) {
             updateData.policy_id = actorPolicyId;
+
+            // Re-cap the EXISTING reach when the update omits realm_scope: a restricted actor
+            // mutating the binding (e.g. a policy-only edit) must not leave a wider pre-existing
+            // realm_scope standing — that would persist a binding broader than any grant it
+            // holds (fail-OPEN otherwise).
+            if (!touchesScope) {
+                updateData.realm_scope = minRealmScope([entity.realm_scope as RealmScope, actorScope]);
+            }
         }
 
         await this.repository.validateJoinColumns(updateData);

--- a/apps/server-core/src/core/identity/permission/index.ts
+++ b/apps/server-core/src/core/identity/permission/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './checker/index.ts';
+export * from './junction-grant.ts';
 export * from './module.ts';
 export * from './types.ts';

--- a/apps/server-core/src/core/identity/permission/junction-grant.ts
+++ b/apps/server-core/src/core/identity/permission/junction-grant.ts
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { RealmScope, minRealmScope } from '@authup/access';
+import { hasOwnProperty } from '@authup/kit';
+import type { ResolveJunctionGrantResult } from './types.ts';
+
+/**
+ * The privilege-escalation boundary for permission-binding junctions, shared verbatim by
+ * role/user/client/robot-permission. Kept in ONE place (rather than copied into each service)
+ * so the fail-closed cap/inherit rule is audited and changed once — see #3160 / #3158 / #3159,
+ * which each had to patch this rule across all four services.
+ *
+ * It depends on a server-core type (`ResolveJunctionGrantResult`) and so cannot live on the
+ * generic `JunctionEntityService` in `@authup/server-kit` (that would invert the layering).
+ */
+
+/**
+ * Cap a junction CREATE to the actor's request-relative selected grant and inherit its policy.
+ *
+ * - `realm_scope` is capped to the actor's selected reach (`min(requested, grant.realmScope)`).
+ * - The policy follows the grant: only a genuinely unrestricted actor (an UNCAPPED `any` reach
+ *   AND no policy) may keep an explicitly-requested `policy_id`; any restricted/policy-bound
+ *   actor inherits its own grant's policy (it can neither attach an unowned policy nor detach to
+ *   widen). The check reads `grant.realmScope` UNCAPPED precisely to distinguish that case — the
+ *   grant is returned uncapped by `resolveJunctionGrant` for exactly this reason.
+ *
+ * Mutates `validated` in place (mirrors the surrounding service style).
+ */
+export function applyJunctionCreateGrant(
+    validated: Record<string, any>,
+    grant: ResolveJunctionGrantResult,
+): void {
+    validated.realm_scope = minRealmScope([validated.realm_scope ?? RealmScope.OWN, grant.realmScope]);
+
+    if (grant.realmScope !== RealmScope.ANY || grant.policy) {
+        validated.policy_id = grant.policy ? grant.policy.id : null;
+    }
+}
+
+export type BuildJunctionUpdateDataInput = {
+    /** The validated update payload (UPDATE group) — presence of a key signals caller intent. */
+    data: Record<string, any>,
+    /** The persisted junction's current reach (used to re-cap a policy-only edit). */
+    existingScope: `${RealmScope}`,
+    /** The actor's UNCAPPED selected reach for this permission (`any` for system context). */
+    actorScope: `${RealmScope}`,
+    /** Whether the actor's selected grant carries no policy. */
+    actorPolicyFree: boolean,
+    /** The id of the actor's selected grant policy (null when policy-free). */
+    actorPolicyId: string | null,
+};
+
+/**
+ * Build the `{ realm_scope?, policy_id? }` delta for a junction UPDATE, capped to the actor's
+ * request-relative grant.
+ *
+ * - An unrestricted (`any`, policy-free) actor may set/clear `policy_id` explicitly and is never
+ *   narrowed.
+ * - A restricted/policy-bound actor that touches the binding inherits its own grant's policy AND
+ *   has the reach re-capped — including the EXISTING `realm_scope` when the update omits it, so a
+ *   policy-only edit cannot leave a wider pre-existing reach standing (fail-OPEN otherwise: the
+ *   persisted binding must always be dominated by a grant the actor really holds — #3160).
+ */
+export function buildJunctionUpdateData(input: BuildJunctionUpdateDataInput): Record<string, any> {
+    const {
+        data, 
+        existingScope, 
+        actorScope, 
+        actorPolicyFree, 
+        actorPolicyId,
+    } = input;
+
+    const updateData: Record<string, any> = {};
+
+    const touchesScope = hasOwnProperty(data, 'realm_scope');
+    const touchesPolicy = hasOwnProperty(data, 'policy_id');
+
+    // CAP to the actor's ceiling — a restricted actor may narrow but never widen.
+    // (`data` is the validated UPDATE payload, so realm_scope is already a valid enum value;
+    // minRealmScope additionally normalizes any out-of-band input fail-closed to `own`.)
+    if (touchesScope) {
+        updateData.realm_scope = minRealmScope([data.realm_scope as `${RealmScope}`, actorScope]);
+    }
+
+    if (actorScope === RealmScope.ANY && actorPolicyFree) {
+        if (touchesPolicy) {
+            updateData.policy_id = data.policy_id;
+        }
+    } else if (touchesScope || touchesPolicy) {
+        updateData.policy_id = actorPolicyId;
+
+        if (!touchesScope) {
+            updateData.realm_scope = minRealmScope([existingScope, actorScope]);
+        }
+    }
+
+    return updateData;
+}

--- a/apps/server-core/src/core/identity/permission/module.ts
+++ b/apps/server-core/src/core/identity/permission/module.ts
@@ -113,7 +113,8 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
         }
 
         // Consider EVERY matching grant (a caller omitting realmId/clientId may leave more
-        // than one permission-key group) so the selection never depends on repository order.
+        // than one permission-key group); combined with the total ordering in
+        // selectGrantForRequest, the selection never depends on grant/repository order.
         const grants = aggregatePermissionPolicyBindings(matching)
             .flatMap((item) => item.grants);
         if (grants.length === 0) {
@@ -234,24 +235,56 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
  * ORIGINAL (uncapped) grant is returned: the consumer applies the `min` cap itself, and its
  * uncapped `realm_scope`/`policy` drive the "actor is unrestricted-any?" check that decides
  * whether an explicitly-requested `policy_id` may stand.
+ *
+ * The ordering is TOTAL and deterministic (independent of grant/repository order): ties between
+ * two policy-bound grants on equal capped reach are broken by higher uncapped reach, then a
+ * propagatable policy (one with an id) over an id-less composite that would fail closed, then
+ * lexicographic policy id.
  */
 function selectGrantForRequest(
     grants: PermissionGrant[],
     requested: `${RealmScope}`,
 ): PermissionGrant {
-    return grants.reduce((best, grant) => {
-        const bestScope = minRealmScope([best.realm_scope, requested]);
-        const grantScope = minRealmScope([grant.realm_scope, requested]);
+    return grants.reduce((best, grant) => (isGrantPreferred(grant, best, requested) ? grant : best));
+}
 
-        const comparison = compareRealmScope(grantScope, bestScope);
-        if (comparison > 0) {
-            return grant;
+/** True when `candidate` is a strictly better propagation source than `incumbent` for `requested`. */
+function isGrantPreferred(
+    candidate: PermissionGrant,
+    incumbent: PermissionGrant,
+    requested: `${RealmScope}`,
+): boolean {
+    const byCapped = compareRealmScope(
+        minRealmScope([candidate.realm_scope, requested]),
+        minRealmScope([incumbent.realm_scope, requested]),
+    );
+    if (byCapped !== 0) {
+        return byCapped > 0;
+    }
+
+    // Least restrictive: a policy-free grant beats a policy-bound one on equal capped reach.
+    if (!candidate.policy !== !incumbent.policy) {
+        return !candidate.policy;
+    }
+
+    // Deterministic tie-break for two policy-bound grants on equal capped reach.
+    const byUncapped = compareRealmScope(candidate.realm_scope, incumbent.realm_scope);
+    if (byUncapped !== 0) {
+        return byUncapped > 0;
+    }
+
+    // Prefer a propagatable policy (has an id) over an id-less composite that would fail closed.
+    const candidateId = candidate.policy && isPolicy(candidate.policy) ? candidate.policy.id : undefined;
+    const incumbentId = incumbent.policy && isPolicy(incumbent.policy) ? incumbent.policy.id : undefined;
+    if (candidateId !== incumbentId) {
+        if (typeof candidateId === 'undefined') {
+            return false;
         }
-
-        if (comparison === 0 && !grant.policy && best.policy) {
-            return grant;
+        if (typeof incumbentId === 'undefined') {
+            return true;
         }
+        return candidateId < incumbentId;
+    }
 
-        return best;
-    });
+    return false;
 }

--- a/apps/server-core/src/core/identity/permission/module.ts
+++ b/apps/server-core/src/core/identity/permission/module.ts
@@ -16,6 +16,7 @@ import {
     compareRealmScope,
     grantDominates,
     isPermissionPolicyBindingEqual,
+    minRealmScope,
 } from '@authup/access';
 import type { Policy } from '@authup/core-kit';
 import { isPolicy } from '@authup/core-kit';
@@ -112,33 +113,37 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
         }
 
         // Consider EVERY matching grant (a caller omitting realmId/clientId may leave more
-        // than one permission-key group) so the ceiling never depends on repository order.
+        // than one permission-key group) so the selection never depends on repository order.
         const grants = aggregatePermissionPolicyBindings(matching)
             .flatMap((item) => item.grants);
         if (grants.length === 0) {
             return { realmScope: RealmScope.OWN };
         }
 
-        // The propagation ceiling is the actor's MOST-permissive single grant (highest reach,
-        // policy-free preferred on a tie). The capped junction `(min(requested, ceiling.scope),
-        // ceiling.policy)` is then dominated by a real held grant, so the creator never confers
-        // reach/policy it does not itself hold.
-        const ceiling = selectCeilingGrant(grants);
+        // Select the actor's grant RELATIVE to the requested reach (#3160): the grant that
+        // confers the least-restrictive junction once capped to `realmScope` (highest capped
+        // reach, policy-free preferred on a tie) — NOT a global "ceiling". A mixed-grant actor
+        // (e.g. own+no-policy and any+policy) thus propagates its policy-free own grant for an
+        // own request instead of inheriting the wider grant's policy. The selected grant is
+        // returned UNCAPPED so the consumer's own cap (`min(requested, realmScope)`) and its
+        // "actor is unrestricted-any?" check (which honours an explicit policy_id) still hold.
+        const requested = options.realmScope ?? RealmScope.OWN;
+        const selected = selectGrantForRequest(grants, requested);
 
         let policy: Policy | undefined;
-        if (ceiling.policy) {
-            // The ceiling is policy-restricted but its policy is not a propagatable Policy
-            // (e.g. a composite with no id). Fail CLOSED: a `none` reach blocks propagation
-            // rather than silently dropping the restriction and widening to an unrestricted
-            // grant.
-            if (!isPolicy(ceiling.policy)) {
+        if (selected.policy) {
+            // The selected grant is policy-restricted but its policy is not a propagatable
+            // Policy (e.g. a composite with no id). Fail CLOSED: a `none` reach blocks
+            // propagation rather than silently dropping the restriction and widening to an
+            // unrestricted grant.
+            if (!isPolicy(selected.policy)) {
                 return { realmScope: RealmScope.NONE };
             }
 
-            policy = ceiling.policy;
+            policy = selected.policy;
         }
 
-        return { policy, realmScope: ceiling.realm_scope };
+        return { policy, realmScope: selected.realm_scope };
     }
 
     async getFor(identity: IdentityPolicyData) : Promise<PermissionPolicyBinding[]> {
@@ -220,12 +225,25 @@ export class IdentityPermissionProvider implements IIdentityPermissionProvider {
 }
 
 /**
- * The actor's most-permissive single grant — highest realm reach, policy-free preferred on a
- * tie — used as the junction propagation ceiling.
+ * Select the held grant that confers the least-restrictive junction for `requested` reach.
+ *
+ * Each grant is ranked by the reach it can actually confer for THIS request — its own
+ * `realm_scope` capped to `requested` — so a lower-scoped policy-free grant beats a
+ * higher-scoped policy-bound grant when both cap to the same requested reach (the mixed-grant
+ * fix, #3160). On equal capped reach, a policy-free grant wins (least restrictive). The
+ * ORIGINAL (uncapped) grant is returned: the consumer applies the `min` cap itself, and its
+ * uncapped `realm_scope`/`policy` drive the "actor is unrestricted-any?" check that decides
+ * whether an explicitly-requested `policy_id` may stand.
  */
-function selectCeilingGrant(grants: PermissionGrant[]): PermissionGrant {
+function selectGrantForRequest(
+    grants: PermissionGrant[],
+    requested: `${RealmScope}`,
+): PermissionGrant {
     return grants.reduce((best, grant) => {
-        const comparison = compareRealmScope(grant.realm_scope, best.realm_scope);
+        const bestScope = minRealmScope([best.realm_scope, requested]);
+        const grantScope = minRealmScope([grant.realm_scope, requested]);
+
+        const comparison = compareRealmScope(grantScope, bestScope);
         if (comparison > 0) {
             return grant;
         }

--- a/apps/server-core/src/core/identity/permission/types.ts
+++ b/apps/server-core/src/core/identity/permission/types.ts
@@ -21,6 +21,15 @@ export type ResolveJunctionPolicyOptions = {
     name: string;
     realmId?: string | null;
     clientId?: string | null;
+    /**
+     * The realm reach the junction is requested to confer (default `own`). The actor's
+     * grant disjunction is selected RELATIVE to this request: the grant chosen is the one
+     * that confers the least-restrictive junction once capped to `realmScope`, not the
+     * actor's absolute most-permissive grant. Lets a mixed-grant actor propagate a
+     * policy-free `own` grant for an `own` request even while holding a wider policy-bound
+     * grant (#3160).
+     */
+    realmScope?: `${RealmScope}`;
 };
 
 /**

--- a/apps/server-core/src/core/identity/permission/types.ts
+++ b/apps/server-core/src/core/identity/permission/types.ts
@@ -33,9 +33,11 @@ export type ResolveJunctionPolicyOptions = {
 };
 
 /**
- * The actor's own grant for a permission: the policy to inherit (if any) and the
- * realm_scope ceiling the actor is allowed to propagate (a creator may not grant
- * a broader scope than it holds).
+ * The actor's grant SELECTED for the requested reach (`ResolveJunctionPolicyOptions.realmScope`):
+ * the policy to inherit (if any) and the grant's UNCAPPED `realmScope`. Returned uncapped on
+ * purpose — the consumer applies the `min(requested, realmScope)` cap itself, and the uncapped
+ * reach distinguishes a genuinely unrestricted actor (see `applyJunctionCreateGrant` /
+ * `buildJunctionUpdateData`). This is not a global ceiling; it is request-relative (#3160).
  */
 export type ResolveJunctionGrantResult = {
     policy?: Policy;

--- a/apps/server-core/test/unit/core/entities/user-permission/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-permission/service.spec.ts
@@ -15,22 +15,30 @@ import {
     it,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
+import { RealmScope } from '@authup/access';
 import { UserPermissionService } from '../../../../../src/core/entities/user-permission/service.ts';
-import { FakeEntityRepository, createAllowAllActor, createDenyAllActor } from '@authup/server-test-kit';
+import {
+    FakeEntityRepository,
+    createAllowAllActor,
+    createDenyAllActor,
+    createMasterRealmActor,
+} from '@authup/server-test-kit';
 import { FakeIdentityPermissionProvider } from '../../helpers/index.ts';
 
 describe('core/entities/user-permission/service', () => {
     let repository: FakeEntityRepository<UserPermission>;
     let permissionRepository: FakeEntityRepository<Permission>;
+    let identityPermissionProvider: FakeIdentityPermissionProvider;
     let service: UserPermissionService;
 
     beforeEach(() => {
         repository = new FakeEntityRepository<UserPermission>();
         permissionRepository = new FakeEntityRepository<Permission>();
+        identityPermissionProvider = new FakeIdentityPermissionProvider();
         service = new UserPermissionService({
-            repository, 
-            permissionRepository, 
-            identityPermissionProvider: new FakeIdentityPermissionProvider(), 
+            repository,
+            permissionRepository,
+            identityPermissionProvider,
         });
     });
 
@@ -190,6 +198,45 @@ describe('core/entities/user-permission/service', () => {
             );
             expect(result.policy_id).toBe(policyId);
             expect(result.user_id).toBe(originalUserId);
+        });
+
+        // #3160 review: a restricted actor (holds only `own`, no policy) must NOT be able to
+        // strip the policy off a wider pre-existing `any` binding while keeping `any` reach.
+        // A policy-only update has to re-cap the existing scope down to the actor's grant.
+        it('re-caps a wider existing realm_scope on a policy-only update by a restricted actor', async () => {
+            identityPermissionProvider.setJunctionRealmScope(RealmScope.OWN);
+            identityPermissionProvider.setJunctionPolicy(undefined);
+
+            const permission = permissionRepository.seed({ name: 'user_read', realm_id: null });
+            const entity = repository.seed({
+                permission_id: permission.id,
+                realm_scope: RealmScope.ANY,
+                policy_id: randomUUID(),
+            });
+
+            const result = await service.update(entity.id, { policy_id: null }, createMasterRealmActor());
+
+            expect(result.realm_scope).toBe(RealmScope.OWN);
+            expect(result.policy_id).toBeNull();
+        });
+
+        // The asymmetry: an unrestricted (`any`, policy-free) actor may drop the policy off a
+        // wide binding WITHOUT its reach being narrowed.
+        it('lets an unrestricted actor drop policy on a wide binding without narrowing reach', async () => {
+            identityPermissionProvider.setJunctionRealmScope(RealmScope.ANY);
+            identityPermissionProvider.setJunctionPolicy(undefined);
+
+            const permission = permissionRepository.seed({ name: 'user_read', realm_id: null });
+            const entity = repository.seed({
+                permission_id: permission.id,
+                realm_scope: RealmScope.ANY,
+                policy_id: randomUUID(),
+            });
+
+            const result = await service.update(entity.id, { policy_id: null }, createMasterRealmActor());
+
+            expect(result.realm_scope).toBe(RealmScope.ANY);
+            expect(result.policy_id).toBeNull();
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/user-permission/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-permission/service.spec.ts
@@ -238,6 +238,50 @@ describe('core/entities/user-permission/service', () => {
             expect(result.realm_scope).toBe(RealmScope.ANY);
             expect(result.policy_id).toBeNull();
         });
+
+        // Member-permission gate parity with create(): an actor may only modify a binding for a
+        // permission it itself holds.
+        it('runs the member-permission gate on update', async () => {
+            const permission = permissionRepository.seed({ name: 'user_read', realm_id: null });
+            const entity = repository.seed({ permission_id: permission.id, policy_id: null });
+            const actor = createMasterRealmActor();
+
+            await service.update(entity.id, { policy_id: null }, actor);
+
+            expect(actor.permissionEvaluator.preEvaluateCalls).toContainEqual(
+                expect.objectContaining({ name: 'user_read' }),
+            );
+        });
+
+        it('rejects a malformed realm_scope on update (validator no longer silently coerces)', async () => {
+            const entity = repository.seed({ policy_id: null });
+            await expect(
+                service.update(entity.id, { realm_scope: 'superadmin' }, createAllowAllActor()),
+            ).rejects.toThrow(/realm_scope/);
+        });
+
+        it('rejects a non-UUID policy_id on update', async () => {
+            const entity = repository.seed({ policy_id: null });
+            await expect(
+                service.update(entity.id, { policy_id: 'not-a-uuid' }, createAllowAllActor()),
+            ).rejects.toThrow(/policy_id/);
+        });
+
+        it('blocks the update when the actor lacks the member permission', async () => {
+            const permission = permissionRepository.seed({ name: 'user_read', realm_id: null });
+            const entity = repository.seed({ permission_id: permission.id, policy_id: null });
+
+            const actor = createMasterRealmActor();
+            actor.permissionEvaluator.setBehavior(({ method, ctx }) => {
+                if (method === 'preEvaluate' && ctx.name === 'user_read') {
+                    throw new Error('member-denied');
+                }
+            });
+
+            await expect(
+                service.update(entity.id, { policy_id: randomUUID() }, actor),
+            ).rejects.toThrow('member-denied');
+        });
     });
 
     describe('delete', () => {

--- a/apps/server-core/test/unit/core/identity/permission/junction-grant.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/junction-grant.spec.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { BuiltInPolicyType, RealmScope } from '@authup/access';
+import { describe, expect, it } from 'vitest';
+import {
+    applyJunctionCreateGrant,
+    buildJunctionUpdateData,
+} from '../../../../../src/core/identity/permission/junction-grant.ts';
+
+/**
+ * Exhaustive coverage of the shared permission-binding cap/inherit/re-cap rule used by all four
+ * junction services (role/user/client/robot-permission). The security invariant: the resulting
+ * (realm_scope, policy_id) must always be dominated by the actor's selected grant — never widen
+ * reach nor drop a policy the actor lacks.
+ */
+const policy = { id: 'policy-1', type: BuiltInPolicyType.IDENTITY } as any;
+
+describe('core/identity/permission/junction-grant', () => {
+    describe('applyJunctionCreateGrant', () => {
+        it('caps reach to an own grant and stamps no policy (policy-free own actor)', () => {
+            const validated: Record<string, any> = {};
+            applyJunctionCreateGrant(validated, { realmScope: RealmScope.OWN });
+            expect(validated.realm_scope).toBe(RealmScope.OWN);
+            expect(validated.policy_id).toBeNull();
+        });
+
+        it('inherits the grant policy at the capped reach (policy-bound any actor, any request)', () => {
+            const validated: Record<string, any> = { realm_scope: RealmScope.ANY };
+            applyJunctionCreateGrant(validated, { realmScope: RealmScope.ANY, policy });
+            expect(validated.realm_scope).toBe(RealmScope.ANY);
+            expect(validated.policy_id).toBe('policy-1');
+        });
+
+        it('caps an over-broad request down to the grant reach', () => {
+            const validated: Record<string, any> = { realm_scope: RealmScope.ANY };
+            applyJunctionCreateGrant(validated, { realmScope: RealmScope.OWN });
+            expect(validated.realm_scope).toBe(RealmScope.OWN);
+        });
+
+        it('leaves an explicit policy_id untouched for a genuinely unrestricted (any, policy-free) actor', () => {
+            const validated: Record<string, any> = { realm_scope: RealmScope.OWN, policy_id: 'explicit' };
+            applyJunctionCreateGrant(validated, { realmScope: RealmScope.ANY });
+            // any + policy-free => the explicit policy_id stands; reach capped to the request.
+            expect(validated.realm_scope).toBe(RealmScope.OWN);
+            expect(validated.policy_id).toBe('explicit');
+        });
+    });
+
+    describe('buildJunctionUpdateData', () => {
+        it('re-caps a wider existing reach on a policy-only update by a restricted actor (fail-closed)', () => {
+            const result = buildJunctionUpdateData({
+                data: { policy_id: null },
+                existingScope: RealmScope.ANY,
+                actorScope: RealmScope.OWN,
+                actorPolicyFree: true,
+                actorPolicyId: null,
+            });
+            expect(result.realm_scope).toBe(RealmScope.OWN);
+            expect(result.policy_id).toBeNull();
+        });
+
+        it('lets an unrestricted actor drop policy without narrowing reach', () => {
+            const result = buildJunctionUpdateData({
+                data: { policy_id: null },
+                existingScope: RealmScope.ANY,
+                actorScope: RealmScope.ANY,
+                actorPolicyFree: true,
+                actorPolicyId: null,
+            });
+            expect(result.policy_id).toBeNull();
+            expect(result).not.toHaveProperty('realm_scope');
+        });
+
+        it('caps a widening realm_scope update to the actor reach and inherits its policy', () => {
+            const result = buildJunctionUpdateData({
+                data: { realm_scope: RealmScope.ANY },
+                existingScope: RealmScope.OWN,
+                actorScope: RealmScope.OWN,
+                actorPolicyFree: true,
+                actorPolicyId: null,
+            });
+            expect(result.realm_scope).toBe(RealmScope.OWN);
+            expect(result.policy_id).toBeNull();
+        });
+
+        it('forces a policy-bound actor to keep its own policy (cannot detach)', () => {
+            const result = buildJunctionUpdateData({
+                data: { policy_id: null },
+                existingScope: RealmScope.OWN,
+                actorScope: RealmScope.OWN,
+                actorPolicyFree: false,
+                actorPolicyId: 'policy-1',
+            });
+            expect(result.policy_id).toBe('policy-1');
+            expect(result.realm_scope).toBe(RealmScope.OWN);
+        });
+
+        it('ignores a restricted actor trying to attach an arbitrary policy', () => {
+            const result = buildJunctionUpdateData({
+                data: { policy_id: 'attacker-policy' },
+                existingScope: RealmScope.OWN,
+                actorScope: RealmScope.OWN,
+                actorPolicyFree: true,
+                actorPolicyId: null,
+            });
+            expect(result.policy_id).toBeNull();
+            expect(result.realm_scope).toBe(RealmScope.OWN);
+        });
+
+        it('lets an unrestricted actor set an explicit policy_id without narrowing reach', () => {
+            const result = buildJunctionUpdateData({
+                data: { policy_id: 'explicit' },
+                existingScope: RealmScope.OWN,
+                actorScope: RealmScope.ANY,
+                actorPolicyFree: true,
+                actorPolicyId: null,
+            });
+            expect(result.policy_id).toBe('explicit');
+            expect(result).not.toHaveProperty('realm_scope');
+        });
+
+        it('is a no-op when the update touches neither field', () => {
+            const result = buildJunctionUpdateData({
+                data: {},
+                existingScope: RealmScope.ANY,
+                actorScope: RealmScope.OWN,
+                actorPolicyFree: true,
+                actorPolicyId: null,
+            });
+            expect(result).toEqual({});
+        });
+    });
+});

--- a/apps/server-core/test/unit/core/identity/permission/provider.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/provider.spec.ts
@@ -140,37 +140,65 @@ describe('core/identity/permission — IdentityPermissionProvider disjunction (#
         });
     });
 
-    describe('resolveJunctionGrant', () => {
-        it('selects the most-permissive grant as the ceiling (mixed: any + policy)', async () => {
-            const provider = createProvider({
-                actor: [
-                    { permission: { name: 'user_read' }, realm_scope: RealmScope.OWN },
-                    {
-                        permission: { name: 'user_read' }, 
-                        policies: [policy], 
-                        realm_scope: RealmScope.ANY, 
-                    },
-                ],
-            });
+    describe('resolveJunctionGrant (#3160 — selection is relative to the requested reach)', () => {
+        // The actor holds BOTH (own, no-policy) and (any, IDENTITY-policy) for one permission.
+        const mixedActor = () => createProvider({
+            actor: [
+                { permission: { name: 'user_read' }, realm_scope: RealmScope.OWN },
+                {
+                    permission: { name: 'user_read' },
+                    policies: [policy],
+                    realm_scope: RealmScope.ANY,
+                },
+            ],
+        });
 
-            const result = await provider.resolveJunctionGrant({ type: 'role', id: 'actor' }, { name: 'user_read' });
+        it('selects the policy-free own grant for an own request (no spurious policy inheritance)', async () => {
+            // The actor genuinely holds (own, no-policy), so an own-scoped junction must stay
+            // ungated — it must NOT inherit the wider (any, policy) grant's policy (the #3160 bug).
+            const result = await mixedActor().resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.OWN },
+            );
+            expect(result.realmScope).toBe(RealmScope.OWN);
+            expect(result.policy).toBeUndefined();
+        });
+
+        it('selects the wider policy-bound grant when the request needs its reach', async () => {
+            // Reaching `any` is only possible via the (any, policy) grant, so its policy rides along.
+            const result = await mixedActor().resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.ANY },
+            );
             expect(result.realmScope).toBe(RealmScope.ANY);
             expect(result.policy?.id).toBe('policy-1');
         });
 
-        it('prefers a policy-free grant on a scope tie (admin stays unrestricted)', async () => {
+        it('defaults the request to own when no realmScope option is given', async () => {
+            const result = await mixedActor().resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read' },
+            );
+            expect(result.realmScope).toBe(RealmScope.OWN);
+            expect(result.policy).toBeUndefined();
+        });
+
+        it('prefers a policy-free grant on a capped-scope tie (admin stays unrestricted)', async () => {
             const provider = createProvider({
                 actor: [
                     {
-                        permission: { name: 'user_read' }, 
-                        policies: [policy], 
-                        realm_scope: RealmScope.ANY, 
+                        permission: { name: 'user_read' },
+                        policies: [policy],
+                        realm_scope: RealmScope.ANY,
                     },
                     { permission: { name: 'user_read' }, realm_scope: RealmScope.ANY },
                 ],
             });
 
-            const result = await provider.resolveJunctionGrant({ type: 'role', id: 'actor' }, { name: 'user_read' });
+            const result = await provider.resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.ANY },
+            );
             expect(result.realmScope).toBe(RealmScope.ANY);
             expect(result.policy).toBeUndefined();
         });
@@ -183,7 +211,7 @@ describe('core/identity/permission — IdentityPermissionProvider disjunction (#
             expect(result.policy).toBeUndefined();
         });
 
-        it('fails closed (none) when the ceiling policy is not a propagatable Policy', async () => {
+        it('fails closed (none) when the only grant covering the request has a non-propagatable policy', async () => {
             // Two policies => buildGrant wraps them in a composite (no id) => not isPolicy.
             // The grant is policy-RESTRICTED, so it must NOT degrade to an unrestricted grant.
             const provider = createProvider({
@@ -196,8 +224,33 @@ describe('core/identity/permission — IdentityPermissionProvider disjunction (#
                 ],
             });
 
-            const result = await provider.resolveJunctionGrant({ type: 'role', id: 'actor' }, { name: 'user_read' });
+            const result = await provider.resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.ANY },
+            );
             expect(result.realmScope).toBe(RealmScope.NONE);
+            expect(result.policy).toBeUndefined();
+        });
+
+        it('avoids the non-propagatable composite by selecting a clean own grant for an own request', async () => {
+            // #3160: a clean own grant lets an own request succeed even when a wider grant carries
+            // a non-propagatable composite policy (the old global-ceiling collapse failed closed here).
+            const provider = createProvider({
+                actor: [
+                    { permission: { name: 'user_read' }, realm_scope: RealmScope.OWN },
+                    {
+                        permission: { name: 'user_read' },
+                        policies: [policy, { type: BuiltInPolicyType.REALM_MATCH } as any],
+                        realm_scope: RealmScope.ANY,
+                    },
+                ],
+            });
+
+            const result = await provider.resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.OWN },
+            );
+            expect(result.realmScope).toBe(RealmScope.OWN);
             expect(result.policy).toBeUndefined();
         });
     });

--- a/apps/server-core/test/unit/core/identity/permission/provider.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/provider.spec.ts
@@ -232,6 +232,51 @@ describe('core/identity/permission — IdentityPermissionProvider disjunction (#
             expect(result.policy).toBeUndefined();
         });
 
+        it('selects deterministically between two policy-bound grants regardless of order', async () => {
+            // Two equally-reaching policy-bound grants: the total ordering breaks the tie by policy
+            // id (policy-1 < policy-2), so the selection is identical no matter the binding order.
+            const forward = createProvider({
+                actor: [
+                    {
+                        permission: { name: 'user_read' }, 
+                        policies: [policy], 
+                        realm_scope: RealmScope.ANY, 
+                    },
+                    {
+                        permission: { name: 'user_read' }, 
+                        policies: [policyOther], 
+                        realm_scope: RealmScope.ANY, 
+                    },
+                ],
+            });
+            const reverse = createProvider({
+                actor: [
+                    {
+                        permission: { name: 'user_read' }, 
+                        policies: [policyOther], 
+                        realm_scope: RealmScope.ANY, 
+                    },
+                    {
+                        permission: { name: 'user_read' }, 
+                        policies: [policy], 
+                        realm_scope: RealmScope.ANY, 
+                    },
+                ],
+            });
+
+            const a = await forward.resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.ANY },
+            );
+            const b = await reverse.resolveJunctionGrant(
+                { type: 'role', id: 'actor' },
+                { name: 'user_read', realmScope: RealmScope.ANY },
+            );
+
+            expect(a.policy?.id).toBe('policy-1');
+            expect(b.policy?.id).toBe('policy-1');
+        });
+
         it('avoids the non-propagatable composite by selecting a clean own grant for an own request', async () => {
             // #3160: a clean own grant lets an own request succeed even when a wider grant carries
             // a non-propagatable composite policy (the old global-ceiling collapse failed closed here).


### PR DESCRIPTION
## Summary

Closes #3160.

`IdentityPermissionProvider.resolveJunctionGrant` collapsed the actor's grant
**disjunction** into a single global *ceiling* (`selectCeilingGrant`: highest
`realm_scope`, policy-free preferred on a tie). When an actor held *mixed* grants
for one permission, that single ceiling could not represent all of them, so the
consumer capped reach to the ceiling and **inherited the ceiling's policy** —
which can be more restrictive than another grant the actor genuinely holds.

This was the last write-side site still folding the disjunction to one value —
the read path (evaluator) and `isSuperset` already evaluate the full disjunction
(#3155 / #3158, #3159).

### Concrete bug

Actor holds `user_update` as **both** `(own, no-policy)` and `(any, IDENTITY-policy)`.
Creating an `own`-scoped junction with no explicit policy → `selectCeilingGrant`
picks `(any, IDENTITY)` (highest reach) → the junction is capped to `own` but
**forced to carry the `IDENTITY` policy**. The actor could legitimately confer
`(own, no-policy)` ungated; the recipient gets a more restricted grant than the
actor was entitled to give. (Fail-closed, so not a leak — but wrong.)

## Fix

- `resolveJunctionGrant` now selects the grant **relative to the requested reach**
  (`selectGrantForRequest`): each held grant is ranked by its `realm_scope`
  **capped to** the requested scope (highest capped reach wins, policy-free preferred
  on a tie), so a lower-scoped policy-free grant beats a higher-scoped policy-bound
  one when both cap to the same reach. The selected grant is returned **uncapped**,
  preserving the consumer's own `min` cap and its "actor is unrestricted-`any`?"
  check that decides whether an explicit `policy_id` may stand.
- `ResolveJunctionPolicyOptions` gained `realmScope?` — the requested junction reach.
- The four junction services (`role`/`user`/`client`/`robot-permission`) pass it on
  **create** (`validated.realm_scope`) and **update** (`data.realm_scope ?? entity.realm_scope`).

For the example above: an `own` request now selects `(own, no-policy)` (ungated);
an `any` request selects `(any, IDENTITY)` (reaching `any` requires the gated grant).

### Additional fix — update-path fail-OPEN (surfaced while implementing)

In the junction **update** path, `realm_scope` was capped only when
`data.realm_scope` was present. A restricted actor (e.g. a `realm_admin` holding
only `(own, no-policy)`) doing a **policy-only** update on an existing `(any, P)`
binding kept `realm_scope = any` while dropping/replacing the policy — persisting
`(any, no-policy)`, a binding **no held grant dominates** (privilege escalation).
Now a restricted actor that touches the binding re-caps the existing reach down to
its own grant. Unrestricted (`any`, policy-free) actors are unaffected.

## Tests

- `provider.spec.ts`: 8 request-aware `resolveJunctionGrant` cases incl. mixed-grant
  own-vs-any selection and a composite-policy avoidance case.
- `user-permission/service.spec.ts`: regression tests for the update fail-open and
  its asymmetry (unrestricted actor may still drop policy without narrowing reach).
  Mutation-checked: the regression test fails when the re-cap is removed.
- Full `apps/server-core` suite green: **938 passed**.

## Notes

Marked `!` for consistency with the realm-scope series (#3151/#3157/#3158/#3159):
this changes runtime authorization outcomes for mixed-grant actors and closes a
fail-open update path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Permission create/update now correctly applies `realm_scope` capping and `policy_id` inheritance/clearing, preventing unintended broader access when policy settings change.
  * Junction grant selection is now based on the requested reach (with safer fail-closed behavior when only non-propagatable policies apply).
* **Tests**
  * Expanded unit test coverage for junction grant creation and update-data building, including edge cases for policy-only updates, realm-scope reach behavior, member gating, and input validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->