### PR TITLE
docs: correct realm_scope migration revert-safety comment

### DIFF
--- a/apps/server-core/src/adapters/database/migrations/mysql/1779300000000-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1779300000000-Default.ts
@@ -13,8 +13,22 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
  * up() ordering is LOAD-BEARING: schema -> convert-by-policy-name -> lift-admin ->
  * delete policy rows (the policy-name joins must resolve before the rows are deleted).
  *
- * down() is BEST-EFFORT: it drops the column only. The deleted system policies and the
- * nulled junction policy_id pointers are NOT reconstructed (re-provisioning restores them).
+ * BREAKING (existing data): only admin (-> any, matched by role name) and realm_admin
+ * (its realm-or-global / realm-bound junction policies -> ownOrNull / own) are converted.
+ * Every OTHER pre-existing grant with no realm policy keeps the 'own' default, so a custom
+ * role or a direct identity grant that previously reached global (realm_id = null) building
+ * blocks via the old system.realm-match baseline is now fail-closed to its own realm. Those
+ * grants must be re-widened to ownOrNull/any by hand: there is deliberately no automatic
+ * bump, because a policy-less grant that managed global resources is indistinguishable in
+ * the data from one that only ever acted on its own realm (auto-widening would fail open).
+ *
+ * down() is BEST-EFFORT and NOT a true inverse: it drops the column only. The deleted
+ * system policies and the nulled junction policy_id pointers are NOT reconstructed, and
+ * boot re-provisioning does NOT repair them either -- the junction synchronizer is
+ * create-only (it never rewrites realm_scope/policy_id on an already-existing row). So a
+ * revert (or revert + re-run) on a POPULATED database permanently pins realm_admin and any
+ * converted grant to the fail-closed 'own' default until fixed by hand; a forward-only
+ * upgrade is unaffected.
  */
 const JUNCTION_TABLES = [
     'auth_role_permissions',

--- a/apps/server-core/src/adapters/database/migrations/postgres/1779300000000-Default.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1779300000000-Default.ts
@@ -13,8 +13,22 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
  * up() ordering is LOAD-BEARING: schema -> convert-by-policy-name -> lift-admin ->
  * delete policy rows (the policy-name joins must resolve before the rows are deleted).
  *
- * down() is BEST-EFFORT: it drops the column only. The deleted system policies and the
- * nulled junction policy_id pointers are NOT reconstructed (re-provisioning restores them).
+ * BREAKING (existing data): only admin (-> any, matched by role name) and realm_admin
+ * (its realm-or-global / realm-bound junction policies -> ownOrNull / own) are converted.
+ * Every OTHER pre-existing grant with no realm policy keeps the 'own' default, so a custom
+ * role or a direct identity grant that previously reached global (realm_id = null) building
+ * blocks via the old system.realm-match baseline is now fail-closed to its own realm. Those
+ * grants must be re-widened to ownOrNull/any by hand: there is deliberately no automatic
+ * bump, because a policy-less grant that managed global resources is indistinguishable in
+ * the data from one that only ever acted on its own realm (auto-widening would fail open).
+ *
+ * down() is BEST-EFFORT and NOT a true inverse: it drops the column only. The deleted
+ * system policies and the nulled junction policy_id pointers are NOT reconstructed, and
+ * boot re-provisioning does NOT repair them either -- the junction synchronizer is
+ * create-only (it never rewrites realm_scope/policy_id on an already-existing row). So a
+ * revert (or revert + re-run) on a POPULATED database permanently pins realm_admin and any
+ * converted grant to the fail-closed 'own' default until fixed by hand; a forward-only
+ * upgrade is unaffected.
  */
 const JUNCTION_TABLES = [
     'auth_role_permissions',


### PR DESCRIPTION
## Context

Follow-up to an audit of the latest `realm_scope` migration pair (`1779300000000-Default.ts`, MySQL + Postgres, from #3151) for safety against **pre-existing data**.

**Audit outcome:** the forward migration is sound on a normally-provisioned install — the `DELETE` is FK-safe (junction `policy_id` is `ON DELETE SET NULL`; `parent_id` / closure / `auth_permission_policies` are `ON DELETE CASCADE`), no orphaned rows, and `admin` (→ `any`) + `realm_admin` (`realm-or-global`/`realm-bound` → `ownOrNull`/`own`) convert faithfully. No data corruption, no broken login, no privilege-escalation path.

One thing was worth correcting. This PR is **migration-comment only — no schema, SQL, or behavior change.**

## Change

**Fix an inaccurate claim in the migration header comment (both DBs).**
The header stated the nulled junction `policy_id` pointers are *"NOT reconstructed (re-provisioning restores them)"*. The parenthetical is wrong: the junction synchronizer is **create-only** (`if (!existing)`) and never rewrites `realm_scope`/`policy_id` on an existing row. So a `migration revert` (or revert + re-run) on a **populated** database permanently pins `realm_admin` and any converted grant to the fail-closed `own` default until fixed by hand. The comment now says so, and flags that a forward-only upgrade is unaffected.

While there, added a `BREAKING (existing data)` note documenting the intended fail-closed behavior: only `admin`/`realm_admin` are converted; every other pre-existing grant with no realm policy keeps the `own` default, so a custom role — or a permission granted directly to a user/client/robot — that previously reached global (`realm_id = null`) building blocks is now confined to its own realm and must be re-widened by hand.

## Deliberately NOT done

- **No automatic data-remediation step.** A policy-less grant that managed global resources is indistinguishable in the data from one that only ever acted on its own realm; auto-widening `own` → `ownOrNull` would fail *open* (a security regression). This stays operator-driven, consistent with the fail-closed design.
- **No MySQL `IF NOT EXISTS`/`IF EXISTS` guards.** That syntax is MariaDB-only and breaks on MySQL 8; the partial-apply hardening is a suite-wide convention concern, not this migration's to solve unilaterally.

## Notes

- The migration is **unreleased** (not in any tag; latest is `v1.0.0-beta.50`), so touching it is safe.
- ESLint passes on both `.ts` files. Comment-only TS change — no build impact.