### PR TITLE
fix(server-core): re-check role ownership on identity-provider-role-mapping update (#3166)

### DIFF
--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -483,6 +483,13 @@ export class HTTPControllerModule {
         });
     }
 
+    private createRoleRepository(container: IContainer): RoleRepositoryAdapter {
+        return new RoleRepositoryAdapter({
+            repository: container.resolve<Repository<Role>>(RoleEntity),
+            realmRepository: container.resolve<Repository<Realm>>(RealmEntity),
+        });
+    }
+
     async createPermissionController(container: IContainer) {
         const dataSource = container.resolve(DatabaseInjectionKey.DataSource);
         const realmRepository = container.resolve<Repository<Realm>>(RealmEntity);
@@ -730,8 +737,13 @@ export class HTTPControllerModule {
         const repository = new IdentityProviderRoleMappingRepositoryAdapter(
             container.resolve<Repository<any>>(IdentityProviderRoleMappingEntity),
         );
+        const roleRepository = this.createRoleRepository(container);
         const identityPermissionProvider = container.resolve(IdentityInjectionKey.PermissionProvider);
-        const service = new IdentityProviderRoleMappingService({ repository, identityPermissionProvider });
+        const service = new IdentityProviderRoleMappingService({
+            repository, 
+            roleRepository, 
+            identityPermissionProvider, 
+        });
         return new IdentityProviderRoleMappingController({ service });
     }
 

--- a/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
+++ b/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
@@ -9,14 +9,15 @@ import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/ac
 import { BadRequestError, EntityConflictError, EntityNotFoundError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import { IdentityProviderRoleMappingValidator, PermissionName } from '@authup/core-kit';
-import type { IdentityProviderRoleMapping } from '@authup/core-kit';
-import type { ActorContext, EntityRepositoryFindManyResult  } from '@authup/server-kit';
+import type { IdentityProviderRoleMapping, Role } from '@authup/core-kit';
+import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository } from '@authup/server-kit';
 import { JunctionEntityService } from '@authup/server-kit';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
 import type { IIdentityProviderRoleMappingRepository, IIdentityProviderRoleMappingService } from './types.ts';
 
 export type IdentityProviderRoleMappingServiceContext = {
     repository: IIdentityProviderRoleMappingRepository;
+    roleRepository: IEntityRepository<Role>;
     identityPermissionProvider: IIdentityPermissionProvider;
 };
 
@@ -25,6 +26,8 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
 
     protected repository: IIdentityProviderRoleMappingRepository;
 
+    protected roleRepository: IEntityRepository<Role>;
+
     protected identityPermissionProvider: IIdentityPermissionProvider;
 
     protected validator: IdentityProviderRoleMappingValidator;
@@ -32,6 +35,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
     constructor(ctx: IdentityProviderRoleMappingServiceContext) {
         super();
         this.repository = ctx.repository;
+        this.roleRepository = ctx.roleRepository;
         this.identityPermissionProvider = ctx.identityPermissionProvider;
         this.validator = new IdentityProviderRoleMappingValidator();
     }
@@ -154,6 +158,29 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
         const validated = await this.validator.run(data, { group: ValidatorGroup.UPDATE });
 
         await this.repository.validateJoinColumns(validated);
+
+        // `role_id` is immutable on update (CREATE-group only in the validator), so the conferred
+        // role never changes here — only the attribute-matching criteria do. Still re-verify the
+        // actor OWNS that role before letting it edit (e.g. broaden) the mapping, mirroring create()
+        // and the permission-junction member gate (#3164): you may not modify a role-conferring
+        // mapping for a role you no longer own.
+        const role = await this.roleRepository.findOneById(entity.role_id);
+        if (role && actor.identity) {
+            const hasPermissions = await this.identityPermissionProvider.isSuperset(
+                {
+                    type: actor.identity.type,
+                    id: actor.identity.data.id,
+                },
+                {
+                    type: 'role',
+                    id: role.id,
+                    clientId: role.client_id,
+                },
+            );
+            if (!hasPermissions) {
+                throw new PermissionError({ message: 'You don\'t own the required permissions.' });
+            }
+        }
 
         const merged = this.repository.merge(entity, validated);
 

--- a/apps/server-core/test/unit/core/entities/identity-provider-role-mapping/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/identity-provider-role-mapping/service.spec.ts
@@ -7,7 +7,7 @@
 
 import { randomUUID } from 'node:crypto';
 import { PermissionName } from '@authup/core-kit';
-import type { IdentityProviderRoleMapping } from '@authup/core-kit';
+import type { IdentityProviderRoleMapping, Role } from '@authup/core-kit';
 import {
     beforeEach,
     describe,
@@ -26,13 +26,19 @@ import { FakeIdentityPermissionProvider } from '../../helpers/fake-identity-perm
 
 describe('core/entities/identity-provider-role-mapping/service', () => {
     let repository: FakeEntityRepository<IdentityProviderRoleMapping>;
+    let roleRepository: FakeEntityRepository<Role>;
     let identityPermissionProvider: FakeIdentityPermissionProvider;
     let service: IdentityProviderRoleMappingService;
 
     beforeEach(() => {
         repository = new FakeEntityRepository<IdentityProviderRoleMapping>();
+        roleRepository = new FakeEntityRepository<Role>();
         identityPermissionProvider = new FakeIdentityPermissionProvider();
-        service = new IdentityProviderRoleMappingService({ repository, identityPermissionProvider });
+        service = new IdentityProviderRoleMappingService({
+            repository, 
+            roleRepository, 
+            identityPermissionProvider, 
+        });
     });
 
     describe('getMany', () => {
@@ -214,6 +220,37 @@ describe('core/entities/identity-provider-role-mapping/service', () => {
             await expect(
                 service.update(entity.id, { name: 'test' }, createDenyAllActor()),
             ).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('re-checks role ownership on update and blocks when the superset check fails (#3166)', async () => {
+            const roleId = randomUUID();
+            roleRepository.seed({ id: roleId, client_id: null } as Partial<Role>);
+            const entity = repository.seed({
+                provider_id: randomUUID(), 
+                role_id: roleId, 
+                name: 'old', 
+            });
+
+            identityPermissionProvider.setSuperset(false);
+
+            await expect(
+                service.update(entity.id, { value: '.*' }, createMasterRealmActor()),
+            ).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('allows the update when the actor still owns the role', async () => {
+            const roleId = randomUUID();
+            roleRepository.seed({ id: roleId, client_id: null } as Partial<Role>);
+            const entity = repository.seed({
+                provider_id: randomUUID(), 
+                role_id: roleId, 
+                name: 'old', 
+            });
+
+            identityPermissionProvider.setSuperset(true);
+
+            const result = await service.update(entity.id, { name: 'new' }, createMasterRealmActor());
+            expect(result.name).toBe('new');
         });
 
         it('should not allow changing provider_id or role_id', async () => {


### PR DESCRIPTION
Closes #3166.

## Finding

The issue hypothesized that `identity-provider-role-mapping.update()` might allow changing `role_id` while skipping the `isSuperset` gate that `create()` enforces. **That role-swap escalation is provably impossible**: `role_id` is mounted `{ group: CREATE }` in `IdentityProviderRoleMappingValidator`, so it is stripped on update (already covered by the existing "should not allow changing provider_id or role_id" test).

## Real residual + fix

What remained was a create/update **authorization parity gap**: `create()` requires the actor to own the role's permissions (`isSuperset`), but `update()` did not — so an actor could edit/**broaden** an existing mapping's match criteria (`value`, `value_is_regex`, …) *after* losing ownership of the conferred role. This is the same class of gap #3164 closed for the permission junctions (member-permission gate on update).

This PR re-runs `isSuperset` on update (resolving the role via an injected role repository to get `role.client_id`), mirroring `create()`. The conferred role is unchanged (immutable), so the check verifies the actor *still* owns it before allowing the edit.

## Scope note

This was the **one** non-permission junction with an `update()` path left uncovered by the #3155→#3160 realm-reach series. The role-binding junctions (`user/client/robot-role`) and `client-scope` / `permission-policy` have **no** `update()` method, so create-time gating is sufficient there.

## Tests

- `update()` is blocked when the superset check fails (mutation-verified: fails without the re-check).
- `update()` succeeds when the actor still owns the role.
- Full `apps/server-core` suite: **956 passing**.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role-mapping updates by rechecking permissions before saving changes.
  * Updates are now blocked if the actor no longer has access to the linked role.
  * Only editable mapping details can be changed; the role reference remains fixed.

* **Tests**
  * Added coverage for successful and denied update scenarios to verify the new permission check.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->