### PR TITLE
fix: scope OAuth2 password grant user resolution to a realm (default master)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1015,8 +1015,44 @@ The `/token` endpoint authenticates the calling client according to RFC 6749. Co
 | `client_credentials` | Authentication is the grant's purpose. Confidential client only — public clients are rejected. |
 | `authorization_code` | Confidential client MUST authenticate (RFC §4.1.3). Authenticated `client_id` MUST match the auth code's bound `client_id` — mismatch = `invalid_grant`. |
 | `refresh_token` | Confidential client MUST authenticate (RFC §6). If the refresh token's payload has `client_id`, the request MUST authenticate as that client. Authenticated `client_id` MUST match — mismatch = `invalid_grant`. Tokens with no bound client may refresh without auth (legacy/no-client flow). |
-| `password` | Confidential client MUST authenticate (RFC §4.3.2). The token's `client_id` claim and the OpenID `aud` claim use the **authenticated** client's id, not any user-side association. |
+| `password` | Confidential client MUST authenticate (RFC §4.3.2). The token's `client_id` claim and the OpenID `aud` claim use the **authenticated** client's id, not any user-side association. See *Password grant realm resolution* for how the user realm is resolved. |
 | `robot_credentials` | Authentication is the grant's purpose (Authup-specific extension). |
+
+### Password grant realm resolution
+
+The password grant resolves the **user realm** before any authentication
+(`HTTPPasswordGrant.runWithRequest`, `adapters/http/adapters/oauth2/grant-types/password.ts`):
+
+- The realm hint is `realm_id ?? realm_name` from the request body — **both
+  denote the user realm** and each accepts a realm UUID **or** name (there is
+  no "client realm vs user realm" split; `realm_name` used to be silently
+  dropped and is now honored). The hint is canonicalized at the ingress
+  (`trim().toLowerCase()`, per *Canonical Identifier Form* layer 3) since no
+  validator runs on the token body.
+- The hint is resolved once via `IRealmRepository.resolve(hint, true)` —
+  **defaults to the master realm** when the hint is absent (or unknown; same
+  fallback convention as registration / password-recovery; a missing master
+  realm row throws `InternalError` — violated provisioning invariant). The
+  resolved `realm.id` is passed to both the client authenticator and the user
+  authenticator, so name-based user resolution is deterministic (previously a
+  realm-less login with a name matched an arbitrary cross-realm row) and the
+  LDAP-collection `findByProtocol(LDAP, realmId)` lookup is realm-scoped.
+- **The client leg is scoped to the same realm:** a *name*-identified
+  confidential client must live in the user realm (or be identified by its
+  UUID — UUID lookups skip the realm filter). A client named in a different
+  realm than its users now fails with `invalid_client` where the old unscoped
+  name lookup might have matched; register the client in the users' realm or
+  pass its UUID. On the SSR `/authorize` page the login realm is pinned to the
+  **client's** realm (`codeRequest.realm_id`, seeded into the login form), so
+  that page authenticates that realm's users only.
+- **Localized to the HTTP password grant.** HTTP Basic auth shares the same
+  `UserAuthenticator` class but is intentionally untouched — realm-less
+  Basic-auth-by-name resolution is unchanged. The same unscoped-name ambiguity
+  remains latent for Basic auth, `robot_credentials` / `client_credentials`
+  (robot/client names are unique per `(name, realm_id)`), and client-by-name
+  resolution on the `authorization_code` / `refresh_token` grants (which still
+  treat body `realm_id` as a raw, fallback-less client-realm key) — see plan
+  037 non-goals.
 
 ### Credential transport
 

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1114,13 +1114,14 @@ Cross-DB collation behavior diverges:
 
 Without canonicalization, the same code base produces different uniqueness behavior on each DB. Canonicalizing identifier columns at write time eliminates the divergence: `=` is sufficient for lookups across both DBs, `UNIQUE` constraints behave identically.
 
-### Three layers of enforcement
+### Four layers of enforcement
 
-Canonical form is enforced at three boundaries (defense-in-depth):
+Canonical form is enforced at four boundaries (defense-in-depth):
 
 1. **Validator transform** — every `name` / `email` validator chains `.trim().toLowerCase()` before its format check (Zod path) or `.matches(...)` (validup path). Mixed-case input is silently lowercased; callers see canonical form in the response.
 2. **Validator regex** — the format check (`isNameValid` for names: `/^[a-z0-9-_.]+$/`; emails: `/^[^A-Z]+$/`) operates on the post-transform value. After `.toLowerCase()` the regex always passes; it remains as documentation of the contract and as a catch for code paths that bypass the transform.
-3. **External boundary canonicalization** — when an identifier enters Authup outside the validator chain (currently: `IdentityProviderAccountManager` taking attribute candidates from external IdPs), it is lowercased at the ingress so external mixed-case usernames don't fall through to the random-nanoid fallback.
+3. **External boundary canonicalization** — when an identifier enters Authup outside the validator chain, it is lowercased at the ingress. Currently: `IdentityProviderAccountManager` taking attribute candidates from external IdPs (so external mixed-case usernames don't fall through to the random-nanoid fallback), and the OAuth2 password grant's `realm_id`/`realm_name` hint.
+4. **Repository-level lookup canonicalization** — name-based *lookups* on the authentication surface canonicalize the key before binding it: the identity repositories (`app/modules/identity/repositories/{user,client,robot}.ts`, both the name and a realm-name filter), `OAuth2ClientRepository.findOneByIdOrName` (the `/authorize` client resolution), and `RealmRepositoryAdapter.findOneByName`. An auth ingress that misses layer 3 (the `/realms/<key>` URL segment specifically, an HTTP Basic username, a token-body credential key) still matches canonically stored rows instead of diverging by database collation. Lookup-only, auth-surface-only — write paths rely on layers 1–3, and the entity repository adapters' `findOneByName` (`GET /roles/<name>` etc.) still bind raw (see plan 038).
 
 ### Adding a new identifier column
 

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
@@ -10,21 +10,24 @@ import type { OAuth2TokenGrantResponse } from '@authup/specs';
 import { readRequestBody } from '@routup/basic/body';
 import type { IAppEvent } from 'routup';
 import { getRequestHeader, getRequestIP } from 'routup';
-import type { ICredentialsAuthenticator, OAuth2ClientAuthenticator } from '../../../../../core/index.ts';
+import type { ICredentialsAuthenticator, IRealmRepository, OAuth2ClientAuthenticator } from '../../../../../core/index.ts';
 import { PasswordGrantType } from '../../../../../core/index.ts';
 import type { HTTPOAuth2PasswordGrantContext, IHTTPOAuth2Grant } from './types.ts';
-import { extractClientCredentialsFromRequest } from './utils/index.ts';
+import { extractClientCredentialsFromRequest, readStringField } from './utils/index.ts';
 
 export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2Grant {
     protected authenticator : ICredentialsAuthenticator<User>;
 
     protected clientAuthenticator : OAuth2ClientAuthenticator;
 
+    protected realmRepository : IRealmRepository;
+
     constructor(ctx: HTTPOAuth2PasswordGrantContext) {
         super(ctx);
 
         this.authenticator = ctx.authenticator;
         this.clientAuthenticator = ctx.clientAuthenticator;
+        this.realmRepository = ctx.realmRepository;
     }
 
     async runWithRequest(event: IAppEvent): Promise<OAuth2TokenGrantResponse> {
@@ -32,20 +35,26 @@ export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2G
         const {
             username,
             password,
-            realm_id: realmId,
         } = body || {};
 
         const { clientId, clientSecret } = await extractClientCredentialsFromRequest(event);
+
+        // canonical identifier form: realm names are stored LOWER(TRIM(...))
+        const realmHint = (
+            readStringField(body, 'realm_id') ?? readStringField(body, 'realm_name')
+        )?.trim().toLowerCase() || undefined;
+
+        const realm = await this.realmRepository.resolve(realmHint, true);
 
         const client = clientId ?
             await this.clientAuthenticator.authenticate(
                 clientId,
                 clientSecret,
-                typeof realmId === 'string' ? realmId : undefined,
+                realm.id,
             ) :
             undefined;
 
-        const user = await this.authenticator.authenticate(username, password, realmId);
+        const user = await this.authenticator.authenticate(username, password, realm.id);
 
         return this.runWith(
             { user, client },

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
@@ -7,6 +7,7 @@
 
 import type { User } from '@authup/core-kit';
 import type { OAuth2TokenGrantResponse } from '@authup/specs';
+import { OAuth2RequestError } from '@authup/specs';
 import { readRequestBody } from '@routup/basic/body';
 import type { IAppEvent } from 'routup';
 import { getRequestHeader, getRequestIP } from 'routup';
@@ -32,17 +33,22 @@ export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2G
 
     async runWithRequest(event: IAppEvent): Promise<OAuth2TokenGrantResponse> {
         const body = await readRequestBody(event);
-        const {
-            username,
-            password,
-        } = body || {};
+
+        const username = readStringField(body, 'username');
+        const password = readStringField(body, 'password');
+        if (!username || !password) {
+            throw OAuth2RequestError.malformed('username and password must be provided.');
+        }
 
         const { clientId, clientSecret } = await extractClientCredentialsFromRequest(event);
 
         // canonical identifier form: realm names are stored LOWER(TRIM(...))
-        const realmHint = (
-            readStringField(body, 'realm_id') ?? readStringField(body, 'realm_name')
-        )?.trim().toLowerCase() || undefined;
+        const realmHint = [
+            readStringField(body, 'realm_id'),
+            readStringField(body, 'realm_name'),
+        ]
+            .map((value) => value?.trim().toLowerCase())
+            .find((value) => !!value);
 
         const realm = await this.realmRepository.resolve(realmHint, true);
 

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/types.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/types.ts
@@ -12,6 +12,7 @@ import type {
     BaseGrantContext,
     ICredentialsAuthenticator,
     IOAuth2AuthorizationCodeVerifier,
+    IRealmRepository,
     OAuth2AuthorizeGrantContext,
     OAuth2ClientAuthenticator,
     OAuth2PasswordGrantContext,
@@ -30,6 +31,7 @@ export interface IHTTPOAuth2Grant {
 export type HTTPOAuth2PasswordGrantContext = OAuth2PasswordGrantContext & {
     authenticator : ICredentialsAuthenticator<User>,
     clientAuthenticator: OAuth2ClientAuthenticator,
+    realmRepository: IRealmRepository,
 };
 
 export type HTTPOAuth2RefreshTokenGrantContext = OAuth2RefreshTokenGrantContext & {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/credentials.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/credentials.ts
@@ -54,7 +54,7 @@ export async function extractClientCredentialsFromRequest(event: IAppEvent): Pro
     return {};
 }
 
-function readStringField(body: Record<string, any> | undefined, key: string): string | undefined {
+export function readStringField(body: Record<string, any> | undefined, key: string): string | undefined {
     const value = body?.[key];
     return typeof value === 'string' && value.length > 0 ? value : undefined;
 }

--- a/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
@@ -88,6 +88,7 @@ export class TokenController {
                 authenticator: ctx.userAuthenticator,
                 clientAuthenticator: ctx.oauth2ClientAuthenticator,
                 sessionManager: ctx.sessionManager,
+                realmRepository: ctx.realmRepository,
             }),
             [OAuth2TokenGrant.REFRESH_TOKEN]: new HTTPOAuth2RefreshTokenGrant({
                 accessTokenIssuer: ctx.accessTokenIssuer,

--- a/apps/server-core/src/adapters/http/controllers/workflows/token/types.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/token/types.ts
@@ -14,6 +14,7 @@ import type {
     IOAuth2TokenIssuer,
     IOAuth2TokenRevoker,
     IOAuth2TokenVerifier,
+    IRealmRepository,
     ISessionManager,
     OAuth2ClientAuthenticator,
 } from '../../../../../core/index.ts';
@@ -36,4 +37,6 @@ export type TokenControllerContext = {
     userAuthenticator: ICredentialsAuthenticator<User>
 
     oauth2ClientAuthenticator: OAuth2ClientAuthenticator
+
+    realmRepository: IRealmRepository
 };

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -167,9 +167,11 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
                 qb.andWhere('provider.realm_id = :realmId', { realmId: realmKey });
             } else {
                 const realm = await this.realmRepository.resolve(realmKey);
-                if (realm) {
-                    qb.andWhere('provider.realm_id = :realmId', { realmId: realm.id });
+                if (!realm) {
+                    return [];
                 }
+
+                qb.andWhere('provider.realm_id = :realmId', { realmId: realm.id });
             }
         }
 

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -163,9 +163,13 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
         qb.where('provider.protocol = :protocol', { protocol });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('provider.realm_id = :realmId', { realmId: realm.id });
+            if (isUUID(realmKey)) {
+                qb.andWhere('provider.realm_id = :realmId', { realmId: realmKey });
+            } else {
+                const realm = await this.realmRepository.resolve(realmKey);
+                if (realm) {
+                    qb.andWhere('provider.realm_id = :realmId', { realmId: realm.id });
+                }
             }
         }
 

--- a/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
@@ -29,7 +29,7 @@ export class RealmRepositoryAdapter implements IRealmRepository {
 
     findOneByName(name: string): Promise<Realm | null> {
         const qb = this.repository.createQueryBuilder('realm');
-        qb.where('realm.name = :name', { name });
+        qb.where('realm.name = :name', { name: name.trim().toLowerCase() });
 
         return qb.getOne();
     }

--- a/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
@@ -7,6 +7,7 @@
 
 import type { Realm } from '@authup/core-kit';
 import { REALM_MASTER_NAME } from '@authup/core-kit';
+import { InternalError } from '@authup/errors';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { applyQuery, validateEntityJoinColumns } from 'typeorm-extension';
@@ -106,6 +107,9 @@ export class RealmRepositoryAdapter implements IRealmRepository {
 
         if (!entity && withFallback) {
             entity = await this.findOneBy({ name: REALM_MASTER_NAME });
+            if (!entity) {
+                throw new InternalError('The master realm could not be resolved.');
+            }
         }
 
         return entity;

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -286,6 +286,8 @@ export class HTTPControllerModule {
 
             oauth2ClientAuthenticator,
 
+            realmRepository: new RealmRepositoryAdapter(container.resolve<Repository<Realm>>(RealmEntity)),
+
             sessionManager,
         });
     }

--- a/apps/server-core/src/app/modules/identity/repositories/client.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/client.ts
@@ -43,13 +43,13 @@ export class ClientIdentityRepository implements IClientIdentityRepository {
         if (isId) {
             query.where('client.id = :id', { id: key });
         } else {
-            query.where('client.name = :name', { name: key });
+            query.where('client.name = :name', { name: key.trim().toLowerCase() });
 
             if (realmKey) {
                 if (isUUID(realmKey)) {
                     query.andWhere('client.realm_id = :realmId', { realmId: realmKey });
                 } else {
-                    query.andWhere('realm.name = :realmName', { realmName: realmKey });
+                    query.andWhere('realm.name = :realmName', { realmName: realmKey.trim().toLowerCase() });
                 }
             }
         }

--- a/apps/server-core/src/app/modules/identity/repositories/robot.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/robot.ts
@@ -43,13 +43,13 @@ export class RobotIdentityRepository implements IRobotIdentityRepository {
         if (isId) {
             query.where('robot.id = :id', { id: key });
         } else {
-            query.where('robot.name = :name', { name: key });
+            query.where('robot.name = :name', { name: key.trim().toLowerCase() });
 
             if (realmKey) {
                 if (isUUID(realmKey)) {
                     query.andWhere('robot.realm_id = :realmId', { realmId: realmKey });
                 } else {
-                    query.andWhere('realm.name = :realmName', { realmName: realmKey });
+                    query.andWhere('realm.name = :realmName', { realmName: realmKey.trim().toLowerCase() });
                 }
             }
         }

--- a/apps/server-core/src/app/modules/identity/repositories/user.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/user.ts
@@ -58,13 +58,13 @@ export class UserIdentityRepository implements IUserIdentityRepository {
         if (isId) {
             query.where('user.id = :id', { id: key });
         } else {
-            query.where('user.name = :name', { name: key });
+            query.where('user.name = :name', { name: key.trim().toLowerCase() });
 
             if (realmKey) {
                 if (isUUID(realmKey)) {
                     query.andWhere('user.realm_id = :realmId', { realmId: realmKey });
                 } else {
-                    query.andWhere('realm.name = :realmName', { realmName: realmKey });
+                    query.andWhere('realm.name = :realmName', { realmName: realmKey.trim().toLowerCase() });
                 }
             }
         }

--- a/apps/server-core/src/app/modules/oauth2/repositories/client/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/client/repository.ts
@@ -26,13 +26,13 @@ export class OAuth2ClientRepository implements IOAuth2ClientRepository {
         if (isUUID(key)) {
             query.where('client.id = :id', { id: key });
         } else {
-            query.where('client.name = :name', { name: key });
+            query.where('client.name = :name', { name: key.trim().toLowerCase() });
 
             if (realmKey) {
                 if (isUUID(realmKey)) {
                     query.andWhere('client.realm_id = :realmId', { realmId: realmKey });
                 } else {
-                    query.andWhere('realm.name = :realmName', { realmName: realmKey });
+                    query.andWhere('realm.name = :realmName', { realmName: realmKey.trim().toLowerCase() });
                 }
             }
         }

--- a/apps/server-core/src/core/entities/realm/types.ts
+++ b/apps/server-core/src/core/entities/realm/types.ts
@@ -9,6 +9,10 @@ import type { Realm } from '@authup/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository  } from '@authup/server-kit';
 
 export interface IRealmRepository extends IEntityRepository<Realm> {
+    /**
+     * @throws InternalError when withFallback is set but the master realm does not exist
+     * (a violated provisioning invariant, not a client fault).
+     */
     resolve(id: string | undefined, withFallback: true): Promise<Realm>;
     resolve(id: string | undefined, withFallback?: boolean): Promise<Realm | null>;
 }

--- a/apps/server-core/src/core/provisioning/synchronizer/base.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/base.ts
@@ -19,4 +19,14 @@ export abstract class BaseProvisioningSynchronizer<T> implements IProvisioningSy
     }
 
     abstract synchronize(input: T): Promise<T>;
+
+    // canonical identifier form: provisioning sources may carry raw names
+    // (the file-source entity validators run group-less, so the validator
+    // transforms don't apply); lookups against canonically stored rows
+    // and canonical persistence both require it.
+    protected canonicalizeName(attributes: { name?: string | null } | undefined): void {
+        if (attributes && typeof attributes.name === 'string') {
+            attributes.name = attributes.name.trim().toLowerCase();
+        }
+    }
 }

--- a/apps/server-core/src/core/provisioning/synchronizer/client/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/client/module.ts
@@ -62,6 +62,8 @@ export class ClientProvisioningSynchronizer extends BaseProvisioningSynchronizer
     }
 
     async synchronize(input: ClientProvisioningEntity): Promise<ClientProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
 
         let attributes = await this.clientRepository.findOneBy({

--- a/apps/server-core/src/core/provisioning/synchronizer/entity-resolver.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/entity-resolver.ts
@@ -20,6 +20,8 @@ export class ProvisioningEntityResolver<T extends ObjectLiteral = ObjectLiteral>
             return [];
         }
 
+        names = names.map((name) => name.trim().toLowerCase());
+
         const hasWildcard = names.includes('*');
         if (hasWildcard) {
             return this.repository.findManyBy({
@@ -40,6 +42,8 @@ export class ProvisioningEntityResolver<T extends ObjectLiteral = ObjectLiteral>
             return [];
         }
 
+        names = names.map((name) => name.trim().toLowerCase());
+
         const hasWildcard = names.includes('*');
         if (hasWildcard) {
             return this.repository.findManyBy({
@@ -59,6 +63,8 @@ export class ProvisioningEntityResolver<T extends ObjectLiteral = ObjectLiteral>
         if (!names || names.length === 0) {
             return [];
         }
+
+        names = names.map((name) => name.trim().toLowerCase());
 
         const hasWildcard = names.includes('*');
         if (hasWildcard) {

--- a/apps/server-core/src/core/provisioning/synchronizer/permission/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/permission/module.ts
@@ -30,6 +30,8 @@ export class PermissionProvisioningSynchronizer extends BaseProvisioningSynchron
     }
 
     async synchronize(input: PermissionProvisioningEntity): Promise<PermissionProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
 
         let attributes = await this.repository.findOneBy({
@@ -87,7 +89,7 @@ export class PermissionProvisioningSynchronizer extends BaseProvisioningSynchron
         }
 
         for (const policyName of policyNames) {
-            const policy = await this.policyRepository.findOneByName(policyName);
+            const policy = await this.policyRepository.findOneByName(policyName.trim().toLowerCase());
             if (!policy) {
                 throw new Error(
                     `Provisioning: policy '${policyName}' not found for permission '${permission.name}'.`,

--- a/apps/server-core/src/core/provisioning/synchronizer/policy/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/policy/module.ts
@@ -37,6 +37,8 @@ export class PolicyProvisioningSynchronizer extends BaseProvisioningSynchronizer
     }
 
     async synchronize(input: PolicyProvisioningEntity): Promise<PolicyProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         let entity = await this.repository.findOneBy({
             name: input.attributes.name,
             realm_id: input.attributes.realm_id || null,

--- a/apps/server-core/src/core/provisioning/synchronizer/policy/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/policy/module.ts
@@ -77,14 +77,16 @@ export class PolicyProvisioningSynchronizer extends BaseProvisioningSynchronizer
         parentId: string,
         children: PolicyProvisioningEntity[] = [],
     ): Promise<void> {
-        const declaredNames = children.map((c) => c.attributes.name);
-
         await children.reduce(async (prev, child) => {
             await prev;
             child.attributes.parent_id = parentId;
             child.attributes.parent = { id: parentId } as any;
             await this.synchronize(child);
         }, Promise.resolve());
+
+        // derived AFTER synchronize() so the names are canonicalized —
+        // a pre-sync snapshot would misidentify mixed-case children as stale
+        const declaredNames = children.map((c) => c.attributes.name);
 
         await this.cleanupStaleChildren(parentId, declaredNames);
     }

--- a/apps/server-core/src/core/provisioning/synchronizer/realm/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/realm/module.ts
@@ -46,6 +46,8 @@ export class RealmProvisioningSynchronizer extends BaseProvisioningSynchronizer<
     }
 
     async synchronize(input: RealmProvisioningEntity): Promise<RealmProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
         let attributes = await this.repository.findOneBy({ name: input.attributes.name });
 

--- a/apps/server-core/src/core/provisioning/synchronizer/robot/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/robot/module.ts
@@ -52,6 +52,8 @@ export class RobotProvisioningSynchronizer extends BaseProvisioningSynchronizer<
     }
 
     async synchronize(input: RobotProvisioningEntity): Promise<RobotProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
 
         let attributes = await this.robotRepository.findOneBy({

--- a/apps/server-core/src/core/provisioning/synchronizer/role/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/role/module.ts
@@ -35,6 +35,8 @@ export class RoleProvisioningSynchronizer extends BaseProvisioningSynchronizer<R
     }
 
     async synchronize(input: RoleProvisioningEntity): Promise<RoleProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
         let attributes = await this.repository.findOneBy({
             name: input.attributes.name,

--- a/apps/server-core/src/core/provisioning/synchronizer/scope/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/scope/module.ts
@@ -22,6 +22,8 @@ export class ScopeProvisioningSynchronizer extends BaseProvisioningSynchronizer<
     }
 
     async synchronize(input: ScopeProvisioningEntity): Promise<ScopeProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
 
         let attributes = await this.repository.findOneBy({

--- a/apps/server-core/src/core/provisioning/synchronizer/user/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/user/module.ts
@@ -59,6 +59,8 @@ export class UserProvisioningSynchronizer extends BaseProvisioningSynchronizer<U
     }
 
     async synchronize(input: UserProvisioningEntity): Promise<UserProvisioningEntity> {
+        this.canonicalizeName(input.attributes);
+
         const strategy = normalizeEntityProvisioningStrategy(input.strategy);
 
         let attributes = await this.userRepository.findOneBy({

--- a/apps/server-core/test/unit/core/provisioning/synchronizer/canonicalization.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/synchronizer/canonicalization.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Permission, PermissionPolicy } from '@authup/core-kit';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { FakeEntityRepository } from '@authup/server-test-kit';
+import { PermissionProvisioningSynchronizer } from '../../../../../src/core/provisioning/synchronizer/permission/module.ts';
+import { ProvisioningEntityStrategyType } from '../../../../../src/core/provisioning/strategy/index.ts';
+import { FakePolicyRepository } from '../../entities/policy/fake-repository.ts';
+import type { IPermissionPolicyRepository } from '../../../../../src/core/entities/permission-policy/types.ts';
+import type { IPermissionRepository } from '../../../../../src/core/entities/index.ts';
+
+describe('core/provisioning/synchronizer canonical names', () => {
+    let permissionRepository: FakeEntityRepository<Permission> & IPermissionRepository;
+    let policyRepository: FakePolicyRepository;
+    let permissionPolicyRepository: FakeEntityRepository<PermissionPolicy> & IPermissionPolicyRepository;
+    let synchronizer: PermissionProvisioningSynchronizer;
+
+    beforeEach(() => {
+        permissionRepository = new FakeEntityRepository<Permission>() as
+            FakeEntityRepository<Permission> & IPermissionRepository;
+        policyRepository = new FakePolicyRepository();
+        permissionPolicyRepository = new FakeEntityRepository<PermissionPolicy>() as
+            FakeEntityRepository<PermissionPolicy> & IPermissionPolicyRepository;
+        synchronizer = new PermissionProvisioningSynchronizer({
+            repository: permissionRepository,
+            policyRepository,
+            permissionPolicyRepository,
+        });
+    });
+
+    it('should persist a canonical name for a mixed-case provisioned entity', async () => {
+        await synchronizer.synchronize({
+            strategy: { type: ProvisioningEntityStrategyType.MERGE },
+            attributes: { name: ' Test_Permission ' },
+        });
+
+        const all = permissionRepository.getAll();
+        expect(all).toHaveLength(1);
+        expect(all[0].name).toBe('test_permission');
+    });
+
+    it('should match an existing canonical row for a mixed-case provisioned entity', async () => {
+        permissionRepository.seed({
+            name: 'test_permission', 
+            realm_id: null, 
+            client_id: null, 
+        });
+
+        await synchronizer.synchronize({
+            strategy: { type: ProvisioningEntityStrategyType.MERGE },
+            attributes: { name: ' Test_Permission ' },
+        });
+
+        expect(permissionRepository.getAll()).toHaveLength(1);
+    });
+
+    it('should resolve a mixed-case policy reference against the canonical row', async () => {
+        policyRepository.seed({ name: 'system.default' });
+
+        await synchronizer.synchronize({
+            strategy: { type: ProvisioningEntityStrategyType.MERGE },
+            attributes: { name: 'test_permission' },
+            relations: { policies: [' System.Default '] },
+        });
+
+        expect(permissionPolicyRepository.getAll()).toHaveLength(1);
+    });
+});

--- a/apps/server-core/test/unit/core/provisioning/synchronizer/policy.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/synchronizer/policy.spec.ts
@@ -98,6 +98,31 @@ describe('core/provisioning/synchronizer/policy', () => {
     });
 
     describe('stale child cleanup', () => {
+        it('should not treat a mixed-case declared child as stale', async () => {
+            await synchronizer.synchronize({
+                attributes: {
+                    name: 'system.default',
+                    type: BuiltInPolicyType.COMPOSITE,
+                    built_in: true,
+                    realm_id: null,
+                },
+                children: [
+                    {
+                        attributes: {
+                            name: ' Mixed-Child ',
+                            type: BuiltInPolicyType.IDENTITY,
+                            built_in: true,
+                            realm_id: null,
+                        },
+                    },
+                ],
+            });
+
+            const child = policyRepository.getAll().find((p) => p.name === 'mixed-child');
+            expect(child).toBeDefined();
+            expect(child?.parent_id).toBeTruthy();
+        });
+
         it('should delete unreferenced children when parent policy children change', async () => {
             const initialInput: PolicyProvisioningEntity = {
                 attributes: {

--- a/apps/server-core/test/unit/http/controllers/entities/realm-scoped.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-scoped.spec.ts
@@ -53,6 +53,13 @@ describe('src/http/controllers/realm-scoped', () => {
             expect(response.status).toEqual(200);
         });
 
+        it('should resolve a mixed-case realm key and Basic username', async () => {
+            const mixedCaseAuth = `Basic ${Buffer.from('ADMIN:start123').toString('base64')}`;
+            const response = await httpRequest(suite, 'GET', '/realms/MASTER/users', { headers: { Authorization: mixedCaseAuth } });
+
+            expect(response.status).toEqual(200);
+        });
+
         it('should 404 on unknown realm key in path', async () => {
             const response = await httpRequest(suite, 'GET', '/realms/this-realm-does-not-exist/users', { headers: { Authorization: basicAuth } });
 

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
@@ -12,7 +12,12 @@ import {
     it,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
-import { createFakeClient, createFakeUser, expectClientError } from '../../../../../utils';
+import {
+    createFakeClient,
+    createFakeRealm,
+    createFakeUser,
+    expectClientError,
+} from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
 describe('src/http/controllers/token', () => {
@@ -128,5 +133,105 @@ describe('src/http/controllers/token', () => {
             }),
             { status: 400, code: ErrorCode.ENTITY_CREDENTIALS_INVALID },
         );
+    });
+
+    it('should default realm-less password grant to the master realm', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+
+        const { name } = createFakeUser();
+        await suite.client.user.create(createFakeUser({
+            name,
+            password: 'master-secret-123',
+        }));
+        await suite.client.user.create(createFakeUser({
+            name,
+            realm_id: realm.id,
+            password: 'other-secret-123',
+        }));
+
+        const response = await suite.client
+            .token
+            .createWithPassword({
+                username: name,
+                password: 'master-secret-123',
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        await expectClientError(
+            () => suite.client.token.createWithPassword({
+                username: name,
+                password: 'other-secret-123',
+            }),
+            { status: 400, code: ErrorCode.ENTITY_CREDENTIALS_INVALID },
+        );
+    });
+
+    it('should grant token with password for a realm selected via realm hint', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password: 'realm-user-secret',
+        }));
+
+        let response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                realm_id: realm.id,
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                realm_id: realm.name,
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                realm_name: realm.name,
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                realm_name: ` ${realm.name.toUpperCase()} `,
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        await expectClientError(
+            () => suite.client.token.createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+            }),
+            { status: 400, code: ErrorCode.ENTITY_CREDENTIALS_INVALID },
+        );
+    });
+
+    it('should fall back to the master realm for an unknown realm hint', async () => {
+        const response = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                realm_id: 'this-realm-does-not-exist',
+            });
+
+        expect(response.access_token).toBeDefined();
     });
 });

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
@@ -214,12 +214,63 @@ describe('src/http/controllers/token', () => {
 
         expect(response.access_token).toBeDefined();
 
+        response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                realm_id: '   ',
+                realm_name: realm.name,
+            });
+
+        expect(response.access_token).toBeDefined();
+
         await expectClientError(
             () => suite.client.token.createWithPassword({
                 username: user.name,
                 password: 'realm-user-secret',
             }),
             { status: 400, code: ErrorCode.ENTITY_CREDENTIALS_INVALID },
+        );
+    });
+
+    it('should scope name-identified confidential client authentication to the resolved realm', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const secret = 'client-realm-scope-secret';
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                realm_id: realm.id,
+                secret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password: 'realm-user-secret',
+        }));
+
+        const response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                client_id: client.name,
+                client_secret: secret,
+                realm_id: realm.id,
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        await expectClientError(
+            () => suite.client.token.createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: client.name,
+                client_secret: secret,
+            }),
+            { status: 401, code: ErrorCode.OAUTH_CLIENT_INVALID },
         );
     });
 

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
@@ -263,6 +263,18 @@ describe('src/http/controllers/token', () => {
 
         expect(response.access_token).toBeDefined();
 
+        const mixedCaseResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                client_id: client.name.toUpperCase(),
+                client_secret: secret,
+                realm_id: realm.id,
+            });
+
+        expect(mixedCaseResponse.access_token).toBeDefined();
+
         await expectClientError(
             () => suite.client.token.createWithPassword({
                 username: 'admin',
@@ -272,6 +284,19 @@ describe('src/http/controllers/token', () => {
             }),
             { status: 401, code: ErrorCode.OAUTH_CLIENT_INVALID },
         );
+    });
+
+    it('should match a mixed-case username against the canonical stored name', async () => {
+        const user = await suite.client.user.create(createFakeUser({ password: 'case-user-secret' }));
+
+        const response = await suite.client
+            .token
+            .createWithPassword({
+                username: ` ${user.name.toUpperCase()} `,
+                password: 'case-user-secret',
+            });
+
+        expect(response.access_token).toBeDefined();
     });
 
     it('should fall back to the master realm for an unknown realm hint', async () => {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-robot-credentials.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-robot-credentials.spec.ts
@@ -64,4 +64,15 @@ describe('refresh-token', () => {
             { status: 400, code: ErrorCode.ENTITY_CREDENTIALS_INVALID },
         );
     });
+
+    it('should grant token with robot credentials (mixed-case name)', async () => {
+        const response = await suite.client
+            .token
+            .createWithRobotCredentials({
+                id: ` ${robot.name.toUpperCase()} `,
+                secret: robot.secret,
+            });
+
+        expect(response.access_token).toBeDefined();
+    });
 });

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -44,6 +44,23 @@ curl -X POST 'http://localhost:3001/token' \
   -d 'password=USER_PASSWORD'
 ```
 
+The user is resolved within a single realm. Pass `realm_id` or `realm_name`
+(both accept a realm UUID or name) to select it; when neither is provided,
+the **master** realm is used. In multi-realm deployments, users outside the
+master realm must therefore include a realm parameter:
+
+```shell
+curl -X POST 'http://localhost:3001/token' \
+  -H 'Content-Type: application/x-www-form-urlencoded' \
+  -d 'grant_type=password' \
+  -d 'username=USER_USERNAME' \
+  -d 'password=USER_PASSWORD' \
+  -d 'realm_id=REALM_ID_OR_NAME'
+```
+
+A confidential client authenticating on this grant by **name** must belong to
+the same realm as the user; clients identified by UUID are unaffected.
+
 #### Response
 ```json
 {

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -45,9 +45,10 @@ curl -X POST 'http://localhost:3001/token' \
 ```
 
 The user is resolved within a single realm. Pass `realm_id` or `realm_name`
-(both accept a realm UUID or name) to select it; when neither is provided,
-the **master** realm is used. In multi-realm deployments, users outside the
-master realm must therefore include a realm parameter:
+(both accept a realm UUID or name) to select it; when neither is provided —
+or the provided value does not match any realm — the **master** realm is
+used. In multi-realm deployments, users outside the master realm must
+therefore include a realm parameter:
 
 ```shell
 curl -X POST 'http://localhost:3001/token' \

--- a/packages/client-web-kit/src/components/workflows/login/LoginForm.vue
+++ b/packages/client-web-kit/src/components/workflows/login/LoginForm.vue
@@ -88,7 +88,9 @@ export default defineComponent({
         const form = reactive({
             name: '',
             password: '',
-            realm_id: '',
+            realm_id: props.codeRequest && props.codeRequest.realm_id ?
+                props.codeRequest.realm_id :
+                '',
         });
 
         const v = useValidup(new LoginCredentialsValidator(), form);
@@ -125,19 +127,11 @@ export default defineComponent({
 
         const busy = ref(false);
 
-        const realmId = computed(() => {
-            if (props.codeRequest && props.codeRequest.realm_id) {
-                return props.codeRequest.realm_id;
-            }
-
-            return form.realm_id;
-        });
-
         const identityProviderQuery: Ref<BuildInput<IdentityProvider>> = ref({});
         const resetIdentityProviderQuery = () => {
             identityProviderQuery.value = {
                 filters: {
-                    realm_id: realmId.value || '',
+                    realm_id: form.realm_id || '',
                     protocol: `!${IdentityProviderProtocol.LDAP}`,
                     enabled: true,
                 },

--- a/packages/client-web-kit/src/components/workflows/login/LoginForm.vue
+++ b/packages/client-web-kit/src/components/workflows/login/LoginForm.vue
@@ -7,6 +7,7 @@ import {
     nextTick,
     reactive,
     ref,
+    watch,
 } from 'vue';
 import type { IdentityProvider, OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { IdentityProviderProtocol } from '@authup/core-kit';
@@ -88,9 +89,7 @@ export default defineComponent({
         const form = reactive({
             name: '',
             password: '',
-            realm_id: props.codeRequest && props.codeRequest.realm_id ?
-                props.codeRequest.realm_id :
-                '',
+            realm_id: '',
         });
 
         const v = useValidup(new LoginCredentialsValidator(), form);
@@ -159,6 +158,16 @@ export default defineComponent({
                 updateIdentityProviderList();
             });
         };
+
+        watch(
+            () => (props.codeRequest ? props.codeRequest.realm_id : undefined),
+            (value) => {
+                if (value && value !== form.realm_id) {
+                    updateRealmId(value);
+                }
+            },
+            { immediate: true },
+        );
 
         const submit = async () => {
             try {

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -337,7 +337,7 @@ export function createStore(context: StoreCreateContext) {
         const response = await client.token.createWithPassword({
             username: ctx.name,
             password: ctx.password,
-            ...(realmId.value ? { realm_id: ctx.realmId } : {}),
+            ...(ctx.realmId ? { realm_id: ctx.realmId } : {}),
         });
 
         applyTokenGrantResponse(response);


### PR DESCRIPTION
## Problem

The OAuth2 password grant did not scope user resolution to a realm. With no realm hint and a name-based username, the lookup ran with no realm predicate and no ordering, returning a **non-deterministic cross-realm row** in multi-realm deployments with same-named users — a legitimate user could be denied login (password verified against another realm's row), and it was a latent cross-realm auth-confusion surface.

## Change

- The grant resolves the **user realm** once from `realm_id ?? realm_name` (each accepts a realm UUID or name; the hint is trimmed/lowercased per the canonical-identifier convention; `realm_name` was previously silently dropped and is now honored) via `IRealmRepository.resolve(hint, true)`, **defaulting to the master realm** when no hint is supplied. The resolved `realm.id` feeds both the client and user authenticators, so name-based resolution is deterministic and the LDAP provider lookup is realm-scoped.
- `resolve(hint, true)` now throws `InternalError` when the master realm row is missing, instead of returning `null` at runtime despite the non-null overload (previously a `TypeError` 500 on `/token` for unprovisioned deployments).
- `findByProtocol` skips the redundant realm re-resolve for UUID keys (and fails closed on unknown UUIDs).
- **client-web-kit:** `store.login()` gated the realm on the wrong ref, and `LoginForm` submitted a stale `form.realm_id` while the SSR `/authorize` page supplies the realm via `codeRequest.realm_id` (picker hidden) — the picked realm was never transmitted. `form.realm_id` is now seeded from `codeRequest.realm_id` (single source) and forwarded end-to-end.

## Behavior changes (release-note worthy)

- Realm-less password grants now match **master-realm users only**. Non-master users must pass `realm_id` or `realm_name` (UUID or name). Single-realm deployments and the provisioned master `admin` are unaffected.
- An LDAP identity provider registered in a non-master realm is no longer tried on realm-less grants — send a realm hint.
- A **name**-identified confidential client on this grant must live in the user's realm (UUID-identified clients are unaffected).
- An unknown realm hint falls back to master (consistent with registration / password-recovery).
- On the SSR `/authorize` page, login is pinned to the client's realm — that page authenticates that realm's users only.
- HTTP Basic auth, `authorization_code`, `refresh_token`, `client_credentials`, and `robot_credentials` are intentionally untouched (see plan 037 non-goals in `.agents/architecture.md`).

## Testing

- New HTTP-level cases in `grant-password.spec.ts`: same-name-in-two-realms determinism guard, realm selection via `realm_id` (UUID and name) and `realm_name` (incl. mixed-case/whitespace canonicalization), realm-less rejection of non-master users, unknown-hint master fallback.
- Full server-core suite: **95 files / 959 tests green** (includes LDAP password grant, Basic-auth-authenticated suite, all other grants, SSR UI pages).
- Reviewed by a multi-agent adversarial pass; all confirmed findings addressed or documented (deferred: regression test for the interactive-login realm plumbing — client-web-kit has no test infra; realm lookup on `/token` is uncached — one indexed SELECT per login).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Password-based login now deterministically resolves the realm from the provided realm hint (realm_id/realm_name) and scopes credential + token issuance to the resolved realm, falling back to the master realm.
  * Login form now reactively synchronizes the realm field from an existing code request.

* **Bug Fixes**
  * Improved realm/client/user/robot/policy lookups by normalizing names (trim + lowercase) for non-UUID matching.
  * Added clearer handling for missing master realm during fallback resolution.

* **Documentation**
  * Updated OAuth2 password-flow documentation and authentication realm-resolution rules.

* **Tests**
  * Added unit coverage for realm selection, realm-scoped user routing case-insensitivity, and canonicalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-up review pass

A second review pass over the branch produced three more commits:

- **server-core:** `username`/`password` are now extracted as non-empty strings and rejected with `invalid_request` when missing (no raw non-string values reach the SQL layer); the realm hint is trimmed per field, so a whitespace-only `realm_id` no longer masks a valid `realm_name`; `findByProtocol` fails closed for unknown realm names (symmetric with unknown UUIDs). Regression coverage added for the name-identified confidential-client realm scoping.
- **client-web-kit:** `LoginForm` tracks `codeRequest.realm_id` through an immediate watch instead of a one-shot setup seed, so a late-arriving or replaced `codeRequest` prop in downstream consumers cannot strand the form realm-less.
- **docs:** the OAuth2 guide notes that an unknown realm value also falls back to master.

Full server-core suite after the pass: 95 files / 960 tests green.


## Canonical name lookups (auth surface)

Two follow-up items were pulled in after review discussion:

- **Repository-level lookup canonicalization:** name-based lookups on the authentication surface (`trim().toLowerCase()` on the lookup key) in the user/client/robot identity repositories, `OAuth2ClientRepository` (`/authorize` client resolution), and `RealmRepositoryAdapter.findOneByName`. Mixed-case Basic usernames, token-body credentials, and `/realms/<key>` path segments now resolve identically on MySQL and PostgreSQL (names are stored canonically; previously PostgreSQL missed where MySQL's `ci` collation matched). LDAP binds still receive the raw credential. Tests: mixed-case password-grant username, client-by-name, robot-by-name, `/realms/MASTER` path + Basic `ADMIN` username.
- **Provisioning canonical persistence:** the file-source entity validators run group-less, so core-kit validator transforms never apply — file-provisioned names could persist raw, and the scoped lookups above would then lock those identities out on PostgreSQL. Every entity synchronizer now canonicalizes `attributes.name`, and relation-name references (entity resolver, permission→policy names) are canonicalized before lookup. Covered by new synchronizer unit tests.

Full server-core suite: 95 files / 966 tests green.
