### PR TITLE
fix: reuse bearer session on interactive authorization_code login

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1267,6 +1267,38 @@ straight to TypeORM. **`SessionRepository.findMany` force-selects `realm_id` /
 could strip `realm_id` and neutralize the realm_scope reach factor (cross-realm
 leak). `client-web` UI is a follow-up (PR G2).
 
+### Session continuity: one session per interactive login
+
+An interactive client-web login used to create **two** `auth_sessions` rows: the
+SSR `/authorize` page password-grants a (client-less) bearer session purely to
+authenticate `POST /authorize`, then `/login/callback` exchanges the auth code —
+whose `authorization_code` grant `create()`d a *second* session. The bearer
+session was then abandoned but lingered until expiry (and showed up in the
+sessions list).
+
+The authorization_code grant now **reuses** that bearer session instead of
+minting a second one. The mechanism threads the bearer's session id through the
+auth-code blob:
+
+- `OAuth2AuthorizationCode` carries an optional `session_id` (cache-backed blob —
+  Redis, **no migration**). `HTTPOAuth2Authorizer.authorizeWithRequest` reads
+  `useRequestSessionId(event)` (the id the authorization middleware stashed from
+  the authenticated bearer — server-derived, never client input) and threads it
+  `OAuth2Authorization.authorize(data, identity, { sessionId })` →
+  `OAuth2AuthorizationCodeIssuer.issue(..., { sessionId })` → `entity.session_id`.
+- `OAuth2AuthorizeGrant.resolveSession` reuses the referenced session iff it
+  still exists **and** matches the code's `sub` / `sub_kind` / `realm_id`
+  (defense in depth); it stamps the authorizing `client_id` onto the row and
+  `sessionManager.refresh()`es it. Any mismatch, or a **session-less** authorize
+  flow (external-IdP callback — `IdentityProviderController` issues its code with
+  no `sessionId`; non-interactive clients), falls back to `sessionManager.create()`,
+  preserving prior behavior.
+
+Covered by `test/unit/core/oauth2/grant-types/authorize.spec.ts` (reuse vs.
+fallback branches, incl. the sub/realm-mismatch fail-safes) and the end-to-end
+`test/unit/http/controllers/workflows/token/grant-authorize-session.spec.ts`
+(login → authorize → exchange asserts a single session survives).
+
 ## Provisioning Permissions With Policies
 
 `PermissionProvisioningEntity.relations.policies` is a list of policy names to attach to the permission via the `auth_permission_policies` junction. Used by the default provisioning source to wire `system.default` (security baseline) plus the optional ATTRIBUTE_NAMES allowlist:

--- a/apps/server-core/src/adapters/http/adapters/oauth2/authorization/module.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/authorization/module.ts
@@ -9,7 +9,7 @@ import type { IAppEvent } from 'routup';
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import type { IOAuth2AuthorizationCodeRequestVerifier, OAuth2AuthorizationResult } from '../../../../../core/index.ts';
 import { OAuth2Authorization, OAuth2AuthorizationCodeRequestValidator } from '../../../../../core/index.ts';
-import { readFromLocations, useRequestIdentityOrFail } from '../../../request/index.ts';
+import { readFromLocations, useRequestIdentityOrFail, useRequestSessionId } from '../../../request/index.ts';
 import type { HTTPOAuth2AuthorizationManagerContext } from './types.ts';
 
 export class HTTPOAuth2Authorizer extends OAuth2Authorization {
@@ -32,7 +32,7 @@ export class HTTPOAuth2Authorizer extends OAuth2Authorization {
 
         const identity = useRequestIdentityOrFail(event);
 
-        return this.authorize(data, identity.raw);
+        return this.authorize(data, identity.raw, { sessionId: useRequestSessionId(event) });
     }
 
     /**

--- a/apps/server-core/src/core/oauth2/authorization/code/issuer/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code/issuer/module.ts
@@ -45,6 +45,10 @@ export class OAuth2AuthorizationCodeIssuer implements IOAuth2AuthorizationCodeIs
             entity.id_token = options.idToken;
         }
 
+        if (options.sessionId) {
+            entity.session_id = options.sessionId;
+        }
+
         return this.repository.save(entity, { maxAge: options.maxAge ?? this.options.maxAge });
     }
 

--- a/apps/server-core/src/core/oauth2/authorization/code/issuer/types.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code/issuer/types.ts
@@ -14,6 +14,12 @@ export type OAuth2AuthorizationCodeIssuerOptions = {
     maxAge?: number,
 
     idToken?: string,
+
+    /**
+     * The id of the session the authorizing bearer belongs to, persisted on the
+     * authorization code so the token exchange can reuse it.
+     */
+    sessionId?: string | null,
 };
 
 export interface IOAuth2AuthorizationCodeIssuer {

--- a/apps/server-core/src/core/oauth2/authorization/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/module.ts
@@ -20,6 +20,7 @@ import type { IOAuth2AuthorizationCodeIssuer } from './code/index.ts';
 import { buildOAuth2TokenHash } from './helpers.ts';
 import type {
     OAuth2AuthorizationManagerContext,
+    OAuth2AuthorizationOptions,
     OAuth2AuthorizationResult,
 } from './types.ts';
 import type { IIdentityResolver } from '../../identity/index.ts';
@@ -45,10 +46,12 @@ export class OAuth2Authorization {
      *
      * @param data
      * @param identity
+     * @param options
      */
     async authorize(
         data: OAuth2AuthorizationCodeRequest,
         identity: Identity,
+        options: OAuth2AuthorizationOptions = {},
     ) : Promise<OAuth2AuthorizationResult> {
         const availableResponseTypes : string[] = Object.values(OAuth2AuthorizationResponseType);
 
@@ -106,6 +109,7 @@ export class OAuth2Authorization {
             codeEntity = await this.codeIssuer.issue(
                 data,
                 identity,
+                { sessionId: options.sessionId },
             );
 
             output.authorizationCode = codeEntity.id;

--- a/apps/server-core/src/core/oauth2/authorization/types.ts
+++ b/apps/server-core/src/core/oauth2/authorization/types.ts
@@ -24,3 +24,12 @@ export type OAuth2AuthorizationResult = {
     redirectUri: string,
     state?: string
 };
+
+export type OAuth2AuthorizationOptions = {
+    /**
+     * The id of the session the authorizing bearer belongs to. Persisted on the
+     * issued authorization code so the token exchange can reuse that session
+     * instead of creating a second one.
+     */
+    sessionId?: string | null,
+};

--- a/apps/server-core/src/core/oauth2/grant-types/authorize.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/authorize.ts
@@ -7,7 +7,7 @@
 
 import type { OAuth2TokenGrantResponse, OAuth2TokenPayload } from '@authup/specs';
 import { hasOAuth2Scopes } from '@authup/specs';
-import type { OAuth2AuthorizationCode } from '@authup/core-kit';
+import type { OAuth2AuthorizationCode, Session } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
 import type { IOAuth2TokenIssuer } from '../token/index.ts';
 import { OAuth2BaseGrant } from './base.ts';
@@ -31,14 +31,7 @@ export class OAuth2AuthorizeGrant extends OAuth2BaseGrant<OAuth2AuthorizationCod
         authorizationCode: OAuth2AuthorizationCode,
         options: OAuth2GrantRunWIthOptions = {},
     ) : Promise<OAuth2TokenGrantResponse> {
-        const session = await this.sessionManager.create({
-            user_agent: options.userAgent,
-            ip_address: options.ipAddress,
-            realm_id: authorizationCode.realm_id,
-            client_id: authorizationCode.client_id,
-            sub_kind: authorizationCode.sub_kind,
-            sub: authorizationCode.sub,
-        });
+        const session = await this.resolveSession(authorizationCode, options);
 
         const issuePayload : Partial<OAuth2TokenPayload> = {
             user_agent: options.userAgent,
@@ -70,5 +63,46 @@ export class OAuth2AuthorizeGrant extends OAuth2BaseGrant<OAuth2AuthorizationCod
         }
 
         return buildOAuth2BearerTokenResponse(buildContext);
+    }
+
+    /**
+     * Reuse the bearer's session when the authorization code was issued from an
+     * (interactive) `/authorize` request that carried one — otherwise the
+     * interactive login would create a second session (the abandoned bearer
+     * session that authenticated `POST /authorize`, plus this one).
+     *
+     * The reuse is gated on the session still existing and belonging to the
+     * same subject/realm as the code (defense in depth — the id is
+     * server-derived from the authenticated bearer, never client input). Any
+     * mismatch, or a session-less authorize flow (external IdP, non-interactive
+     * clients), falls back to creating a fresh session — preserving prior
+     * behavior.
+     */
+    protected async resolveSession(
+        authorizationCode: OAuth2AuthorizationCode,
+        options: OAuth2GrantRunWIthOptions,
+    ) : Promise<Session> {
+        if (authorizationCode.session_id) {
+            const existing = await this.sessionManager.findOneById(authorizationCode.session_id);
+            if (
+                existing &&
+                existing.sub === authorizationCode.sub &&
+                existing.sub_kind === authorizationCode.sub_kind &&
+                existing.realm_id === authorizationCode.realm_id
+            ) {
+                existing.client_id = authorizationCode.client_id || null;
+
+                return this.sessionManager.refresh(existing);
+            }
+        }
+
+        return this.sessionManager.create({
+            user_agent: options.userAgent,
+            ip_address: options.ipAddress,
+            realm_id: authorizationCode.realm_id,
+            client_id: authorizationCode.client_id,
+            sub_kind: authorizationCode.sub_kind,
+            sub: authorizationCode.sub,
+        });
     }
 }

--- a/apps/server-core/test/unit/core/oauth2/grant-types/authorize.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/grant-types/authorize.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { OAuth2AuthorizationCode } from '@authup/core-kit';
+import { ScopeName } from '@authup/core-kit';
+import { OAuth2SubKind } from '@authup/specs';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { OAuth2AuthorizeGrant } from '../../../../../src/core/oauth2/grant-types/authorize.ts';
+import { FakeOAuth2TokenIssuer } from '../../helpers/fake-oauth2-token-issuer.ts';
+import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
+
+describe('OAuth2AuthorizeGrant', () => {
+    let accessTokenIssuer: FakeOAuth2TokenIssuer;
+    let refreshTokenIssuer: FakeOAuth2TokenIssuer;
+    let sessionManager: FakeSessionManager;
+    let grant: OAuth2AuthorizeGrant;
+
+    const realmId = randomUUID();
+    const userId = randomUUID();
+    const clientId = randomUUID();
+
+    const buildCode = (
+        overrides: Partial<OAuth2AuthorizationCode> = {},
+    ): OAuth2AuthorizationCode => ({
+        id: randomUUID(),
+        sub: userId,
+        sub_kind: OAuth2SubKind.USER,
+        realm_id: realmId,
+        realm_name: 'master',
+        client_id: clientId,
+        scope: ScopeName.GLOBAL,
+        ...overrides,
+    });
+
+    beforeEach(() => {
+        accessTokenIssuer = new FakeOAuth2TokenIssuer();
+        refreshTokenIssuer = new FakeOAuth2TokenIssuer();
+        sessionManager = new FakeSessionManager();
+        grant = new OAuth2AuthorizeGrant({
+            accessTokenIssuer,
+            refreshTokenIssuer,
+            sessionManager,
+        });
+    });
+
+    it('should create a fresh session when the code carries no session_id', async () => {
+        const result = await grant.runWith(buildCode(), {
+            userAgent: 'TestAgent',
+            ipAddress: '10.0.0.1',
+        });
+
+        expect(sessionManager.createCalls).toHaveLength(1);
+        expect(sessionManager.refreshCalls).toHaveLength(0);
+        expect(sessionManager.findOneByIdCalls).toHaveLength(0);
+        expect(sessionManager.createCalls[0]).toEqual(
+            expect.objectContaining({
+                realm_id: realmId,
+                sub: userId,
+                sub_kind: OAuth2SubKind.USER,
+                client_id: clientId,
+                user_agent: 'TestAgent',
+                ip_address: '10.0.0.1',
+            }),
+        );
+
+        expect(result).toHaveProperty('access_token');
+        expect(result).toHaveProperty('refresh_token');
+    });
+
+    it('should reuse the bearer session when the code carries a matching session_id', async () => {
+        const sessionId = randomUUID();
+        // pre-seed a client-less bearer session (as created by the SSR password grant)
+        await sessionManager.create({
+            id: sessionId,
+            sub: userId,
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: realmId,
+            client_id: null,
+        });
+        sessionManager.createCalls.length = 0;
+
+        const result = await grant.runWith(buildCode({ session_id: sessionId }));
+
+        // no second session created
+        expect(sessionManager.createCalls).toHaveLength(0);
+        expect(sessionManager.findOneByIdCalls).toContain(sessionId);
+        expect(sessionManager.refreshCalls).toHaveLength(1);
+        // the reused session gets the authorize client stamped onto it
+        expect(sessionManager.refreshCalls[0]).toEqual(
+            expect.objectContaining({ id: sessionId, client_id: clientId }),
+        );
+
+        // the issued tokens reference the reused session
+        const payload = expect.objectContaining({ session_id: sessionId });
+        expect(accessTokenIssuer.issueCalls).toContainEqual(payload);
+        expect(refreshTokenIssuer.issueCalls).toContainEqual(payload);
+
+        expect(result).toHaveProperty('access_token');
+    });
+
+    it('should fall back to create when the referenced session does not exist', async () => {
+        await grant.runWith(buildCode({ session_id: randomUUID() }));
+
+        expect(sessionManager.createCalls).toHaveLength(1);
+        expect(sessionManager.refreshCalls).toHaveLength(0);
+    });
+
+    it('should fall back to create when the referenced session belongs to another subject', async () => {
+        const sessionId = randomUUID();
+        await sessionManager.create({
+            id: sessionId,
+            sub: randomUUID(), // different subject
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: realmId,
+            client_id: null,
+        });
+        sessionManager.createCalls.length = 0;
+
+        await grant.runWith(buildCode({ session_id: sessionId }));
+
+        expect(sessionManager.refreshCalls).toHaveLength(0);
+        expect(sessionManager.createCalls).toHaveLength(1);
+    });
+
+    it('should fall back to create when the referenced session belongs to another realm', async () => {
+        const sessionId = randomUUID();
+        await sessionManager.create({
+            id: sessionId,
+            sub: userId,
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: randomUUID(), // different realm
+            client_id: null,
+        });
+        sessionManager.createCalls.length = 0;
+
+        await grant.runWith(buildCode({ session_id: sessionId }));
+
+        expect(sessionManager.refreshCalls).toHaveLength(0);
+        expect(sessionManager.createCalls).toHaveLength(1);
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize-session.spec.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { Client as HTTPClient } from '@authup/core-http-kit';
+import { ScopeName } from '@authup/core-kit';
+import { OAuth2AuthorizationResponseType } from '@authup/specs';
+import { generateOAuth2CodeVerifier } from '../../../../../../src/core';
+import {
+    createFakeClient,
+    createFakeUser,
+} from '../../../../../utils';
+import { createTestApplication } from '../../../../../app';
+
+describe('grant-authorize session reuse', () => {
+    const suite = createTestApplication();
+
+    beforeAll(async () => {
+        await suite.setup();
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    it('reuses the bearer session across the interactive login → authorize → token exchange', async () => {
+        const password = 'authorize-session-reuse-pw';
+        const user = await suite.client.user.create(createFakeUser({ password }));
+
+        const secret = generateOAuth2CodeVerifier();
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                secret,
+                secret_hashed: false,
+                secret_encrypted: false,
+                is_confidential: true,
+            }));
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: client.id,
+        });
+
+        // 1) interactive login: password grant creates the (client-less) bearer session
+        const login = await suite.client
+            .token
+            .createWithPassword({ username: user.name, password });
+
+        const userClient = new HTTPClient({ baseURL: suite.baseURL });
+        userClient.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
+
+        const loginIntrospect = await userClient.token.introspect({ token: login.access_token });
+        const userId = loginIntrospect.sub!;
+        const loginSessionId = loginIntrospect.session_id!;
+        expect(loginSessionId).toBeDefined();
+
+        // 2) that same bearer authorizes the web/confidential client (SSR POST /authorize)
+        const authorizeResponse = await userClient
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: client.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                state: generateOAuth2CodeVerifier(),
+            });
+
+        const code = new URL(authorizeResponse.url).searchParams.get('code')!;
+
+        // 3) token exchange — must reuse the login session, not create a second one
+        const tokenResponse = await suite.client
+            .token
+            .createWithAuthorizationCode({
+                client_id: client.id,
+                client_secret: secret,
+                redirect_uri: 'https://example.com/redirect',
+                code,
+            });
+
+        expect(tokenResponse.access_token).toBeDefined();
+
+        const exchangeClient = new HTTPClient({ baseURL: suite.baseURL });
+        exchangeClient.setAuthorizationHeader({ type: 'Bearer', token: tokenResponse.access_token });
+        const exchangeIntrospect = await exchangeClient.token.introspect({ token: tokenResponse.access_token });
+
+        // the exchanged token rides the very same session as the login
+        expect(exchangeIntrospect.session_id).toEqual(loginSessionId);
+
+        // 4) exactly ONE session exists for the user — no duplicate on login
+        const sessions = await suite.client.session.getMany({ filter: { sub: userId } });
+        const own = sessions.data.filter((s) => s.sub === userId);
+        expect(own).toHaveLength(1);
+        expect(own[0].id).toEqual(loginSessionId);
+        // and the reused session now carries the authorizing client
+        expect(own[0].client_id).toEqual(client.id);
+    });
+});

--- a/packages/core-kit/src/domains/authorization-code/entity.ts
+++ b/packages/core-kit/src/domains/authorization-code/entity.ts
@@ -26,6 +26,16 @@ export interface OAuth2AuthorizationCode {
 
     client_id?: Client['id'] | null,
 
+    /**
+     * The id of the session the authorizing bearer belongs to.
+     *
+     * Threaded from the (interactive) `/authorize` request so the
+     * authorization_code grant can reuse that session instead of creating a
+     * second one on token exchange. Absent for non-interactive / session-less
+     * authorize flows, in which case the grant creates a fresh session.
+     */
+    session_id?: string | null,
+
     sub: string,
 
     sub_kind: `${OAuth2SubKind}`,


### PR DESCRIPTION
## Problem

An interactive **client-web login created two `auth_sessions` rows**:

1. The SSR `/authorize` page password-grants a **client-less bearer session** purely to authenticate `POST /authorize`.
2. `/login/callback` then exchanges the authorization code, whose `authorization_code` grant **`create()`d a second session**.

The bearer session (#1) was abandoned but lingered until expiry — and showed up in the user's sessions list, producing two near-simultaneous sessions per login.

## Fix

Thread the bearer's session id through the authorization-code blob and **reuse** it in the `authorization_code` grant instead of minting a second session:

- `OAuth2AuthorizationCode` gains an optional `session_id` (the auth-code blob is **Redis-backed → no migration**).
- `HTTPOAuth2Authorizer.authorizeWithRequest` reads `useRequestSessionId(event)` — the id the authorization middleware stashed from the authenticated bearer (**server-derived, never client input**) — and threads it through `OAuth2Authorization.authorize` → `OAuth2AuthorizationCodeIssuer.issue` → `entity.session_id`.
- `OAuth2AuthorizeGrant.resolveSession` reuses the referenced session **iff** it still exists and matches the code's `sub` / `sub_kind` / `realm_id` (defense in depth), stamps the authorizing `client_id` onto the row, and `refresh()`es it.
- **Fallback preserved:** any mismatch, or a session-less authorize flow (external-IdP callback, non-interactive clients), still calls `sessionManager.create()` — prior behavior is unchanged.

## Tests

- `test/unit/core/oauth2/grant-types/authorize.spec.ts` — reuse vs. create-fallback branches, including the sub/realm-mismatch fail-safes.
- `test/unit/http/controllers/workflows/token/grant-authorize-session.spec.ts` — end-to-end login → authorize → exchange asserting a **single** session survives (verified to fail without the fix).

Full server-core suite (1094 tests) + `check:types` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Interactive login sessions are now reused during authorization-code sign-in, helping keep users in a single session instead of creating duplicates.
  * Token exchanges now preserve session continuity when the original session is still valid.

* **Bug Fixes**
  * Fixed cases where returning from web authorization could create extra session records.
  * If a prior session no longer matches, the app safely falls back to creating a new one.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->