### PR TITLE
fix: accessible names for icon-only action buttons on entity index pages

### DIFF
--- a/apps/client-web/pages/clients/index/index.vue
+++ b/apps/client-web/pages/clients/index/index.vue
@@ -3,7 +3,12 @@
 import { storeToRefs } from 'pinia';
 import type { Client } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationCommonKey, TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import {
+    TranslatorTranslationAppKey,
+    TranslatorTranslationCommonKey,
+    TranslatorTranslationFieldKey,
+    TranslatorTranslationNamespace,
+} from '@authup/i18n';
 import {
     AClients,
     AEntityDelete,
@@ -69,6 +74,10 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.FIELD,
                 key: TranslatorTranslationFieldKey.UPDATED_AT,
             },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
         ]);
 
         const columns = computed<TableColumn<Client>[]>(() => [
@@ -123,6 +132,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -181,6 +191,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/clients/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/identity-providers/index/index.vue
+++ b/apps/client-web/pages/identity-providers/index/index.vue
@@ -5,7 +5,7 @@ import { VCIcon } from '@vuecs/icon';
 import { VCTimeago } from '@vuecs/timeago';
 import type { IdentityProvider } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import { TranslatorTranslationAppKey, TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import {
     AEntityDelete,
     AIdentityProviders,
@@ -67,6 +67,10 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.FIELD,
                 key: TranslatorTranslationFieldKey.UPDATED_AT,
             },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
         ]);
 
         const columns = computed<TableColumn<IdentityProvider>[]>(() => [
@@ -115,6 +119,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -155,6 +160,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/identity-providers/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/permissions/index/index.vue
+++ b/apps/client-web/pages/permissions/index/index.vue
@@ -10,9 +10,11 @@ import {
     ATitle,
     injectStore,
     usePermissionCheck,
+    useTranslations,
 } from '@authup/client-web-kit';
 import type { Permission } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { TranslatorTranslationAppKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { storeToRefs } from 'pinia';
 import type { BuildInput } from 'rapiq';
 import type { TableColumn } from '@vuecs/table';
@@ -42,6 +44,13 @@ export default defineComponent({
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.PERMISSION_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.PERMISSION_DELETE });
+
+        const translations = useTranslations([
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
+        ]);
 
         const columns: TableColumn<Permission>[] = [
             {
@@ -89,6 +98,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -141,6 +151,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/permissions/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/policies/index/index.vue
+++ b/apps/client-web/pages/policies/index/index.vue
@@ -12,9 +12,11 @@ import {
     ATitle,
     injectStore,
     usePermissionCheck,
+    useTranslations,
 } from '@authup/client-web-kit';
 import type { Policy } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
+import { TranslatorTranslationAppKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { storeToRefs } from 'pinia';
 import type { BuildInput } from 'rapiq';
 import type { TableColumn } from '@vuecs/table';
@@ -43,6 +45,13 @@ export default defineComponent({
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.PERMISSION_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.PERMISSION_DELETE });
+
+        const translations = useTranslations([
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
+        ]);
 
         const columns: TableColumn<Policy>[] = [
             {
@@ -84,6 +93,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -124,6 +134,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/policies/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/realms/index/index.vue
+++ b/apps/client-web/pages/realms/index/index.vue
@@ -12,7 +12,9 @@ import {
     ATitle,
     injectStore,
     usePermissionCheck,
+    useTranslations,
 } from '@authup/client-web-kit';
+import { TranslatorTranslationAppKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { storeToRefs } from 'pinia';
 import type { TableColumn } from '@vuecs/table';
 import { defineComponent, resolveComponent } from 'vue';
@@ -39,6 +41,17 @@ export default defineComponent({
 
         const hasEditPermission = usePermissionCheck({ name: PermissionName.REALM_UPDATE });
         const hasDropPermission = usePermissionCheck({ name: PermissionName.REALM_DELETE });
+
+        const translations = useTranslations([
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.SET_MANAGEMENT_REALM,
+            },
+        ]);
 
         const columns: TableColumn<Realm>[] = [
             {
@@ -75,6 +88,7 @@ export default defineComponent({
             handleDeleted,
             realmManagementId,
             setRealmManagement: store.setRealmManagement,
+            translations,
             NuxtLink,
         };
     },
@@ -113,6 +127,8 @@ export default defineComponent({
                 <template #cell-options="{ row }">
                     <VCButton
                         v-if="realmManagementId !== row.id"
+                        :aria-label="translations.setManagementRealm"
+                        :title="translations.setManagementRealm"
                         size="sm"
                         color="primary"
                         class="me-1 border border-transparent"
@@ -125,6 +141,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/realms/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/robots/index/index.vue
+++ b/apps/client-web/pages/robots/index/index.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { Robot } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import { TranslatorTranslationAppKey, TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
@@ -56,6 +56,10 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.FIELD,
                 key: TranslatorTranslationFieldKey.UPDATED_AT,
             },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
         ]);
 
         const columns = computed<TableColumn<Robot>[]>(() => [
@@ -92,6 +96,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -132,6 +137,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/robots/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/roles/index/index.vue
+++ b/apps/client-web/pages/roles/index/index.vue
@@ -2,7 +2,12 @@
 
 import type { Role } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationCommonKey, TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import {
+    TranslatorTranslationAppKey,
+    TranslatorTranslationCommonKey,
+    TranslatorTranslationFieldKey,
+    TranslatorTranslationNamespace,
+} from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
@@ -65,6 +70,10 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.FIELD,
                 key: TranslatorTranslationFieldKey.UPDATED_AT,
             },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
         ]);
 
         const columns = computed<TableColumn<Role>[]>(() => [
@@ -113,6 +122,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -165,6 +175,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/roles/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/scopes/index/index.vue
+++ b/apps/client-web/pages/scopes/index/index.vue
@@ -1,7 +1,12 @@
 <script lang="ts">
 import type { Scope } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationCommonKey, TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import {
+    TranslatorTranslationAppKey,
+    TranslatorTranslationCommonKey,
+    TranslatorTranslationFieldKey,
+    TranslatorTranslationNamespace,
+} from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
@@ -60,6 +65,10 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.FIELD,
                 key: TranslatorTranslationFieldKey.UPDATED_AT,
             },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
         ]);
 
         const columns = computed<TableColumn<Scope>[]>(() => [
@@ -102,6 +111,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -148,6 +158,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/scopes/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/apps/client-web/pages/users/index/index.vue
+++ b/apps/client-web/pages/users/index/index.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
 import type { User } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import { TranslatorTranslationAppKey, TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
@@ -56,6 +56,10 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.FIELD,
                 key: TranslatorTranslationFieldKey.UPDATED_AT,
             },
+            {
+                namespace: TranslatorTranslationNamespace.APP,
+                key: TranslatorTranslationAppKey.DETAILS,
+            },
         ]);
 
         const columns = computed<TableColumn<User>[]>(() => [
@@ -92,6 +96,7 @@ export default defineComponent({
             hasDropPermission,
             handleDeleted,
             query,
+            translations,
             NuxtLink,
         };
     },
@@ -134,6 +139,8 @@ export default defineComponent({
                     <VCButton
                         :as="NuxtLink"
                         :to="'/users/'+ row.id"
+                        :aria-label="translations.details"
+                        :title="translations.details"
                         size="sm"
                         color="primary"
                         variant="outline"

--- a/packages/client-web-kit/src/components/utility/entity/AEntityDelete.ts
+++ b/packages/client-web-kit/src/components/utility/entity/AEntityDelete.ts
@@ -194,6 +194,10 @@ const AEntityDelete = defineComponent({
                         color: 'error',
                         variant: 'outline',
                         label: props.withText ? translation.value : undefined,
+                        // Icon-only form has no visible text, so surface the
+                        // localized action as the accessible name (+ tooltip).
+                        'aria-label': props.withText ? undefined : translation.value,
+                        title: props.withText ? undefined : translation.value,
                         disabled: isDisabled,
                         onClick,
                     },
@@ -234,6 +238,8 @@ const AEntityDelete = defineComponent({
                 tag as string,
                 mergeProps({
                     disabled: isDisabled,
+                    'aria-label': props.withText ? undefined : translation.value,
+                    title: props.withText ? undefined : translation.value,
                     onClick,
                 }),
                 [

--- a/packages/i18n/src/catalogs/de/app.ts
+++ b/packages/i18n/src/catalogs/de/app.ts
@@ -20,6 +20,7 @@ export const TranslatorTranslationAppGerman : NamespaceTranslations<`${Translato
 
     [TranslatorTranslationAppKey.MANAGEMENT]: 'Verwaltung',
     [TranslatorTranslationAppKey.DETAILS]: 'Details',
+    [TranslatorTranslationAppKey.SET_MANAGEMENT_REALM]: 'Als Verwaltungs-Realm festlegen',
     [TranslatorTranslationAppKey.API_DOCS]: 'API-Dokumentation',
     [TranslatorTranslationAppKey.MADE_WITH]: 'Erstellt mit',
 

--- a/packages/i18n/src/catalogs/en/app.ts
+++ b/packages/i18n/src/catalogs/en/app.ts
@@ -20,6 +20,7 @@ export const TranslatorTranslationAppEnglish : NamespaceTranslations<`${Translat
 
     [TranslatorTranslationAppKey.MANAGEMENT]: 'Management',
     [TranslatorTranslationAppKey.DETAILS]: 'Details',
+    [TranslatorTranslationAppKey.SET_MANAGEMENT_REALM]: 'Set as management realm',
     [TranslatorTranslationAppKey.API_DOCS]: 'API Docs',
     [TranslatorTranslationAppKey.MADE_WITH]: 'Made with',
 

--- a/packages/i18n/src/catalogs/es/app.ts
+++ b/packages/i18n/src/catalogs/es/app.ts
@@ -20,6 +20,7 @@ export const TranslatorTranslationAppSpanish : NamespaceTranslations<`${Translat
 
     [TranslatorTranslationAppKey.MANAGEMENT]: 'Gestión',
     [TranslatorTranslationAppKey.DETAILS]: 'Detalles',
+    [TranslatorTranslationAppKey.SET_MANAGEMENT_REALM]: 'Establecer como realm de gestión',
     [TranslatorTranslationAppKey.API_DOCS]: 'Documentación de la API',
     [TranslatorTranslationAppKey.MADE_WITH]: 'Hecho con',
 

--- a/packages/i18n/src/catalogs/fr/app.ts
+++ b/packages/i18n/src/catalogs/fr/app.ts
@@ -20,6 +20,7 @@ export const TranslatorTranslationAppFrench : NamespaceTranslations<`${Translato
 
     [TranslatorTranslationAppKey.MANAGEMENT]: 'Gestion',
     [TranslatorTranslationAppKey.DETAILS]: 'Détails',
+    [TranslatorTranslationAppKey.SET_MANAGEMENT_REALM]: 'Définir comme realm de gestion',
     [TranslatorTranslationAppKey.API_DOCS]: 'Documentation API',
     [TranslatorTranslationAppKey.MADE_WITH]: 'Fait avec',
 

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -126,6 +126,7 @@ export enum TranslatorTranslationAppKey {
 
     MANAGEMENT = 'management',
     DETAILS = 'details',
+    SET_MANAGEMENT_REALM = 'setManagementRealm',
     API_DOCS = 'apiDocs',
     MADE_WITH = 'madeWith',
 


### PR DESCRIPTION
## Summary

Fixes #3153. The icon-only `<VCButton>` action buttons in the `#cell-options` column of every entity index page rendered only a `<VCIcon>` with no visible text and no accessible name, so keyboard and screen-reader users couldn't identify the action.

This follows the existing a11y pattern in `AToggleButton.vue` (`useTranslations` + `:aria-label`).

## Changes

**`@authup/i18n`**
- Add one new `authupApp` key `SET_MANAGEMENT_REALM` (`setManagementRealm`), authored across all four locales (en/de/fr/es); locale-parity test enforces the parity.
- The "details" button reuses the **existing** `authupApp.DETAILS` key — it's literally the nav label of the `[id]` detail page the button links to, so no redundant key.

**`apps/client-web` — all 9 entity index pages** (clients, roles, permissions, policies, users, realms, identity-providers, robots, scopes)
- Add a localized `:aria-label` (+ `:title` tooltip) to the `fa6-solid:bars` "details" button.
- Realms page: same for the `fa6-solid:check` "set as management realm" button.
- Pages that already used `useTranslations` gained the `DETAILS` key; permissions/policies/realms gained a minimal `useTranslations` batch.

**`@authup/client-web-kit` — `AEntityDelete`**
- The sibling delete button on those same rows (`:with-text="false"`) was *also* icon-only with no accessible name — the same defect the issue title describes. Its icon-only variant now derives an accessible name (+ title) from the localized delete label. Gated on `withText` (default `true`), so only icon-only usages are affected; every text-labelled consumer is unchanged.

## Notes / decisions

- **`title` alongside `aria-label`**: the issue permits it ("optionally title"). Kept because the `bars`/`check` icons are genuinely ambiguous, so a hover tooltip helps sighted mouse users too. `aria-label` wins over `title` for the accessible name (ARIA name computation), so there's no double announcement.
- **Out of scope**: permissions/policies/realms still have hardcoded English column headers — full column-header i18n is a separate coverage task; this PR only adds the aria-label plumbing.

## Verification

- `nuxi typecheck` (client-web): pass — confirms every `translations.*` binding resolves.
- `@authup/i18n` tests: 77 passed (locale parity).
- `@authup/client-web-kit` tests: 7 passed.
- ESLint: clean on all changed files.
- Verified `VCButton` forwards fallthrough `aria-label`/`title` to the DOM via `mergeProps(..., attrs)` in both the native-button and `NuxtLink` render paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized text for a new “Set as management realm” action in multiple languages.
* **Bug Fixes**
  * Improved accessibility for icon-only action buttons by adding proper labels and tooltips.
  * Updated list-page action buttons to use translated “Details” text consistently.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->