### PR TITLE
fix: do not attach undefined identity policy data for global-scoped requests

### DIFF
--- a/apps/server-core/src/adapters/http/request/permission/module.ts
+++ b/apps/server-core/src/adapters/http/request/permission/module.ts
@@ -48,9 +48,17 @@ export class RequestPermissionEvaluator implements IPermissionEvaluator {
 
     protected extendContext(ctx: PermissionEvaluationContext) {
         const scopes = useRequestScopes(this.event);
-        if (scopes.includes(ScopeName.GLOBAL)) {
+        const identity = useRequestIdentity(this.event);
+
+        // Only attach the identity policy data when an identity was actually
+        // resolved. Setting it to `undefined` would still make
+        // `PolicyData.has('identity')` true (key presence), so the built-in
+        // identity evaluator would run its validator against `undefined` and
+        // throw an uncaught error instead of a clean permission denial — see
+        // the deleted-subject edge case in issue #3184.
+        if (scopes.includes(ScopeName.GLOBAL) && identity) {
             ctx.data = ctx.data || new PolicyData();
-            ctx.data.set(BuiltInPolicyType.IDENTITY, useRequestIdentity(this.event));
+            ctx.data.set(BuiltInPolicyType.IDENTITY, identity);
         }
 
         return ctx;

--- a/apps/server-core/test/unit/adapters/http/request/permission.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/request/permission.spec.ts
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { BuiltInPolicyType } from '@authup/access';
+import type { Client, Identity } from '@authup/core-kit';
+import { IdentityType, ScopeName } from '@authup/core-kit';
+import { FakePermissionEvaluator } from '@authup/server-test-kit';
+import type { IAppEvent } from 'routup';
+import { describe, expect, it } from 'vitest';
+import {
+    RequestIdentity,
+    RequestPermissionEvaluator,
+    setRequestIdentity,
+    setRequestScopes,
+} from '../../../../../src/adapters/http/request';
+
+// The request helpers under test only read/write `event.store`.
+function createEvent(): IAppEvent {
+    return { store: {} } as unknown as IAppEvent;
+}
+
+function clientIdentity(data: Partial<Client>): Identity {
+    return { type: IdentityType.CLIENT, data: data as Client };
+}
+
+describe('RequestPermissionEvaluator', () => {
+    it('should not attach identity policy data for a global-scoped request without an identity', async () => {
+        const event = createEvent();
+        setRequestScopes(event, [ScopeName.GLOBAL]);
+        // Deliberately no identity — mirrors a Bearer token whose subject was
+        // deleted after issuance (issue #3184). Setting `undefined` here would
+        // make the built-in identity evaluator throw against undefined data.
+
+        const base = new FakePermissionEvaluator();
+        const evaluator = new RequestPermissionEvaluator(event, base);
+
+        await evaluator.evaluate({ name: 'test' });
+
+        const ctx = base.evaluateCalls[0];
+        expect(ctx.data?.has(BuiltInPolicyType.IDENTITY)).toBeFalsy();
+    });
+
+    it('should attach identity policy data when a global-scoped request has an identity', async () => {
+        const event = createEvent();
+        setRequestScopes(event, [ScopeName.GLOBAL]);
+        setRequestIdentity(event, clientIdentity({ id: 'c1' }));
+
+        const base = new FakePermissionEvaluator();
+        const evaluator = new RequestPermissionEvaluator(event, base);
+
+        await evaluator.evaluate({ name: 'test' });
+
+        const ctx = base.evaluateCalls[0];
+        expect(ctx.data?.has(BuiltInPolicyType.IDENTITY)).toBe(true);
+        expect(ctx.data?.get(BuiltInPolicyType.IDENTITY)).toBeInstanceOf(RequestIdentity);
+    });
+
+    it('should not attach identity policy data without global scope', async () => {
+        const event = createEvent();
+        setRequestIdentity(event, clientIdentity({ id: 'c1' }));
+        // No scopes → not global.
+
+        const base = new FakePermissionEvaluator();
+        const evaluator = new RequestPermissionEvaluator(event, base);
+
+        await evaluator.evaluate({ name: 'test' });
+
+        const ctx = base.evaluateCalls[0];
+        expect(ctx.data?.has(BuiltInPolicyType.IDENTITY)).toBeFalsy();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #3184.

`RequestPermissionEvaluator.extendContext` attached the built-in identity policy data whenever a request carried `global` scope — **even when no identity was resolved**:

```ts
if (scopes.includes(ScopeName.GLOBAL)) {
    ctx.data ||= new PolicyData();
    ctx.data.set(BuiltInPolicyType.IDENTITY, useRequestIdentity(this.event)); // may be undefined
}
```

`PolicyData.has()` is key-presence based (`key in data`), so `set('identity', undefined)` makes `has('identity')` return `true`. `IdentityPolicyEvaluator.accessData()` then runs `PolicyIdentityDataValidator.run(undefined)`, whose required `type`/`id` mounts throw a `ValidupError`. The evaluator doesn't catch it (it has an explicit `// todo: catch errors`), so an **uncaught validation error propagates instead of a clean permission denial**.

### Reachability

A Bearer access token with a still-valid session whose subject (user/client/robot) was **deleted after the token was issued**, hitting an endpoint whose permission binds `system.identity` (part of `system.default`). The authorization middleware sets the token's `global` scope but never calls `setIdentity()` because `identityResolver.resolve()` returns `null`. Basic auth is unaffected — it always sets scope and identity together.

### Fix

Guard the assignment on a resolved identity. When absent, `has('identity')` stays `false` → `accessData()` returns `null` → the evaluator returns a clean `DATA_MISSING` denial. **Fail-closed either way — the access outcome is unchanged; only the error path is fixed** (uncaught throw → clean denial).

## Test

`test/unit/adapters/http/request/permission.spec.ts` — a focused unit test on `RequestPermissionEvaluator` asserting that identity policy data is:
- **not** attached for a global-scoped request without an identity (fails against the pre-fix code — verified),
- attached (as the `RequestIdentity`) when an identity is present,
- not attached without global scope.

## Notes / out of scope

- The deeper root cause — `IdentityPolicyEvaluator.evaluate()` not honoring its own `// todo: catch errors + transform to issue(s)` — lives in `@authup/access` and is left for a separate change; the guard here resolves the reported scenario without touching shared evaluator error semantics.

## Verification

- `tsc` (src + tests) ✅
- Full server-core suite — 98 files, 995 tests ✅
- ESLint ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request permission handling so identity-based checks only run when a request identity is actually available.
  * Prevented identity policy data from being attached for requests outside the global scope.
  * Made permission evaluation behavior more consistent when identity information is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->