### PR TITLE
feat(client-web-kit): realm_scope UI follow-up — labels + assignment-time scope (plan 034)

### DIFF
--- a/packages/client-web-kit/src/components/entities/client-permission/AClientPermissionAssignment.vue
+++ b/packages/client-web-kit/src/components/entities/client-permission/AClientPermissionAssignment.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import { EntityType } from '@authup/core-kit';
 import type { ClientPermission } from '@authup/core-kit';
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import {
     defineEntityManager,
     defineEntityVEmitOptions,
@@ -61,14 +61,28 @@ export default defineComponent({
             return manager.delete();
         };
 
+        const handleCreated = (entity: ClientPermission) => {
+            manager.created(entity);
+        };
+
         const handleUpdated = (entity: ClientPermission) => {
             manager.updated(entity);
         };
 
+        // The existing junction in edit mode, else a stable create template (FK base) carrying
+        // no id → the binding control treats it as create mode. Memoized so the template keeps a
+        // stable reference while unassigned.
+        const bindingEntity = computed<Partial<ClientPermission>>(() => manager.data.value || {
+            client_id: props.clientId,
+            permission_id: props.permissionId,
+        });
+
         return {
             manager,
             handleChanged,
+            handleCreated,
             handleUpdated,
+            bindingEntity,
             EntityType,
         };
     },
@@ -82,10 +96,10 @@ export default defineComponent({
             @changed="handleChanged"
         />
         <APermissionPolicyBindingButton
-            v-if="manager.data.value"
-            :key="manager.data.value.id"
+            :key="manager.data.value?.id || 'create'"
             :entity-type="EntityType.CLIENT_PERMISSION"
-            :entity="manager.data.value"
+            :entity="bindingEntity"
+            @created="handleCreated"
             @updated="handleUpdated"
         />
     </span>

--- a/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
+++ b/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
@@ -411,12 +411,18 @@ export const APermissionPolicyBindingButton = defineComponent({
                 triggerVariant = 'solid';
             }
 
+            // The trigger is icon-only, so give it a programmatic name that also conveys the mode
+            // (assign-with-options vs edit the binding) to assistive tech.
+            const triggerLabel = createMode ? translationAdd.value : translationJunctionPolicy.value;
+
             return h('span', { class: 'inline-flex items-center' }, [
                 h(VCButton, {
                     size: props.size,
                     color: triggerColor,
                     variant: triggerVariant,
                     disabled: busy.value,
+                    'aria-label': triggerLabel,
+                    title: triggerLabel,
                     onClick(e: Event) {
                         e.preventDefault();
                         modalOpen.value = true;

--- a/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
+++ b/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
@@ -205,10 +205,15 @@ export const APermissionPolicyBindingButton = defineComponent({
             key: TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE,
         });
 
-        // Localized label + one-line hint per selectable reach. Keyed off the string VALUE of
-        // REALM_SCOPE (camelCase `ownOrNull`), not a member-name derivation. `none` (a dead
-        // grant) is intentionally not offered — see realmScopeOptions below.
+        // Localized label + one-line hint per reach. Keyed off the string VALUE of REALM_SCOPE
+        // (camelCase `ownOrNull`), not a member-name derivation. `none` is included so a persisted
+        // none-scoped binding can be shown read-only in edit mode (it is never user-selectable —
+        // see realmScopeOptions).
         const realmScopeLabels: Record<string, Ref<string>> = {
+            [REALM_SCOPE.NONE]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_NONE,
+            }),
             [REALM_SCOPE.OWN]: useTranslation({
                 namespace: TranslatorTranslationNamespace.CLIENT,
                 key: TranslatorTranslationClientKey.REALM_SCOPE_OWN,
@@ -224,6 +229,10 @@ export const APermissionPolicyBindingButton = defineComponent({
         };
 
         const realmScopeHints: Record<string, Ref<string>> = {
+            [REALM_SCOPE.NONE]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_NONE_HINT,
+            }),
             [REALM_SCOPE.OWN]: useTranslation({
                 namespace: TranslatorTranslationNamespace.CLIENT,
                 key: TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT,
@@ -264,28 +273,44 @@ export const APermissionPolicyBindingButton = defineComponent({
         }, () => h(VCIcon, { name: 'fa6-solid:xmark' }));
 
         const renderRealmScopeSelector = () => {
-            const selectedHint = currentRealmScope.value ?
-                realmScopeHints[currentRealmScope.value]?.value :
-                undefined;
+            const current = currentRealmScope.value;
+            const selectedHint = current ? realmScopeHints[current]?.value : undefined;
+            // `none` is a valid persisted reach (e.g. a fail-closed propagation) but not
+            // user-selectable. Surface it read-only so an existing none-scoped binding still
+            // renders its state instead of appearing unset.
+            const showNone = current === REALM_SCOPE.NONE;
 
             return h('div', { class: 'flex flex-col gap-1' }, [
                 h('div', { class: 'text-sm font-medium' }, translationJunctionRealmScope.value),
-                h('div', { class: 'flex flex-wrap gap-1' }, realmScopeOptions.map((scope) => {
-                    const isSelected = currentRealmScope.value === scope;
-                    return h(VCButton, {
-                        key: scope,
-                        size: props.size,
-                        color: isSelected ? 'primary' : 'neutral',
-                        variant: isSelected ? 'solid' : 'soft',
-                        disabled: busy.value,
-                        label: realmScopeLabels[scope]?.value ?? scope,
-                        title: realmScopeHints[scope]?.value,
-                        onClick(e: Event) {
-                            e.preventDefault();
-                            handleRealmScopeSelect(scope as RealmScopeValue);
-                        },
-                    });
-                })),
+                h('div', { class: 'flex flex-wrap gap-1' }, [
+                    showNone ?
+                        h(VCButton, {
+                            key: REALM_SCOPE.NONE,
+                            size: props.size,
+                            color: 'primary',
+                            variant: 'solid',
+                            disabled: true,
+                            label: realmScopeLabels[REALM_SCOPE.NONE]?.value ?? REALM_SCOPE.NONE,
+                            title: realmScopeHints[REALM_SCOPE.NONE]?.value,
+                        }) :
+                        undefined,
+                    ...realmScopeOptions.map((scope) => {
+                        const isSelected = current === scope;
+                        return h(VCButton, {
+                            key: scope,
+                            size: props.size,
+                            color: isSelected ? 'primary' : 'neutral',
+                            variant: isSelected ? 'solid' : 'soft',
+                            disabled: busy.value,
+                            label: realmScopeLabels[scope]?.value ?? scope,
+                            title: realmScopeHints[scope]?.value,
+                            onClick(e: Event) {
+                                e.preventDefault();
+                                handleRealmScopeSelect(scope as RealmScopeValue);
+                            },
+                        });
+                    }),
+                ]),
                 selectedHint ?
                     h('div', { class: 'text-xs text-fg-muted' }, selectedHint) :
                     undefined,

--- a/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
+++ b/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
@@ -49,23 +49,36 @@ export const APermissionPolicyBindingButton = defineComponent({
             type: String as PropType<keyof EntityTypeMap>,
             required: true,
         },
+        // The junction this control manages. With an `id` it is an existing binding → EDIT mode
+        // (each selection patches immediately). Without an `id` it is a "template" carrying just
+        // the base fields the new junction is born with (owner FK + permission_id) → CREATE mode
+        // (selections are staged, then the control performs the create itself). One prop, both
+        // modes — the form-initialValue pattern.
         entity: {
-            type: Object as PropType<PermissionBindingEntity>,
-            required: true,
+            type: Object as PropType<Partial<PermissionBindingEntity>>,
+            required: false,
+            default: undefined,
         },
         size: {
             type: String as PropType<ButtonSize>,
             default: DEFAULT_BUTTON_SIZE,
         },
     },
-    emits: ['updated', 'failed'],
+    emits: ['created', 'updated', 'failed'],
     setup(props, { emit }) {
         const client = injectHTTPClient();
 
         const modalOpen = ref(false);
         const busy = ref(false);
-        const currentPolicyId = ref<string | null>(props.entity.policy_id);
-        const currentRealmScope = ref<RealmScopeValue | null>(props.entity.realm_scope ?? null);
+        // Create mode = no persisted junction yet (no id). In that mode selections are STAGED
+        // locally and committed once via the create; in edit mode each selection patches
+        // immediately.
+        const isCreateMode = () => !props.entity?.id;
+        const currentPolicyId = ref<string | null>(props.entity?.policy_id ?? null);
+        // Preselect the backend default (`own`) in create mode so a sensible reach is staged.
+        const currentRealmScope = ref<RealmScopeValue | null>(
+            props.entity?.realm_scope ?? (props.entity?.id ? null : REALM_SCOPE.OWN),
+        );
         // The detail view is a nested modal: Escape / outside-click close it
         // back to the list (handled by the inner VCModalContent), and another
         // Escape then closes the outer list modal.
@@ -73,22 +86,29 @@ export const APermissionPolicyBindingButton = defineComponent({
 
         const entityRef = toRef(props, 'entity');
         watch(entityRef, (val) => {
-            currentPolicyId.value = val.policy_id;
-            currentRealmScope.value = val.realm_scope ?? null;
+            currentPolicyId.value = val?.policy_id ?? null;
+            currentRealmScope.value = val?.realm_scope ?? (val?.id ? null : REALM_SCOPE.OWN);
         }, { deep: true });
 
         const handlePolicySelect = async (policyId: string | null) => {
             if (busy.value) return;
 
+            // Create mode: stage the choice; it is committed by the `create` emit.
+            if (isCreateMode()) {
+                currentPolicyId.value = policyId;
+                return;
+            }
+
+            const entityId = props.entity?.id;
             const api = hasOwnProperty(client, props.entityType) ?
                 client[props.entityType] as any :
                 undefined;
 
-            if (!api || !api.update) return;
+            if (!api || !api.update || !entityId) return;
 
             busy.value = true;
             try {
-                const response = await api.update(props.entity.id, { policy_id: policyId });
+                const response = await api.update(entityId, { policy_id: policyId });
                 currentPolicyId.value = policyId;
                 emit('updated', response);
             } catch (e) {
@@ -103,15 +123,22 @@ export const APermissionPolicyBindingButton = defineComponent({
         const handleRealmScopeSelect = async (scope: RealmScopeValue) => {
             if (busy.value || currentRealmScope.value === scope) return;
 
+            // Create mode: stage the choice; it is committed by the `create` emit.
+            if (isCreateMode()) {
+                currentRealmScope.value = scope;
+                return;
+            }
+
+            const entityId = props.entity?.id;
             const api = hasOwnProperty(client, props.entityType) ?
                 client[props.entityType] as any :
                 undefined;
 
-            if (!api || !api.update) return;
+            if (!api || !api.update || !entityId) return;
 
             busy.value = true;
             try {
-                const response = await api.update(props.entity.id, { realm_scope: scope });
+                const response = await api.update(entityId, { realm_scope: scope });
                 // Reflect the server-capped value: a restricted actor's chosen scope may be
                 // narrowed server-side, so prefer the persisted scope from the response.
                 currentRealmScope.value = (
@@ -131,9 +158,46 @@ export const APermissionPolicyBindingButton = defineComponent({
             }
         };
 
+        // Commit the staged (realm_scope, policy_id) as a NEW junction. Performed here via the
+        // injected client — symmetric with the update path — using the entity template (the FK
+        // base fields) as the create payload base. The created entity is emitted so the parent can
+        // sync its manager (manager.created); it flows back as `props.entity` (now with an id),
+        // switching the control to edit mode. The server caps the chosen scope.
+        const handleCreate = async () => {
+            if (busy.value || !isCreateMode() || !props.entity) return;
+
+            const api = hasOwnProperty(client, props.entityType) ?
+                client[props.entityType] as any :
+                undefined;
+
+            if (!api || !api.create) return;
+
+            busy.value = true;
+            try {
+                const response = await api.create({
+                    ...props.entity,
+                    realm_scope: currentRealmScope.value ?? undefined,
+                    policy_id: currentPolicyId.value ?? undefined,
+                });
+                emit('created', response);
+                modalOpen.value = false;
+            } catch (e) {
+                if (e instanceof Error) {
+                    emit('failed', e);
+                }
+            } finally {
+                busy.value = false;
+            }
+        };
+
         const translationJunctionPolicy = useTranslation({
             namespace: TranslatorTranslationNamespace.CLIENT,
             key: TranslatorTranslationClientKey.JUNCTION_POLICY,
+        });
+
+        const translationAdd = useTranslation({
+            namespace: TranslatorTranslationNamespace.ACTION,
+            key: TranslatorTranslationActionKey.ADD,
         });
 
         const translationJunctionRealmScope = useTranslation({
@@ -275,7 +339,8 @@ export const APermissionPolicyBindingButton = defineComponent({
                 },
             }),
             h('div', { class: 'flex items-center justify-end gap-2' }, [
-                currentPolicyId.value ?
+                // Edit mode only: a quick "reset policy" shortcut (create stages, so no reset).
+                (!isCreateMode() && currentPolicyId.value) ?
                     h(VCButton, {
                         type: 'button',
                         size: props.size,
@@ -297,6 +362,19 @@ export const APermissionPolicyBindingButton = defineComponent({
                         modalOpen.value = false;
                     },
                 }),
+                // Create mode: commit the staged (scope, policy) as a new binding.
+                isCreateMode() ?
+                    h(VCButton, {
+                        type: 'button',
+                        size: props.size,
+                        color: 'primary',
+                        label: translationAdd.value,
+                        disabled: busy.value,
+                        onClick() {
+                            handleCreate();
+                        },
+                    }, { leading: () => h(VCIcon, { name: 'fa6-solid:plus' }) }) :
+                    undefined,
             ]),
         ];
 
@@ -321,11 +399,14 @@ export const APermissionPolicyBindingButton = defineComponent({
         ];
 
         return () => {
+            const createMode = isCreateMode();
+
             let triggerColor: 'neutral' | 'primary' = 'neutral';
             let triggerVariant: 'solid' | 'soft' = 'soft';
             if (busy.value) {
                 triggerVariant = 'solid';
-            } else if (currentPolicyId.value) {
+            } else if (!createMode && currentPolicyId.value) {
+                // Edit mode with a bound policy → highlight the gear.
                 triggerColor = 'primary';
                 triggerVariant = 'solid';
             }
@@ -340,7 +421,8 @@ export const APermissionPolicyBindingButton = defineComponent({
                         e.preventDefault();
                         modalOpen.value = true;
                     },
-                }, { leading: () => h(VCIcon, { name: 'fa6-solid:gear' }) }),
+                    // Create mode → "assign with options" (sliders); edit mode → gear.
+                }, { leading: () => h(VCIcon, { name: createMode ? 'fa6-solid:sliders' : 'fa6-solid:gear' }) }),
                 h(VCModal, {
                     open: modalOpen.value,
                     'onUpdate:open': (value: boolean) => {

--- a/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
+++ b/packages/client-web-kit/src/components/entities/permission-policy-binding/APermissionPolicyBindingButton.ts
@@ -12,7 +12,7 @@ import type {
     RealmScopeValue,  
 } from '@authup/core-kit';
 import { REALM_SCOPE } from '@authup/core-kit';
-import type { PropType } from 'vue';
+import type { PropType, Ref } from 'vue';
 import {
     defineComponent,
     h,
@@ -141,6 +141,44 @@ export const APermissionPolicyBindingButton = defineComponent({
             key: TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE,
         });
 
+        // Localized label + one-line hint per selectable reach. Keyed off the string VALUE of
+        // REALM_SCOPE (camelCase `ownOrNull`), not a member-name derivation. `none` (a dead
+        // grant) is intentionally not offered — see realmScopeOptions below.
+        const realmScopeLabels: Record<string, Ref<string>> = {
+            [REALM_SCOPE.OWN]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_OWN,
+            }),
+            [REALM_SCOPE.OWN_OR_NULL]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL,
+            }),
+            [REALM_SCOPE.ANY]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_ANY,
+            }),
+        };
+
+        const realmScopeHints: Record<string, Ref<string>> = {
+            [REALM_SCOPE.OWN]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT,
+            }),
+            [REALM_SCOPE.OWN_OR_NULL]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL_HINT,
+            }),
+            [REALM_SCOPE.ANY]: useTranslation({
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.REALM_SCOPE_ANY_HINT,
+            }),
+        };
+
+        // Only the reachable scopes are user-selectable; `none` stays a valid stored value but
+        // is never offered (it would create a grant that matches no realm).
+        const realmScopeOptions = Object.values(REALM_SCOPE)
+            .filter((scope) => scope !== REALM_SCOPE.NONE);
+
         const translationBack = useTranslation({
             namespace: TranslatorTranslationNamespace.ACTION,
             key: TranslatorTranslationActionKey.BACK,
@@ -161,24 +199,34 @@ export const APermissionPolicyBindingButton = defineComponent({
             'aria-label': translationClose.value,
         }, () => h(VCIcon, { name: 'fa6-solid:xmark' }));
 
-        const renderRealmScopeSelector = () => h('div', { class: 'flex flex-col gap-1' }, [
-            h('div', { class: 'text-sm font-medium' }, translationJunctionRealmScope.value),
-            h('div', { class: 'flex flex-wrap gap-1' }, Object.values(REALM_SCOPE).map((scope) => {
-                const isSelected = currentRealmScope.value === scope;
-                return h(VCButton, {
-                    key: scope,
-                    size: props.size,
-                    color: isSelected ? 'primary' : 'neutral',
-                    variant: isSelected ? 'solid' : 'soft',
-                    disabled: busy.value,
-                    label: scope,
-                    onClick(e: Event) {
-                        e.preventDefault();
-                        handleRealmScopeSelect(scope as RealmScopeValue);
-                    },
-                });
-            })),
-        ]);
+        const renderRealmScopeSelector = () => {
+            const selectedHint = currentRealmScope.value ?
+                realmScopeHints[currentRealmScope.value]?.value :
+                undefined;
+
+            return h('div', { class: 'flex flex-col gap-1' }, [
+                h('div', { class: 'text-sm font-medium' }, translationJunctionRealmScope.value),
+                h('div', { class: 'flex flex-wrap gap-1' }, realmScopeOptions.map((scope) => {
+                    const isSelected = currentRealmScope.value === scope;
+                    return h(VCButton, {
+                        key: scope,
+                        size: props.size,
+                        color: isSelected ? 'primary' : 'neutral',
+                        variant: isSelected ? 'solid' : 'soft',
+                        disabled: busy.value,
+                        label: realmScopeLabels[scope]?.value ?? scope,
+                        title: realmScopeHints[scope]?.value,
+                        onClick(e: Event) {
+                            e.preventDefault();
+                            handleRealmScopeSelect(scope as RealmScopeValue);
+                        },
+                    });
+                })),
+                selectedHint ?
+                    h('div', { class: 'text-xs text-fg-muted' }, selectedHint) :
+                    undefined,
+            ]);
+        };
 
         const renderListContent = () => [
             h('div', { class: 'flex items-center justify-between gap-2' }, [

--- a/packages/client-web-kit/src/components/entities/robot-permission/ARobotPermissionAssignment.vue
+++ b/packages/client-web-kit/src/components/entities/robot-permission/ARobotPermissionAssignment.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import { EntityType } from '@authup/core-kit';
 import type { RobotPermission } from '@authup/core-kit';
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import {
     defineEntityManager,
     defineEntityVEmitOptions,
@@ -61,14 +61,28 @@ export default defineComponent({
             return manager.delete();
         };
 
+        const handleCreated = (entity: RobotPermission) => {
+            manager.created(entity);
+        };
+
         const handleUpdated = (entity: RobotPermission) => {
             manager.updated(entity);
         };
 
+        // The existing junction in edit mode, else a stable create template (FK base) carrying
+        // no id → the binding control treats it as create mode. Memoized so the template keeps a
+        // stable reference while unassigned.
+        const bindingEntity = computed<Partial<RobotPermission>>(() => manager.data.value || {
+            robot_id: props.robotId,
+            permission_id: props.permissionId,
+        });
+
         return {
             manager,
             handleChanged,
+            handleCreated,
             handleUpdated,
+            bindingEntity,
             EntityType,
         };
     },
@@ -82,10 +96,10 @@ export default defineComponent({
             @changed="handleChanged"
         />
         <APermissionPolicyBindingButton
-            v-if="manager.data.value"
-            :key="manager.data.value.id"
+            :key="manager.data.value?.id || 'create'"
             :entity-type="EntityType.ROBOT_PERMISSION"
-            :entity="manager.data.value"
+            :entity="bindingEntity"
+            @created="handleCreated"
             @updated="handleUpdated"
         />
     </span>

--- a/packages/client-web-kit/src/components/entities/role-permission/ARolePermissionAssignment.vue
+++ b/packages/client-web-kit/src/components/entities/role-permission/ARolePermissionAssignment.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import { EntityType } from '@authup/core-kit';
 import type { RolePermission } from '@authup/core-kit';
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import {
     defineEntityManager,
     defineEntityVEmitOptions,
@@ -61,14 +61,28 @@ export default defineComponent({
             return manager.delete();
         };
 
+        const handleCreated = (entity: RolePermission) => {
+            manager.created(entity);
+        };
+
         const handleUpdated = (entity: RolePermission) => {
             manager.updated(entity);
         };
 
+        // The existing junction in edit mode, else a stable create template (FK base) carrying
+        // no id → the binding control treats it as create mode. Memoized so the template keeps a
+        // stable reference while unassigned.
+        const bindingEntity = computed<Partial<RolePermission>>(() => manager.data.value || {
+            role_id: props.roleId,
+            permission_id: props.permissionId,
+        });
+
         return {
             manager,
             handleChanged,
+            handleCreated,
             handleUpdated,
+            bindingEntity,
             EntityType,
         };
     },
@@ -82,10 +96,10 @@ export default defineComponent({
             @changed="handleChanged"
         />
         <APermissionPolicyBindingButton
-            v-if="manager.data.value"
-            :key="manager.data.value.id"
+            :key="manager.data.value?.id || 'create'"
             :entity-type="EntityType.ROLE_PERMISSION"
-            :entity="manager.data.value"
+            :entity="bindingEntity"
+            @created="handleCreated"
             @updated="handleUpdated"
         />
     </span>

--- a/packages/client-web-kit/src/components/entities/user-permission/AUserPermissionAssignment.vue
+++ b/packages/client-web-kit/src/components/entities/user-permission/AUserPermissionAssignment.vue
@@ -8,7 +8,7 @@
 <script lang="ts">
 import { EntityType } from '@authup/core-kit';
 import type { UserPermission } from '@authup/core-kit';
-import { defineComponent } from 'vue';
+import { computed, defineComponent } from 'vue';
 import {
     defineEntityManager,
     defineEntityVEmitOptions,
@@ -61,14 +61,28 @@ export default defineComponent({
             return manager.delete();
         };
 
+        const handleCreated = (entity: UserPermission) => {
+            manager.created(entity);
+        };
+
         const handleUpdated = (entity: UserPermission) => {
             manager.updated(entity);
         };
 
+        // The existing junction in edit mode, else a stable create template (FK base) carrying
+        // no id → the binding control treats it as create mode. Memoized so the template keeps a
+        // stable reference while unassigned.
+        const bindingEntity = computed<Partial<UserPermission>>(() => manager.data.value || {
+            user_id: props.userId,
+            permission_id: props.permissionId,
+        });
+
         return {
             manager,
             handleChanged,
+            handleCreated,
             handleUpdated,
+            bindingEntity,
             EntityType,
         };
     },
@@ -82,10 +96,10 @@ export default defineComponent({
             @changed="handleChanged"
         />
         <APermissionPolicyBindingButton
-            v-if="manager.data.value"
-            :key="manager.data.value.id"
+            :key="manager.data.value?.id || 'create'"
             :entity-type="EntityType.USER_PERMISSION"
-            :entity="manager.data.value"
+            :entity="bindingEntity"
+            @created="handleCreated"
             @updated="handleUpdated"
         />
     </span>

--- a/packages/client-web-kit/src/components/utility/entity/record/module.ts
+++ b/packages/client-web-kit/src/components/utility/entity/record/module.ts
@@ -82,6 +82,13 @@ function create<
     }
 
     const created = (value: RECORD) => {
+        // Adopt the created record as the managed entity — consistent with updated()/deleted()
+        // and with create() (which sets entity.value before notifying). Without this, an
+        // externally-performed create (e.g. APermissionPolicyBindingButton's create mode, or a
+        // socket-originated create) would notify but leave the manager's data unset, so the
+        // consumer never transitions out of the "no record" state.
+        entity.value = value;
+
         if (ctx.setup && ctx.setup.emit) {
             ctx.setup.emit('created', value);
         }

--- a/packages/i18n/src/catalogs/de/client.ts
+++ b/packages/i18n/src/catalogs/de/client.ts
@@ -62,6 +62,12 @@ export const TranslatorTranslationClientGerman : NamespaceTranslations<`${Transl
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Verknüpfungsrichtlinie',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Realm-Geltungsbereich',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Eigener Realm',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'Wirkt nur im eigenen Realm des Inhabers.',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Eigener + global',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL_HINT]: 'Eigener Realm sowie globale (realm-lose) Ressourcen.',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY]: 'Beliebiger Realm',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY_HINT]: 'Wirkt auf alle Realms, einschließlich global. Reichweite auf Administratorebene.',
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Auswahl wird aktualisiert',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Aus der Auswahl entfernen',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Zur Auswahl hinzufügen',

--- a/packages/i18n/src/catalogs/de/client.ts
+++ b/packages/i18n/src/catalogs/de/client.ts
@@ -62,6 +62,8 @@ export const TranslatorTranslationClientGerman : NamespaceTranslations<`${Transl
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Verknüpfungsrichtlinie',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Realm-Geltungsbereich',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE]: 'Keiner',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE_HINT]: 'Keine Reichweite — trifft auf keinen Realm zu; eine deaktivierte Berechtigung.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Eigener Realm',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'Wirkt nur im eigenen Realm des Inhabers.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Eigener + global',

--- a/packages/i18n/src/catalogs/en/client.ts
+++ b/packages/i18n/src/catalogs/en/client.ts
@@ -50,6 +50,8 @@ export const TranslatorTranslationClientEnglish : NamespaceTranslations<`${Trans
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Junction Policy',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Realm Scope',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE]: 'None',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE_HINT]: 'No reach — matches no realm; a disabled grant.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Own realm',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'Acts only on the holder\'s own realm.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Own + global',

--- a/packages/i18n/src/catalogs/en/client.ts
+++ b/packages/i18n/src/catalogs/en/client.ts
@@ -50,6 +50,12 @@ export const TranslatorTranslationClientEnglish : NamespaceTranslations<`${Trans
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Junction Policy',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Realm Scope',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Own realm',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'Acts only on the holder\'s own realm.',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Own + global',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL_HINT]: 'Own realm plus global (realm-less) resources.',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY]: 'Any realm',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY_HINT]: 'Acts on every realm, including global. Admin-level reach.',
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Updating selection',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Remove from selection',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Add to selection',

--- a/packages/i18n/src/catalogs/es/client.ts
+++ b/packages/i18n/src/catalogs/es/client.ts
@@ -62,6 +62,12 @@ export const TranslatorTranslationClientSpanish : NamespaceTranslations<`${Trans
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Política de unión',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Ámbito del dominio',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Dominio propio',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'Actúa solo en el dominio propio del titular.',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Propio + global',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL_HINT]: 'Dominio propio más recursos globales (sin dominio).',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY]: 'Cualquier dominio',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY_HINT]: 'Actúa en todos los dominios, incluido el global. Alcance de nivel administrador.',
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Actualizando selección',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Quitar de la selección',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Añadir a la selección',

--- a/packages/i18n/src/catalogs/es/client.ts
+++ b/packages/i18n/src/catalogs/es/client.ts
@@ -62,6 +62,8 @@ export const TranslatorTranslationClientSpanish : NamespaceTranslations<`${Trans
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Política de unión',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Ámbito del dominio',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE]: 'Ninguno',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE_HINT]: 'Sin alcance — no coincide con ningún dominio; una concesión deshabilitada.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Dominio propio',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'Actúa solo en el dominio propio del titular.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Propio + global',

--- a/packages/i18n/src/catalogs/fr/client.ts
+++ b/packages/i18n/src/catalogs/fr/client.ts
@@ -62,6 +62,8 @@ export const TranslatorTranslationClientFrench : NamespaceTranslations<`${Transl
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Politique de liaison',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Portée du domaine',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE]: 'Aucune',
+    [TranslatorTranslationClientKey.REALM_SCOPE_NONE_HINT]: 'Aucune portée — ne correspond à aucun domaine ; une attribution désactivée.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Domaine propre',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'N\'agit que sur le domaine propre du titulaire.',
     [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Propre + global',

--- a/packages/i18n/src/catalogs/fr/client.ts
+++ b/packages/i18n/src/catalogs/fr/client.ts
@@ -62,6 +62,12 @@ export const TranslatorTranslationClientFrench : NamespaceTranslations<`${Transl
 
     [TranslatorTranslationClientKey.JUNCTION_POLICY]: 'Politique de liaison',
     [TranslatorTranslationClientKey.JUNCTION_REALM_SCOPE]: 'Portée du domaine',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN]: 'Domaine propre',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_HINT]: 'N\'agit que sur le domaine propre du titulaire.',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL]: 'Propre + global',
+    [TranslatorTranslationClientKey.REALM_SCOPE_OWN_OR_NULL_HINT]: 'Domaine propre ainsi que les ressources globales (sans domaine).',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY]: 'Tout domaine',
+    [TranslatorTranslationClientKey.REALM_SCOPE_ANY_HINT]: 'Agit sur tous les domaines, y compris global. Portée de niveau administrateur.',
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Mise à jour de la sélection',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Retirer de la sélection',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Ajouter à la sélection',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -81,6 +81,12 @@ export enum TranslatorTranslationClientKey {
 
     JUNCTION_POLICY = 'junctionPolicy',
     JUNCTION_REALM_SCOPE = 'junctionRealmScope',
+    REALM_SCOPE_OWN = 'realmScopeOwn',
+    REALM_SCOPE_OWN_HINT = 'realmScopeOwnHint',
+    REALM_SCOPE_OWN_OR_NULL = 'realmScopeOwnOrNull',
+    REALM_SCOPE_OWN_OR_NULL_HINT = 'realmScopeOwnOrNullHint',
+    REALM_SCOPE_ANY = 'realmScopeAny',
+    REALM_SCOPE_ANY_HINT = 'realmScopeAnyHint',
     SELECTION_UPDATING = 'selectionUpdating',
     SELECTION_REMOVE = 'selectionRemove',
     SELECTION_ADD = 'selectionAdd',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -81,6 +81,8 @@ export enum TranslatorTranslationClientKey {
 
     JUNCTION_POLICY = 'junctionPolicy',
     JUNCTION_REALM_SCOPE = 'junctionRealmScope',
+    REALM_SCOPE_NONE = 'realmScopeNone',
+    REALM_SCOPE_NONE_HINT = 'realmScopeNoneHint',
     REALM_SCOPE_OWN = 'realmScopeOwn',
     REALM_SCOPE_OWN_HINT = 'realmScopeOwnHint',
     REALM_SCOPE_OWN_OR_NULL = 'realmScopeOwnOrNull',


### PR DESCRIPTION
Plan 034 — realm_scope UI follow-up, **goal G1 (labels + hints)**.

## Problem

The junction realm-scope selector in `APermissionPolicyBindingButton` rendered the **raw enum values** as button labels — admins literally saw `none` / `own` / `ownOrNull` / `any`. For an authorization-**reach** control that's a misconfiguration hazard, and `none` (a grant that matches no realm) was offered as a selectable option.

## Change

- New i18n keys (`REALM_SCOPE_OWN` / `_OWN_OR_NULL` / `_ANY` + matching `*_HINT`) on `TranslatorTranslationClientKey`, authored across **all four locales** (en/de/fr/es; the locale-parity test enforces this). "realm" follows each locale's existing term (de `Realm`, fr `domaine`, es `dominio`).
- The selector now renders the **localized label** per button, the **hint as a tooltip**, and a **hint legend** for the currently-selected scope (keyed off the string value of `REALM_SCOPE`, so `ownOrNull` maps correctly).
- **`none` is no longer offered** — it remains a valid stored/migration value but is not user-selectable (a dead grant shouldn't be a one-click option).

## Scope

`realm_scope` lives only on the four `*-permission` junctions, surfaced through this one shared control, so this is the entire UI surface for G1.

## Follow-up

Goal **G2 (assignment-time scope)** — letting a user pick the reach when *assigning* a permission (today the junction is created at the `own` default and edited afterwards) — is a separate change with a UX design choice still to settle (where the picker lives); it will follow once that's decided.

## Verification

i18n build + locale-parity test green (77); client-web-kit builds clean; lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Permission assignment controls now support both creating new bindings and editing existing ones more smoothly.
  * Added realm-scope options with localized labels and hints in multiple languages.
* **Bug Fixes**
  * Improved permission assignment behavior so new bindings can be saved even when no existing record is present.
  * Existing permission changes now update immediately and reflect the latest saved state in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->