### PR TITLE
feat: session-management UI follow-ups

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1267,6 +1267,21 @@ straight to TypeORM. **`SessionRepository.findMany` force-selects `realm_id` /
 could strip `realm_id` and neutralize the realm_scope reach factor (cross-realm
 leak). `client-web` UI is a follow-up (PR G2).
 
+**UI (PR G2):** two `<VCTable>` pages backed by the kit `<ASessions>` collection —
+`pages/settings/index/sessions.vue` (the actor's **own** sessions, `filter:
+{ user_id }`) and `pages/users/[id]/sessions.vue` (an admin viewing a user's
+sessions). The settings page carries a **"log out other devices"** button
+(`authupApp` `SESSION_REVOKE_OTHERS*` keys) that confirms via `useAlertDialog`
+then calls `client.session.deleteMany()` (`DELETE /sessions` — revoke-all-but-
+current), toasts the returned `count`, and reloads the collection; it disables
+when `total <= 1` (only the current session). The admin sessions **tab is gated
+on `SESSION_READ`** in `pages/users/[id].vue` (hidden otherwise — the server
+force-scopes a reader lacking it to their own sessions, so the tab would render
+empty/misleading), and the child route is defense-in-depth-protected via
+`definePageMeta({ [LayoutKey.REQUIRED_PERMISSIONS]: [SESSION_READ] })` (the
+routing interceptor checks every `route.matched` record, so the child meta is
+enforced on direct navigation).
+
 ### Session continuity: one session per interactive login
 
 An interactive client-web login used to create **two** `auth_sessions` rows: the

--- a/apps/client-web/pages/settings/index/sessions.vue
+++ b/apps/client-web/pages/settings/index/sessions.vue
@@ -1,19 +1,29 @@
 <script lang="ts">
 import type { Session } from '@authup/core-kit';
-import { TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import {
+    TranslatorTranslationActionKey,
+    TranslatorTranslationAppKey,
+    TranslatorTranslationFieldKey,
+    TranslatorTranslationNamespace,
+} from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
     ASearch,
     ASessions,
+    injectHTTPClient,
     injectStore,
     useTranslations,
+    useTranslator,
 } from '@authup/client-web-kit';
 import { storeToRefs } from 'pinia';
 import type { BuildInput } from 'rapiq';
 import type { TableColumn } from '@vuecs/table';
-import { computed, defineComponent } from 'vue';
-import { definePageMeta } from '#imports';
+import { VCButton } from '@vuecs/button';
+import { VCIcon } from '@vuecs/icon';
+import { useAlertDialog } from '@vuecs/overlays';
+import { computed, defineComponent, ref } from 'vue';
+import { definePageMeta, useErrorToast, useToast } from '#imports';
 import { LayoutKey } from '~/config/layout';
 
 export default defineComponent({
@@ -22,6 +32,8 @@ export default defineComponent({
         APagination,
         ASearch,
         ASessions,
+        VCButton,
+        VCIcon,
     },
     setup() {
         definePageMeta({ [LayoutKey.REQUIRED_LOGGED_IN]: true });
@@ -42,6 +54,11 @@ export default defineComponent({
             { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.USER_AGENT },
             { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.SEEN_AT },
             { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.EXPIRES_AT },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.LOGOUT },
+            { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.ABORT },
         ]);
 
         const columns = computed<TableColumn<Session>[]>(() => [
@@ -76,11 +93,60 @@ export default defineComponent({
             },
         ]);
 
+        const httpClient = injectHTTPClient();
+        const toast = useToast();
+        const errorToast = useErrorToast();
+        const translate = useTranslator();
+        const confirmDialog = useAlertDialog();
+        const revoking = ref(false);
+
+        // "Log out my other devices" — DELETE /sessions revokes every session of
+        // the current identity except the one this request authenticates with.
+        const revokeOthers = async (reload: () => Promise<void>) => {
+            if (revoking.value) {
+                return;
+            }
+
+            const confirmed = await confirmDialog({
+                title: translations.sessionRevokeOthersConfirmTitle,
+                description: translations.sessionRevokeOthersConfirmDescription,
+                confirmLabel: translations.logout,
+                cancelLabel: translations.abort,
+                tone: 'warning',
+            });
+
+            if (!confirmed) {
+                return;
+            }
+
+            revoking.value = true;
+            try {
+                const response = await httpClient.session.deleteMany();
+
+                toast.show({
+                    variant: 'success',
+                    body: await translate({
+                        namespace: TranslatorTranslationNamespace.APP,
+                        key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS,
+                        data: { amount: response.count },
+                    }),
+                });
+
+                await reload();
+            } catch (e) {
+                await errorToast.show(e);
+            } finally {
+                revoking.value = false;
+            }
+        };
+
         return {
             userId,
             query,
             columns,
             translations,
+            revoking,
+            revokeOthers,
         };
     },
 });
@@ -93,10 +159,26 @@ export default defineComponent({
         :footer="true"
     >
         <template #header="props">
-            <ASearch
-                :load="props.load"
-                :busy="props.busy"
-            />
+            <div class="flex flex-wrap items-center gap-2">
+                <div class="flex-grow">
+                    <ASearch
+                        :load="props.load"
+                        :busy="props.busy"
+                    />
+                </div>
+                <VCButton
+                    :label="translations.sessionRevokeOthers"
+                    size="sm"
+                    color="error"
+                    variant="outline"
+                    :disabled="revoking || (props.total ?? 0) <= 1"
+                    @click="revokeOthers(props.load)"
+                >
+                    <template #leading>
+                        <VCIcon name="fa6-solid:right-from-bracket" />
+                    </template>
+                </VCButton>
+            </div>
         </template>
         <template #footer="props">
             <APagination

--- a/apps/client-web/pages/users/[id].vue
+++ b/apps/client-web/pages/users/[id].vue
@@ -5,11 +5,12 @@ import {
     TranslatorTranslationEntityKey, 
     TranslatorTranslationNamespace, 
 } from '@authup/i18n';
-import { 
-    injectHTTPClient, 
-    useTranslations, 
-    useTranslationsForNamespace, 
-    useTranslator, 
+import {
+    injectHTTPClient,
+    usePermissionCheck,
+    useTranslations,
+    useTranslationsForNamespace,
+    useTranslator,
 } from '@authup/client-web-kit';
 import type { User } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
@@ -76,6 +77,12 @@ export default defineComponent({
 
         const translate = useTranslator();
 
+        // The sessions tab surfaces the user's login sessions — only an actor
+        // holding SESSION_READ may list another identity's sessions (the server
+        // force-scopes everyone else to their own), so gate the tab on it. The
+        // route itself is protected in the child page's definePageMeta.
+        const hasSessionReadPermission = usePermissionCheck({ name: PermissionName.SESSION_READ });
+
         try {
             entity.value = await injectHTTPClient()
                 .user
@@ -106,11 +113,11 @@ export default defineComponent({
                 icon: 'fa6-solid:user-group',
                 url: `/users/${entity.value.id}/roles`,
             },
-            {
+            ...(hasSessionReadPermission.value ? [{
                 name: translationsDefault.session,
                 icon: 'fa6-solid:desktop',
                 url: `/users/${entity.value.id}/sessions`,
-            },
+            }] : []),
         ]);
 
         const handleUpdated = async (e: User) => {

--- a/apps/client-web/pages/users/[id]/sessions.vue
+++ b/apps/client-web/pages/users/[id]/sessions.vue
@@ -15,6 +15,8 @@ import type { TableColumn } from '@vuecs/table';
 import type { PropType } from 'vue';
 import { computed } from 'vue';
 import { defineNuxtComponent } from '#app';
+import { definePageMeta } from '#imports';
+import { LayoutKey } from '~/config/layout';
 
 export default defineNuxtComponent({
     components: {
@@ -30,6 +32,8 @@ export default defineNuxtComponent({
         },
     },
     setup(props) {
+        definePageMeta({ [LayoutKey.REQUIRED_PERMISSIONS]: [PermissionName.SESSION_READ] });
+
         const query = computed<BuildInput<Session>>(() => ({
             filter: { user_id: props.entity.id },
             sort: { seen_at: 'DESC' },

--- a/packages/i18n/src/catalogs/de/app.ts
+++ b/packages/i18n/src/catalogs/de/app.ts
@@ -48,4 +48,9 @@ export const TranslatorTranslationAppGerman : NamespaceTranslations<`${Translato
 
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_TITLE]: 'Entfernen bestätigen',
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_DESCRIPTION]: 'Möchten Sie diese Zuordnung wirklich entfernen? Sie können sie jederzeit erneut zuweisen.',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS]: 'Andere Geräte abmelden',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: 'Andere Geräte abmelden?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'Dadurch werden alle anderen Sitzungen abgemeldet. Ihre aktuelle Sitzung bleibt aktiv.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: '{{amount}} andere Sitzung(en) abgemeldet.',
 };

--- a/packages/i18n/src/catalogs/en/app.ts
+++ b/packages/i18n/src/catalogs/en/app.ts
@@ -48,4 +48,9 @@ export const TranslatorTranslationAppEnglish : NamespaceTranslations<`${Translat
 
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_TITLE]: 'Confirm removal',
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_DESCRIPTION]: 'Are you sure you want to remove this assignment? You can re-assign it at any time.',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS]: 'Log out other devices',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: 'Log out other devices?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'This signs out all your other sessions. Your current session stays active.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: 'Logged out {{amount}} other session(s).',
 };

--- a/packages/i18n/src/catalogs/es/app.ts
+++ b/packages/i18n/src/catalogs/es/app.ts
@@ -48,4 +48,9 @@ export const TranslatorTranslationAppSpanish : NamespaceTranslations<`${Translat
 
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_TITLE]: 'Confirmar eliminación',
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_DESCRIPTION]: '¿Seguro que quieres quitar esta asignación? Puedes volver a asignarla en cualquier momento.',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS]: 'Cerrar sesión en otros dispositivos',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: '¿Cerrar sesión en otros dispositivos?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'Esto cierra todas tus otras sesiones. Tu sesión actual permanece activa.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: '{{amount}} otra(s) sesión(es) cerradas.',
 };

--- a/packages/i18n/src/catalogs/fr/app.ts
+++ b/packages/i18n/src/catalogs/fr/app.ts
@@ -48,4 +48,9 @@ export const TranslatorTranslationAppFrench : NamespaceTranslations<`${Translato
 
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_TITLE]: 'Confirmer le retrait',
     [TranslatorTranslationAppKey.REMOVE_CONFIRM_DESCRIPTION]: 'Voulez-vous vraiment retirer cette attribution ? Vous pourrez la réattribuer à tout moment.',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS]: 'Déconnecter les autres appareils',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: 'Déconnecter les autres appareils ?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'Cela déconnecte toutes vos autres sessions. Votre session actuelle reste active.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: '{{amount}} autre(s) session(s) déconnectée(s).',
 };

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -154,6 +154,11 @@ export enum TranslatorTranslationAppKey {
 
     REMOVE_CONFIRM_TITLE = 'removeConfirmTitle',
     REMOVE_CONFIRM_DESCRIPTION = 'removeConfirmDescription',
+
+    SESSION_REVOKE_OTHERS = 'sessionRevokeOthers',
+    SESSION_REVOKE_OTHERS_CONFIRM_TITLE = 'sessionRevokeOthersConfirmTitle',
+    SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION = 'sessionRevokeOthersConfirmDescription',
+    SESSION_REVOKE_OTHERS_SUCCESS = 'sessionRevokeOthersSuccess',
 }
 
 /**


### PR DESCRIPTION
Follow-ups to the session-management UI (PR G2, #3189).

## Changes

### "Log out other devices" (self-service)
`pages/settings/index/sessions.vue` gains a **Log out other devices** button in the list header. It:
- confirms via `useAlertDialog` (warning tone),
- calls `client.session.deleteMany()` — `DELETE /sessions`, which revokes every session of the current identity **except** the one making the request,
- toasts the revoked `count` and reloads the collection,
- is disabled while only the current session exists (`total <= 1`).

### Gate the admin sessions tab on `SESSION_READ`
- `pages/users/[id].vue` — the **Sessions** tab is now shown only when the actor holds `SESSION_READ`. Without it, the server force-scopes a reader to *their own* sessions, so an admin's user-sessions tab would render empty/misleading.
- `pages/users/[id]/sessions.vue` — the child route is defense-in-depth-protected via `definePageMeta({ [LayoutKey.REQUIRED_PERMISSIONS]: [SESSION_READ] })`. The routing interceptor evaluates every `route.matched` record, so the child meta is enforced on direct navigation too.

### i18n
Adds the `authupApp` keys `sessionRevokeOthers`, `sessionRevokeOthersConfirmTitle`, `sessionRevokeOthersConfirmDescription`, `sessionRevokeOthersSuccess` across `en`/`de`/`fr`/`es` (locale-parity test enforces completeness).

## Verification
- `@authup/i18n` build + locale-parity tests (77) pass.
- `@authup/client-web-kit` tests (8) pass.
- `apps/client-web` `nuxi typecheck` clean (verified it genuinely fails on an injected error).
- eslint clean on all changed files.

Docs: `.agents/architecture.md` Session Management API section extended with the UI follow-up notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “revoke other sessions” action in session settings, with confirmation, success feedback, and automatic refresh after revoking.
  * Added sessions views for both your own account and admin user pages, with access controlled by permissions.

* **Bug Fixes**
  * Hid the sessions tab when the current user doesn’t have permission to view sessions.
  * Disabled the revoke action when only the current session remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->