### PR TITLE
fix: dispatch SSR self-calls against the listen address

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -378,6 +378,28 @@ not by client-web:
   restores the authorize request. `sanitizeRelativeRedirect()` in
   `adapters/http/ui/render.ts` rejects absolute / protocol-relative URLs
   (open-redirect guard).
+- **Internal HTTP client (SSR self-calls)**: the render's API calls
+  (session hydration, identity-provider/scope fetches) go through the
+  client registered under `HTTPInjectionKey.UIHttpClient`.
+  `HTTPModule.setup` registers the production default —
+  `createInternalUIHttpClient` (`adapters/http/ui/internal-http-client.ts`),
+  a `@authup/core-http-kit` `Client` whose hapic `FetchTransport` rewrites
+  every request targeting `publicUrl` (origin + sub-path prefix, wildcard
+  listen hosts normalized to loopback) onto the server's own listen
+  address (`HTTPInjectionKey.Server` → `server.url`, resolved lazily per
+  request). So SSR self-calls never round-trip through the reverse proxy:
+  no TLS (a self-signed `publicUrl` cert would fail Node's fetch with
+  `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`), no dependency on the public
+  hostname resolving from inside the deployment. The rewrite is
+  transport-level ONLY — `baseURL` stays `publicUrl` because rendered
+  hrefs (e.g. identity-provider authorize links via `getAuthorizeUri`)
+  derive from it and hydration does not patch attribute mismatches. The
+  registration is `lifetime: 'transient'` (fresh client per render — the
+  kit's auth hook writes per-user state) and is skipped when the token is
+  already bound (test fakes win; see testing.md). Relatedly, the kit's
+  entity-collection manager catches its own load errors and emits
+  `failed` instead of rejecting — a failed SSR fetch renders the page
+  degraded rather than killing the process via an unhandled rejection.
 - **Sub-path deployment**: the SSR UI works behind a prefix-stripping
   reverse proxy (e.g. `https://example.com/auth/* → authup /*`) with no
   extra config — the prefix is derived from `publicUrl`'s pathname

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -135,7 +135,7 @@ selfClient.setAuthorizationHeader({ type: 'Bearer', token: token.access_token })
 
 ### Testing the SSR'd UI pages (fake HTTP client)
 
-The five SSR auth pages (`GET /authorize`, `/register`, `/activate`, `/password-forgot`, `/password-reset`) render the bundled Vue app under `apps/server-core/ui/`, which fires HTTP calls during render (session hydration via `store.resolve()`, identity-provider and scope fetches). Tests stub those by injecting a fake HTTP client into the SSR — never let the rendered app reach a real server:
+The five SSR auth pages (`GET /authorize`, `/register`, `/activate`, `/password-forgot`, `/password-reset`) render the bundled Vue app under `apps/server-core/ui/`, which fires HTTP calls during render (session hydration via `store.resolve()`, identity-provider and scope fetches). Tests stub those by injecting a fake HTTP client into the SSR — don't let the rendered app depend on real network behavior unless the test targets exactly that (see `ui-pages-internal-client.spec.ts`):
 
 ```typescript
 import { createFakeClient as createFakeHTTPClient } from '@authup/core-http-kit/testing';
@@ -152,12 +152,12 @@ await suite.setup();
 const response = await httpRequest(suite, 'GET', '/register');
 ```
 
-Wiring: the HTTP module mounts a per-request middleware (only when `HTTPInjectionKey.UIHttpClient` is registered — production registers nothing) that stamps a resolve-thunk onto `event.store`; `renderUIPage` resolves per render. Register with `useFactory` + `lifetime: 'transient'` (eldin) — never a singleton-lifetime instance, the client carries per-user Authorization state — and the client is forwarded into the SSR `render()`, and `@authup/client-web-kit`'s `install({ httpClient })` uses it for the provided client, the session store, and the authentication hook alike. See `test/unit/http/controllers/workflows/ui-pages.spec.ts` for hydration-payload assertions (XSS escaping, redirect sanitizing, feature flags).
+Wiring: `HTTPModule.setup` registers a DEFAULT client under `HTTPInjectionKey.UIHttpClient` — `createInternalUIHttpClient`, whose transport rewrites requests targeting `publicUrl` onto the server's own listen address (see architecture.md → Auth Workflow UI) — unless the token is already bound, so a fake registered before `suite.setup()` wins. A per-request middleware stamps a resolve-thunk onto `event.store`; `renderUIPage` resolves per render. Register with `useFactory` + `lifetime: 'transient'` (eldin) — never a singleton-lifetime instance, the client carries per-user Authorization state — and the client is forwarded into the SSR `render()`, and `@authup/client-web-kit`'s `install({ httpClient })` uses it for the provided client, the session store, and the authentication hook alike. See `test/unit/http/controllers/workflows/ui-pages.spec.ts` for hydration-payload assertions (XSS escaping, redirect sanitizing, feature flags) and `ui-pages-internal-client.spec.ts` for the default-client path (loopback dispatch, public hrefs, sub-path `publicUrl` — the test factory takes a config override: `createTestApplication({ config: (c) => { c.publicUrl = '...'; } })`).
 
 Caveats:
 - Register the fake **before** `suite.setup()` — the middleware mount is decided at boot.
 - The SSR renders from the **dist** bundle (`dist/ui/server/server.js`) — rebuild `apps/server-core` after changing the UI app or `client-web-kit`, or the tests exercise a stale bundle.
-- The default unmatched-route fallback returns a collection shape (`{ data: [], meta: { total: 0 } }`); session endpoints need explicit handlers for logged-in renders, and handlers on fire-and-forget fetch paths must not throw (an unawaited rejection fails vitest).
+- The default unmatched-route fallback returns a collection shape (`{ data: [], meta: { total: 0 } }`); session endpoints need explicit handlers for logged-in renders. Entity-collection loads catch their own errors (they emit `failed` instead of rejecting — SSR crash hardening), but handlers on OTHER fire-and-forget fetch paths must not throw (an unawaited rejection fails vitest).
 - Alias the import (`createFakeHTTPClient`) — `test/utils` already exports a `createFakeClient` entity factory.
 
 ## Component Tests (packages/client-web-kit)

--- a/apps/server-core/src/adapters/http/middleware/built-in/ui-http-client.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/ui-http-client.ts
@@ -16,8 +16,8 @@ import { defineCoreHandler } from 'routup';
  * whose registration carries `lifetime: 'transient'`, so every SSR
  * render resolves a fresh client — never share one client instance
  * across renders (the authentication hook writes per-user state onto
- * it). Mounted only when the token is bound (test injection);
- * production mounts nothing.
+ * it). Production binds the internal loopback client by default
+ * (`HTTPModule.registerUIHttpClient`); tests may pre-register a fake.
  */
 export const UI_HTTP_CLIENT_FACTORY_STORE_KEY = Symbol('UIHttpClientFactory');
 

--- a/apps/server-core/src/adapters/http/ui/index.ts
+++ b/apps/server-core/src/adapters/http/ui/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './base-path.ts';
+export * from './internal-http-client.ts';
 export * from './render.ts';
 export * from './serve.ts';
 export * from './types.ts';

--- a/apps/server-core/src/adapters/http/ui/internal-http-client.ts
+++ b/apps/server-core/src/adapters/http/ui/internal-http-client.ts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { Client } from '@authup/core-http-kit';
+import type { IClient } from '@authup/core-http-kit';
+import { FetchTransport, fetch } from 'hapic';
+import type { InternalUIHttpClientContext } from './types.ts';
+
+/**
+ * Build a rewriter that maps URLs under the public base URL
+ * (scheme://host[/prefix]) onto the server's own listen address. URLs
+ * outside the public origin/prefix pass through untouched.
+ */
+export function createPublicToInternalURLRewriter(
+    publicURL: string,
+    internalURL: string,
+) : (url: string) => string {
+    const publicParsed = new URL(publicURL);
+    const internalParsed = new URL(internalURL);
+    // a wildcard listen address (0.0.0.0 / [::]) is not reliably dialable —
+    // loop back explicitly
+    if (internalParsed.hostname === '0.0.0.0' || internalParsed.hostname === '[::]') {
+        internalParsed.hostname = '127.0.0.1';
+    }
+    const basePath = publicParsed.pathname.replace(/\/+$/, '');
+
+    return (url: string) => {
+        let parsed : URL;
+        try {
+            parsed = new URL(url);
+        } catch {
+            return url;
+        }
+
+        if (parsed.origin !== publicParsed.origin) {
+            return url;
+        }
+
+        let { pathname } = parsed;
+        if (basePath) {
+            if (pathname === basePath) {
+                pathname = '/';
+            } else if (pathname.startsWith(`${basePath}/`)) {
+                pathname = pathname.substring(basePath.length);
+            } else {
+                return url;
+            }
+        }
+
+        return new URL(pathname + parsed.search, internalParsed.origin).href;
+    };
+}
+
+/**
+ * HTTP client for the SSR'd UI pages: the render's API calls target the
+ * server itself, so they are dispatched against its own listen address —
+ * no reverse-proxy round-trip, no TLS (a self-signed publicUrl certificate
+ * would otherwise fail Node's fetch), no dependency on the public hostname
+ * resolving from inside the deployment.
+ *
+ * The rewrite happens at the TRANSPORT layer only: `baseURL` must stay the
+ * public URL because the rendered HTML derives user-facing URLs from it
+ * (e.g. the identity-provider authorize hrefs via `getAuthorizeUri`), and
+ * hydration does not patch attribute mismatches.
+ */
+export function createInternalUIHttpClient(ctx: InternalUIHttpClientContext) : IClient {
+    const rewriteURL = createPublicToInternalURLRewriter(ctx.publicURL, ctx.internalURL);
+
+    return new Client({
+        baseURL: ctx.publicURL,
+        transport: new FetchTransport({ fetch: (input, init) => fetch(rewriteURL(input), init) }),
+    });
+}

--- a/apps/server-core/src/adapters/http/ui/types.ts
+++ b/apps/server-core/src/adapters/http/ui/types.ts
@@ -12,3 +12,16 @@ export type UIRenderContext = {
         data: Record<string, any>,
     },
 };
+
+export type InternalUIHttpClientContext = {
+    /**
+     * The public base URL (config `publicUrl`) — stays the client's
+     * `baseURL` so URLs rendered into the HTML remain user-facing.
+     */
+    publicURL: string,
+    /**
+     * The server's own listen address (e.g. http://localhost:3010/) —
+     * where the transport actually dispatches requests.
+     */
+    internalURL: string,
+};

--- a/apps/server-core/src/app/modules/http/constants.ts
+++ b/apps/server-core/src/app/modules/http/constants.ts
@@ -14,8 +14,10 @@ export type HTTPServer = ReturnType<typeof serve>;
 export const HTTPInjectionKey = {
     Server: new TypedToken<HTTPServer>('Server'),
     /**
-     * Optional HTTP-client override for the SSR'd UI pages (test
-     * injection — production registers nothing). Register it with a
+     * HTTP client for the SSR'd UI pages. `HTTPModule.setup` registers a
+     * default whose transport dispatches against the server's own listen
+     * address (see `createInternalUIHttpClient`); a registration made
+     * BEFORE setup wins (test injection). Register it with a
      * `useFactory` provider and `lifetime: 'transient'` so every
      * resolve yields a FRESH client: client-web-kit's authentication
      * hook writes per-user Authorization state onto the client it

--- a/apps/server-core/src/app/modules/http/module.ts
+++ b/apps/server-core/src/app/modules/http/module.ts
@@ -5,10 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { Client } from '@authup/core-http-kit';
 import { App } from 'routup';
 import { serve } from 'routup/node';
 import { ConfigInjectionKey } from '../config/index.ts';
 import type { IModule } from 'orkos';
+import { createInternalUIHttpClient } from '../../../adapters/http/ui/index.ts';
 import { ModuleName } from '../constants.ts';
 import type { HTTPServer } from './constants.ts';
 import { HTTPInjectionKey } from './constants.ts';
@@ -27,11 +29,14 @@ export class HTTPModule implements IModule {
 
     protected controller : HTTPControllerModule;
 
+    protected uiHttpClientRegistered : boolean;
+
     constructor() {
         this.name = ModuleName.HTTP;
         this.dependencies = [ModuleName.CONFIG, ModuleName.LOGGER, ModuleName.AUTHENTICATION, ModuleName.IDENTITY, ModuleName.OAUTH2];
         this.controller = new HTTPControllerModule();
         this.middleware = new HTTPMiddlewareModule();
+        this.uiHttpClientRegistered = false;
     }
 
     // ----------------------------------------------------
@@ -43,6 +48,8 @@ export class HTTPModule implements IModule {
         logger.debug('Starting http server...');
 
         const router = new App();
+
+        this.registerUIHttpClient(container);
 
         await this.middleware.mountBefore(router, container);
         await this.controller.mount(router, container);
@@ -72,7 +79,53 @@ export class HTTPModule implements IModule {
 
     // ----------------------------------------------------
 
+    /**
+     * Default HTTP client for the SSR'd UI pages: dispatches against the
+     * server's own listen address instead of round-tripping through the
+     * reverse proxy at `publicUrl` (see `createInternalUIHttpClient`).
+     * Skipped when the token is already bound (test injection wins).
+     * Transient lifetime is mandatory — client-web-kit's authentication
+     * hook writes per-user Authorization state onto the client.
+     */
+    protected registerUIHttpClient(container: IContainer): void {
+        if (container.has(HTTPInjectionKey.UIHttpClient)) {
+            return;
+        }
+
+        container.register(HTTPInjectionKey.UIHttpClient, {
+            useFactory: (c) => {
+                const config = c.resolve(ConfigInjectionKey);
+
+                // The server token is registered after listen; a resolve can
+                // only happen on a request, so it is present by then. The
+                // guards keep an edge case on the previous (public URL)
+                // dispatch behavior instead of failing the render.
+                const server = c.has(HTTPInjectionKey.Server) ?
+                    c.resolve(HTTPInjectionKey.Server) :
+                    undefined;
+
+                if (server && server.url) {
+                    return createInternalUIHttpClient({
+                        publicURL: config.publicUrl,
+                        internalURL: server.url,
+                    });
+                }
+
+                return new Client({ baseURL: config.publicUrl });
+            },
+        }, { lifetime: 'transient' });
+
+        this.uiHttpClientRegistered = true;
+    }
+
+    // ----------------------------------------------------
+
     async teardown(container: IContainer): Promise<void> {
+        if (this.uiHttpClientRegistered) {
+            container.unregister(HTTPInjectionKey.UIHttpClient);
+            this.uiHttpClientRegistered = false;
+        }
+
         if (!this.instance) return;
 
         container.unregister(HTTPInjectionKey.Server);

--- a/apps/server-core/test/app/factory.ts
+++ b/apps/server-core/test/app/factory.ts
@@ -17,7 +17,7 @@ import { TestApplication } from './module.ts';
 import { TestHTTPApplication } from './http.ts';
 import { createTestDatabaseModuleForSuite } from './database.ts';
 
-async function buildTestConfig(): Promise<Config> {
+async function buildTestConfig(alter?: (config: Config) => void): Promise<Config> {
     const raw = readConfigRawFromEnv();
     const config = await normalizeConfig(raw);
 
@@ -37,12 +37,20 @@ async function buildTestConfig(): Promise<Config> {
     config.emailVerificationEnabled = true;
     config.passwordRecoveryEnabled = true;
 
+    if (alter) {
+        alter(config);
+    }
+
     return config;
 }
 
-export function createTestApplication() : TestHTTPApplication {
+export type TestApplicationOptions = {
+    config?: (config: Config) => void,
+};
+
+export function createTestApplication(options: TestApplicationOptions = {}) : TestHTTPApplication {
     const modules = new ApplicationBuilder()
-        .withConfig(new ConfigModule(buildTestConfig))
+        .withConfig(new ConfigModule(() => buildTestConfig(options.config)))
         .withLogger()
         .withCache()
         .withLdap()

--- a/apps/server-core/test/unit/adapters/http/ui/internal-http-client.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/internal-http-client.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    createInternalUIHttpClient,
+    createPublicToInternalURLRewriter,
+} from '../../../../../src/adapters/http/ui/internal-http-client.ts';
+
+describe('createPublicToInternalURLRewriter', () => {
+    it('rewrites urls under a prefixed public url onto the internal address', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('https://hub.local/auth/identity-providers?filter%5Benabled%5D=true'))
+            .toEqual('http://localhost:3010/identity-providers?filter%5Benabled%5D=true');
+    });
+
+    it('rewrites the bare prefix to the internal root', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('https://hub.local/auth')).toEqual('http://localhost:3010/');
+    });
+
+    it('rewrites urls under a prefix-less public url', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://auth.example.com',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('https://auth.example.com/token')).toEqual('http://localhost:3010/token');
+    });
+
+    it('normalizes a trailing slash on the public url', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth/',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('https://hub.local/auth/realms')).toEqual('http://localhost:3010/realms');
+    });
+
+    it('leaves urls with a foreign origin untouched', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('https://idp.example.com/oauth2/authorize'))
+            .toEqual('https://idp.example.com/oauth2/authorize');
+    });
+
+    it('leaves same-origin urls outside the prefix untouched', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('https://hub.local/other/thing'))
+            .toEqual('https://hub.local/other/thing');
+
+        // prefix must match on a segment boundary
+        expect(rewrite('https://hub.local/authorize'))
+            .toEqual('https://hub.local/authorize');
+    });
+
+    it('normalizes a wildcard internal listen address to loopback', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://0.0.0.0:64331/',
+        );
+
+        expect(rewrite('https://hub.local/auth/realms')).toEqual('http://127.0.0.1:64331/realms');
+    });
+
+    it('leaves non-absolute input untouched', () => {
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://localhost:3010/',
+        );
+
+        expect(rewrite('/identity-providers')).toEqual('/identity-providers');
+    });
+});
+
+describe('createInternalUIHttpClient', () => {
+    it('keeps the public url as baseURL so rendered hrefs stay user-facing', () => {
+        const client = createInternalUIHttpClient({
+            publicURL: 'https://hub.local/auth',
+            internalURL: 'http://localhost:3010/',
+        });
+
+        expect(client.getBaseURL()).toEqual('https://hub.local/auth');
+        expect(client.identityProvider.getAuthorizeUri('foo')).toContain('https://hub.local/auth');
+    });
+});

--- a/apps/server-core/test/unit/adapters/http/ui/internal-http-client.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/internal-http-client.spec.ts
@@ -82,6 +82,17 @@ describe('createPublicToInternalURLRewriter', () => {
         expect(rewrite('https://hub.local/auth/realms')).toEqual('http://127.0.0.1:64331/realms');
     });
 
+    it('normalizes an ipv6 wildcard internal listen address to loopback', () => {
+        // WHATWG URL serializes an IPv6 hostname WITH brackets:
+        // new URL('http://[::]:64331/').hostname === '[::]'
+        const rewrite = createPublicToInternalURLRewriter(
+            'https://hub.local/auth',
+            'http://[::]:64331/',
+        );
+
+        expect(rewrite('https://hub.local/auth/realms')).toEqual('http://127.0.0.1:64331/realms');
+    });
+
     it('leaves non-absolute input untouched', () => {
         const rewrite = createPublicToInternalURLRewriter(
             'https://hub.local/auth',

--- a/apps/server-core/test/unit/http/controllers/workflows/ui-pages-internal-client.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/ui-pages-internal-client.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { ScopeName } from '@authup/core-kit';
+import { ConfigInjectionKey, HTTPInjectionKey } from '../../../../../src/app';
+import { createFakeClient, createFakeOAuth2IdentityProvider, httpRequest } from '../../../../utils';
+import { createTestApplication } from '../../../../app';
+import type { TestHTTPApplication } from '../../../../app';
+
+/**
+ * Unlike ui-pages.spec.ts, no fake UI http client is registered here — the
+ * suites exercise the DEFAULT client wired by `HTTPModule.setup`, whose
+ * transport rewrites requests targeting the public base URL onto the
+ * server's own listen address. The SSR renders therefore fetch from the
+ * live test server itself (the identity-provider list is loaded
+ * fire-and-forget during the render, so its DATA is asserted through the
+ * resolved client, not the emitted HTML).
+ */
+async function renderAuthorizePage(suite: TestHTTPApplication) : Promise<string> {
+    const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+    const client = await suite.client.client.create(createFakeClient());
+    await suite.client.clientScope.create({
+        scope_id: scope.id,
+        client_id: client.id,
+    });
+
+    const query = new URLSearchParams({
+        response_type: 'code',
+        client_id: client.id,
+        redirect_uri: 'https://example.com/redirect',
+        scope: ScopeName.GLOBAL,
+    });
+
+    const response = await httpRequest(suite, 'GET', `/authorize?${query.toString()}`);
+    expect(response.status).toEqual(200);
+    expect(response.headers.get('content-type')).toContain('text/html');
+
+    return response.text();
+}
+
+describe('src/http/controllers/workflows (SSR pages, internal client)', () => {
+    const suite = createTestApplication();
+
+    beforeAll(async () => {
+        await suite.setup();
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    it('should dispatch against the listen address while keeping the public baseURL', async () => {
+        const provider = await suite.client.identityProvider.create(createFakeOAuth2IdentityProvider());
+
+        const config = suite.container.resolve(ConfigInjectionKey);
+        const uiHttpClient = suite.container.resolve(HTTPInjectionKey.UIHttpClient);
+        expect(uiHttpClient.getBaseURL()).toEqual(config.publicUrl);
+        expect(uiHttpClient.getBaseURL()).not.toContain(suite.baseURL);
+
+        const response = await uiHttpClient.identityProvider.getMany();
+        expect(response.data.map((item) => item.id)).toContain(provider.id);
+    });
+
+    it('should resolve a fresh client per request', async () => {
+        const first = suite.container.resolve(HTTPInjectionKey.UIHttpClient);
+        const second = suite.container.resolve(HTTPInjectionKey.UIHttpClient);
+        expect(first).not.toBe(second);
+    });
+
+    it('should serve the authorize page without leaking the listen address', async () => {
+        const body = await renderAuthorizePage(suite);
+
+        expect(body).not.toContain(suite.baseURL);
+    });
+});
+
+describe('src/http/controllers/workflows (SSR pages, internal client, sub-path public url)', () => {
+    const suite = createTestApplication({
+        config: (config) => {
+            config.publicUrl = 'https://hub.local/auth/';
+        },
+    });
+
+    beforeAll(async () => {
+        await suite.setup();
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    it('should rewrite prefixed public urls onto the listen address', async () => {
+        const provider = await suite.client.identityProvider.create(createFakeOAuth2IdentityProvider());
+
+        const uiHttpClient = suite.container.resolve(HTTPInjectionKey.UIHttpClient);
+        expect(uiHttpClient.getBaseURL()).toContain('https://hub.local/auth');
+
+        // an actual https://hub.local dispatch could never resolve here —
+        // data proves the transport rewrote origin AND prefix
+        const response = await uiHttpClient.identityProvider.getMany();
+        expect(response.data.map((item) => item.id)).toContain(provider.id);
+
+        // user-facing URL building stays on the prefixed public base
+        expect(uiHttpClient.identityProvider.getAuthorizeUri(provider.id))
+            .toContain(`https://hub.local/auth/identity-providers/${provider.id}/`);
+    });
+
+    it('should serve the authorize page with prefixed asset urls', async () => {
+        const body = await renderAuthorizePage(suite);
+
+        expect(body).toContain('/auth/public/');
+        expect(body).not.toContain(suite.baseURL);
+    });
+});

--- a/packages/client-web-kit/src/components/utility/entity/collection/module.ts
+++ b/packages/client-web-kit/src/components/utility/entity/collection/module.ts
@@ -48,6 +48,7 @@ import {
     ListHandlers,
     mergeEntityCollectionRenderOptions,
 } from './utils';
+import { isError } from '@authup/errors';
 
 const merger = createMerger({
     array: false,
@@ -97,9 +98,10 @@ function create<
         }
     };
 
-    // Never rejects: every call site is fire-and-forget (the setup-time
-    // initial load below, template refs, pagination footers). During SSR an
-    // unhandled rejection is fatal to the server process, so a failed load
+    // Never rejects: callers don't reliably handle rejections — most call
+    // sites are fire-and-forget (the setup-time initial load below, template
+    // refs, pagination footers) and the awaiting ones don't catch. During SSR
+    // an unhandled rejection is fatal to the server process, so a failed load
     // emits `failed` and leaves the list empty instead of throwing.
     async function load(input: ListMeta<RECORD> = {}) {
         if (!domainAPI || busy.value) return;
@@ -168,7 +170,7 @@ function create<
                 offset: response.meta.offset,
             };
         } catch (e) {
-            failed(e instanceof Error ? e : new Error('The entities could not be loaded.'));
+            failed(isError(e) ? e : new Error('The entities could not be loaded.'));
             return;
         } finally {
             busy.value = false;

--- a/packages/client-web-kit/src/components/utility/entity/collection/module.ts
+++ b/packages/client-web-kit/src/components/utility/entity/collection/module.ts
@@ -91,6 +91,16 @@ function create<
 
     let query : BuildInput<Entity<RECORD>> | undefined;
 
+    const failed = (error: Error) => {
+        if (context.setup && typeof context.setup.emit === 'function') {
+            context.setup.emit('failed', error);
+        }
+    };
+
+    // Never rejects: every call site is fire-and-forget (the setup-time
+    // initial load below, template refs, pagination footers). During SSR an
+    // unhandled rejection is fatal to the server process, so a failed load
+    // emits `failed` and leaves the list empty instead of throwing.
     async function load(input: ListMeta<RECORD> = {}) {
         if (!domainAPI || busy.value) return;
 
@@ -157,6 +167,9 @@ function create<
                 limit: response.meta.limit,
                 offset: response.meta.offset,
             };
+        } catch (e) {
+            failed(e instanceof Error ? e : new Error('The entities could not be loaded.'));
+            return;
         } finally {
             busy.value = false;
             meta.value.busy = false;

--- a/packages/client-web-kit/src/components/utility/entity/collection/types.ts
+++ b/packages/client-web-kit/src/components/utility/entity/collection/types.ts
@@ -124,7 +124,8 @@ export type EntityCollectionVSlots<T extends Record<string, any>> = {
 export type EntityCollectionVEmitOptions<T> = {
     created: (item: T) => true,
     deleted: (item: T) => true,
-    updated: (item: T) => true
+    updated: (item: T) => true,
+    failed: (error: Error) => true
 };
 
 export type EntityCollectionManagerCreateContext<

--- a/packages/client-web-kit/src/components/utility/entity/collection/utils/component.ts
+++ b/packages/client-web-kit/src/components/utility/entity/collection/utils/component.ts
@@ -18,12 +18,14 @@ import type {
 
 export function defineEntityCollectionVEmitOptions<T>() : EntityCollectionVEmitOptions<T> {
     return {
-         
+
         created: (_item: T) => true,
-         
+
         deleted: (_item: T) => true,
-         
+
         updated: (_item: T) => true,
+
+        failed: (_error: Error) => true,
     };
 }
 export function defineEntityCollectionVProps<T>() {

--- a/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
@@ -7,7 +7,7 @@
 
 import { flushPromises } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
-import { ARealmPicker } from '../../../../src/components/entities';
+import { AIdentityProviders, ARealmPicker } from '../../../../src/components/entities';
 import { findTokenRequest, mountLoginForm } from '../../../utils';
 
 type LoginFormWrapper = ReturnType<typeof mountLoginForm>['wrapper'];
@@ -101,5 +101,24 @@ describe('components/workflows/login', () => {
         expect(body.username).toEqual('admin');
         expect(body.password).toEqual('start123');
         expect('realm_id' in body).toBe(false);
+    });
+
+    // Regression: the collection manager's setup-time load is
+    // fire-and-forget — an uncaught rejection is fatal to an SSR process.
+    // A failing request must be routed into the `failed` emit and leave
+    // the form usable (rendered without the provider list).
+    it('should render when identity provider load fails', async () => {
+        const { wrapper } = mountLoginForm({}, {
+            'GET /identity-providers': () => {
+                throw new Error('unable to get local issuer certificate');
+            },
+        });
+        await flushPromises();
+
+        expect(wrapper.find('form').exists()).toBe(true);
+
+        const providers = wrapper.findComponent(AIdentityProviders);
+        expect(providers.exists()).toBe(true);
+        expect(providers.emitted('failed')).toBeTruthy();
     });
 });

--- a/packages/core-http-kit/src/client/type.ts
+++ b/packages/core-http-kit/src/client/type.ts
@@ -6,7 +6,7 @@
  */
 
 import type { OAuth2JsonWebKey, OpenIDProviderMetadata } from '@authup/specs';
-import type { IClient as IBaseClient, RequestBaseOptions } from 'hapic';
+import type { ClientOptionsInput, IClient as IBaseClient } from 'hapic';
 import type {
     IClientAPI,
     IClientPermissionAPI,
@@ -35,7 +35,7 @@ import type {
     IUserRoleAPI,
 } from '../domains';
 
-export type ClientOptions = RequestBaseOptions;
+export type ClientOptions = ClientOptionsInput;
 
 /**
  * Replaceable contract of the authup HTTP client: the base transport


### PR DESCRIPTION
## Problem

The SSR'd auth pages (`/authorize`, `/register`, ...) build their API client from `publicUrl`, so every server-side render round-trips through the reverse proxy. With a self-signed local certificate (e.g. `https://hub.local`), Node's fetch fails with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` — and because the identity-provider list load fires as an unawaited promise, the rejection escaped the request pipeline and crashed the whole server process. The setup also silently required the container to be able to resolve and reach its own public hostname.

## Changes

**server-core — internal loopback client for SSR self-calls**
- `HTTPModule.setup` now registers a production default under `HTTPInjectionKey.UIHttpClient` (previously test-injection only; a registration made before setup still wins).
- The client (`createInternalUIHttpClient`, `adapters/http/ui/internal-http-client.ts`) keeps `baseURL = publicUrl` — rendered hrefs (e.g. identity-provider authorize links) derive from it and hydration does not patch attribute mismatches — while its hapic `FetchTransport` rewrites every request targeting the public origin + sub-path prefix onto the server's own listen address (`server.url`, wildcard binds normalized to loopback, resolved lazily per request).
- Registration is `lifetime: 'transient'`: a fresh client per render, no shared per-user state.

**client-web-kit — SSR crash hardening**
- The entity-collection manager's `load()` no longer rejects: errors are caught and emitted as a new `failed` event. A failed SSR fetch renders the page degraded (login form without the provider list) instead of killing the process via an unhandled rejection.

**core-http-kit**
- `ClientOptions` widened from `RequestBaseOptions` to hapic's `ClientOptionsInput` (strictly additive), exposing the `transport` seam.

## Tests

- Unit spec for the URL rewriter: prefixed public URLs (`https://hub.local/auth`), trailing slash, bare prefix, foreign origins, segment-boundary safety (`/authorize` vs `/auth/...`), wildcard-host normalization.
- New integration suite `ui-pages-internal-client.spec.ts`: exercises the default client (no fake registered) against a live test server, once with default config and once with `publicUrl = 'https://hub.local/auth/'` (the test factory gained a config-override hook) — loopback dispatch returns real data, `getBaseURL()`/`getAuthorizeUri()` stay public, per-request resolves yield distinct clients, and the rendered `/authorize` page never leaks the listen address (and carries `/auth/public/` asset URLs in sub-path mode).
- Kit spec: a throwing `GET /identity-providers` handler → login form still renders and `failed` is emitted.

Full server-core suite (105 files / 1057 tests), client-web-kit and core-http-kit suites pass. `.agents/architecture.md` / `.agents/testing.md` updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SSR-auth pages now use a more reliable internal request path, improving page rendering behind proxies and in local/test environments.
  * URL handling now keeps user-facing links and assets aligned with the configured public address, even when the app is served from a sub-path.

* **Bug Fixes**
  * SSR page loads degrade gracefully when internal requests fail, reducing the chance of render failures.
  * Login and identity-provider flows now handle fetch errors more safely without breaking the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->