### PR TITLE
fix: harden DataSource cleanup on setup and migration error paths

### DIFF
--- a/apps/server-core/src/app/modules/database/module.ts
+++ b/apps/server-core/src/app/modules/database/module.ts
@@ -90,13 +90,22 @@ export class DatabaseModule implements IModule {
                 await this.migrate(container, dataSource);
             }
 
-            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
-
             this.registerRepositories(container, dataSource);
             this.registerEventPublisher(container, dataSource);
+
+            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
         } catch (e) {
-            if (dataSource.isInitialized) {
-                await dataSource.destroy();
+            // teardown() is skipped for a module that fails its own setup(),
+            // so release the connection pool and any event-publisher handles
+            // here. Guard cleanup so it can never mask the original error.
+            try {
+                if (dataSource.isInitialized) {
+                    await dataSource.destroy();
+                }
+
+                await this.disposeEventPublisher();
+            } catch (cleanupError) {
+                logger.warn(`Failed to clean up database resources after setup error: ${cleanupError}`);
             }
 
             throw e;
@@ -106,13 +115,19 @@ export class DatabaseModule implements IModule {
     async teardown(container: IContainer): Promise<void> {
         const dataSource = container.tryResolve(DatabaseInjectionKey.DataSource);
         if (dataSource.success) {
-            await dataSource.data.destroy();
+            if (dataSource.data.isInitialized) {
+                await dataSource.data.destroy();
+            }
 
             container.unregister(DatabaseInjectionKey.DataSource);
         }
 
         container.unregister(DatabaseInjectionKey.DomainEventPublisher);
 
+        await this.disposeEventPublisher();
+    }
+
+    protected async disposeEventPublisher(): Promise<void> {
         if (this.eventPublisher) {
             await this.eventPublisher.dispose();
             this.eventPublisher = undefined;

--- a/apps/server-core/src/app/modules/database/module.ts
+++ b/apps/server-core/src/app/modules/database/module.ts
@@ -83,16 +83,24 @@ export class DatabaseModule implements IModule {
         await dataSource.initialize();
         logger.debug('Established database connection.');
 
-        if (this.options.migrate) {
-            await this.options.migrate(container, dataSource);
-        } else {
-            await this.migrate(container, dataSource);
+        try {
+            if (this.options.migrate) {
+                await this.options.migrate(container, dataSource);
+            } else {
+                await this.migrate(container, dataSource);
+            }
+
+            container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
+
+            this.registerRepositories(container, dataSource);
+            this.registerEventPublisher(container, dataSource);
+        } catch (e) {
+            if (dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
+
+            throw e;
         }
-
-        container.register(DatabaseInjectionKey.DataSource, { useValue: dataSource });
-
-        this.registerRepositories(container, dataSource);
-        this.registerEventPublisher(container, dataSource);
     }
 
     async teardown(container: IContainer): Promise<void> {

--- a/apps/server-core/src/cli/commands/migration.ts
+++ b/apps/server-core/src/cli/commands/migration.ts
@@ -89,7 +89,11 @@ async function runMigrationOperation(
         }
     } finally {
         if (dataSource.isInitialized) {
-            await dataSource.destroy();
+            try {
+                await dataSource.destroy();
+            } catch (e) {
+                logger.error(`Failed to destroy data source after migration operation: ${e}`);
+            }
         }
     }
 }
@@ -150,7 +154,12 @@ async function generateMigrations(): Promise<void> {
             });
         } finally {
             if (dataSource.isInitialized) {
-                await dataSource.destroy();
+                try {
+                    await dataSource.destroy();
+                } catch (e) {
+                    // eslint-disable-next-line no-console
+                    console.error(e);
+                }
             }
         }
     }

--- a/apps/server-core/src/cli/commands/migration.ts
+++ b/apps/server-core/src/cli/commands/migration.ts
@@ -76,9 +76,10 @@ async function runMigrationOperation(
         ...options,
         logging: ['error', 'schema', 'migration'],
     });
-    await dataSource.initialize();
 
     try {
+        await dataSource.initialize();
+
         if (operation === MigrationOperation.REVERT) {
             await dataSource.undoLastMigration();
         } else if (operation === MigrationOperation.STATUS) {
@@ -87,7 +88,9 @@ async function runMigrationOperation(
             await dataSource.runMigrations();
         }
     } finally {
-        await dataSource.destroy();
+        if (dataSource.isInitialized) {
+            await dataSource.destroy();
+        }
     }
 }
 
@@ -132,9 +135,10 @@ async function generateMigrations(): Promise<void> {
         });
 
         const dataSource = new DataSource(dataSourceOptions);
-        await dataSource.initialize();
 
         try {
+            await dataSource.initialize();
+
             await dataSource.runMigrations();
 
             await generateMigration({
@@ -145,7 +149,9 @@ async function generateMigrations(): Promise<void> {
                 prettify: true,
             });
         } finally {
-            await dataSource.destroy();
+            if (dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

Closes #3179.

`DatabaseModule.setup()` initializes a `DataSource` and then runs several steps that can throw — `migrate()` / `synchronizeDatabaseSchema()`, `registerRepositories()`, `registerEventPublisher()`. If any threw once `initialize()` had succeeded, the connection pool was never destroyed:

- `migrate()` runs **before** `container.register(DatabaseInjectionKey.DataSource, ...)`, so `teardown()` cannot find the `DataSource` to destroy it.
- Even for the steps that run after registration, module `teardown()` is not guaranteed to run when `setup()` throws.

The result was a leaked pool and, for short-lived / one-shot invocations, active handles keeping the event loop alive (process hangs).

Mirrors PrivateAIM/hub#1741 (same pattern was reported downstream in PrivateAIM/hub#1716).

## Changes

**`app/modules/database/module.ts` — `DatabaseModule.setup()`**

Wrap the post-`initialize()` work (migrate → register DataSource → register repositories → register event publisher) in a `try/catch` that destroys the pool and re-throws on error, keeping it alive only on the success path (`catch`+rethrow, not `finally`).

**`cli/commands/migration.ts` — `runMigrationOperation()` and `generateMigrations()`**

Move `dataSource.initialize()` inside the `try` block so an init failure that opened resources still reaches cleanup, and guard `destroy()` with `if (dataSource.isInitialized)` (TypeORM throws `CannotExecuteNotConnectedError` when destroying an uninitialized `DataSource`).

## Verification

- `npm run build -w apps/server-core` — passes
- `eslint` on both changed files — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database migration reliability by ensuring partially started connections are cleaned up if an error occurs.
  * Reduced the chance of lingering database connections during failed migration or setup attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->