### PR TITLE
fix: realm-scoping and provisioning-validation follow-ups

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -556,6 +556,32 @@ The provisioning system declaratively synchronizes entities (permissions, roles,
   - `composite/`: Merges multiple sources with dedup by composite key (`name:realm_id:client_id`)
 - **app/modules/provisioning/module.ts**: `ProvisionerModule` — creates shared repository adapter instances and wires them to synchronizers
 
+### File-Source Validation (`ValidatorGroup.PROVISIONING`)
+
+Only the **file** source validates (the default and programmatic sources are
+code-built and bypass validation — which is why
+`BaseProvisioningSynchronizer.canonicalizeName` stays as defense in depth).
+`FileProvisioningSource` runs `RootProvisioningValidator` with
+`ValidatorGroup.PROVISIONING` and **uses the validated output**: every nested
+entity run (`createProvisioningEntitiesValidator`,
+`core/provisioning/entities/utils.ts`) passes the group explicitly (zod
+check closures don't inherit the validup run group), assigns the result back
+(so validator transforms — canonicalization, stripping — reach the
+synchronizers), and prefixes the array index onto issue paths.
+
+The PROVISIONING group lives in the core-kit entity validators alongside
+CREATE/UPDATE: identifier fields (`name`, `realm_id`, policy `type`) are
+mounted `[CREATE, PROVISIONING]`; `built_in` is mounted **only** under
+PROVISIONING (the API groups deliberately strip it — no HTTP service ever
+runs the PROVISIONING group); `user.email` is optional under PROVISIONING
+(the user synchronizer backfills a placeholder) while staying required at
+CREATE. Consequences for file configs: invalid entities now fail startup
+(fail-closed — the load throws before anything synchronizes), unmounted
+attribute keys are stripped, and top-level `policies` (previously silently
+dropped from the validator output) are validated via
+`PolicyProvisioningValidator` (attributes + `extraAttributes` + recursive
+`children`) and provisioned.
+
 ### Synchronization Order
 
 `ProvisionerModule` runs (1) `GraphProvisioningSynchronizer`, (2) backfill via `assignDefaultPolicy` (config-gated, deprecated).
@@ -814,9 +840,21 @@ This applies to the six controllers that read realm context: `client`, `robot`, 
 
 **Request flow**:
 
-1. `RealmResolverMiddleware` (mounted at `router.use('/realms/:realmId', middleware)` in `HTTPMiddlewareModule.mountRealmResolver`) fires on any URL whose first segment is `/realms/<key>`. It accepts either a UUID or a realm name, resolves via `IRealmRepository.resolve()`, and stashes the resolved UUID on `event.store[sym]` via `setRequestRealmID(event, uuid)`. Unknown realm key → `EntityNotFoundError` → 404.
+1. `RealmResolverMiddleware` (mounted at `router.use('/realms/:realmId', middleware)` in `HTTPMiddlewareModule.mountRealmResolver`) fires on any URL whose first segment is `/realms/<key>`. It accepts either a UUID or a realm name, resolves via `IRealmRepository.resolveId()` (UUID pass-through — no existence check; names resolve canonically), and stashes the resolved UUID on `event.store[sym]` via `setRequestRealmID(event, uuid)`. Unknown realm name → `EntityNotFoundError` → 404; an unknown realm UUID passes through and fails closed at the repository predicate below.
 2. The decorator-mounted route subsequently re-extracts `:realmId` from the URL into `event.params.realmId`, clobbering the raw URL value with itself — this is why the resolved UUID is stored on `event.store`, not `event.params`.
 3. Controllers read the realm via `getRequestRealmID(event)` (helper in `adapters/http/request/helpers/realm-id.ts`), which prefers the stashed UUID and falls back to `event.params.realmId` for cases where the middleware didn't run.
+
+**Fail-closed realm-key predicates**: every repository adapter that filters a
+name lookup by a realm key routes it through `IRealmRepository.resolveId(key)`
+(UUID → returned as-is, binding an unknown UUID matches zero rows; name →
+canonicalizing lookup, `null` on miss) and **fails closed** — `return null` /
+`[]` — instead of silently dropping the filter. This covers the
+`findOneByName` / `findOne` / `findByProtocol` blocks in the
+identity-provider, user, client, robot, role, scope, permission, and policy
+adapters plus the permission/policy checker services (`EntityNotFoundError`
+on an unknown realm key; a realm-less check still runs unfiltered). Never
+reintroduce the fail-open `resolve(...)` + `if (realm)` filter-drop shape — it
+let `GET /realms/<unknown-uuid>/users/<name>` match a cross-realm row.
 
 **Route-realm precedence (writes)**: controllers call `applyRouteRealmIDToBody(event, data)` at the top of `add`/`edit`/`put` (and inside `IdentityProviderController.write()`). When the route has `:realmId`, the helper overwrites `data.realm_id` with the route value — *route wins silently over body* (no `BadRequestError` for mismatch; the body value is simply discarded).
 
@@ -1013,46 +1051,59 @@ The `/token` endpoint authenticates the calling client according to RFC 6749. Co
 | Grant | Client auth requirement |
 |---|---|
 | `client_credentials` | Authentication is the grant's purpose. Confidential client only — public clients are rejected. |
-| `authorization_code` | Confidential client MUST authenticate (RFC §4.1.3). Authenticated `client_id` MUST match the auth code's bound `client_id` — mismatch = `invalid_grant`. |
-| `refresh_token` | Confidential client MUST authenticate (RFC §6). If the refresh token's payload has `client_id`, the request MUST authenticate as that client. Authenticated `client_id` MUST match — mismatch = `invalid_grant`. Tokens with no bound client may refresh without auth (legacy/no-client flow). |
-| `password` | Confidential client MUST authenticate (RFC §4.3.2). The token's `client_id` claim and the OpenID `aud` claim use the **authenticated** client's id, not any user-side association. See *Password grant realm resolution* for how the user realm is resolved. |
+| `authorization_code` | Confidential client MUST authenticate (RFC §4.1.3). Authenticated `client_id` MUST match the auth code's bound `client_id` — mismatch = `invalid_grant`. Client-by-name resolution is scoped by the shared realm hint (see *Token endpoint realm resolution*). |
+| `refresh_token` | Confidential client MUST authenticate (RFC §6). If the refresh token's payload has `client_id`, the request MUST authenticate as that client. Authenticated `client_id` MUST match — mismatch = `invalid_grant`. Tokens with no bound client may refresh without auth (legacy/no-client flow). Client-by-name resolution is scoped by the shared realm hint. |
+| `password` | Confidential client MUST authenticate (RFC §4.3.2). The token's `client_id` claim and the OpenID `aud` claim use the **authenticated** client's id, not any user-side association. The shared realm hint resolves the **user realm** and scopes the client leg. |
 | `robot_credentials` | Authentication is the grant's purpose (Authup-specific extension). |
 
-### Password grant realm resolution
+### Token endpoint realm resolution
 
-The password grant resolves the **user realm** before any authentication
-(`HTTPPasswordGrant.runWithRequest`, `adapters/http/adapters/oauth2/grant-types/password.ts`):
+The three client-authenticating grants (`password`, `authorization_code`,
+`refresh_token`) share ONE realm-hint semantic (helper `readRealmHint` in
+`adapters/http/adapters/oauth2/grant-types/utils/realm.ts`):
 
-- The realm hint is `realm_id ?? realm_name` from the request body — **both
-  denote the user realm** and each accepts a realm UUID **or** name (there is
-  no "client realm vs user realm" split; `realm_name` used to be silently
-  dropped and is now honored). The hint is canonicalized at the ingress
-  (`trim().toLowerCase()`, per *Canonical Identifier Form* layer 3) since no
-  validator runs on the token body.
+- The realm hint is `realm_id ?? realm_name` from the request body (the
+  authorization_code grant also accepts them from the query string, body
+  wins) — each accepts a realm UUID **or** name. The hint is canonicalized at
+  the ingress (`trim().toLowerCase()`, per *Canonical Identifier Form* layer
+  3) since no validator runs on the token body.
 - The hint is resolved once via `IRealmRepository.resolve(hint, true)` —
   **defaults to the master realm** when the hint is absent (or unknown; same
   fallback convention as registration / password-recovery; a missing master
   realm row throws `InternalError` — violated provisioning invariant). The
-  resolved `realm.id` is passed to both the client authenticator and the user
-  authenticator, so name-based user resolution is deterministic (previously a
-  realm-less login with a name matched an arbitrary cross-realm row) and the
-  LDAP-collection `findByProtocol(LDAP, realmId)` lookup is realm-scoped.
-- **The client leg is scoped to the same realm:** a *name*-identified
-  confidential client must live in the user realm (or be identified by its
-  UUID — UUID lookups skip the realm filter). A client named in a different
-  realm than its users now fails with `invalid_client` where the old unscoped
-  name lookup might have matched; register the client in the users' realm or
-  pass its UUID. On the SSR `/authorize` page the login realm is pinned to the
-  **client's** realm (`codeRequest.realm_id`, seeded into the login form), so
-  that page authenticates that realm's users only.
-- **Localized to the HTTP password grant.** HTTP Basic auth shares the same
+  by-id leg of that resolve is query-cached (60s, `CachePrefix.REALM` id key,
+  invalidated by the realm subscriber), so the per-login SELECT is amortized.
+  The refresh grant resolves lazily — a bare refresh (no client auth) does no
+  realm lookup.
+- **What the resolved realm scopes:** on `password`, both the user leg
+  (name-based user resolution is deterministic; the LDAP-collection
+  `findByProtocol(LDAP, realmId)` lookup is realm-scoped) and the client leg.
+  On `authorization_code` / `refresh_token`, only client-by-name resolution —
+  a *name*-identified client must live in the resolved realm (or be
+  identified by its UUID). This makes the refresh leg deterministic: a
+  password login via master's client refreshes against master's client again
+  instead of an unscoped name lookup matching an arbitrary same-named client
+  in another realm (every realm has a built-in `web` client, so collisions
+  are guaranteed). A client name that does not exist in the resolved realm
+  fails with `invalid_client`; register the client in that realm, pass a
+  matching hint, or use its UUID. On the SSR `/authorize` page the login realm is
+  pinned to the **client's** realm (`codeRequest.realm_id`, seeded into the
+  login form), so that page authenticates that realm's users only.
+- **UUID keys skip the realm predicate — intended.** A UUID-identified user
+  or client is resolved globally by primary key (`IdentityResolver` drops the
+  realm key for UUID lookups; UUIDs are globally unique, so the hint adds no
+  disambiguation). The realm hint constrains NAME resolution only, and the
+  issued token always carries the identity's true `realm_id`. Enforcing the
+  predicate for UUIDs would break realm-less id-identified logins, because
+  the master fallback makes "defaulted" indistinguishable from "explicit" by
+  the time the realm reaches the authenticator.
+- **Localized to `/token`.** HTTP Basic auth shares the same
   `UserAuthenticator` class but is intentionally untouched — realm-less
-  Basic-auth-by-name resolution is unchanged. The same unscoped-name ambiguity
-  remains latent for Basic auth, `robot_credentials` / `client_credentials`
-  (robot/client names are unique per `(name, realm_id)`), and client-by-name
-  resolution on the `authorization_code` / `refresh_token` grants (which still
-  treat body `realm_id` as a raw, fallback-less client-realm key) — see plan
-  037 non-goals.
+  Basic-auth-by-name resolution is unchanged (and never carries a realm
+  hint). The same raw, fallback-less `realm_id` handling remains on
+  `robot_credentials` / `client_credentials` (robot/client names are unique
+  per `(name, realm_id)`) and on the `/authorize` code-request verifier's
+  `data.realm_id` — see plan 037/038 non-goals.
 
 ### Credential transport
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -160,6 +160,35 @@ Caveats:
 - The default unmatched-route fallback returns a collection shape (`{ data: [], meta: { total: 0 } }`); session endpoints need explicit handlers for logged-in renders, and handlers on fire-and-forget fetch paths must not throw (an unawaited rejection fails vitest).
 - Alias the import (`createFakeHTTPClient`) — `test/utils` already exports a `createFakeClient` entity factory.
 
+## Component Tests (packages/client-web-kit)
+
+The kit has a vitest + `@vue/test-utils` + `happy-dom` setup
+(`test/vitest.config.ts`, `@vitejs/plugin-vue` for SFC compilation). Run with
+`npm run test --workspace=packages/client-web-kit` — the package script passes
+`--config test/vitest.config.ts` explicitly, which is **mandatory**: vitest
+does NOT auto-discover a config under `test/` (packages/access carries a dead
+config as a cautionary example — its plain `vitest run` script never loads it).
+
+Mounting a kit component needs the same wiring a consumer app does —
+`test/utils/index.ts` exports a `mountLoginForm(props?, handlers?)` harness
+that assembles it: fresh `createPinia()` + `createFakeClient` (from
+`@authup/core-http-kit/testing`, records every request in `.requests` with
+URLSearchParams bodies normalized to plain objects) per mount, `app.use(vuecs,
+{})` (ThemeManager + DefaultsManager — `useSubmitButton`/`VC*` throw without
+them), and the kit `install(app, { baseURL, httpClient, pinia, isServer:
+true, cookieGet/cookieSet/cookieUnset })` (`isServer: true` disables the
+auth-hook refresh timer; cookie stubs avoid `useCookies`). The only global
+component lookup in the login subtree is `resolveComponent('VCIcon')` in
+`ATitle` — stub via `global.components`.
+
+The realm-plumbing regression suite pins the interactive-login contract at two
+layers: `test/unit/components/workflows/login-form.spec.ts` (picker-selected
+realm transmitted; `codeRequest.realm_id` transmitted incl. late-arriving prop
+via `setProps`; empty realm omitted from the grant body) and
+`test/unit/core/store/login.spec.ts` (the `store.login()` gate forwards
+`ctx.realmId` even though the store's own realm ref is null pre-login — the
+original one-line bug).
+
 ## Code Coverage
 
 ### Generate coverage report

--- a/apps/server-core/src/adapters/database/subscriber/module.ts
+++ b/apps/server-core/src/adapters/database/subscriber/module.ts
@@ -91,13 +91,17 @@ export class EntitySubscriber<T extends ObjectLiteral> implements EntitySubscrib
     }
 
     async afterRemove(event: RemoveEvent<T>): Promise<any> {
-        if (!event.entity) {
+        // remove() strips the primary key from event.entity before the
+        // subscriber runs — databaseEntity is the pre-removal row and keeps
+        // the id-keyed cache invalidation (and the DELETED payload) intact.
+        const entity = event.databaseEntity ?? event.entity;
+        if (!entity) {
             return;
         }
 
-        await this.dropCacheKeys(event.connection, event.entity);
+        await this.dropCacheKeys(event.connection, entity);
 
-        await this.publish(EntityDefaultEventName.DELETED, event.entity);
+        await this.publish(EntityDefaultEventName.DELETED, entity);
     }
 
     protected async dropCacheKeys(connection: DataSource, data: T) : Promise<void> {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/authorize.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/authorize.ts
@@ -14,21 +14,25 @@ import { getRequestHeader, getRequestIP } from 'routup';
 import { OAuth2AuthorizeGrant } from '../../../../../core/index.ts';
 import type {
     IOAuth2AuthorizationCodeVerifier,
+    IRealmRepository,
     OAuth2ClientAuthenticator,
 } from '../../../../../core/index.ts';
 import type { HTTPOAuth2AuthorizeGrantContext, IHTTPOAuth2Grant } from './types.ts';
-import { extractClientCredentialsFromRequest } from './utils/index.ts';
+import { extractClientCredentialsFromRequest, readRealmHint } from './utils/index.ts';
 
 export class HTTPOAuth2AuthorizeGrant extends OAuth2AuthorizeGrant implements IHTTPOAuth2Grant {
     protected codeVerifier : IOAuth2AuthorizationCodeVerifier;
 
     protected clientAuthenticator : OAuth2ClientAuthenticator;
 
+    protected realmRepository : IRealmRepository;
+
     constructor(ctx: HTTPOAuth2AuthorizeGrantContext) {
         super(ctx);
 
         this.codeVerifier = ctx.codeVerifier;
         this.clientAuthenticator = ctx.clientAuthenticator;
+        this.realmRepository = ctx.realmRepository;
     }
 
     async runWithRequest(event: IAppEvent): Promise<OAuth2TokenGrantResponse> {
@@ -43,9 +47,9 @@ export class HTTPOAuth2AuthorizeGrant extends OAuth2AuthorizeGrant implements IH
         }
 
         const { clientId, clientSecret } = await extractClientCredentialsFromRequest(event);
-        const realmId = this.pickStringParam(body, query, 'realm_id');
+        const realm = await this.realmRepository.resolve(readRealmHint(body, query), true);
 
-        const client = await this.clientAuthenticator.authenticate(clientId, clientSecret, realmId);
+        const client = await this.clientAuthenticator.authenticate(clientId, clientSecret, realm.id);
 
         const entity = await this.codeVerifier.verify(code, {
             redirectUri,

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
@@ -14,7 +14,7 @@ import { getRequestHeader, getRequestIP } from 'routup';
 import type { ICredentialsAuthenticator, IRealmRepository, OAuth2ClientAuthenticator } from '../../../../../core/index.ts';
 import { PasswordGrantType } from '../../../../../core/index.ts';
 import type { HTTPOAuth2PasswordGrantContext, IHTTPOAuth2Grant } from './types.ts';
-import { extractClientCredentialsFromRequest, readStringField } from './utils/index.ts';
+import { extractClientCredentialsFromRequest, readRealmHint, readStringField } from './utils/index.ts';
 
 export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2Grant {
     protected authenticator : ICredentialsAuthenticator<User>;
@@ -42,15 +42,7 @@ export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2G
 
         const { clientId, clientSecret } = await extractClientCredentialsFromRequest(event);
 
-        // canonical identifier form: realm names are stored LOWER(TRIM(...))
-        const realmHint = [
-            readStringField(body, 'realm_id'),
-            readStringField(body, 'realm_name'),
-        ]
-            .map((value) => value?.trim().toLowerCase())
-            .find((value) => !!value);
-
-        const realm = await this.realmRepository.resolve(realmHint, true);
+        const realm = await this.realmRepository.resolve(readRealmHint(body), true);
 
         const client = clientId ?
             await this.clientAuthenticator.authenticate(

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/refresh_token.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/refresh_token.ts
@@ -13,21 +13,25 @@ import { getRequestHeader, getRequestIP } from 'routup';
 import { OAuth2RefreshTokenGrant } from '../../../../../core/index.ts';
 import type {
     IOAuth2TokenVerifier,
+    IRealmRepository,
     OAuth2ClientAuthenticator,
 } from '../../../../../core/index.ts';
 import type { HTTPOAuth2RefreshTokenGrantContext, IHTTPOAuth2Grant } from './types.ts';
-import { extractClientCredentialsFromRequest } from './utils/index.ts';
+import { extractClientCredentialsFromRequest, readRealmHint } from './utils/index.ts';
 
 export class HTTPOAuth2RefreshTokenGrant extends OAuth2RefreshTokenGrant implements IHTTPOAuth2Grant {
     protected clientAuthenticator : OAuth2ClientAuthenticator;
 
     protected refreshTokenVerifier : IOAuth2TokenVerifier;
 
+    protected realmRepository : IRealmRepository;
+
     constructor(ctx: HTTPOAuth2RefreshTokenGrantContext) {
         super(ctx);
 
         this.clientAuthenticator = ctx.clientAuthenticator;
         this.refreshTokenVerifier = ctx.tokenVerifier;
+        this.realmRepository = ctx.realmRepository;
     }
 
     async runWithRequest(event: IAppEvent): Promise<OAuth2TokenGrantResponse> {
@@ -38,7 +42,6 @@ export class HTTPOAuth2RefreshTokenGrant extends OAuth2RefreshTokenGrant impleme
         }
 
         const { clientId, clientSecret } = await extractClientCredentialsFromRequest(event);
-        const realmId = body?.realm_id;
 
         // RFC 6749 §6: verify the refresh token first to learn its bound
         // client (if any), then enforce binding. Authenticate the requesting
@@ -47,10 +50,13 @@ export class HTTPOAuth2RefreshTokenGrant extends OAuth2RefreshTokenGrant impleme
         const payload = await this.refreshTokenVerifier.verify(refreshToken);
 
         if (clientId) {
+            // resolved lazily — a bare refresh (no client auth) skips the SELECT
+            const realm = await this.realmRepository.resolve(readRealmHint(body), true);
+
             const client = await this.clientAuthenticator.authenticate(
                 clientId,
                 clientSecret,
-                typeof realmId === 'string' ? realmId : undefined,
+                realm.id,
             );
 
             if (payload.client_id && payload.client_id !== client.id) {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/types.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/types.ts
@@ -22,6 +22,7 @@ import type {
 export type HTTPOAuth2AuthorizeGrantContext = OAuth2AuthorizeGrantContext & {
     codeVerifier: IOAuth2AuthorizationCodeVerifier,
     clientAuthenticator: OAuth2ClientAuthenticator,
+    realmRepository: IRealmRepository,
 };
 
 export interface IHTTPOAuth2Grant {
@@ -36,6 +37,7 @@ export type HTTPOAuth2PasswordGrantContext = OAuth2PasswordGrantContext & {
 
 export type HTTPOAuth2RefreshTokenGrantContext = OAuth2RefreshTokenGrantContext & {
     clientAuthenticator: OAuth2ClientAuthenticator,
+    realmRepository: IRealmRepository,
 };
 
 export type HTTPOAuth2ClientCredentialsGrantContext = BaseGrantContext & {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/index.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/index.ts
@@ -7,3 +7,4 @@
 
 export * from './credentials.ts';
 export * from './guess.ts';
+export * from './realm.ts';

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/realm.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/utils/realm.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { readStringField } from './credentials.ts';
+
+/**
+ * Read the realm hint (`realm_id` ?? `realm_name`) from the given request
+ * sources (checked in order). Both fields denote the same realm key and each
+ * accepts a realm UUID or name. Values are canonicalized at the ingress
+ * (`trim().toLowerCase()`, canonical identifier form layer 3) since no
+ * validator runs on the token body.
+ */
+export function readRealmHint(...sources: (Record<string, any> | undefined)[]): string | undefined {
+    for (const source of sources) {
+        const hint = [
+            readStringField(source, 'realm_id'),
+            readStringField(source, 'realm_name'),
+        ]
+            .map((value) => value?.trim().toLowerCase())
+            .find((value) => !!value);
+
+        if (hint) {
+            return hint;
+        }
+    }
+
+    return undefined;
+}

--- a/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/token/module.ts
@@ -71,6 +71,7 @@ export class TokenController {
                 accessTokenIssuer: ctx.accessTokenIssuer,
                 refreshTokenIssuer: ctx.refreshTokenIssuer,
                 sessionManager: ctx.sessionManager,
+                realmRepository: ctx.realmRepository,
             }),
             [OAuth2TokenGrant.CLIENT_CREDENTIALS]: new HTTPClientCredentialsGrant({
                 accessTokenIssuer: ctx.accessTokenIssuer,
@@ -97,6 +98,7 @@ export class TokenController {
                 tokenRevoker: ctx.tokenRevoker,
                 sessionManager: ctx.sessionManager,
                 clientAuthenticator: ctx.oauth2ClientAuthenticator,
+                realmRepository: ctx.realmRepository,
             }),
         };
     }

--- a/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/module.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/realm-resolver/module.ts
@@ -5,7 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isUUID } from '@authup/kit';
 import { EntityNotFoundError } from '@authup/errors';
 import type { IAppEvent } from 'routup';
 import type { IRealmRepository } from '../../../../../core/index.ts';
@@ -25,16 +24,11 @@ export class RealmResolverMiddleware {
             return;
         }
 
-        if (isUUID(value)) {
-            setRequestRealmID(event, value);
-            return;
-        }
-
-        const realm = await this.realmRepository.resolve(value);
-        if (!realm) {
+        const realmId = await this.realmRepository.resolveId(value);
+        if (!realmId) {
             throw new EntityNotFoundError(`realm '${value}' not found`);
         }
 
-        setRequestRealmID(event, realm.id);
+        setRequestRealmID(event, realmId);
     }
 }

--- a/apps/server-core/src/app/modules/database/repositories/client/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client/repository.ts
@@ -98,10 +98,11 @@ export class ClientRepositoryAdapter implements IClientRepository {
         qb.where('client.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('client.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('client.realm_id = :realmId', { realmId });
         }
 
         return qb.getOne();
@@ -116,11 +117,11 @@ export class ClientRepositoryAdapter implements IClientRepository {
             qb.where('client.name = :name', { name: id });
 
             if (realmKey) {
-                const realm = await this.realmRepository.resolve(realmKey);
-                if (!realm) {
+                const realmId = await this.realmRepository.resolveId(realmKey);
+                if (!realmId) {
                     return null;
                 }
-                qb.andWhere('client.realm_id = :realmId', { realmId: realm.id });
+                qb.andWhere('client.realm_id = :realmId', { realmId });
             }
         }
 

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -86,10 +86,11 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
         qb.where('provider.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('provider.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('provider.realm_id = :realmId', { realmId });
         }
 
         const entity = await qb.getOne();
@@ -163,16 +164,11 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
         qb.where('provider.protocol = :protocol', { protocol });
 
         if (realmKey) {
-            if (isUUID(realmKey)) {
-                qb.andWhere('provider.realm_id = :realmId', { realmId: realmKey });
-            } else {
-                const realm = await this.realmRepository.resolve(realmKey);
-                if (!realm) {
-                    return [];
-                }
-
-                qb.andWhere('provider.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return [];
             }
+            qb.andWhere('provider.realm_id = :realmId', { realmId });
         }
 
         const entities = await qb.getMany();

--- a/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
@@ -63,10 +63,11 @@ export class PermissionRepositoryAdapter implements IPermissionRepository {
         qb.where('permission.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('permission.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('permission.realm_id = :realmId', { realmId });
         }
 
         return qb.getOne();

--- a/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
@@ -93,10 +93,11 @@ export class PolicyRepositoryAdapter implements IPolicyRepository {
         qb.where('policy.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('policy.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('policy.realm_id = :realmId', { realmId });
         }
 
         const entity = await qb.getOne();

--- a/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
@@ -12,8 +12,9 @@ import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { applyQuery, validateEntityJoinColumns } from 'typeorm-extension';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
+import { buildRedisKeyPath } from '@authup/server-kit';
 import type { IRealmRepository } from '../../../../../core/index.ts';
-import { RealmEntity } from '../../../../../adapters/database/domains/index.ts';
+import { CachePrefix, RealmEntity } from '../../../../../adapters/database/domains/index.ts';
 import { translateWhereConditions } from '../helpers.ts';
 
 export class RealmRepositoryAdapter implements IRealmRepository {
@@ -24,7 +25,17 @@ export class RealmRepositoryAdapter implements IRealmRepository {
     }
 
     findOneById(id: string): Promise<Realm | null> {
-        return this.findOneBy({ id });
+        const qb = this.repository.createQueryBuilder('realm');
+        qb.where('realm.id = :id', { id });
+        qb.cache(
+            buildRedisKeyPath({
+                prefix: CachePrefix.REALM,
+                key: id,
+            }),
+            60_000,
+        );
+
+        return qb.getOne();
     }
 
     findOneByName(name: string): Promise<Realm | null> {
@@ -92,6 +103,15 @@ export class RealmRepositoryAdapter implements IRealmRepository {
             dataSource: this.repository.manager.connection,
             entityTarget: RealmEntity,
         });
+    }
+
+    async resolveId(key: string): Promise<string | null> {
+        if (isUUID(key)) {
+            return key;
+        }
+
+        const entity = await this.findOneByName(key);
+        return entity ? entity.id : null;
     }
 
     async resolve(id: string | undefined, withFallback: true): Promise<Realm>;

--- a/apps/server-core/src/app/modules/database/repositories/robot/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/robot/repository.ts
@@ -93,10 +93,11 @@ export class RobotRepositoryAdapter implements IRobotRepository {
         qb.where('robot.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('robot.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('robot.realm_id = :realmId', { realmId });
         }
 
         return qb.getOne();
@@ -117,11 +118,11 @@ export class RobotRepositoryAdapter implements IRobotRepository {
             qb.where('robot.name = :name', { name: id });
 
             if (realmKey) {
-                const realm = await this.realmRepository.resolve(realmKey);
-                if (!realm) {
+                const realmId = await this.realmRepository.resolveId(realmKey);
+                if (!realmId) {
                     return null;
                 }
-                qb.andWhere('robot.realm_id = :realmId', { realmId: realm.id });
+                qb.andWhere('robot.realm_id = :realmId', { realmId });
             }
         }
 

--- a/apps/server-core/src/app/modules/database/repositories/role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role/repository.ts
@@ -80,10 +80,11 @@ export class RoleRepositoryAdapter implements IRoleRepository {
         qb.where('role.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('role.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('role.realm_id = :realmId', { realmId });
         }
 
         return qb.getOne();

--- a/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
@@ -74,10 +74,11 @@ export class ScopeRepositoryAdapter implements IScopeRepository {
         qb.where('scope.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('scope.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('scope.realm_id = :realmId', { realmId });
         }
 
         return qb.getOne();

--- a/apps/server-core/src/app/modules/database/repositories/user/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user/repository.ts
@@ -100,10 +100,11 @@ export class UserRepositoryAdapter implements IUserRepository {
         qb.where('user.name = :name', { name });
 
         if (realmKey) {
-            const realm = await this.realmRepository.resolve(realmKey);
-            if (realm) {
-                qb.andWhere('user.realm_id = :realmId', { realmId: realm.id });
+            const realmId = await this.realmRepository.resolveId(realmKey);
+            if (!realmId) {
+                return null;
             }
+            qb.andWhere('user.realm_id = :realmId', { realmId });
         }
 
         const entity = await qb.getOne();
@@ -128,10 +129,11 @@ export class UserRepositoryAdapter implements IUserRepository {
             qb.where('user.name = :name', { name: id });
 
             if (realmKey) {
-                const realm = await this.realmRepository.resolve(realmKey);
-                if (realm) {
-                    qb.andWhere('user.realm_id = :realmId', { realmId: realm.id });
+                const realmId = await this.realmRepository.resolveId(realmKey);
+                if (!realmId) {
+                    return null;
                 }
+                qb.andWhere('user.realm_id = :realmId', { realmId });
             }
         }
 

--- a/apps/server-core/src/app/modules/provisioning/sources/file/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/sources/file/module.ts
@@ -5,6 +5,7 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import { ValidatorGroup } from '@authup/kit';
 import { load, locateMany } from 'locter';
 import path from 'node:path';
 import type { RootProvisioningEntity } from '../../../../../core/provisioning/entities/index.ts';
@@ -36,7 +37,7 @@ export class FileProvisioningSource implements IProvisioningSource {
         const output : RootProvisioningEntity = {};
         for (const location of locations) {
             const raw = await load(location);
-            const data = await this.rootValidator.run(raw.default);
+            const data = await this.rootValidator.run(raw.default, { group: ValidatorGroup.PROVISIONING });
 
             compositeSource.merge(output, data);
         }

--- a/apps/server-core/src/core/entities/realm/types.ts
+++ b/apps/server-core/src/core/entities/realm/types.ts
@@ -15,6 +15,16 @@ export interface IRealmRepository extends IEntityRepository<Realm> {
      */
     resolve(id: string | undefined, withFallback: true): Promise<Realm>;
     resolve(id: string | undefined, withFallback?: boolean): Promise<Realm | null>;
+
+    /**
+     * Resolve a realm key (UUID or name) to a realm id for use in a
+     * realm_id predicate. A UUID key is returned as-is without existence
+     * verification (binding an unknown UUID matches zero rows — fail-closed
+     * by construction). A name key resolves through the canonicalizing
+     * findOneByName; null means "no such realm" and the caller MUST fail
+     * closed (return null / [] / throw), never drop the predicate.
+     */
+    resolveId(key: string): Promise<string | null>;
 }
 
 export interface IRealmService {

--- a/apps/server-core/src/core/identity/permission/checker/service.ts
+++ b/apps/server-core/src/core/identity/permission/checker/service.ts
@@ -35,11 +35,15 @@ export class PermissionCheckerService implements IPermissionCheckerService {
         if (isUUID(idOrName)) {
             criteria = { id: idOrName };
         } else {
-            const realmEntity = await this.ctx.realmRepository.resolve(realm);
-            criteria = {
-                name: idOrName,
-                ...(realmEntity ? { realm_id: realmEntity.id } : {}),
-            };
+            criteria = { name: idOrName };
+
+            if (realm) {
+                const realmId = await this.ctx.realmRepository.resolveId(realm);
+                if (!realmId) {
+                    throw new EntityNotFoundError();
+                }
+                criteria.realm_id = realmId;
+            }
         }
 
         const entity = await this.ctx.repository.findOneBy(criteria);

--- a/apps/server-core/src/core/identity/policy/checker/service.ts
+++ b/apps/server-core/src/core/identity/policy/checker/service.ts
@@ -34,11 +34,15 @@ export class PolicyCheckerService implements IPolicyCheckerService {
         if (isUUID(idOrName)) {
             criteria = { id: idOrName };
         } else {
-            const realmEntity = await this.ctx.realmRepository.resolve(realm);
-            criteria = {
-                name: idOrName,
-                ...(realmEntity ? { realm_id: realmEntity.id } : {}),
-            };
+            criteria = { name: idOrName };
+
+            if (realm) {
+                const realmId = await this.ctx.realmRepository.resolveId(realm);
+                if (!realmId) {
+                    throw new EntityNotFoundError();
+                }
+                criteria.realm_id = realmId;
+            }
         }
 
         const entity = await this.ctx.repository.findOneBy(criteria);

--- a/apps/server-core/src/core/identity/resolver/module.ts
+++ b/apps/server-core/src/core/identity/resolver/module.ts
@@ -32,6 +32,13 @@ export class IdentityResolver implements IIdentityResolver {
         this.robotRepository = ctx.robotRepository;
     }
 
+    /**
+     * A UUID key is resolved globally by primary key — `realmKey` scopes NAME
+     * resolution only (UUIDs are globally unique, and the realm hint on the
+     * password grant is always set via the master fallback, so applying it to
+     * UUID keys would break realm-less id-identified logins). See
+     * architecture.md → Password grant realm resolution.
+     */
     async resolve(
         type: `${IdentityType}`,
         key: string,

--- a/apps/server-core/src/core/provisioning/entities/client/relations-validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/client/relations-validator.ts
@@ -10,6 +10,7 @@ import { Container } from 'validup';
 import { z } from 'zod';
 import { PermissionProvisioningValidator } from '../permission/index.ts';
 import { RoleProvisioningValidator } from '../role/index.ts';
+import { createProvisioningEntitiesValidator } from '../utils.ts';
 import type { ClientProvisioningRelations } from './types.ts';
 
 export class ClientProvisioningRelationsValidator extends Container<ClientProvisioningRelations> {
@@ -19,7 +20,11 @@ export class ClientProvisioningRelationsValidator extends Container<ClientProvis
         const permissionValidator = new PermissionProvisioningValidator();
         const roleValidator = new RoleProvisioningValidator();
 
-        this.mount('permissions.*', { optional: true }, permissionValidator);
+        this.mount('permissions', { optional: true }, createValidator(
+            z
+                .array(z.any())
+                .check(createProvisioningEntitiesValidator(permissionValidator)),
+        ));
 
         this.mount('realmPermissions', { optional: true }, createValidator(
             z.array(z.string()),
@@ -29,7 +34,11 @@ export class ClientProvisioningRelationsValidator extends Container<ClientProvis
             z.array(z.string()),
         ));
 
-        this.mount('roles.*', { optional: true }, roleValidator);
+        this.mount('roles', { optional: true }, createValidator(
+            z
+                .array(z.any())
+                .check(createProvisioningEntitiesValidator(roleValidator)),
+        ));
 
         this.mount('realmRoles', { optional: true }, createValidator(
             z.array(z.string()),

--- a/apps/server-core/src/core/provisioning/entities/index.ts
+++ b/apps/server-core/src/core/provisioning/entities/index.ts
@@ -16,3 +16,4 @@ export * from './scope/index.ts';
 export * from './user/index.ts';
 
 export * from './types.ts';
+export * from './utils.ts';

--- a/apps/server-core/src/core/provisioning/entities/permission/index.ts
+++ b/apps/server-core/src/core/provisioning/entities/permission/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './relations-validator.ts';
 export * from './types.ts';
 export * from './validator.ts';

--- a/apps/server-core/src/core/provisioning/entities/permission/relations-validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/permission/relations-validator.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createValidator } from '@validup/zod';
+import { Container } from 'validup';
+import { z } from 'zod';
+import type { PermissionProvisioningRelations } from './types.ts';
+
+export class PermissionProvisioningRelationsValidator extends Container<PermissionProvisioningRelations> {
+    protected initialize() {
+        super.initialize();
+
+        this.mount('policies', { optional: true }, createValidator(
+            z.array(z.string()),
+        ));
+    }
+}

--- a/apps/server-core/src/core/provisioning/entities/permission/validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/permission/validator.ts
@@ -8,6 +8,7 @@
 import { PermissionValidator } from '@authup/core-kit';
 import { Container } from 'validup';
 import { ProvisioningStrategyValidator } from '../../strategy/index.ts';
+import { PermissionProvisioningRelationsValidator } from './relations-validator.ts';
 
 import type { PermissionProvisioningEntity } from './types.ts';
 
@@ -20,5 +21,8 @@ export class PermissionProvisioningValidator extends Container<PermissionProvisi
 
         const attributesValidator = new PermissionValidator();
         this.mount('attributes', attributesValidator);
+
+        const relationsValidator = new PermissionProvisioningRelationsValidator();
+        this.mount('relations', { optional: true }, relationsValidator);
     }
 }

--- a/apps/server-core/src/core/provisioning/entities/policy/index.ts
+++ b/apps/server-core/src/core/provisioning/entities/policy/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './types.ts';
+export * from './validator.ts';

--- a/apps/server-core/src/core/provisioning/entities/policy/validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/policy/validator.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { PolicyValidator } from '@authup/core-kit';
+import { createValidator } from '@validup/zod';
+import { Container } from 'validup';
+import { z } from 'zod';
+import { ProvisioningStrategyValidator } from '../../strategy/index.ts';
+import { createProvisioningEntitiesValidator } from '../utils.ts';
+import type { PolicyProvisioningEntity } from './types.ts';
+
+export class PolicyProvisioningValidator extends Container<PolicyProvisioningEntity> {
+    protected initialize() {
+        super.initialize();
+
+        const strategyValidator = new ProvisioningStrategyValidator();
+        this.mount('strategy', { optional: true }, strategyValidator);
+
+        const attributesValidator = new PolicyValidator();
+        this.mount('attributes', attributesValidator);
+
+        this.mount('extraAttributes', { optional: true }, createValidator(
+            z.record(z.string(), z.any()),
+        ));
+
+        this.mount('children', { optional: true }, createValidator(
+            z
+                .array(z.any())
+                .check(createProvisioningEntitiesValidator(this)),
+        ));
+    }
+}

--- a/apps/server-core/src/core/provisioning/entities/realm/relations-validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/realm/relations-validator.ts
@@ -5,8 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { buildZodIssuesForError, createValidator } from '@validup/zod';
-import { Container, isValidupError } from 'validup';
+import { createValidator } from '@validup/zod';
+import { Container } from 'validup';
 import { z } from 'zod';
 import { ClientProvisioningValidator } from '../client/index.ts';
 import { PermissionProvisioningValidator } from '../permission/index.ts';
@@ -14,6 +14,7 @@ import { RobotProvisioningValidator } from '../robot/index.ts';
 import { RoleProvisioningValidator } from '../role/index.ts';
 import { ScopeProvisioningValidator } from '../scope/index.ts';
 import { UserProvisioningValidator } from '../user/index.ts';
+import { createProvisioningEntitiesValidator } from '../utils.ts';
 import type { RealmProvisioningRelations } from './types.ts';
 
 export class RealmProvisioningRelationsValidator extends Container<RealmProvisioningRelations> {
@@ -30,103 +31,37 @@ export class RealmProvisioningRelationsValidator extends Container<RealmProvisio
         this.mount('clients', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await clientValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(clientValidator)),
         ));
 
         this.mount('roles', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await roleValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push({
-                                code: 'custom',
-                                message: '',
-                                path: [],
-                                input: undefined,
-                            });
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(roleValidator)),
         ));
 
         this.mount('permissions', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await permissionValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(permissionValidator)),
         ));
 
         this.mount('robots', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await robotValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(robotValidator)),
         ));
 
         this.mount('scopes', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await scopeValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(scopeValidator)),
         ));
 
         this.mount('users', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await userValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(userValidator)),
         ));
     }
 }

--- a/apps/server-core/src/core/provisioning/entities/role/relations-validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/role/relations-validator.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { RealmScope } from '@authup/access';
 import { createValidator } from '@validup/zod';
 import { Container } from 'validup';
 import { z } from 'zod';
@@ -20,6 +21,18 @@ export class RoleProvisioningRelationsValidator extends Container<RoleProvisioni
 
         this.mount('globalPermissions', { optional: true }, createValidator(
             z.array(z.string()),
+        ));
+
+        this.mount('globalPermissionsExclude', { optional: true }, createValidator(
+            z.array(z.string()),
+        ));
+
+        this.mount('globalPermissionsRealmScope', { optional: true }, createValidator(
+            z.enum(RealmScope),
+        ));
+
+        this.mount('globalPermissionsRealmScopeOverrides', { optional: true }, createValidator(
+            z.partialRecord(z.enum(RealmScope), z.array(z.string())),
         ));
     }
 }

--- a/apps/server-core/src/core/provisioning/entities/root/validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/root/validator.ts
@@ -5,14 +5,16 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { buildZodIssuesForError, createValidator } from '@validup/zod';
-import { Container, isValidupError } from 'validup';
+import { createValidator } from '@validup/zod';
+import { Container } from 'validup';
 import { z } from 'zod';
 import { ProvisioningStrategyValidator } from '../../strategy/index.ts';
 import { PermissionProvisioningValidator } from '../permission/index.ts';
+import { PolicyProvisioningValidator } from '../policy/index.ts';
 import { RealmProvisioningValidator } from '../realm/index.ts';
 import { RoleProvisioningValidator } from '../role/index.ts';
 import { ScopeProvisioningValidator } from '../scope/index.ts';
+import { createProvisioningEntitiesValidator } from '../utils.ts';
 
 import type { RootProvisioningEntity } from './types.ts';
 
@@ -23,66 +25,39 @@ export class RootProvisioningValidator extends Container<RootProvisioningEntity>
         const strategyValidator = new ProvisioningStrategyValidator();
         this.mount('strategy', { optional: true }, strategyValidator);
 
+        const policyValidator = new PolicyProvisioningValidator();
+        this.mount('policies', { optional: true }, createValidator(
+            z
+                .array(z.any())
+                .check(createProvisioningEntitiesValidator(policyValidator)),
+        ));
+
         const realmValidator = new RealmProvisioningValidator();
         this.mount('realms', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    for (let i = 0; i < ctx.value.length; i++) {
-                        await realmValidator.run(ctx.value[i]);
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(realmValidator)),
         ));
 
         const roleValidator = new RoleProvisioningValidator();
         this.mount('roles', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await roleValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(roleValidator)),
         ));
 
         const scopeValidator = new ScopeProvisioningValidator();
         this.mount('scopes', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await scopeValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(scopeValidator)),
         ));
 
         const permissionValidator = new PermissionProvisioningValidator();
         this.mount('permissions', { optional: true }, createValidator(
             z
                 .array(z.any())
-                .check(async (ctx) => {
-                    try {
-                        for (let i = 0; i < ctx.value.length; i++) {
-                            await permissionValidator.run(ctx.value[i]);
-                        }
-                    } catch (e) {
-                        if (isValidupError(e)) {
-                            ctx.issues.push(...buildZodIssuesForError(e));
-                        }
-                    }
-                }),
+                .check(createProvisioningEntitiesValidator(permissionValidator)),
         ));
     }
 }

--- a/apps/server-core/src/core/provisioning/entities/utils.ts
+++ b/apps/server-core/src/core/provisioning/entities/utils.ts
@@ -25,12 +25,14 @@ export function createProvisioningEntitiesValidator(
             try {
                 ctx.value[i] = await validator.run(ctx.value[i], { group: ValidatorGroup.PROVISIONING });
             } catch (e) {
-                if (isValidupError(e)) {
-                    ctx.issues.push(...buildZodIssuesForError(e).map((issue) => ({
-                        ...issue,
-                        path: [i, ...(issue.path ?? [])],
-                    })));
+                if (!isValidupError(e)) {
+                    throw e;
                 }
+
+                ctx.issues.push(...buildZodIssuesForError(e).map((issue) => ({
+                    ...issue,
+                    path: [i, ...(issue.path ?? [])],
+                })));
             }
         }
     };

--- a/apps/server-core/src/core/provisioning/entities/utils.ts
+++ b/apps/server-core/src/core/provisioning/entities/utils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ValidatorGroup } from '@authup/kit';
+import { buildZodIssuesForError } from '@validup/zod';
+import type { ParsePayload } from 'zod/v4/core';
+import type { Container } from 'validup';
+import { isValidupError } from 'validup';
+
+/**
+ * Run a provisioning entity validator over every array element with the
+ * PROVISIONING group (zod check closures do not inherit the validup run
+ * group) and write the validated output back, so validator transforms
+ * (canonicalization, stripping) reach the synchronizers.
+ */
+export function createProvisioningEntitiesValidator(
+    validator: Container<any>,
+): (ctx: ParsePayload<any[]>) => Promise<void> {
+    return async (ctx) => {
+        for (let i = 0; i < ctx.value.length; i++) {
+            try {
+                ctx.value[i] = await validator.run(ctx.value[i], { group: ValidatorGroup.PROVISIONING });
+            } catch (e) {
+                if (isValidupError(e)) {
+                    ctx.issues.push(...buildZodIssuesForError(e).map((issue) => ({
+                        ...issue,
+                        path: [i, ...(issue.path ?? [])],
+                    })));
+                }
+            }
+        }
+    };
+}

--- a/apps/server-core/src/core/provisioning/synchronizer/base.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/base.ts
@@ -20,10 +20,11 @@ export abstract class BaseProvisioningSynchronizer<T> implements IProvisioningSy
 
     abstract synchronize(input: T): Promise<T>;
 
-    // canonical identifier form: provisioning sources may carry raw names
-    // (the file-source entity validators run group-less, so the validator
-    // transforms don't apply); lookups against canonically stored rows
-    // and canonical persistence both require it.
+    // canonical identifier form: provisioning sources may carry raw names.
+    // The file source validates (and canonicalizes) with the PROVISIONING
+    // group, but the default source and programmatic sources bypass that
+    // validation entirely — defense in depth for lookups against canonically
+    // stored rows and canonical persistence.
     protected canonicalizeName(attributes: { name?: string | null } | undefined): void {
         if (attributes && typeof attributes.name === 'string') {
             attributes.name = attributes.name.trim().toLowerCase();

--- a/apps/server-core/test/data/sources/file.mts
+++ b/apps/server-core/test/data/sources/file.mts
@@ -8,18 +8,30 @@
 import type { RootProvisioningEntity } from '../../../src';
 
 const DATA : RootProvisioningEntity = {
+    policies: [
+        {
+            attributes: {
+                name: 'file-policy',
+                type: 'composite',
+                built_in: true,
+            },
+        },
+    ],
     roles: [
         {
             attributes: { name: 'foo' },
             relations: { globalPermissions: ['foo'] },
         },
         {
-            attributes: { name: 'bar' },
+            attributes: { name: 'bar', built_in: true },
             relations: { globalPermissions: ['*'] },
         },
     ],
     permissions: [
-        { attributes: { name: 'foo' } },
+        {
+            attributes: { name: 'foo' },
+            relations: { policies: ['file-policy'] },
+        },
     ],
     scopes: [
         { attributes: { name: 'foo' } },

--- a/apps/server-core/test/unit/adapters/ldap/helpers.ts
+++ b/apps/server-core/test/unit/adapters/ldap/helpers.ts
@@ -9,23 +9,26 @@ import { inject } from 'vitest';
 import { LdapClient } from '../../../../src/adapters/shared/ldap';
 import type { ILdapClient } from '../../../../src/core';
 
-export async function createLdapTestUserAccount(client: ILdapClient) {
+// Spec files run in parallel workers against ONE shared OpenLDAP container —
+// every spec must use its own account name or a sibling's afterAll drop
+// races a concurrent login.
+export async function createLdapTestUserAccount(client: ILdapClient, name = 'foo') {
     try {
-        await client.add('cn=foo,dc=example,dc=com', {
-            cn: 'foo',
+        await client.add(`cn=${name},dc=example,dc=com`, {
+            cn: name,
             sn: 'bar',
-            mail: 'foo.bar@example.com',
+            mail: `${name}.bar@example.com`,
             objectClass: 'inetOrgPerson',
-            userPassword: 'foo',
+            userPassword: name,
         });
     } catch {
         // do nothing ;)
     }
 }
 
-export async function dropLdapTestUserAccount(client: ILdapClient) {
+export async function dropLdapTestUserAccount(client: ILdapClient, name = 'foo') {
     try {
-        await client.del('cn=foo,dc=example,dc=com');
+        await client.del(`cn=${name},dc=example,dc=com`);
     } catch {
         // do nothing :)
     }

--- a/apps/server-core/test/unit/core/entities/realm/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/realm/fake-repository.ts
@@ -29,6 +29,10 @@ export class FakeRealmRepository extends FakeEntityRepository<Realm> implements 
         this.seed([this.masterRealm]);
     }
 
+    async findOneByName(name: string): Promise<Realm | null> {
+        return super.findOneByName(name.trim().toLowerCase());
+    }
+
     async resolveId(key: string): Promise<string | null> {
         if (isUUID(key)) {
             return key;

--- a/apps/server-core/test/unit/core/entities/realm/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/realm/fake-repository.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import type { Realm } from '@authup/core-kit';
 import { REALM_MASTER_NAME } from '@authup/core-kit';
+import { isUUID } from '@authup/kit';
 import type { IRealmRepository } from '../../../../../src/core/entities/realm/types.ts';
 import { FakeEntityRepository } from '@authup/server-test-kit';
 
@@ -26,6 +27,15 @@ export class FakeRealmRepository extends FakeEntityRepository<Realm> implements 
             updated_at: new Date().toISOString(),
         };
         this.seed([this.masterRealm]);
+    }
+
+    async resolveId(key: string): Promise<string | null> {
+        if (isUUID(key)) {
+            return key;
+        }
+
+        const entity = await this.findOneByName(key);
+        return entity ? entity.id : null;
     }
 
     async resolve(id: string | undefined, withFallback: true): Promise<Realm>;

--- a/apps/server-core/test/unit/core/identity/permission/checker.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/checker.spec.ts
@@ -18,6 +18,7 @@ import { IdentityType } from '@authup/core-kit';
 import { EntityNotFoundError } from '@authup/errors';
 import { createNanoID } from '@authup/kit';
 import { createAllowAllActor } from '@authup/server-test-kit';
+import type { ActorContext } from '@authup/server-kit';
 import type { UserEntity } from '../../../../../src';
 import {
     PermissionEntity,
@@ -53,9 +54,9 @@ describe('core/identity/permission/checker', () => {
             repository: suite.dataSource.getRepository(PermissionEntity),
             realmRepository: realmEntityRepository,
         });
-        const identityPermissionProvider = (suite as any).container.resolve(
+        const identityPermissionProvider = suite.container.resolve<IIdentityPermissionProvider>(
             IdentityInjectionKey.PermissionProvider,
-        ) as IIdentityPermissionProvider;
+        );
 
         service = new PermissionCheckerService({
             repository: permissionRepository,
@@ -120,7 +121,7 @@ describe('core/identity/permission/checker', () => {
             {},
             {
                 permissionEvaluator: createAllowAllActor().permissionEvaluator,
-                identity: { type: IdentityType.USER, data: adminUser as any },
+                identity: { type: IdentityType.USER, data: adminUser },
             },
         )).resolves.toBeUndefined();
     });
@@ -147,7 +148,7 @@ describe('core/identity/permission/checker', () => {
             {},
             {
                 permissionEvaluator: createAllowAllActor().permissionEvaluator,
-                identity: { type: IdentityType.USER, data: adminUser as any },
+                identity: { type: IdentityType.USER, data: adminUser },
             },
         )).rejects.toThrow();
     });
@@ -196,9 +197,9 @@ describe('core/identity/permission/checker', () => {
         const realmRepository = suite.dataSource.getRepository(RealmEntity);
         const otherRealm = await realmRepository.save(realmRepository.create({ name: createNanoID() }));
 
-        const actor = {
+        const actor: ActorContext = {
             permissionEvaluator: createAllowAllActor().permissionEvaluator,
-            identity: { type: IdentityType.USER, data: user as any },
+            identity: { type: IdentityType.USER, data: user },
         };
 
         // cross-realm resource realm -> denied under own

--- a/apps/server-core/test/unit/core/identity/permission/checker.spec.ts
+++ b/apps/server-core/test/unit/core/identity/permission/checker.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import {
     afterAll,
     beforeAll,
@@ -71,6 +72,18 @@ describe('core/identity/permission/checker', () => {
     it('throws EntityNotFoundError for an unknown name', async () => {
         await expect(
             service.check(createNanoID(), {}, createAllowAllActor()),
+        ).rejects.toBeInstanceOf(EntityNotFoundError);
+    });
+
+    it('throws EntityNotFoundError for an unknown realm key instead of dropping the filter', async () => {
+        const permissionRepository = suite.dataSource.getRepository(PermissionEntity);
+        const permission = await permissionRepository.save(permissionRepository.create({
+            name: createNanoID(),
+            built_in: true,
+        }));
+
+        await expect(
+            service.check(permission.name, {}, createAllowAllActor(), randomUUID()),
         ).rejects.toBeInstanceOf(EntityNotFoundError);
     });
 

--- a/apps/server-core/test/unit/core/provisioning/entities/root-validator.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/entities/root-validator.spec.ts
@@ -1,0 +1,209 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { BuiltInPolicyType, RealmScope } from '@authup/access';
+import { ValidatorGroup } from '@authup/kit';
+import { describe, expect, it } from 'vitest';
+import { RootProvisioningValidator } from '../../../../../src/core/provisioning/entities';
+
+const validator = new RootProvisioningValidator();
+const run = (data: Record<string, any>) => validator.run(data, { group: ValidatorGroup.PROVISIONING });
+
+describe('core/provisioning/entities/root-validator', () => {
+    it('should reject a non-string entity name', async () => {
+        await expect(run({ roles: [{ attributes: { name: 123 } }] })).rejects.toThrow();
+    });
+
+    it('should reject a too-short entity name', async () => {
+        await expect(run({ roles: [{ attributes: { name: 'ab' } }] })).rejects.toThrow();
+    });
+
+    it('should reject a missing entity name', async () => {
+        await expect(run({ roles: [{ attributes: { display_name: 'No Name' } }] })).rejects.toThrow();
+    });
+
+    it('should reject an invalid nested realm-relation entity', async () => {
+        await expect(run({
+            realms: [
+                {
+                    attributes: { name: 'foo' },
+                    relations: { users: [{ attributes: { name: 'x' } }] },
+                },
+            ],
+        })).rejects.toThrow();
+    });
+
+    it('should canonicalize entity names in the run output', async () => {
+        const output = await run({ roles: [{ attributes: { name: ' FOO ' } }] });
+
+        expect(output.roles![0].attributes.name).toEqual('foo');
+    });
+
+    it('should preserve built_in in the run output', async () => {
+        const output = await run({
+            roles: [{ attributes: { name: 'foo', built_in: true } }],
+            permissions: [{ attributes: { name: 'foo', built_in: true } }],
+            scopes: [{ attributes: { name: 'foo', built_in: true } }],
+            realms: [
+                {
+                    attributes: { name: 'foo', built_in: true },
+                    relations: { clients: [{ attributes: { name: 'foo', built_in: true } }] },
+                },
+            ],
+        });
+
+        expect(output.roles![0].attributes.built_in).toBe(true);
+        expect(output.permissions![0].attributes.built_in).toBe(true);
+        expect(output.scopes![0].attributes.built_in).toBe(true);
+        expect(output.realms![0].attributes.built_in).toBe(true);
+        expect(output.realms![0].relations!.clients![0].attributes.built_in).toBe(true);
+    });
+
+    it('should strip unmounted attribute keys', async () => {
+        const output = await run({ roles: [{ attributes: { name: 'foo', id: '5e94bb43-cb1c-4324-a3fa-9a3f34595d5c' } }] });
+
+        expect(output.roles![0].attributes).not.toHaveProperty('id');
+    });
+
+    it('should accept a user without an email', async () => {
+        const output = await run({
+            realms: [
+                {
+                    attributes: { name: 'foo' },
+                    relations: { users: [{ attributes: { name: 'foo' } }] },
+                },
+            ],
+        });
+
+        expect(output.realms![0].relations!.users![0].attributes.name).toEqual('foo');
+    });
+
+    it('should reject a user with an invalid email and lowercase a valid one', async () => {
+        await expect(run({
+            realms: [
+                {
+                    attributes: { name: 'foo' },
+                    relations: { users: [{ attributes: { name: 'foo', email: 'not-an-email' } }] },
+                },
+            ],
+        })).rejects.toThrow();
+
+        const output = await run({
+            realms: [
+                {
+                    attributes: { name: 'foo' },
+                    relations: { users: [{ attributes: { name: 'foo', email: 'Foo@Example.com' } }] },
+                },
+            ],
+        });
+
+        expect(output.realms![0].relations!.users![0].attributes.email).toEqual('foo@example.com');
+    });
+
+    it('should preserve permission policy relations', async () => {
+        const output = await run({
+            permissions: [
+                {
+                    attributes: { name: 'foo' },
+                    relations: { policies: ['system.default'] },
+                },
+            ],
+        });
+
+        expect(output.permissions![0].relations!.policies).toEqual(['system.default']);
+    });
+
+    it('should preserve role realm-scope relations', async () => {
+        const output = await run({
+            roles: [
+                {
+                    attributes: { name: 'realm_admin' },
+                    relations: {
+                        globalPermissions: ['*'],
+                        globalPermissionsExclude: ['realm_create'],
+                        globalPermissionsRealmScope: RealmScope.OWN,
+                        globalPermissionsRealmScopeOverrides: { [RealmScope.OWN_OR_NULL]: ['realm_read'] },
+                    },
+                },
+            ],
+        });
+
+        const { relations } = output.roles![0];
+        expect(relations!.globalPermissionsExclude).toEqual(['realm_create']);
+        expect(relations!.globalPermissionsRealmScope).toEqual(RealmScope.OWN);
+        expect(relations!.globalPermissionsRealmScopeOverrides).toEqual({ [RealmScope.OWN_OR_NULL]: ['realm_read'] });
+    });
+
+    it('should validate and preserve top-level policies including children', async () => {
+        const output = await run({
+            policies: [
+                {
+                    attributes: {
+                        name: 'my-policy',
+                        type: BuiltInPolicyType.COMPOSITE,
+                        built_in: true,
+                    },
+                    extraAttributes: { decisionStrategy: 'unanimous' },
+                    children: [
+                        {
+                            attributes: {
+                                name: 'my-child',
+                                type: BuiltInPolicyType.ATTRIBUTE_NAMES,
+                                invert: true,
+                            },
+                            extraAttributes: { names: ['active'] },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        const [policy] = output.policies!;
+        expect(policy.attributes.name).toEqual('my-policy');
+        expect(policy.attributes.built_in).toBe(true);
+        expect(policy.extraAttributes).toEqual({ decisionStrategy: 'unanimous' });
+        expect(policy.children![0].attributes.name).toEqual('my-child');
+        expect(policy.children![0].extraAttributes).toEqual({ names: ['active'] });
+    });
+
+    it('should reject an invalid policy child', async () => {
+        await expect(run({
+            policies: [
+                {
+                    attributes: { name: 'my-policy', type: BuiltInPolicyType.COMPOSITE },
+                    children: [
+                        { attributes: { name: 'my-child' } },
+                    ],
+                },
+            ],
+        })).rejects.toThrow();
+    });
+
+    it('should reject an invalid strategy', async () => {
+        await expect(run({
+            roles: [
+                {
+                    strategy: { type: 'not-a-strategy' },
+                    attributes: { name: 'foo' },
+                },
+            ],
+        })).rejects.toThrow();
+    });
+
+    it('should accept a merge strategy with attributes', async () => {
+        const output = await run({
+            roles: [
+                {
+                    strategy: { type: 'merge', attributes: ['built_in'] },
+                    attributes: { name: 'foo', built_in: true },
+                },
+            ],
+        });
+
+        expect(output.roles![0].strategy).toEqual({ type: 'merge', attributes: ['built_in'] });
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/realm-scoped.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-scoped.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import {
     afterAll,
     beforeAll,
@@ -64,6 +65,24 @@ describe('src/http/controllers/realm-scoped', () => {
             const response = await httpRequest(suite, 'GET', '/realms/this-realm-does-not-exist/users', { headers: { Authorization: basicAuth } });
 
             expect(response.status).toEqual(404);
+        });
+
+        it('should fail closed on name lookups under an unknown realm UUID', async () => {
+            const user = await suite.client.user.create(createFakeUser());
+
+            // unknown realm UUID passes the middleware unverified; the
+            // repository predicate must fail closed instead of matching the
+            // same-named entity from another realm
+            let response = await httpRequest(suite, 'GET', `/realms/${randomUUID()}/users/${user.name}`, { headers: { Authorization: basicAuth } });
+            expect(response.status).toEqual(404);
+
+            // known-but-different realm: same fail-closed outcome
+            response = await httpRequest(suite, 'GET', `/realms/${scopedRealm.id}/users/${user.name}`, { headers: { Authorization: basicAuth } });
+            expect(response.status).toEqual(404);
+
+            // positive control: the owning realm resolves the user
+            response = await httpRequest(suite, 'GET', `/realms/${masterRealm.id}/users/${user.name}`, { headers: { Authorization: basicAuth } });
+            expect(response.status).toEqual(200);
         });
 
         it('should create user under route realm, overriding body realm_id', async () => {

--- a/apps/server-core/test/unit/http/controllers/entities/realm.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm.spec.ts
@@ -6,13 +6,13 @@
  */
 
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
-import { createFakeRealm, expectPropertiesEqualToSrc } from '../../../../utils/index.ts';
+import { createFakeRealm, expectClientError, expectPropertiesEqualToSrc } from '../../../../utils/index.ts';
 import { createTestApplication } from '../../../../app/index.ts';
 
 describe('src/http/controllers/realm', () => {
@@ -80,6 +80,39 @@ describe('src/http/controllers/realm', () => {
             .delete(details.id!);
 
         expect(response.id).toBeDefined();
+    });
+
+    it('should serve fresh data after update of an id-cached read', async () => {
+        const entity = await suite.client
+            .realm
+            .create(createFakeRealm());
+
+        // prime the id-keyed query cache
+        await suite.client.realm.getOne(entity.id);
+
+        await suite.client.realm.update(entity.id, { display_name: 'cache-invalidation-check' });
+
+        const response = await suite.client
+            .realm
+            .getOne(entity.id);
+
+        expect(response.display_name).toEqual('cache-invalidation-check');
+    });
+
+    it('should not serve a deleted resource from the id-keyed cache', async () => {
+        const entity = await suite.client
+            .realm
+            .create(createFakeRealm());
+
+        // prime the id-keyed query cache
+        await suite.client.realm.getOne(entity.id);
+
+        await suite.client.realm.delete(entity.id);
+
+        await expectClientError(
+            () => suite.client.realm.getOne(entity.id),
+            { status: 404 },
+        );
     });
 
     it('should create and update resource with put', async () => {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
@@ -20,7 +20,12 @@ import {
 } from '@authup/specs';
 import { ErrorCode } from '@authup/errors';
 import { buildOAuth2CodeChallenge, generateOAuth2CodeVerifier } from '../../../../../../src/core';
-import { createFakeClient, expectClientError, httpRequest } from '../../../../../utils';
+import {
+    createFakeClient,
+    createFakeRealm,
+    expectClientError,
+    httpRequest,
+} from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
 describe('grant-authorize', () => {
@@ -434,6 +439,124 @@ describe('grant-authorize', () => {
                 redirect_uri: 'https://example.com/redirect',
                 code,
                 code_verifier: codeVerifier,
+            });
+
+        expect(tokenResponse.access_token).toBeDefined();
+    });
+
+    it('should scope a name-identified client on token exchange to the realm hint', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const secret = generateOAuth2CodeVerifier();
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                realm_id: realm.id,
+                secret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: client.id,
+        });
+
+        const issueCode = async () => {
+            const response = await suite.client
+                .authorize
+                .confirm({
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                    client_id: client.id,
+                    redirect_uri: 'https://example.com/redirect',
+                    scope: `${ScopeName.GLOBAL}`,
+                    state: generateOAuth2CodeVerifier(),
+                });
+            return new URL(response.url).searchParams.get('code')!;
+        };
+
+        // realm_id hint (UUID) scopes the client-name lookup
+        let tokenResponse = await suite.client
+            .token
+            .createWithAuthorizationCode({
+                client_id: client.name,
+                client_secret: secret,
+                redirect_uri: 'https://example.com/redirect',
+                code: await issueCode(),
+                realm_id: realm.id,
+            });
+        expect(tokenResponse.access_token).toBeDefined();
+
+        // realm_id also accepts the realm name
+        tokenResponse = await suite.client
+            .token
+            .createWithAuthorizationCode({
+                client_id: client.name,
+                client_secret: secret,
+                redirect_uri: 'https://example.com/redirect',
+                code: await issueCode(),
+                realm_id: realm.name,
+            });
+        expect(tokenResponse.access_token).toBeDefined();
+
+        // without a hint the name resolves in master, where the client does
+        // not exist — deterministic fail-closed instead of an unscoped match
+        const code = await issueCode();
+        await expectClientError(
+            () => suite.client.token.createWithAuthorizationCode({
+                client_id: client.name,
+                client_secret: secret,
+                redirect_uri: 'https://example.com/redirect',
+                code,
+            }),
+            {
+                status: 401,
+                code: ErrorCode.OAUTH_CLIENT_INVALID,
+                data: { error: OAuth2ErrorCode.INVALID_CLIENT },
+            },
+        );
+    });
+
+    it('should exchange a code for a name-identified public client scoped to its realm', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                realm_id: realm.id,
+                is_confidential: false,
+                secret: null,
+            }));
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: client.id,
+        });
+
+        const codeVerifier = generateOAuth2CodeVerifier();
+        const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
+
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: client.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                code_challenge: codeChallenge,
+                code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
+                state: generateOAuth2CodeVerifier(),
+            });
+
+        const code = new URL(response.url).searchParams.get('code')!;
+
+        const tokenResponse = await suite.client
+            .token
+            .createWithAuthorizationCode({
+                client_id: client.name,
+                redirect_uri: 'https://example.com/redirect',
+                code,
+                code_verifier: codeVerifier,
+                realm_id: realm.id,
             });
 
         expect(tokenResponse.access_token).toBeDefined();

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-ldap.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-ldap.spec.ts
@@ -25,13 +25,14 @@ import {
 
 describe('src/http/controllers/identity-provider', () => {
     const suite = createTestApplication();
+    const ldapUserName = 'grant-ldap-user';
 
     beforeAll(async () => {
         await suite.setup();
 
         const client = createLdapTestClient();
         await client.bind();
-        await createLdapTestUserAccount(client);
+        await createLdapTestUserAccount(client, ldapUserName);
         await client.unbind();
     });
 
@@ -40,7 +41,7 @@ describe('src/http/controllers/identity-provider', () => {
 
         const client = createLdapTestClient();
         await client.bind();
-        await dropLdapTestUserAccount(client);
+        await dropLdapTestUserAccount(client, ldapUserName);
         await client.unbind();
     });
 
@@ -64,8 +65,8 @@ describe('src/http/controllers/identity-provider', () => {
         const grantResponse = await suite.client
             .token
             .createWithPassword({
-                username: 'foo',
-                password: 'foo',
+                username: ldapUserName,
+                password: ldapUserName,
             });
 
         expect(grantResponse)

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password.spec.ts
@@ -310,4 +310,31 @@ describe('src/http/controllers/token', () => {
 
         expect(response.access_token).toBeDefined();
     });
+
+    it('should resolve a UUID username globally regardless of realm hint', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password: 'uuid-user-secret',
+        }));
+
+        let response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.id,
+                password: 'uuid-user-secret',
+            });
+
+        expect(response.access_token).toBeDefined();
+
+        response = await suite.client
+            .token
+            .createWithPassword({
+                username: user.id,
+                password: 'uuid-user-secret',
+                realm_name: 'master',
+            });
+
+        expect(response.access_token).toBeDefined();
+    });
 });

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
@@ -13,7 +13,13 @@ import {
 } from 'vitest';
 import type { Client } from '@authup/core-kit';
 import { ErrorCode } from '@authup/errors';
-import { createFakeClient, expectClientError } from '../../../../../utils';
+import {
+    createFakeClient,
+    createFakeRealm,
+    createFakeUser,
+    expectClientError,
+    httpRequest,
+} from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
 describe('refresh-token', () => {
@@ -158,5 +164,133 @@ describe('refresh-token', () => {
             }),
             { status: 401, code: ErrorCode.OAUTH_CLIENT_INVALID },
         );
+    });
+
+    it('should resolve a name-identified client deterministically across password and refresh legs', async () => {
+        // same-named confidential clients in master and another realm — the
+        // realm-less name lookup must resolve master on BOTH legs instead of
+        // matching an arbitrary realm's client on refresh
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const { name } = createFakeClient();
+        const masterSecret = 'master-leg-secret';
+        await suite.client.client.create(createFakeClient({
+            name,
+            secret: masterSecret,
+            secret_hashed: false,
+            secret_encrypted: false,
+            is_confidential: true,
+        }));
+        await suite.client.client.create(createFakeClient({
+            name,
+            realm_id: realm.id,
+            secret: 'other-realm-secret',
+            secret_hashed: false,
+            secret_encrypted: false,
+            is_confidential: true,
+        }));
+
+        const passwordResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: name,
+                client_secret: masterSecret,
+            });
+
+        const refreshed = await suite.client
+            .token
+            .createWithRefreshToken({
+                refresh_token: passwordResponse.refresh_token!,
+                client_id: name,
+                client_secret: masterSecret,
+            });
+
+        expect(refreshed.access_token).toBeDefined();
+    });
+
+    it('should scope a name-identified client on refresh to the realm hint', async () => {
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const secret = 'realm-refresh-secret';
+        const client = await suite.client.client.create(createFakeClient({
+            realm_id: realm.id,
+            secret,
+            secret_hashed: false,
+            secret_encrypted: false,
+            is_confidential: true,
+        }));
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password: 'realm-user-secret',
+        }));
+
+        const login = () => suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-user-secret',
+                client_id: client.name,
+                client_secret: secret,
+                realm_id: realm.id,
+            });
+
+        let passwordResponse = await login();
+        const refreshed = await suite.client
+            .token
+            .createWithRefreshToken({
+                refresh_token: passwordResponse.refresh_token!,
+                client_id: client.name,
+                client_secret: secret,
+                realm_id: realm.id,
+            });
+
+        expect(refreshed.access_token).toBeDefined();
+
+        // realm_name is honored and canonicalized on the refresh leg too
+        passwordResponse = await login();
+        const rawResponse = await httpRequest(suite, 'POST', '/token', {
+            form: {
+                grant_type: 'refresh_token',
+                refresh_token: passwordResponse.refresh_token!,
+                client_id: client.name,
+                client_secret: secret,
+                realm_name: ` ${realm.name.toUpperCase()} `,
+            },
+        });
+        expect(rawResponse.status).toEqual(200);
+
+        // without a hint the name resolves in master, where the client does
+        // not exist — deterministic fail-closed instead of an unscoped match
+        passwordResponse = await login();
+        await expectClientError(
+            () => suite.client.token.createWithRefreshToken({
+                refresh_token: passwordResponse.refresh_token!,
+                client_id: client.name,
+                client_secret: secret,
+            }),
+            { status: 401, code: ErrorCode.OAUTH_CLIENT_INVALID },
+        );
+    });
+
+    it('should ignore the realm hint for a UUID-identified client on refresh', async () => {
+        const passwordResponse = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        const refreshed = await suite.client
+            .token
+            .createWithRefreshToken({
+                refresh_token: passwordResponse.refresh_token!,
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+                realm_id: 'this-realm-does-not-exist',
+            });
+
+        expect(refreshed.access_token).toBeDefined();
     });
 });

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -16,6 +16,7 @@ import type {
     Role, 
 } from '@authup/core-kit';
 import type { DataSource, Repository } from 'typeorm';
+import { IsNull } from 'typeorm';
 import {
     afterAll,
     beforeAll, 
@@ -86,10 +87,16 @@ describe('app/modules/provisioning', () => {
         const source = new FileProvisioningSource({ cwd: 'test/data/sources' });
         const output = await source.load();
 
+        expect(output.policies).toHaveLength(1);
         expect(output.roles).toHaveLength(2);
         expect(output.permissions).toHaveLength(1);
         expect(output.scopes).toHaveLength(1);
         expect(output.realms).toHaveLength(1);
+
+        // validated output preserves provisioning-only fields and relations
+        expect(output.policies![0].attributes.built_in).toBe(true);
+        expect(output.roles![1].attributes.built_in).toBe(true);
+        expect(output.permissions![0].relations?.policies).toEqual(['file-policy']);
 
         const [realm] = output.realms!;
 
@@ -114,6 +121,24 @@ describe('app/modules/provisioning', () => {
 
         const roles = await roleRepository.findBy({ name: 'foo' });
         expect(roles).toHaveLength(2);
+
+        const builtInRole = await roleRepository.findOneBy({ name: 'bar', realm_id: IsNull() });
+        expect(builtInRole?.built_in).toBe(true);
+
+        const filePolicy = await policyRepositoryAdapter.findOneByName('file-policy');
+        expect(filePolicy).toBeDefined();
+        expect(filePolicy?.built_in).toBe(true);
+
+        const permissionRepository = di.resolve<Repository<Permission>>(PermissionEntity);
+        const permission = await permissionRepository.findOneBy({ name: 'foo', realm_id: IsNull() });
+        expect(permission).toBeDefined();
+
+        const permissionPolicyRepository = di.resolve<Repository<PermissionPolicy>>(PermissionPolicyEntity);
+        const junction = await permissionPolicyRepository.findOneBy({
+            permission_id: permission!.id,
+            policy_id: filePolicy!.id,
+        });
+        expect(junction).toBeDefined();
     });
 
     // ---------------------------------------------------------------

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -67,6 +67,15 @@ Supported formats: `.json`, `.yaml`, `.yml`, `.ts`, `.mts`, `.mjs`, `.js`.
 When multiple files exist in the directory, they are loaded alphabetically and merged.
 If two files define the same entity (same `name` + scope), the later file wins.
 
+Provisioning files are **validated on load** with the same field rules the API
+enforces on entity creation: an invalid entity (missing or malformed `name`,
+invalid `email`, unknown policy `type`, ...) aborts startup with a validation
+error instead of being silently provisioned. Identifier fields are
+canonicalized (trimmed and lowercased), and attribute keys that are not part
+of the entity's schema are stripped. Unlike the API, provisioning files may
+set `built_in: true` on policies, permissions, scopes, roles, realms, and
+clients, and a user's `email` is optional (a placeholder is generated).
+
 ### Docker / Kubernetes
 
 Mount your provisioning files into the container's writable directory:
@@ -241,8 +250,8 @@ policies:
 |--------------------------------|------------|--------------------------------------------------------------------------------------|
 | `globalPermissions`                | `string[]`              | Permission names to assign (global scope). `'*'` = all.                             |
 | `globalPermissionsExclude`         | `string[]`              | Permission names to exclude when using `'*'` wildcard in `globalPermissions`.        |
-| `globalPermissionsPolicyName`      | `string`                | Default policy name for each `globalPermissions` assignment entry.                    |
-| `globalPermissionsPolicyOverrides` | `Record<string, string[]>` | Per-permission policy overrides. Key = policy name, value = permission names.      |
+| `globalPermissionsRealmScope`      | `string`                | Default `realm_scope` (`own`, `ownOrNull`, `any`) stamped on each `globalPermissions` junction entry. |
+| `globalPermissionsRealmScopeOverrides` | `Record<string, string[]>` | Per-permission `realm_scope` overrides. Key = `realm_scope` value, value = permission names. |
 | `realmPermissions`                 | `string[]`              | Permission names to assign (realm scope). `'*'` = all.                              |
 
 ### Realm
@@ -392,8 +401,8 @@ roles:
 ```
 
 Use `globalPermissionsExclude` to exclude specific permissions from a wildcard,
-`globalPermissionsPolicyName` to set a default junction policy,
-and `globalPermissionsPolicyOverrides` to override the policy for specific permissions:
+`globalPermissionsRealmScope` to set the default junction `realm_scope`,
+and `globalPermissionsRealmScopeOverrides` to override the scope for specific permissions:
 
 ```typescript
 roles: [
@@ -402,12 +411,10 @@ roles: [
         relations: {
             globalPermissions: ['*'],
             globalPermissionsExclude: ['realm_create', 'realm_update', 'realm_delete'],
-            globalPermissionsPolicyName: 'system.realm-or-global',
-            globalPermissionsPolicyOverrides: {
-                'system.realm-bound': [
-                    'role_create', 'role_update', 'role_delete',
-                    'permission_create', 'permission_update', 'permission_delete',
-                    'scope_create', 'scope_update', 'scope_delete',
+            globalPermissionsRealmScope: 'own',
+            globalPermissionsRealmScopeOverrides: {
+                ownOrNull: [
+                    'role_read', 'permission_read', 'scope_read', 'policy_read',
                 ],
             },
         },

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -60,7 +60,17 @@ curl -X POST 'http://localhost:3001/token' \
 ```
 
 A confidential client authenticating on this grant by **name** must belong to
-the same realm as the user; clients identified by UUID are unaffected.
+the same realm as the user; clients identified by UUID are unaffected. The
+realm parameter constrains **name** resolution only — a UUID-identified user
+is resolved globally by primary key, and the issued token always carries the
+user's actual realm.
+
+The same `realm_id` / `realm_name` semantic (master fallback included) applies
+on the `authorization_code` and `refresh_token` grants, where it scopes
+client-by-name resolution: a client identified by **name** on those grants
+resolves within the hinted realm (master when no hint is given). Pass the
+realm parameter — or the client's UUID — when the client lives outside the
+master realm.
 
 #### Response
 ```json

--- a/package-lock.json
+++ b/package-lock.json
@@ -6426,6 +6426,13 @@
                 "win32"
             ]
         },
+        "node_modules/@one-ini/wasm": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+            "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@opentelemetry/api": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -10841,6 +10848,13 @@
             "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
             "license": "MIT"
         },
+        "node_modules/@types/whatwg-mimetype": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+            "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/ws": {
             "version": "8.18.1",
             "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
@@ -12248,6 +12262,27 @@
             "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
             "license": "MIT"
         },
+        "node_modules/@vue/test-utils": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.11.tgz",
+            "integrity": "sha512-GDqaqZsA6m2E5vNzej0aYiIb6BX8xV9pNSbbbXKOfEYwg7ZNblVX8suyqmUBThq8VIrgAJNxn+z72hVtUeiWHA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-beautify": "^1.14.9",
+                "vue-component-type-helpers": "^3.0.0"
+            },
+            "peerDependencies": {
+                "@vue/compiler-dom": "3.x",
+                "@vue/server-renderer": "3.x",
+                "vue": "3.x"
+            },
+            "peerDependenciesMeta": {
+                "@vue/server-renderer": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@vuecs/design": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@vuecs/design/-/design-1.0.8.tgz",
@@ -13637,6 +13672,19 @@
             "devOptional": true,
             "license": "MIT"
         },
+        "node_modules/buffer-image-size": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+            "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*"
+            },
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
         "node_modules/buildcheck": {
             "version": "0.0.7",
             "resolved": "https://registry.npmjs.org/buildcheck/-/buildcheck-0.0.7.tgz",
@@ -14347,6 +14395,24 @@
             "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.2.4.tgz",
             "integrity": "sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==",
             "license": "MIT"
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
+        },
+        "node_modules/config-chain/node_modules/ini": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/confinity": {
             "version": "1.0.0-beta.1",
@@ -15427,6 +15493,68 @@
             "resolved": "https://registry.npmjs.org/ebec/-/ebec-2.3.0.tgz",
             "integrity": "sha512-bt+0tSL7223VU3PSVi0vtNLZ8pO1AfWolcPPMk2a/a5H+o/ZU9ky0n3A0zhrR4qzJTN61uPsGIO4ShhOukdzxA==",
             "license": "MIT"
+        },
+        "node_modules/editorconfig": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.7.tgz",
+            "integrity": "sha512-e0GOtq/aTQhVdNyDU9e02+wz9oDDM+SIOQxWME2QRjzRX5yyLAuHDE+0aE8vHb9XRC8XD37eO2u57+F09JqFhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@one-ini/wasm": "0.1.1",
+                "commander": "^10.0.0",
+                "minimatch": "^9.0.1",
+                "semver": "^7.5.3"
+            },
+            "bin": {
+                "editorconfig": "bin/editorconfig"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/editorconfig/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/editorconfig/node_modules/commander": {
+            "version": "10.0.1",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+            "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/editorconfig/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
         },
         "node_modules/ee-first": {
             "version": "1.1.1",
@@ -17213,6 +17341,47 @@
                 "node": ">=22.0.0"
             }
         },
+        "node_modules/happy-dom": {
+            "version": "20.10.6",
+            "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+            "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=20.0.0",
+                "@types/whatwg-mimetype": "^3.0.2",
+                "@types/ws": "^8.18.1",
+                "buffer-image-size": "^0.6.4",
+                "entities": "^7.0.1",
+                "whatwg-mimetype": "^3.0.0",
+                "ws": "^8.21.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/happy-dom/node_modules/ws": {
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": ">=5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -18695,6 +18864,140 @@
             "funding": {
                 "url": "https://github.com/sponsors/panva"
             }
+        },
+        "node_modules/js-beautify": {
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.15.4.tgz",
+            "integrity": "sha512-9/KXeZUKKJwqCXUdBxFJ3vPh467OCckSBmYDwSK/EtV090K+iMJ7zx2S3HLVDIWFQdqMIsZWbnaGiba18aWhaA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "config-chain": "^1.1.13",
+                "editorconfig": "^1.0.4",
+                "glob": "^10.4.2",
+                "js-cookie": "^3.0.5",
+                "nopt": "^7.2.1"
+            },
+            "bin": {
+                "css-beautify": "js/bin/css-beautify.js",
+                "html-beautify": "js/bin/html-beautify.js",
+                "js-beautify": "js/bin/js-beautify.js"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/js-beautify/node_modules/abbrev": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+            "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+            "dev": true,
+            "license": "ISC",
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/js-beautify/node_modules/balanced-match": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+            "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/js-beautify/node_modules/brace-expansion": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+            "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/js-beautify/node_modules/glob": {
+            "version": "10.5.0",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+            "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "foreground-child": "^3.1.0",
+                "jackspeak": "^3.1.2",
+                "minimatch": "^9.0.4",
+                "minipass": "^7.1.2",
+                "package-json-from-dist": "^1.0.0",
+                "path-scurry": "^1.11.1"
+            },
+            "bin": {
+                "glob": "dist/esm/bin.mjs"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/js-beautify/node_modules/lru-cache": {
+            "version": "10.4.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+            "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+            "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/js-beautify/node_modules/minimatch": {
+            "version": "9.0.9",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+            "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.2"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/js-beautify/node_modules/nopt": {
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+            "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "abbrev": "^2.0.0"
+            },
+            "bin": {
+                "nopt": "bin/nopt.js"
+            },
+            "engines": {
+                "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+            }
+        },
+        "node_modules/js-beautify/node_modules/path-scurry": {
+            "version": "1.11.1",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+            "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^10.2.0",
+                "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/js-cookie": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.8.tgz",
+            "integrity": "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/js-tokens": {
             "version": "10.0.0",
@@ -23193,6 +23496,13 @@
                 "type": "github",
                 "url": "https://github.com/sponsors/wooorm"
             }
+        },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/protobufjs": {
             "version": "7.6.4",
@@ -28887,6 +29197,13 @@
                 "ufo": "^1.6.1"
             }
         },
+        "node_modules/vue-component-type-helpers": {
+            "version": "3.3.6",
+            "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-3.3.6.tgz",
+            "integrity": "sha512-FkljacAwJ9BUoSUdpFe3VDy0sGigNlTH9+2zcXUWmZOjN8swiCkl3t48wOJun0OsUd2cEIda1l04tsxMiKIIrQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/vue-devtools-stub": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz",
@@ -29062,6 +29379,16 @@
             "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
             "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
             "license": "MIT"
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+            "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",
@@ -29714,6 +30041,7 @@
                 "@types/node": "^26.0.1",
                 "@validup/vue": "^0.3.3",
                 "@vitejs/plugin-vue": "^6.0.5",
+                "@vue/test-utils": "^2.4.6",
                 "@vuecs/button": "^1.3.0",
                 "@vuecs/core": "^3.4.0",
                 "@vuecs/elements": "^1.4.0",
@@ -29725,10 +30053,12 @@
                 "@vuecs/overlays": "^1.2.0",
                 "@vuecs/pagination": "^2.1.7",
                 "cross-env": "^10.1.0",
+                "happy-dom": "^20.10.6",
                 "ilingo": "^6.0.0",
                 "pinia": "^3.0.0",
                 "socket.io-client": "^4.8.3",
                 "validup": "^0.5.1",
+                "vitest": "^4.0.14",
                 "vue": "^3.5.38",
                 "vue-tsc": "^3.3.6"
             },

--- a/packages/client-web-kit/package.json
+++ b/packages/client-web-kit/package.json
@@ -20,7 +20,9 @@
         "build:types": "vue-tsc --declaration --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
-        "build:watch": "npm run build -- --watch"
+        "build:watch": "npm run build -- --watch",
+        "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
+        "test:coverage": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts --coverage"
     },
     "engines": {
         "node": "^22.13.0 || ^23.5.0 || >=24.0.0"
@@ -75,6 +77,7 @@
         "@types/node": "^26.0.1",
         "@validup/vue": "^0.3.3",
         "@vitejs/plugin-vue": "^6.0.5",
+        "@vue/test-utils": "^2.4.6",
         "@vuecs/button": "^1.3.0",
         "@vuecs/core": "^3.4.0",
         "@vuecs/elements": "^1.4.0",
@@ -86,10 +89,12 @@
         "@vuecs/overlays": "^1.2.0",
         "@vuecs/pagination": "^2.1.7",
         "cross-env": "^10.1.0",
+        "happy-dom": "^20.10.6",
         "ilingo": "^6.0.0",
         "pinia": "^3.0.0",
         "socket.io-client": "^4.8.3",
         "validup": "^0.5.1",
+        "vitest": "^4.0.14",
         "vue": "^3.5.38",
         "vue-tsc": "^3.3.6"
     },

--- a/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
@@ -5,13 +5,14 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { VueWrapper } from '@vue/test-utils';
 import { flushPromises } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { ARealmPicker } from '../../../../src/components/entities';
 import { findTokenRequest, mountLoginForm } from '../../../utils';
 
-async function submitWithCredentials(wrapper: VueWrapper<any>) {
+type LoginFormWrapper = ReturnType<typeof mountLoginForm>['wrapper'];
+
+async function submitWithCredentials(wrapper: LoginFormWrapper) {
     const inputs = wrapper.findAll('input');
     await inputs[0].setValue('admin');
     await wrapper.find('input[type="password"]').setValue('start123');

--- a/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { VueWrapper } from '@vue/test-utils';
+import { flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { ARealmPicker } from '../../../../src/components/entities';
+import { findTokenRequest, mountLoginForm } from '../../../utils';
+
+async function submitWithCredentials(wrapper: VueWrapper<any>) {
+    const inputs = wrapper.findAll('input');
+    await inputs[0].setValue('admin');
+    await wrapper.find('input[type="password"]').setValue('start123');
+
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+}
+
+describe('components/workflows/login', () => {
+    it('should transmit picker-selected realm', async () => {
+        const { wrapper, httpClient } = mountLoginForm();
+        await flushPromises();
+
+        const picker = wrapper.findComponent(ARealmPicker);
+        expect(picker.exists()).toBe(true);
+
+        picker.vm.$emit('change', ['realm-a']);
+        await flushPromises();
+
+        await submitWithCredentials(wrapper);
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({
+            grant_type: 'password',
+            username: 'admin',
+            password: 'start123',
+            realm_id: 'realm-a',
+        });
+    });
+
+    it('should pin realm from codeRequest and hide picker', async () => {
+        const { wrapper, httpClient } = mountLoginForm({
+            codeRequest: {
+                response_type: 'code',
+                realm_id: 'realm-b',
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.findComponent(ARealmPicker).exists()).toBe(false);
+
+        await submitWithCredentials(wrapper);
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({
+            grant_type: 'password',
+            realm_id: 'realm-b',
+        });
+    });
+
+    it('should adopt realm of late-arriving codeRequest', async () => {
+        const { wrapper, httpClient } = mountLoginForm();
+        await flushPromises();
+
+        await wrapper.setProps({
+            codeRequest: {
+                response_type: 'code',
+                realm_id: 'realm-c',
+            },
+        });
+        await flushPromises();
+
+        await submitWithCredentials(wrapper);
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({
+            grant_type: 'password',
+            realm_id: 'realm-c',
+        });
+    });
+
+    it('should omit realm_id without selection or codeRequest', async () => {
+        const { wrapper, httpClient } = mountLoginForm();
+        await flushPromises();
+
+        await submitWithCredentials(wrapper);
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+
+        const body = request!.body as Record<string, string>;
+        expect(body.grant_type).toEqual('password');
+        expect(body.username).toEqual('admin');
+        expect(body.password).toEqual('start123');
+        expect('realm_id' in body).toBe(false);
+    });
+});

--- a/packages/client-web-kit/test/unit/core/store/login.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/login.spec.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { FakeClient, FakeRequest } from '@authup/core-http-kit/testing';
+import { describe, expect, it } from 'vitest';
+import { createStore, createStoreDispatcher } from '../../../../src/core/store';
+
+function buildStore() {
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token': () => ({
+                access_token: 'xyz',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: 'abc',
+            }),
+        },
+    });
+
+    const store = createStore({
+        httpClient,
+        dispatcher: createStoreDispatcher(),
+    });
+
+    return { store, httpClient };
+}
+
+function findTokenRequest(httpClient: FakeClient) : FakeRequest | undefined {
+    return httpClient.requests.find(
+        (request) => request.method === 'POST' &&
+            new URL(request.url, 'http://localhost').pathname === '/token',
+    );
+}
+
+describe('core/store/login', () => {
+    it('should transmit realm_id for login with realmId', async () => {
+        const { store, httpClient } = buildStore();
+
+        expect(store.realmId.value).toBeFalsy();
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+            realmId: 'realm-x',
+        });
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({
+            grant_type: 'password',
+            username: 'admin',
+            password: 'start123',
+            realm_id: 'realm-x',
+        });
+    });
+
+    it('should omit realm_id for login without realmId', async () => {
+        const { store, httpClient } = buildStore();
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+        });
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+
+        const body = request!.body as Record<string, string>;
+        expect(body.grant_type).toEqual('password');
+        expect('realm_id' in body).toBe(false);
+    });
+
+    it('should omit realm_id for login with empty realmId', async () => {
+        const { store, httpClient } = buildStore();
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+            realmId: '',
+        });
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect('realm_id' in (request!.body as Record<string, string>)).toBe(false);
+    });
+});

--- a/packages/client-web-kit/test/utils/index.ts
+++ b/packages/client-web-kit/test/utils/index.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { FakeClient, FakeHandlerMap, FakeRequest } from '@authup/core-http-kit/testing';
+import { mount } from '@vue/test-utils';
+import vuecs from '@vuecs/core';
+import { createPinia } from 'pinia';
+import { ALoginForm } from '../../src/components/workflows/login';
+import { install } from '../../src/module';
+import type { Options } from '../../src/types';
+
+const noop = () => undefined;
+
+export function mountLoginForm(
+    props: Record<string, any> = {},
+    handlers: FakeHandlerMap = {},
+) {
+    const pinia = createPinia();
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token': () => ({
+                access_token: 'xyz',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: 'abc',
+            }),
+            ...handlers,
+        },
+    });
+
+    const options : Options = {
+        baseURL: 'http://fake.test',
+        httpClient,
+        pinia,
+        isServer: true,
+        cookieGet: noop,
+        cookieSet: noop,
+        cookieUnset: noop,
+    };
+
+    const wrapper = mount(ALoginForm, {
+        props,
+        global: {
+            components: { VCIcon: { render: () => null } },
+            plugins: [
+                pinia,
+                [vuecs, {}],
+                [{ install }, options],
+            ],
+        },
+    });
+
+    return {
+        wrapper, 
+        httpClient, 
+        pinia, 
+    };
+}
+
+export function findTokenRequest(httpClient: FakeClient) : FakeRequest | undefined {
+    return httpClient.requests.find(
+        (request) => request.method === 'POST' &&
+            new URL(request.url, 'http://localhost').pathname === '/token',
+    );
+}

--- a/packages/client-web-kit/test/vitest.config.ts
+++ b/packages/client-web-kit/test/vitest.config.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import vue from '@vitejs/plugin-vue';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    plugins: [vue()],
+    test: {
+        environment: 'happy-dom',
+        include: ['test/unit/**/*.spec.ts'],
+    },
+});

--- a/packages/core-kit/src/domains/client/validator.ts
+++ b/packages/core-kit/src/domains/client/validator.ts
@@ -54,14 +54,14 @@ export class ClientValidator extends Container<Client> {
 
         this.mount(
             'name',
-            { group: ValidatorGroup.CREATE },
+            { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] },
             nameValidator,
         );
         this.mount(
             'name',
             {
                 group: ValidatorGroup.UPDATE,
-                optional: true, 
+                optional: true,
             },
             nameValidator,
         );
@@ -158,10 +158,21 @@ export class ClientValidator extends Container<Client> {
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
-                optional: true, 
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
+                optional: true,
             },
             createValidator(z.uuid()),
+        );
+
+        // deliberately NOT mounted for CREATE/UPDATE — no API caller may
+        // self-assign built_in; only provisioned entities carry it
+        this.mount(
+            'built_in',
+            {
+                group: ValidatorGroup.PROVISIONING,
+                optional: true,
+            },
+            createValidator(z.boolean()),
         );
     }
 }

--- a/packages/core-kit/src/domains/permission/validator.ts
+++ b/packages/core-kit/src/domains/permission/validator.ts
@@ -37,10 +37,10 @@ export class PermissionValidator extends Container<
                     }
                 }),
         );
-        this.mount('name', { group: ValidatorGroup.CREATE }, nameValidator);
+        this.mount('name', { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] }, nameValidator);
         this.mount('name', {
             group: ValidatorGroup.UPDATE,
-            optional: true, 
+            optional: true,
         }, nameValidator);
 
         this.mount(
@@ -64,8 +64,8 @@ export class PermissionValidator extends Container<
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
-                optional: true, 
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
+                optional: true,
             },
             createValidator(z.uuid().nullable().optional()),
         );
@@ -77,6 +77,15 @@ export class PermissionValidator extends Container<
                 z.enum(DecisionStrategy)
                     .nullable(),
             ),
+        );
+
+        this.mount(
+            'built_in',
+            {
+                group: ValidatorGroup.PROVISIONING,
+                optional: true,
+            },
+            createValidator(z.boolean()),
         );
     }
 }

--- a/packages/core-kit/src/domains/policy/validator.ts
+++ b/packages/core-kit/src/domains/policy/validator.ts
@@ -38,10 +38,10 @@ export class PolicyValidator extends Container<
                 }),
         );
 
-        this.mount('name', { group: ValidatorGroup.CREATE }, nameValidator);
+        this.mount('name', { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] }, nameValidator);
         this.mount('name', {
             group: ValidatorGroup.UPDATE,
-            optional: true, 
+            optional: true,
         }, nameValidator);
 
         this.mount(
@@ -58,7 +58,7 @@ export class PolicyValidator extends Container<
 
         this.mount(
             'type',
-            { group: ValidatorGroup.CREATE },
+            { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] },
             createValidator(z.string().min(3).max(128)),
         );
 
@@ -71,10 +71,19 @@ export class PolicyValidator extends Container<
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
-                optional: true, 
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
+                optional: true,
             },
             createValidator(z.uuid().nullable()),
+        );
+
+        this.mount(
+            'built_in',
+            {
+                group: ValidatorGroup.PROVISIONING,
+                optional: true,
+            },
+            createValidator(z.boolean()),
         );
     }
 }

--- a/packages/core-kit/src/domains/realm/validator.ts
+++ b/packages/core-kit/src/domains/realm/validator.ts
@@ -38,10 +38,10 @@ export class RealmValidator extends Container<
                 }),
         );
 
-        this.mount('name', { group: ValidatorGroup.CREATE }, nameValidator);
+        this.mount('name', { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] }, nameValidator);
         this.mount('name', {
             group: ValidatorGroup.UPDATE,
-            optional: true, 
+            optional: true,
         }, nameValidator);
 
         this.mount(
@@ -54,6 +54,15 @@ export class RealmValidator extends Container<
             'description',
             { optional: true },
             createValidator(z.string().min(5).max(4096).nullable()),
+        );
+
+        this.mount(
+            'built_in',
+            {
+                group: ValidatorGroup.PROVISIONING,
+                optional: true,
+            },
+            createValidator(z.boolean()),
         );
     }
 }

--- a/packages/core-kit/src/domains/robot/validator.ts
+++ b/packages/core-kit/src/domains/robot/validator.ts
@@ -52,14 +52,14 @@ export class RobotValidator extends Container<
 
         this.mount(
             'name',
-            { group: ValidatorGroup.CREATE },
+            { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] },
             nameValidator,
         );
         this.mount(
             'name',
             {
                 group: ValidatorGroup.UPDATE,
-                optional: true, 
+                optional: true,
             },
             nameValidator,
         );
@@ -85,8 +85,8 @@ export class RobotValidator extends Container<
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
-                optional: true, 
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
+                optional: true,
             },
             createValidator(z.uuid()),
         );

--- a/packages/core-kit/src/domains/role/validator.ts
+++ b/packages/core-kit/src/domains/role/validator.ts
@@ -38,10 +38,10 @@ export class RoleValidator extends Container<
                 }),
         );
 
-        this.mount('name', { group: ValidatorGroup.CREATE }, nameValidator);
+        this.mount('name', { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] }, nameValidator);
         this.mount('name', {
             group: ValidatorGroup.UPDATE,
-            optional: true, 
+            optional: true,
         }, nameValidator);
 
         this.mount(
@@ -65,10 +65,19 @@ export class RoleValidator extends Container<
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
                 optional: true,
             },
             createValidator(z.uuid().nullable()),
+        );
+
+        this.mount(
+            'built_in',
+            {
+                group: ValidatorGroup.PROVISIONING,
+                optional: true,
+            },
+            createValidator(z.boolean()),
         );
     }
 }

--- a/packages/core-kit/src/domains/scope/validator.ts
+++ b/packages/core-kit/src/domains/scope/validator.ts
@@ -40,14 +40,14 @@ export class ScopeValidator extends Container<
 
         this.mount(
             'name',
-            { group: ValidatorGroup.CREATE },
+            { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] },
             nameValidator,
         );
         this.mount(
             'name',
             {
                 group: ValidatorGroup.UPDATE,
-                optional: true, 
+                optional: true,
             },
             nameValidator,
         );
@@ -67,10 +67,19 @@ export class ScopeValidator extends Container<
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
-                optional: true, 
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
+                optional: true,
             },
             createValidator(z.uuid().nullable()),
+        );
+
+        this.mount(
+            'built_in',
+            {
+                group: ValidatorGroup.PROVISIONING,
+                optional: true,
+            },
+            createValidator(z.boolean()),
         );
     }
 }

--- a/packages/core-kit/src/domains/user/validator.ts
+++ b/packages/core-kit/src/domains/user/validator.ts
@@ -38,14 +38,14 @@ export class UserValidator extends Container<User> {
 
         this.mount(
             'name',
-            { group: ValidatorGroup.CREATE },
+            { group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING] },
             nameValidator,
         );
         this.mount(
             'name',
             {
                 group: ValidatorGroup.UPDATE,
-                optional: true, 
+                optional: true,
             },
             nameValidator,
         );
@@ -96,7 +96,17 @@ export class UserValidator extends Container<User> {
             'email',
             {
                 optional: true,
-                group: ValidatorGroup.UPDATE, 
+                group: ValidatorGroup.UPDATE,
+            },
+            emailValidator,
+        );
+        // provisioning: email is optional — the user synchronizer backfills
+        // a placeholder when omitted
+        this.mount(
+            'email',
+            {
+                optional: true,
+                group: ValidatorGroup.PROVISIONING,
             },
             emailValidator,
         );
@@ -126,8 +136,8 @@ export class UserValidator extends Container<User> {
         this.mount(
             'realm_id',
             {
-                group: ValidatorGroup.CREATE,
-                optional: true, 
+                group: [ValidatorGroup.CREATE, ValidatorGroup.PROVISIONING],
+                optional: true,
             },
             createValidator(z.uuid()),
         );

--- a/packages/core-kit/test/unit/domains/validator-groups.spec.ts
+++ b/packages/core-kit/test/unit/domains/validator-groups.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ValidatorGroup } from '@authup/kit';
+import { describe, expect, it } from 'vitest';
+import {
+    ClientValidator,
+    PolicyValidator,
+    RealmValidator,
+    UserValidator,
+} from '../../../src';
+
+describe('domains/validator-groups', () => {
+    it('should run zero group-scoped mounts at a group-less run', async () => {
+        const validator = new RealmValidator();
+
+        const output = await validator.run({ name: 'MyRealm' } as any);
+
+        expect(output).not.toHaveProperty('name');
+    });
+
+    it('should require and canonicalize name at CREATE and PROVISIONING', async () => {
+        const validator = new RealmValidator();
+
+        await expect(validator.run({} as any, { group: ValidatorGroup.CREATE })).rejects.toThrow();
+        await expect(validator.run({} as any, { group: ValidatorGroup.PROVISIONING })).rejects.toThrow();
+
+        const created = await validator.run({ name: ' FOO ' } as any, { group: ValidatorGroup.CREATE });
+        expect(created.name).toEqual('foo');
+
+        const provisioned = await validator.run({ name: ' FOO ' } as any, { group: ValidatorGroup.PROVISIONING });
+        expect(provisioned.name).toEqual('foo');
+    });
+
+    it('should keep name optional at UPDATE', async () => {
+        const validator = new RealmValidator();
+
+        const output = await validator.run({ display_name: 'Foo Bar' } as any, { group: ValidatorGroup.UPDATE });
+
+        expect(output.display_name).toEqual('Foo Bar');
+    });
+
+    it('should strip built_in at CREATE/UPDATE but accept it at PROVISIONING', async () => {
+        const validator = new ClientValidator();
+
+        const created = await validator.run(
+            { name: 'foo', built_in: true } as any,
+            { group: ValidatorGroup.CREATE },
+        );
+        expect(created).not.toHaveProperty('built_in');
+
+        const updated = await validator.run(
+            { built_in: true } as any,
+            { group: ValidatorGroup.UPDATE },
+        );
+        expect(updated).not.toHaveProperty('built_in');
+
+        const provisioned = await validator.run(
+            { name: 'foo', built_in: true } as any,
+            { group: ValidatorGroup.PROVISIONING },
+        );
+        expect(provisioned.built_in).toBe(true);
+    });
+
+    it('should require email at CREATE but not at PROVISIONING', async () => {
+        const validator = new UserValidator();
+
+        await expect(validator.run({ name: 'foo' } as any, { group: ValidatorGroup.CREATE })).rejects.toThrow();
+
+        const provisioned = await validator.run({ name: 'foo' } as any, { group: ValidatorGroup.PROVISIONING });
+        expect(provisioned.name).toEqual('foo');
+        expect(provisioned).not.toHaveProperty('email');
+
+        await expect(validator.run(
+            { name: 'foo', email: 'not-an-email' } as any,
+            { group: ValidatorGroup.PROVISIONING },
+        )).rejects.toThrow();
+
+        const withEmail = await validator.run(
+            { name: 'foo', email: 'Foo@Example.com' } as any,
+            { group: ValidatorGroup.PROVISIONING },
+        );
+        expect(withEmail.email).toEqual('foo@example.com');
+    });
+
+    it('should require the policy type at CREATE and PROVISIONING', async () => {
+        const validator = new PolicyValidator();
+
+        await expect(validator.run({ name: 'foo' } as any, { group: ValidatorGroup.CREATE })).rejects.toThrow();
+        await expect(validator.run({ name: 'foo' } as any, { group: ValidatorGroup.PROVISIONING })).rejects.toThrow();
+
+        const provisioned = await validator.run(
+            {
+                name: 'foo', 
+                type: 'composite', 
+                built_in: true, 
+            } as any,
+            { group: ValidatorGroup.PROVISIONING },
+        );
+        expect(provisioned.type).toEqual('composite');
+        expect(provisioned.built_in).toBe(true);
+    });
+});

--- a/packages/core-kit/test/unit/domains/validator-groups.spec.ts
+++ b/packages/core-kit/test/unit/domains/validator-groups.spec.ts
@@ -18,7 +18,7 @@ describe('domains/validator-groups', () => {
     it('should run zero group-scoped mounts at a group-less run', async () => {
         const validator = new RealmValidator();
 
-        const output = await validator.run({ name: 'MyRealm' } as any);
+        const output = await validator.run({ name: 'MyRealm' });
 
         expect(output).not.toHaveProperty('name');
     });
@@ -26,20 +26,20 @@ describe('domains/validator-groups', () => {
     it('should require and canonicalize name at CREATE and PROVISIONING', async () => {
         const validator = new RealmValidator();
 
-        await expect(validator.run({} as any, { group: ValidatorGroup.CREATE })).rejects.toThrow();
-        await expect(validator.run({} as any, { group: ValidatorGroup.PROVISIONING })).rejects.toThrow();
+        await expect(validator.run({}, { group: ValidatorGroup.CREATE })).rejects.toThrow();
+        await expect(validator.run({}, { group: ValidatorGroup.PROVISIONING })).rejects.toThrow();
 
-        const created = await validator.run({ name: ' FOO ' } as any, { group: ValidatorGroup.CREATE });
+        const created = await validator.run({ name: ' FOO ' }, { group: ValidatorGroup.CREATE });
         expect(created.name).toEqual('foo');
 
-        const provisioned = await validator.run({ name: ' FOO ' } as any, { group: ValidatorGroup.PROVISIONING });
+        const provisioned = await validator.run({ name: ' FOO ' }, { group: ValidatorGroup.PROVISIONING });
         expect(provisioned.name).toEqual('foo');
     });
 
     it('should keep name optional at UPDATE', async () => {
         const validator = new RealmValidator();
 
-        const output = await validator.run({ display_name: 'Foo Bar' } as any, { group: ValidatorGroup.UPDATE });
+        const output = await validator.run({ display_name: 'Foo Bar' }, { group: ValidatorGroup.UPDATE });
 
         expect(output.display_name).toEqual('Foo Bar');
     });
@@ -48,19 +48,19 @@ describe('domains/validator-groups', () => {
         const validator = new ClientValidator();
 
         const created = await validator.run(
-            { name: 'foo', built_in: true } as any,
+            { name: 'foo', built_in: true },
             { group: ValidatorGroup.CREATE },
         );
         expect(created).not.toHaveProperty('built_in');
 
         const updated = await validator.run(
-            { built_in: true } as any,
+            { built_in: true },
             { group: ValidatorGroup.UPDATE },
         );
         expect(updated).not.toHaveProperty('built_in');
 
         const provisioned = await validator.run(
-            { name: 'foo', built_in: true } as any,
+            { name: 'foo', built_in: true },
             { group: ValidatorGroup.PROVISIONING },
         );
         expect(provisioned.built_in).toBe(true);
@@ -69,19 +69,19 @@ describe('domains/validator-groups', () => {
     it('should require email at CREATE but not at PROVISIONING', async () => {
         const validator = new UserValidator();
 
-        await expect(validator.run({ name: 'foo' } as any, { group: ValidatorGroup.CREATE })).rejects.toThrow();
+        await expect(validator.run({ name: 'foo' }, { group: ValidatorGroup.CREATE })).rejects.toThrow();
 
-        const provisioned = await validator.run({ name: 'foo' } as any, { group: ValidatorGroup.PROVISIONING });
+        const provisioned = await validator.run({ name: 'foo' }, { group: ValidatorGroup.PROVISIONING });
         expect(provisioned.name).toEqual('foo');
         expect(provisioned).not.toHaveProperty('email');
 
         await expect(validator.run(
-            { name: 'foo', email: 'not-an-email' } as any,
+            { name: 'foo', email: 'not-an-email' },
             { group: ValidatorGroup.PROVISIONING },
         )).rejects.toThrow();
 
         const withEmail = await validator.run(
-            { name: 'foo', email: 'Foo@Example.com' } as any,
+            { name: 'foo', email: 'Foo@Example.com' },
             { group: ValidatorGroup.PROVISIONING },
         );
         expect(withEmail.email).toEqual('foo@example.com');
@@ -90,15 +90,15 @@ describe('domains/validator-groups', () => {
     it('should require the policy type at CREATE and PROVISIONING', async () => {
         const validator = new PolicyValidator();
 
-        await expect(validator.run({ name: 'foo' } as any, { group: ValidatorGroup.CREATE })).rejects.toThrow();
-        await expect(validator.run({ name: 'foo' } as any, { group: ValidatorGroup.PROVISIONING })).rejects.toThrow();
+        await expect(validator.run({ name: 'foo' }, { group: ValidatorGroup.CREATE })).rejects.toThrow();
+        await expect(validator.run({ name: 'foo' }, { group: ValidatorGroup.PROVISIONING })).rejects.toThrow();
 
         const provisioned = await validator.run(
             {
                 name: 'foo', 
                 type: 'composite', 
                 built_in: true, 
-            } as any,
+            },
             { group: ValidatorGroup.PROVISIONING },
         );
         expect(provisioned.type).toEqual('composite');

--- a/packages/kit/src/constants.ts
+++ b/packages/kit/src/constants.ts
@@ -29,4 +29,11 @@ export enum EnvironmentName {
 export enum ValidatorGroup {
     CREATE = 'create',
     UPDATE = 'update',
+    /**
+     * Startup provisioning (file source). Shares the CREATE field rules but
+     * relaxes API-only constraints (e.g. optional user email) and mounts
+     * provisioning-only fields (e.g. built_in) that the API groups
+     * deliberately strip. Never used by HTTP-facing services.
+     */
+    PROVISIONING = 'provisioning',
 }


### PR DESCRIPTION
Implements all six follow-up items deferred from #3175 (plan 038).

## 1. Fail-closed realm-key predicates (repo-wide)

New `IRealmRepository.resolveId(key)` — UUID pass-through (binding an unknown UUID matches zero rows), canonicalizing name lookup, `null` ⇒ caller fails closed. Swept across all 12 resolve-then-filter blocks in the 8 repository adapters, the permission/policy checker services, and the realm-resolver middleware. Previously 9 of those blocks silently **dropped** the realm filter for unknown realm keys, so `GET /realms/<unknown-uuid>/users/<name>` returned a cross-realm name match; it now 404s (pinned by tests).

## 2. Unified realm-hint semantics across token grants

`authorization_code` and `refresh_token` now share the password grant's realm-hint semantic via a common `readRealmHint` helper: `realm_id ?? realm_name`, canonicalized at the ingress, resolved once with master fallback, scoped onto client-by-name resolution. This makes the refresh leg deterministic — a password login via a name-identified client refreshes against the same realm's client instead of an unscoped lookup matching an arbitrary same-named client (every realm has a built-in `web` client, so collisions were guaranteed). The refresh grant resolves lazily; a bare refresh does no realm lookup. `client_credentials` / `robot_credentials` and the `/authorize` code-request verifier keep raw `realm_id` semantics (documented non-goal).

## 3. client-web-kit test infrastructure

vitest + @vue/test-utils + happy-dom stood up in `packages/client-web-kit` (first component tests in the monorepo). Regression suites pin the interactive-login realm plumbing that shipped the same one-line bug class twice in #3175: picker-selected realm transmitted; `codeRequest.realm_id` transmitted including a late-arriving prop; empty realm omitted from the grant; plus a DOM-free spec for the `store.login()` gate.

## 4. Realm lookup caching on `/token`

`RealmRepositoryAdapter.findOneById` is query-cached (60s, `CachePrefix.REALM` id key — byte-identical to the existing realm subscriber invalidation key). Name-key caching stays deferred (rename invalidation prerequisite). The new invalidation tests surfaced a real pre-existing bug: `EntitySubscriber.afterRemove` read `event.entity`, whose primary key TypeORM strips on remove — so id-keyed cache invalidation (and DELETED event payloads) were broken for all subscribers. Fixed by preferring `event.databaseEntity`.

## 5. UUID identifiers skip the realm predicate — decided: intended

Documented (architecture.md + resolver comment) and pinned by test: UUIDs are globally unique, the realm hint constrains NAME resolution only, and the issued token carries the identity's true realm. Enforcing the predicate would break realm-less id-identified logins because the master fallback erases hint explicitness.

## 6. File-provisioning validation was a no-op

Nested provisioning validators ran group-less, executing zero core-kit field validators. New `ValidatorGroup.PROVISIONING`: identifier fields mounted `[CREATE, PROVISIONING]`, `built_in` only under PROVISIONING (API groups keep stripping it), user email optional under PROVISIONING (synchronizer backfills). Nested runs pass the group explicitly, assign validated output back, and prefix array indices onto issue paths. Top-level `policies` — documented but silently dropped from the validated output until now — are validated via the new `PolicyProvisioningValidator` and provisioned (exercised end-to-end by the integration suite). `BaseProvisioningSynchronizer.canonicalizeName` stays as defense in depth for the non-validating default/programmatic sources.

## Verification

- Full monorepo build green; `npm run test` green across all workspaces (server-core: 97 files / 992 tests, incl. new HTTP, service-level, and pure validator suites; client-web-kit: 7 new tests; core-kit: 6 new group tests)
- Also de-flaked a pre-existing LDAP test race (two specs sharing one `cn=foo` account on the shared OpenLDAP container)

## Known follow-up (out of scope)

The kit's silent-refresh path sends a bare `refresh_token` without `client_id`, so sessions with client-bound tokens already die at the RFC 6749 §6 binding check (pre-existing since #3020). A kit-side fix (send `client_id` + realm on refresh) can now build on this PR's scoped name lookup and test infrastructure.

BREAKING CHANGE: a name-identified client on the authorization_code or refresh_token grant without a realm hint now always resolves in the master realm (pass `realm_id`/`realm_name` or the client UUID for other realms). Invalid file-provisioning entities now abort startup instead of being silently accepted, and attribute keys outside the entity schema are stripped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for startup provisioning fields like `built_in`, improved realm-scope settings, and richer policy/permission relations in provisioning files.
  * Login and token flows now accept realm hints more consistently across password, refresh, and authorization-code flows.
  * Added client-web-kit test tooling and login form coverage.

* **Bug Fixes**
  * Realm-scoped lookups now fail closed when a realm can’t be resolved, preventing cross-realm matches.
  * Token, permission, and provisioning behavior now preserves validated data more reliably, including delete handling and cache updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->