### PR TITLE
test: add boundary specs for HTTP request helpers

### DIFF
--- a/apps/server-core/test/unit/adapters/http/request/body-realm-id.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/request/body-realm-id.spec.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { getBodyRealmID } from '../../../../../src/adapters/http/request';
+
+const UUID = '4f4d3b3e-1a2b-4c3d-8e9f-0a1b2c3d4e5f';
+
+describe('getBodyRealmID', () => {
+    it('should return a UUID realm_id', () => {
+        expect(getBodyRealmID({ realm_id: UUID })).toEqual(UUID);
+    });
+
+    it('should ignore a non-UUID realm_id', () => {
+        expect(getBodyRealmID({ realm_id: 'master' })).toBeUndefined();
+    });
+
+    it('should ignore a non-string realm_id', () => {
+        expect(getBodyRealmID({ realm_id: 123 as any })).toBeUndefined();
+    });
+
+    it('should return undefined for a missing realm_id or body', () => {
+        expect(getBodyRealmID({})).toBeUndefined();
+        expect(getBodyRealmID(undefined)).toBeUndefined();
+    });
+});

--- a/apps/server-core/test/unit/adapters/http/request/fake-event.ts
+++ b/apps/server-core/test/unit/adapters/http/request/fake-event.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IAppEvent } from 'routup';
+
+// The routup middlewares parse the request into these globally-registered
+// store slots. Seeding them directly lets a fabricated event exercise the
+// request helpers without the full HTTP dispatch chain.
+const COOKIE_SYMBOL = Symbol.for('@routup/cookie:ReqCookie');
+const QUERY_SYMBOL = Symbol.for('@routup/query:ReqQuery');
+const BODY_SYMBOL = Symbol.for('@routup/body:ReqBody');
+
+export type FakeEventInit = {
+    params?: Record<string, string | undefined>,
+    headers?: Record<string, string>,
+    cookies?: Record<string, string>,
+    query?: Record<string, any>,
+    body?: Record<string, any>,
+    store?: Record<string | symbol, unknown>,
+};
+
+export function createFakeEvent(init: FakeEventInit = {}): IAppEvent {
+    const store: Record<string | symbol, unknown> = { ...(init.store || {}) };
+
+    if (init.cookies) {
+        store[COOKIE_SYMBOL] = { ...init.cookies };
+    }
+    if (init.query) {
+        store[QUERY_SYMBOL] = { ...init.query };
+    }
+    if (init.body) {
+        store[BODY_SYMBOL] = { ...init.body };
+    }
+
+    const headers = new Headers(init.headers || {});
+
+    return {
+        request: new Request('http://localhost/'),
+        params: init.params || {},
+        path: '/',
+        method: 'GET',
+        mountPath: '',
+        headers,
+        searchParams: new URLSearchParams(),
+        store,
+    } as unknown as IAppEvent;
+}

--- a/apps/server-core/test/unit/adapters/http/request/locale.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/request/locale.spec.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { useRequestLocale } from '../../../../../src/adapters/http/request';
+import { createFakeEvent } from './fake-event';
+
+describe('useRequestLocale', () => {
+    it('should resolve the explicit locale cookie', () => {
+        const event = createFakeEvent({ cookies: { 'vc-locale': 'de' } });
+        expect(useRequestLocale(event)).toEqual('de');
+    });
+
+    it('should narrow a regioned cookie value to its base locale', () => {
+        const event = createFakeEvent({ cookies: { 'vc-locale': 'de-DE' } });
+        expect(useRequestLocale(event)).toEqual('de');
+    });
+
+    it('should let the cookie win over Accept-Language', () => {
+        const event = createFakeEvent({
+            cookies: { 'vc-locale': 'fr' },
+            headers: { 'accept-language': 'de' },
+        });
+        expect(useRequestLocale(event)).toEqual('fr');
+    });
+
+    it('should fall through to Accept-Language when the cookie is "auto"', () => {
+        const event = createFakeEvent({
+            cookies: { 'vc-locale': 'auto' },
+            headers: { 'accept-language': 'es' },
+        });
+        expect(useRequestLocale(event)).toEqual('es');
+    });
+
+    it('should fall through to Accept-Language when the cookie is unsupported', () => {
+        const event = createFakeEvent({
+            cookies: { 'vc-locale': 'xx' },
+            headers: { 'accept-language': 'fr' },
+        });
+        expect(useRequestLocale(event)).toEqual('fr');
+    });
+
+    it('should honor q-ordering and skip unauthored languages', () => {
+        const event = createFakeEvent({ headers: { 'accept-language': 'pt-BR, de;q=0.8' } });
+        expect(useRequestLocale(event)).toEqual('de');
+    });
+
+    it('should return undefined when nothing matches', () => {
+        const event = createFakeEvent({ headers: { 'accept-language': 'pt-BR' } });
+        expect(useRequestLocale(event)).toBeUndefined();
+    });
+
+    it('should return undefined when neither cookie nor header is present', () => {
+        expect(useRequestLocale(createFakeEvent())).toBeUndefined();
+    });
+});

--- a/apps/server-core/test/unit/adapters/http/request/locations.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/request/locations.spec.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFromLocations } from '../../../../../src/adapters/http/request';
+import { createFakeEvent } from './fake-event';
+
+describe('readFromLocations', () => {
+    it('should read from a single location', async () => {
+        const event = createFakeEvent({ body: { a: 1 } });
+        await expect(readFromLocations(event, ['body'])).resolves.toEqual({ a: 1 });
+    });
+
+    it('should aggregate distinct keys across locations', async () => {
+        const event = createFakeEvent({
+            body: { a: 1 },
+            query: { b: 2 },
+            params: { c: '3' },
+            cookies: { d: '4' },
+        });
+        await expect(
+            readFromLocations(event, ['body', 'query', 'params', 'cookies']),
+        ).resolves.toEqual({
+            a: 1,
+            b: 2,
+            c: '3',
+            d: '4',
+        });
+    });
+
+    it('should let a later location override an earlier one on key collision', async () => {
+        const event = createFakeEvent({
+            body: { realm_id: 'from-body' },
+            query: { realm_id: 'from-query' },
+        });
+        await expect(readFromLocations(event, ['body', 'query'])).resolves.toEqual({ realm_id: 'from-query' });
+        await expect(readFromLocations(event, ['query', 'body'])).resolves.toEqual({ realm_id: 'from-body' });
+    });
+
+    it('should return an empty object when locations yield nothing', async () => {
+        await expect(readFromLocations(createFakeEvent(), ['body', 'query'])).resolves.toEqual({});
+    });
+});

--- a/apps/server-core/test/unit/adapters/http/request/param-id.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/request/param-id.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { ValidupError } from 'validup';
+import {
+    getRequestParamID,
+    getRequestStringParam,
+    getRequestStringParamOrFail,
+    useRequestParamID,
+} from '../../../../../src/adapters/http/request';
+import { createFakeEvent } from './fake-event';
+
+const UUID = '4f4d3b3e-1a2b-4c3d-8e9f-0a1b2c3d4e5f';
+
+describe('getRequestParamID', () => {
+    it('should return a UUID id by default', () => {
+        const event = createFakeEvent({ params: { id: UUID } });
+        expect(getRequestParamID(event)).toEqual(UUID);
+    });
+
+    it('should reject a non-UUID id by default', () => {
+        const event = createFakeEvent({ params: { id: 'not-a-uuid' } });
+        expect(getRequestParamID(event)).toBeUndefined();
+    });
+
+    it('should accept a non-UUID id when isUUID is disabled', () => {
+        const event = createFakeEvent({ params: { id: 'not-a-uuid' } });
+        expect(getRequestParamID(event, { isUUID: false })).toEqual('not-a-uuid');
+    });
+
+    it('should return undefined when the id param is missing', () => {
+        expect(getRequestParamID(createFakeEvent())).toBeUndefined();
+    });
+});
+
+describe('useRequestParamID', () => {
+    it('should return the id when present', () => {
+        const event = createFakeEvent({ params: { id: UUID } });
+        expect(useRequestParamID(event)).toEqual(UUID);
+    });
+
+    it('should throw when the id is absent', () => {
+        expect(() => useRequestParamID(createFakeEvent())).toThrow(ValidupError);
+    });
+
+    it('should throw when the id is not a UUID and validation is enabled', () => {
+        const event = createFakeEvent({ params: { id: 'not-a-uuid' } });
+        expect(() => useRequestParamID(event)).toThrow(ValidupError);
+    });
+});
+
+describe('getRequestStringParam', () => {
+    it('should return a non-empty string param', () => {
+        const event = createFakeEvent({ params: { realmId: 'master' } });
+        expect(getRequestStringParam(event, 'realmId')).toEqual('master');
+    });
+
+    it('should return undefined for a missing or empty param', () => {
+        expect(getRequestStringParam(createFakeEvent(), 'realmId')).toBeUndefined();
+        expect(getRequestStringParam(createFakeEvent({ params: { realmId: '' } }), 'realmId')).toBeUndefined();
+    });
+});
+
+describe('getRequestStringParamOrFail', () => {
+    it('should return the value when present', () => {
+        const event = createFakeEvent({ params: { realmId: 'master' } });
+        expect(getRequestStringParamOrFail(event, 'realmId')).toEqual('master');
+    });
+
+    it('should throw when the value is absent', () => {
+        expect(() => getRequestStringParamOrFail(createFakeEvent(), 'realmId')).toThrow(ValidupError);
+    });
+});

--- a/apps/server-core/test/unit/adapters/http/request/request-helpers.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/request/request-helpers.spec.ts
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Client, Identity, Robot } from '@authup/core-kit';
+import { IdentityType } from '@authup/core-kit';
+import { UnauthorizedError } from '@authup/errors';
+import { FakePermissionEvaluator } from '@authup/server-test-kit';
+import { describe, expect, it } from 'vitest';
+import {
+    RequestIdentity,
+    RequestPermissionEvaluator,
+    applyRouteRealmIDToBody,
+    buildActorContext,
+    getRequestRealmID,
+    setRequestIdentity,
+    setRequestPermissionEvaluator,
+    setRequestRealmID,
+    setRequestScopes,
+    setRequestToken,
+    useRequestIdentity,
+    useRequestIdentityOrFail,
+    useRequestScopes,
+    useRequestToken,
+} from '../../../../../src/adapters/http/request';
+import { createFakeEvent } from './fake-event';
+
+function clientIdentity(data: Partial<Client>): Identity {
+    return { type: IdentityType.CLIENT, data: data as Client };
+}
+
+function robotIdentity(data: Partial<Robot>): Identity {
+    return { type: IdentityType.ROBOT, data: data as Robot };
+}
+
+describe('RequestIdentity', () => {
+    it('should expose a client identity id as its clientId', () => {
+        const identity = new RequestIdentity(clientIdentity({ id: 'c1', realm_id: 'r1' }));
+        expect(identity.clientId).toEqual('c1');
+        expect(identity.id).toEqual('c1');
+        expect(identity.type).toEqual(IdentityType.CLIENT);
+        expect(identity.realmId).toEqual('r1');
+    });
+
+    it('should derive a non-client clientId from the client_id field', () => {
+        const identity = new RequestIdentity(robotIdentity({ id: 'r1', client_id: 'c9' }));
+        expect(identity.clientId).toEqual('c9');
+    });
+
+    it('should return null clientId when client_id is null', () => {
+        const identity = new RequestIdentity(robotIdentity({ id: 'r1', client_id: null }));
+        expect(identity.clientId).toBeNull();
+    });
+
+    it('should read realm id/name from the nested realm relation', () => {
+        const identity = new RequestIdentity(robotIdentity({
+            id: 'r1',
+            realm: { id: 'r2', name: 'second' } as Robot['realm'],
+        }));
+        expect(identity.realmId).toEqual('r2');
+        expect(identity.realmName).toEqual('second');
+    });
+});
+
+describe('request identity helpers', () => {
+    it('should wrap a raw identity and read it back', () => {
+        const event = createFakeEvent();
+        setRequestIdentity(event, clientIdentity({ id: 'c1' }));
+
+        const identity = useRequestIdentity(event);
+        expect(identity).toBeInstanceOf(RequestIdentity);
+        expect(identity?.id).toEqual('c1');
+    });
+
+    it('should pass a RequestIdentity instance through unchanged', () => {
+        const event = createFakeEvent();
+        const wrapped = new RequestIdentity(clientIdentity({ id: 'c2' }));
+        setRequestIdentity(event, wrapped);
+
+        expect(useRequestIdentity(event)).toBe(wrapped);
+    });
+
+    it('should return undefined when no identity was set', () => {
+        expect(useRequestIdentity(createFakeEvent())).toBeUndefined();
+    });
+
+    it('should throw UnauthorizedError from useRequestIdentityOrFail when unauthenticated', () => {
+        expect(() => useRequestIdentityOrFail(createFakeEvent())).toThrow(UnauthorizedError);
+    });
+
+    it('should return the identity from useRequestIdentityOrFail when present', () => {
+        const event = createFakeEvent();
+        setRequestIdentity(event, clientIdentity({ id: 'c1' }));
+        expect(useRequestIdentityOrFail(event).id).toEqual('c1');
+    });
+});
+
+describe('request scopes', () => {
+    it('should default to an empty array', () => {
+        expect(useRequestScopes(createFakeEvent())).toEqual([]);
+    });
+
+    it('should store and read scopes', () => {
+        const event = createFakeEvent();
+        setRequestScopes(event, ['global']);
+        expect(useRequestScopes(event)).toEqual(['global']);
+    });
+});
+
+describe('request token', () => {
+    it('should default to undefined', () => {
+        expect(useRequestToken(createFakeEvent())).toBeUndefined();
+    });
+
+    it('should store and read the token', () => {
+        const event = createFakeEvent();
+        setRequestToken(event, 'abc');
+        expect(useRequestToken(event)).toEqual('abc');
+    });
+});
+
+describe('request realm id', () => {
+    it('should return undefined when no realm is known', () => {
+        expect(getRequestRealmID(createFakeEvent())).toBeUndefined();
+    });
+
+    it('should fall back to the realmId route param', () => {
+        const event = createFakeEvent({ params: { realmId: 'master' } });
+        expect(getRequestRealmID(event)).toEqual('master');
+    });
+
+    it('should let a stored realm id win over the route param', () => {
+        const event = createFakeEvent({ params: { realmId: 'master' } });
+        setRequestRealmID(event, 'resolved-uuid');
+        expect(getRequestRealmID(event)).toEqual('resolved-uuid');
+    });
+
+    it('should apply the route realm over a body realm', () => {
+        const event = createFakeEvent({ params: { realmId: 'route' } });
+        const body: Record<string, any> = { realm_id: 'body', name: 'x' };
+        applyRouteRealmIDToBody(event, body);
+        expect(body.realm_id).toEqual('route');
+    });
+
+    it('should leave the body realm untouched when no realm is known', () => {
+        const body: Record<string, any> = { realm_id: 'body' };
+        applyRouteRealmIDToBody(createFakeEvent(), body);
+        expect(body.realm_id).toEqual('body');
+    });
+});
+
+describe('buildActorContext', () => {
+    it('should assemble an actor context from identity and permission evaluator', () => {
+        const event = createFakeEvent();
+        const evaluator = new RequestPermissionEvaluator(event, new FakePermissionEvaluator());
+        const raw = clientIdentity({ id: 'c1' });
+
+        setRequestPermissionEvaluator(event, evaluator);
+        setRequestIdentity(event, raw);
+
+        const actor = buildActorContext(event);
+        expect(actor.permissionEvaluator).toBe(evaluator);
+        expect(actor.identity).toBe(raw);
+    });
+
+    it('should assemble an actor context without an identity', () => {
+        const event = createFakeEvent();
+        setRequestPermissionEvaluator(event, new RequestPermissionEvaluator(event, new FakePermissionEvaluator()));
+
+        expect(buildActorContext(event).identity).toBeUndefined();
+    });
+
+    it('should throw when the permission evaluator is not initialised', () => {
+        expect(() => buildActorContext(createFakeEvent())).toThrow('The request permission evaluator is not initialised.');
+    });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage for the previously-untested HTTP request helpers in `apps/server-core/src/adapters/http/request/` — the `locale`, `param-id`, `locations`, `body-realm-id`, `identity`/`actor`/`realm-id`/`scopes`/`token` helpers had no specs (only `redirect` did). **No production code changes.**

Tests are driven by a small fabricated routup event (`fake-event.ts`, which seeds routup's `@routup/{cookie,query,body}` store slots) so the real helper code paths run without an HTTP server:

- `request-helpers.spec.ts` — `RequestIdentity` getters, identity/scopes/token accessors, realm-id precedence (stored realm wins over route param; route wins over body), `buildActorContext` assembly + the "not initialised" guard
- `locale.spec.ts` — cookie vs q-ordered `Accept-Language` vs default negotiation
- `param-id.spec.ts` — UUID param validation / `useRequestParamID` throwing
- `locations.spec.ts` — `readFromLocations` aggregation + later-location override
- `body-realm-id.spec.ts` — `getBodyRealmID` UUID gating

## Note on scope

This PR originally also consolidated the flat request helpers into a single `RequestContext` builder (plan 029). That restructure was **explored and reverted**: it didn't achieve its headline goal ("build-order enforced by construction" — the lazy-created context still degrades gracefully, so the coupling was centralized, not enforced) and it introduced a duplicated call surface (`ctx.realmId` *and* `getRequestRealmID`, …) to avoid churning ~115 call sites. The genuinely valuable part — the test coverage — didn't need the restructure, so that's all that remains here. The flat `helpers/` structure stands unchanged.

A pre-existing rough edge surfaced during review (uncaught validation error when a global-scoped token's subject is unresolvable) is tracked separately in #3184.

## Verification

- `tsc` (src + tests) ✅
- Full server-core suite — 102 files, 1040 tests ✅
- ESLint ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broad unit test coverage for HTTP request handling, including locale resolution, parameter parsing, realm ID behavior, request identity, and location-based value lookup.
  * Added a reusable test helper for building request-like events, improving coverage and consistency across request adapter tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->