### PR TITLE
feat: admin bulk session revocation and current-session marking

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1249,19 +1249,29 @@ A REST surface over `auth_sessions` for "see all my sessions / force logout":
   tokens). Access tokens stay valid on local-JWKS adapters until `exp` (the
   documented limitation; authup's own API rejects immediately via the
   authorization middleware's session check).
-- `DELETE /sessions` — bulk revoke. **No query →** revoke every own session
-  except the current one ("log out my other devices"). Self-service; the current
-  session id comes from the bearer token (stashed by the authorization middleware
-  via `setRequestSessionId`), never from the client. **`?user_id=<uuid>` →** admin
-  force-logout: `SessionService.deleteManyForOwner(actor, { sub, subKind: 'user' })`
-  revokes **every** session of the target user on all devices (no current-session
-  exemption). Gated by `SESSION_DELETE` **plus a per-session `resourceRealmMatch`**
-  (same drop-unauthorized shape as `getMany` — a `realm_admin` in realm A cannot
-  force-logout a user's realm-B sessions; `SESSION_DELETE` alone is realm-agnostic).
-  A non-admin passing `?user_id` (even its own id) takes the admin path and gets
-  `403`; self-service is the no-param call. Typed client:
-  `client.session.deleteMany({ userId })` (optional arg — the no-arg self call is
-  unchanged).
+- `DELETE /sessions` — bulk revoke, discriminated by whether the rapiq query
+  carries a **recognized target filter** (`SESSION_FILTER_KEYS` = `id`, `sub`,
+  `sub_kind`, `user_id`, `client_id`, `robot_id`, `realm_id`; the same
+  vocabulary `getMany` filters on):
+  - **No target filter →** self-service: revoke every own session except the
+    current one ("log out my other devices"). No permission; the current session
+    id comes from the bearer token (stashed by the authorization middleware via
+    `setRequestSessionId`), never from the client. An **unrecognized/empty**
+    filter falls through here too — a typo can never trigger a mass delete.
+  - **A target filter (e.g. `?filter[user_id]=<uuid>`, comma-list for several
+    subjects, or `?filter[realm_id]=…`) →** admin force-logout:
+    `SessionService.deleteManyByQuery` loads **every** matching session
+    (`ISessionRepository.findAllByQuery` — deliberately **unbounded**, no
+    pagination cap: reusing the paginated `findMany` would silently truncate at
+    `maxLimit`) and revokes each. Gated by `SESSION_DELETE` **plus a per-session
+    `resourceRealmMatch`** (same drop-unauthorized shape as `getMany`). Filter
+    breadth **cannot escalate** — the actor only deletes what it is already
+    authorized to delete, so a `realm_admin` in realm A silently drops a target's
+    realm-B sessions, and `filter[realm_id]` is bounded to its reach.
+  A non-admin sending a target filter (even its own `user_id`) takes the admin
+  path and gets `403`; self-service is the no-filter call. Typed client mirrors
+  `getMany`: `client.session.deleteMany(data?: BuildInput<Session>)` — `deleteMany()`
+  (self) / `deleteMany({ filter: { user_id } })` (admin).
 
 **Ownership** = `session.sub === actor.identity.data.id && session.sub_kind ===
 actor.identity.type` (sessions have a polymorphic subject — user/client/robot —
@@ -1293,8 +1303,9 @@ enforced on direct navigation).
 
 The admin page carries a **"Log out everywhere"** button (`authupApp`
 `SESSION_REVOKE_ALL*` keys, gated on `SESSION_DELETE` via `usePermissionCheck`,
-error-tone confirm) that calls `client.session.deleteMany({ userId: entity.id })`
-— the admin force-logout path above. The self page marks the caller's **current
+error-tone confirm) that calls
+`client.session.deleteMany({ filter: { user_id: entity.id } })` — the admin
+force-logout path above. The self page marks the caller's **current
 row** with a "This device" badge (`SESSION_CURRENT` key) and omits its per-row
 delete button (a lone current-session delete would be a confusing silent
 self-logout — the "log out other devices" button covers the rest). The current

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1249,10 +1249,19 @@ A REST surface over `auth_sessions` for "see all my sessions / force logout":
   tokens). Access tokens stay valid on local-JWKS adapters until `exp` (the
   documented limitation; authup's own API rejects immediately via the
   authorization middleware's session check).
-- `DELETE /sessions` — revoke every own session except the current one
-  ("log out my other devices"). Self-service; the current session id comes from
-  the bearer token (stashed by the authorization middleware via
-  `setRequestSessionId`), never from the client.
+- `DELETE /sessions` — bulk revoke. **No query →** revoke every own session
+  except the current one ("log out my other devices"). Self-service; the current
+  session id comes from the bearer token (stashed by the authorization middleware
+  via `setRequestSessionId`), never from the client. **`?user_id=<uuid>` →** admin
+  force-logout: `SessionService.deleteManyForOwner(actor, { sub, subKind: 'user' })`
+  revokes **every** session of the target user on all devices (no current-session
+  exemption). Gated by `SESSION_DELETE` **plus a per-session `resourceRealmMatch`**
+  (same drop-unauthorized shape as `getMany` — a `realm_admin` in realm A cannot
+  force-logout a user's realm-B sessions; `SESSION_DELETE` alone is realm-agnostic).
+  A non-admin passing `?user_id` (even its own id) takes the admin path and gets
+  `403`; self-service is the no-param call. Typed client:
+  `client.session.deleteMany({ userId })` (optional arg — the no-arg self call is
+  unchanged).
 
 **Ownership** = `session.sub === actor.identity.data.id && session.sub_kind ===
 actor.identity.type` (sessions have a polymorphic subject — user/client/robot —
@@ -1265,9 +1274,9 @@ straight to TypeORM. **`SessionRepository.findMany` force-selects `realm_id` /
 — the per-row `resourceRealmMatch` gate reads `realm_id`, and rapiq honors a
 `fields` projection over `default`, so without the force-select a scoped reader
 could strip `realm_id` and neutralize the realm_scope reach factor (cross-realm
-leak). `client-web` UI is a follow-up (PR G2).
+leak).
 
-**UI (PR G2):** two `<VCTable>` pages backed by the kit `<ASessions>` collection —
+**UI:** two `<VCTable>` pages backed by the kit `<ASessions>` collection —
 `pages/settings/index/sessions.vue` (the actor's **own** sessions, `filter:
 { user_id }`) and `pages/users/[id]/sessions.vue` (an admin viewing a user's
 sessions). The settings page carries a **"log out other devices"** button
@@ -1281,6 +1290,17 @@ empty/misleading), and the child route is defense-in-depth-protected via
 `definePageMeta({ [LayoutKey.REQUIRED_PERMISSIONS]: [SESSION_READ] })` (the
 routing interceptor checks every `route.matched` record, so the child meta is
 enforced on direct navigation).
+
+The admin page carries a **"Log out everywhere"** button (`authupApp`
+`SESSION_REVOKE_ALL*` keys, gated on `SESSION_DELETE` via `usePermissionCheck`,
+error-tone confirm) that calls `client.session.deleteMany({ userId: entity.id })`
+— the admin force-logout path above. The self page marks the caller's **current
+row** with a "This device" badge (`SESSION_CURRENT` key) and omits its per-row
+delete button (a lone current-session delete would be a confusing silent
+self-logout — the "log out other devices" button covers the rest). The current
+session id is exposed by the `@authup/client-web-kit` store as a `sessionId` ref,
+sourced from the token-introspection `session_id` in `resolveToken` (cleared on
+logout).
 
 ### Session continuity: one session per interactive login
 

--- a/apps/client-web/pages/settings/index/sessions.vue
+++ b/apps/client-web/pages/settings/index/sessions.vue
@@ -37,7 +37,7 @@ export default defineComponent({
         definePageMeta({ [LayoutKey.REQUIRED_LOGGED_IN]: true });
 
         const store = injectStore();
-        const { userId } = storeToRefs(store);
+        const { userId, sessionId } = storeToRefs(store);
 
         // Scope to the current user's own sessions (an admin holding SESSION_READ
         // would otherwise see every session here); non-admins are self-scoped by
@@ -55,6 +55,7 @@ export default defineComponent({
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_CURRENT },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.LOGOUT },
             { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.ABORT },
         ]);
@@ -140,6 +141,7 @@ export default defineComponent({
 
         return {
             userId,
+            sessionId,
             query,
             columns,
             translations,
@@ -199,7 +201,14 @@ export default defineComponent({
                     <VCTimeago :datetime="row.expires_at" />
                 </template>
                 <template #cell-options="{ row }">
+                    <span
+                        v-if="row.id === sessionId"
+                        class="inline-flex items-center rounded-full bg-primary-600/10 px-2 py-0.5 text-xs font-medium text-primary-600"
+                    >
+                        {{ translations.sessionCurrent }}
+                    </span>
                     <AEntityDelete
+                        v-else
                         :entity-id="row.id"
                         entity-type="session"
                         :with-text="false"

--- a/apps/client-web/pages/users/[id]/sessions.vue
+++ b/apps/client-web/pages/users/[id]/sessions.vue
@@ -1,20 +1,30 @@
 <script lang="ts">
 import type { Session, User } from '@authup/core-kit';
 import { PermissionName } from '@authup/core-kit';
-import { TranslatorTranslationFieldKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import {
+    TranslatorTranslationActionKey,
+    TranslatorTranslationAppKey,
+    TranslatorTranslationFieldKey,
+    TranslatorTranslationNamespace,
+} from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
     ASessions,
+    injectHTTPClient,
     usePermissionCheck,
     useTranslations,
+    useTranslator,
 } from '@authup/client-web-kit';
 import type { BuildInput } from 'rapiq';
 import type { TableColumn } from '@vuecs/table';
+import { VCButton } from '@vuecs/button';
+import { VCIcon } from '@vuecs/icon';
+import { useAlertDialog } from '@vuecs/overlays';
 import type { PropType } from 'vue';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { defineNuxtComponent } from '#app';
-import { definePageMeta } from '#imports';
+import { definePageMeta, useErrorToast, useToast } from '#imports';
 import { LayoutKey } from '~/config/layout';
 
 export default defineNuxtComponent({
@@ -22,6 +32,8 @@ export default defineNuxtComponent({
         AEntityDelete,
         APagination,
         ASessions,
+        VCButton,
+        VCIcon,
     },
     props: {
         entity: {
@@ -44,6 +56,11 @@ export default defineNuxtComponent({
             { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.USER_AGENT },
             { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.SEEN_AT },
             { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.EXPIRES_AT },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_ALL },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_TITLE },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.LOGOUT },
+            { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.ABORT },
         ]);
 
         const columns = computed<TableColumn<Session>[]>(() => [
@@ -78,11 +95,60 @@ export default defineNuxtComponent({
             },
         ]);
 
+        const httpClient = injectHTTPClient();
+        const toast = useToast();
+        const errorToast = useErrorToast();
+        const translate = useTranslator();
+        const confirmDialog = useAlertDialog();
+        const revoking = ref(false);
+
+        // Admin "Log out everywhere" — DELETE /sessions?user_id=<id> revokes every
+        // session of the target user on all devices (SESSION_DELETE + realm reach).
+        const revokeAll = async (reload: () => Promise<void>) => {
+            if (revoking.value) {
+                return;
+            }
+
+            const confirmed = await confirmDialog({
+                title: translations.sessionRevokeAllConfirmTitle,
+                description: translations.sessionRevokeAllConfirmDescription,
+                confirmLabel: translations.logout,
+                cancelLabel: translations.abort,
+                tone: 'error',
+            });
+
+            if (!confirmed) {
+                return;
+            }
+
+            revoking.value = true;
+            try {
+                const response = await httpClient.session.deleteMany({ userId: props.entity.id });
+
+                toast.show({
+                    variant: 'success',
+                    body: await translate({
+                        namespace: TranslatorTranslationNamespace.APP,
+                        key: TranslatorTranslationAppKey.SESSION_REVOKE_ALL_SUCCESS,
+                        data: { amount: response.count },
+                    }),
+                });
+
+                await reload();
+            } catch (e) {
+                await errorToast.show(e);
+            } finally {
+                revoking.value = false;
+            }
+        };
+
         return {
             query,
             columns,
             hasDropPermission,
             translations,
+            revoking,
+            revokeAll,
         };
     },
 });
@@ -93,6 +159,25 @@ export default defineNuxtComponent({
         :body="{ tag: 'div' }"
         :footer="true"
     >
+        <template #header="props">
+            <div
+                v-if="hasDropPermission"
+                class="flex justify-end mb-2"
+            >
+                <VCButton
+                    :label="translations.sessionRevokeAll"
+                    size="sm"
+                    color="error"
+                    variant="outline"
+                    :disabled="revoking || (props.total ?? 0) === 0"
+                    @click="revokeAll(props.load)"
+                >
+                    <template #leading>
+                        <VCIcon name="fa6-solid:right-from-bracket" />
+                    </template>
+                </VCButton>
+            </div>
+        </template>
         <template #footer="props">
             <APagination
                 :busy="props.busy"

--- a/apps/client-web/pages/users/[id]/sessions.vue
+++ b/apps/client-web/pages/users/[id]/sessions.vue
@@ -102,8 +102,8 @@ export default defineNuxtComponent({
         const confirmDialog = useAlertDialog();
         const revoking = ref(false);
 
-        // Admin "Log out everywhere" — DELETE /sessions?user_id=<id> revokes every
-        // session of the target user on all devices (SESSION_DELETE + realm reach).
+        // Admin "Log out everywhere" — DELETE /sessions?filter[user_id]=<id> revokes
+        // every session of the target user on all devices (SESSION_DELETE + realm reach).
         const revokeAll = async (reload: () => Promise<void>) => {
             if (revoking.value) {
                 return;
@@ -123,7 +123,7 @@ export default defineNuxtComponent({
 
             revoking.value = true;
             try {
-                const response = await httpClient.session.deleteMany({ userId: props.entity.id });
+                const response = await httpClient.session.deleteMany({ filter: { user_id: props.entity.id } });
 
                 toast.show({
                     variant: 'success',

--- a/apps/server-core/src/adapters/http/controllers/entities/session/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/session/module.ts
@@ -14,7 +14,6 @@ import {
     DTags,
 } from '@routup/decorators';
 import type { Session } from '@authup/core-kit';
-import { IdentityType } from '@authup/core-kit';
 import type { IAppEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type { EntityCollectionResponse, SessionDeleteManyResponse } from '@authup/core-http-kit';
@@ -71,17 +70,13 @@ export class SessionController {
     ): Promise<SessionDeleteManyResponse> {
         const actor = buildActorContext(event);
 
-        // `?user_id=<uuid>` → admin force-logout of that user everywhere
-        // (SESSION_DELETE + per-session realm-match). No param → self-service
-        // "log out my other devices" (keeps the current session).
-        const userId = useRequestQuery(event)?.user_id;
-
-        const result = userId ?
-            await this.service.deleteManyForOwner(actor, {
-                sub: String(userId),
-                subKind: IdentityType.USER,
-            }) :
-            await this.service.deleteManyForActor(actor, useRequestSessionId(event));
+        // A recognized target filter (e.g. `?filter[user_id]=<uuid>`) → admin
+        // force-logout (SESSION_DELETE + per-session realm-match). No filter →
+        // self-service "log out my other devices" (keeps the current session).
+        const result = await this.service.deleteMany(actor, {
+            query: useRequestQuery(event),
+            currentSessionId: useRequestSessionId(event),
+        });
 
         event.response.status = 202;
         return result;

--- a/apps/server-core/src/adapters/http/controllers/entities/session/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/session/module.ts
@@ -14,6 +14,7 @@ import {
     DTags,
 } from '@routup/decorators';
 import type { Session } from '@authup/core-kit';
+import { IdentityType } from '@authup/core-kit';
 import type { IAppEvent } from 'routup';
 import { useRequestQuery } from '@routup/basic/query';
 import type { EntityCollectionResponse, SessionDeleteManyResponse } from '@authup/core-http-kit';
@@ -69,7 +70,18 @@ export class SessionController {
         @DContext() event: IAppEvent,
     ): Promise<SessionDeleteManyResponse> {
         const actor = buildActorContext(event);
-        const result = await this.service.deleteManyForActor(actor, useRequestSessionId(event));
+
+        // `?user_id=<uuid>` → admin force-logout of that user everywhere
+        // (SESSION_DELETE + per-session realm-match). No param → self-service
+        // "log out my other devices" (keeps the current session).
+        const userId = useRequestQuery(event)?.user_id;
+
+        const result = userId ?
+            await this.service.deleteManyForOwner(actor, {
+                sub: String(userId),
+                subKind: IdentityType.USER,
+            }) :
+            await this.service.deleteManyForActor(actor, useRequestSessionId(event));
 
         event.response.status = 202;
         return result;

--- a/apps/server-core/src/app/modules/authentication/repositories/session.ts
+++ b/apps/server-core/src/app/modules/authentication/repositories/session.ts
@@ -15,6 +15,7 @@ import type {
     SessionFindManyOptions,
     SessionOwner,
 } from '../../../../core/index.ts';
+import { SESSION_FILTER_KEYS } from '../../../../core/index.ts';
 import { AuthenticationCachePrefix } from './constants.ts';
 
 type SessionRepositoryContext = {
@@ -79,7 +80,7 @@ export class SessionRepository implements ISessionRepository {
                     'realm_id',
                 ],
             },
-            filters: { allowed: ['id', 'sub', 'sub_kind', 'user_id', 'client_id', 'robot_id', 'realm_id'] },
+            filters: { allowed: [...SESSION_FILTER_KEYS] },
             relations: { allowed: ['realm'] },
             sort: { allowed: ['seen_at', 'expires_at', 'created_at', 'updated_at'] },
             pagination: { maxLimit: 50 },
@@ -123,6 +124,30 @@ export class SessionRepository implements ISessionRepository {
                 subKind: owner.subKind,
             })
             .getMany();
+    }
+
+    async findAllByQuery(query: Record<string, any>): Promise<Session[]> {
+        const qb = this.repository.createQueryBuilder('session');
+
+        // NOTE: deliberately no `pagination` — a bulk revoke must reach every
+        // matching row. `applyQuery` with a `pagination.maxLimit` would default
+        // the limit to that cap when the caller sends no page (rapiq
+        // `finalizePagination`), silently truncating the delete.
+        applyQuery(qb, query, {
+            defaultAlias: 'session',
+            filters: { allowed: [...SESSION_FILTER_KEYS] },
+        });
+
+        // Same force-select as findMany: the per-session realm gate + ownership
+        // check read realm_id / sub / sub_kind regardless of any `fields`
+        // projection in the query.
+        qb.addSelect([
+            'session.realm_id',
+            'session.sub',
+            'session.sub_kind',
+        ]);
+
+        return qb.getMany();
     }
 
     // -----------------------------------------------------

--- a/apps/server-core/src/core/authentication/session/types.ts
+++ b/apps/server-core/src/core/authentication/session/types.ts
@@ -13,6 +13,21 @@ export type SessionOwner = {
     subKind: string,
 };
 
+/**
+ * Filter keys a session query (list + bulk revoke) may target. Shared by the
+ * repository's rapiq `filters.allowed` and the service's "is this a targeted
+ * bulk revoke?" discriminator, so the two can never drift.
+ */
+export const SESSION_FILTER_KEYS = [
+    'id',
+    'sub',
+    'sub_kind',
+    'user_id',
+    'client_id',
+    'robot_id',
+    'realm_id',
+] as const;
+
 export type SessionFindManyOptions = {
     /**
      * Force the result to a single subject (self-service). Applied as a
@@ -27,6 +42,14 @@ export interface ISessionRepository {
     findMany(query: Record<string, any>, options?: SessionFindManyOptions): Promise<EntityRepositoryFindManyResult<Session>>;
 
     findAllByOwner(owner: SessionOwner): Promise<Session[]>;
+
+    /**
+     * Load EVERY session matching a rapiq query filter — **unbounded** (no
+     * pagination cap), because a bulk revoke must reach every match. Used by
+     * the admin "force-logout" path; per-session authorization is enforced by
+     * the caller (`SessionService`).
+     */
+    findAllByQuery(query: Record<string, any>): Promise<Session[]>;
 
     save(session: Partial<Session>): Promise<Session>;
 

--- a/apps/server-core/src/core/entities/session/service.ts
+++ b/apps/server-core/src/core/entities/session/service.ts
@@ -11,8 +11,9 @@ import { PermissionName } from '@authup/core-kit';
 import type { Session } from '@authup/core-kit';
 import { AbstractEntityService } from '@authup/server-kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
-import type { ISessionRepository, SessionOwner } from '../../authentication/index.ts';
-import type { ISessionService, SessionDeleteManyResult } from './types.ts';
+import type { ISessionRepository } from '../../authentication/index.ts';
+import { SESSION_FILTER_KEYS } from '../../authentication/index.ts';
+import type { ISessionService, SessionDeleteManyOptions, SessionDeleteManyResult } from './types.ts';
 
 export type SessionServiceContext = {
     repository: ISessionRepository,
@@ -134,17 +135,46 @@ export class SessionService extends AbstractEntityService implements ISessionSer
         return entity;
     }
 
-    async deleteManyForActor(
+    async deleteMany(
         actor: ActorContext,
-        currentSessionId?: string,
+        options: SessionDeleteManyOptions = {},
     ): Promise<SessionDeleteManyResult> {
         if (!actor.identity) {
             throw new UnauthorizedError();
         }
 
+        if (this.hasTargetFilter(options.query)) {
+            return this.deleteManyByQuery(actor, options.query!);
+        }
+
+        return this.deleteManyForSelf(actor, options.currentSessionId);
+    }
+
+    /**
+     * True when the query carries at least one recognized target filter — the
+     * discriminator between the admin bulk-revoke path and self-service. An
+     * unrecognized / empty filter falls through to self-service (fail-safe: a
+     * typo can never trigger an unconstrained mass delete).
+     */
+    protected hasTargetFilter(query?: Record<string, any>): boolean {
+        const filter = query?.filter;
+        if (!filter || typeof filter !== 'object') {
+            return false;
+        }
+
+        return SESSION_FILTER_KEYS.some((key) => {
+            const value = filter[key];
+            return typeof value !== 'undefined' && value !== '';
+        });
+    }
+
+    protected async deleteManyForSelf(
+        actor: ActorContext,
+        currentSessionId?: string,
+    ): Promise<SessionDeleteManyResult> {
         const sessions = await this.repository.findAllByOwner({
-            sub: actor.identity.data.id,
-            subKind: actor.identity.type,
+            sub: actor.identity!.data.id,
+            subKind: actor.identity!.type,
         });
 
         let count = 0;
@@ -159,29 +189,33 @@ export class SessionService extends AbstractEntityService implements ISessionSer
         return { count };
     }
 
-    async deleteManyForOwner(
+    protected async deleteManyByQuery(
         actor: ActorContext,
-        owner: SessionOwner,
+        query: Record<string, any>,
     ): Promise<SessionDeleteManyResult> {
         // Gate: an actor without SESSION_DELETE cannot force-logout anyone → 403.
         await actor.permissionEvaluator.preEvaluate({ name: PermissionName.SESSION_DELETE });
 
-        const sessions = await this.repository.findAllByOwner(owner);
+        const sessions = await this.repository.findAllByQuery(query);
 
         let count = 0;
         for (const session of sessions) {
-            // Per-session realm-match: a realm_admin only reaches sessions in
-            // its realm. Cross-realm sessions are silently skipped, not failed.
-            try {
-                await actor.permissionEvaluator.evaluate({
-                    name: PermissionName.SESSION_DELETE,
-                    data: definePolicyData({
-                        [BuiltInPolicyType.ATTRIBUTES]: session,
-                        ...this.resourceRealmMatch(session),
-                    }),
-                });
-            } catch {
-                continue;
+            // Own sessions are always deletable by the actor (mirrors getMany).
+            // Otherwise per-session realm-match: a realm_admin only reaches
+            // sessions in its realm — cross-realm rows are skipped, not failed,
+            // so filter breadth cannot escalate beyond the actor's reach.
+            if (!this.isOwnedBy(session, actor)) {
+                try {
+                    await actor.permissionEvaluator.evaluate({
+                        name: PermissionName.SESSION_DELETE,
+                        data: definePolicyData({
+                            [BuiltInPolicyType.ATTRIBUTES]: session,
+                            ...this.resourceRealmMatch(session),
+                        }),
+                    });
+                } catch {
+                    continue;
+                }
             }
 
             await this.repository.remove(session);

--- a/apps/server-core/src/core/entities/session/service.ts
+++ b/apps/server-core/src/core/entities/session/service.ts
@@ -11,7 +11,7 @@ import { PermissionName } from '@authup/core-kit';
 import type { Session } from '@authup/core-kit';
 import { AbstractEntityService } from '@authup/server-kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
-import type { ISessionRepository } from '../../authentication/index.ts';
+import type { ISessionRepository, SessionOwner } from '../../authentication/index.ts';
 import type { ISessionService, SessionDeleteManyResult } from './types.ts';
 
 export type SessionServiceContext = {
@@ -152,6 +152,38 @@ export class SessionService extends AbstractEntityService implements ISessionSer
             if (currentSessionId && session.id === currentSessionId) {
                 continue;
             }
+            await this.repository.remove(session);
+            count += 1;
+        }
+
+        return { count };
+    }
+
+    async deleteManyForOwner(
+        actor: ActorContext,
+        owner: SessionOwner,
+    ): Promise<SessionDeleteManyResult> {
+        // Gate: an actor without SESSION_DELETE cannot force-logout anyone → 403.
+        await actor.permissionEvaluator.preEvaluate({ name: PermissionName.SESSION_DELETE });
+
+        const sessions = await this.repository.findAllByOwner(owner);
+
+        let count = 0;
+        for (const session of sessions) {
+            // Per-session realm-match: a realm_admin only reaches sessions in
+            // its realm. Cross-realm sessions are silently skipped, not failed.
+            try {
+                await actor.permissionEvaluator.evaluate({
+                    name: PermissionName.SESSION_DELETE,
+                    data: definePolicyData({
+                        [BuiltInPolicyType.ATTRIBUTES]: session,
+                        ...this.resourceRealmMatch(session),
+                    }),
+                });
+            } catch {
+                continue;
+            }
+
             await this.repository.remove(session);
             count += 1;
         }

--- a/apps/server-core/src/core/entities/session/service.ts
+++ b/apps/server-core/src/core/entities/session/service.ts
@@ -7,6 +7,7 @@
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { EntityNotFoundError, UnauthorizedError } from '@authup/errors';
+import { isObject } from '@authup/kit';
 import { PermissionName } from '@authup/core-kit';
 import type { Session } from '@authup/core-kit';
 import { AbstractEntityService } from '@authup/server-kit';
@@ -158,7 +159,7 @@ export class SessionService extends AbstractEntityService implements ISessionSer
      */
     protected hasTargetFilter(query?: Record<string, any>): boolean {
         const filter = query?.filter;
-        if (!filter || typeof filter !== 'object') {
+        if (!isObject(filter)) {
             return false;
         }
 

--- a/apps/server-core/src/core/entities/session/types.ts
+++ b/apps/server-core/src/core/entities/session/types.ts
@@ -7,6 +7,7 @@
 
 import type { Session } from '@authup/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
+import type { SessionOwner } from '../../authentication/index.ts';
 
 export type SessionDeleteManyResult = {
     count: number,
@@ -35,4 +36,13 @@ export interface ISessionService {
      * ("log out my other devices"). Self-service — no permission required.
      */
     deleteManyForActor(actor: ActorContext, currentSessionId?: string): Promise<SessionDeleteManyResult>;
+
+    /**
+     * Revoke every session of a target subject ("force-logout this user
+     * everywhere"). Requires `SESSION_DELETE`; each session is additionally
+     * realm-matched, so a `realm_admin` only revokes sessions in its reach.
+     * Unlike `deleteManyForActor` there is NO current-session exemption — the
+     * actor is (typically) not the owner.
+     */
+    deleteManyForOwner(actor: ActorContext, owner: SessionOwner): Promise<SessionDeleteManyResult>;
 }

--- a/apps/server-core/src/core/entities/session/types.ts
+++ b/apps/server-core/src/core/entities/session/types.ts
@@ -7,10 +7,23 @@
 
 import type { Session } from '@authup/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
-import type { SessionOwner } from '../../authentication/index.ts';
 
 export type SessionDeleteManyResult = {
     count: number,
+};
+
+export type SessionDeleteManyOptions = {
+    /**
+     * The parsed request query. When it carries a recognized target filter
+     * (`SESSION_FILTER_KEYS`, e.g. `filter[user_id]`) the call is an admin
+     * bulk revoke; otherwise it is the self-service path.
+     */
+    query?: Record<string, any>,
+    /**
+     * The caller's current session id (from the bearer). Preserved on the
+     * self-service path so "log out my other devices" keeps this device.
+     */
+    currentSessionId?: string,
 };
 
 export interface ISessionService {
@@ -32,17 +45,16 @@ export interface ISessionService {
     delete(id: string, actor: ActorContext): Promise<Session>;
 
     /**
-     * Revoke every session of the actor except (optionally) the current one
-     * ("log out my other devices"). Self-service — no permission required.
+     * Bulk revoke.
+     *
+     * - **No recognized target filter** → self-service: revoke every session of
+     *   the actor except the current one ("log out my other devices"). No
+     *   permission required.
+     * - **A recognized target filter** (`SESSION_FILTER_KEYS`, e.g.
+     *   `filter[user_id]`, `filter[realm_id]`) → admin "force-logout": revoke
+     *   every matching session. Requires `SESSION_DELETE`, and each session is
+     *   additionally realm-matched (drop-unauthorized), so a `realm_admin` only
+     *   revokes sessions in its reach and filter breadth cannot escalate.
      */
-    deleteManyForActor(actor: ActorContext, currentSessionId?: string): Promise<SessionDeleteManyResult>;
-
-    /**
-     * Revoke every session of a target subject ("force-logout this user
-     * everywhere"). Requires `SESSION_DELETE`; each session is additionally
-     * realm-matched, so a `realm_admin` only revokes sessions in its reach.
-     * Unlike `deleteManyForActor` there is NO current-session exemption — the
-     * actor is (typically) not the owner.
-     */
-    deleteManyForOwner(actor: ActorContext, owner: SessionOwner): Promise<SessionDeleteManyResult>;
+    deleteMany(actor: ActorContext, options?: SessionDeleteManyOptions): Promise<SessionDeleteManyResult>;
 }

--- a/apps/server-core/test/unit/core/entities/session/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/session/fake-repository.ts
@@ -13,6 +13,7 @@ import type {
     SessionFindManyOptions,
     SessionOwner,
 } from '../../../../../src/core/index.ts';
+import { SESSION_FILTER_KEYS } from '../../../../../src/core/index.ts';
 
 export class FakeSessionRepository implements ISessionRepository {
     public removeCalls: Session[] = [];
@@ -53,6 +54,22 @@ export class FakeSessionRepository implements ISessionRepository {
 
     async findAllByOwner(owner: SessionOwner): Promise<Session[]> {
         return [...this.sessions.values()].filter((s) => this.ownedBy(s, owner));
+    }
+
+    async findAllByQuery(query: Record<string, any>): Promise<Session[]> {
+        const filter = (query?.filter ?? {}) as Record<string, any>;
+
+        return [...this.sessions.values()].filter((session) => Object
+            .keys(filter)
+            .every((key) => {
+                if (!(SESSION_FILTER_KEYS as readonly string[]).includes(key)) {
+                    // unknown key → applyQuery would ignore it (no constraint)
+                    return true;
+                }
+                const raw = filter[key];
+                const values = typeof raw === 'string' ? raw.split(',') : [raw];
+                return values.map(String).includes(String((session as any)[key]));
+            }));
     }
 
     async save(input: Partial<Session>): Promise<Session> {

--- a/apps/server-core/test/unit/core/entities/session/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/session/service.spec.ts
@@ -55,15 +55,17 @@ describe('SessionService', () => {
 
     function seedOwn(): Session {
         return repository.seed({
-            sub: userId, 
-            sub_kind: IdentityType.USER, 
+            sub: userId,
+            sub_kind: IdentityType.USER,
+            user_id: userId,
             realm_id: realmId,
         });
     }
     function seedOther(): Session {
         return repository.seed({
-            sub: otherUserId, 
-            sub_kind: IdentityType.USER, 
+            sub: otherUserId,
+            sub_kind: IdentityType.USER,
+            user_id: otherUserId,
             realm_id: realmId,
         });
     }
@@ -165,7 +167,7 @@ describe('SessionService', () => {
         });
     });
 
-    describe('deleteManyForActor', () => {
+    describe('deleteMany (self-service — no target filter)', () => {
         it('revokes every own session except the current one', async () => {
             const s1 = seedOwn();
             const current = seedOwn();
@@ -173,7 +175,7 @@ describe('SessionService', () => {
             seedOther();
 
             const actor = makeActor({ allow: false });
-            const { count } = await service.deleteManyForActor(actor, current.id);
+            const { count } = await service.deleteMany(actor, { currentSessionId: current.id });
 
             expect(count).toEqual(2);
             const removed = repository.removeCalls.map((s) => s.id);
@@ -187,32 +189,66 @@ describe('SessionService', () => {
             seedOwn();
 
             const actor = makeActor({ allow: false });
-            const { count } = await service.deleteManyForActor(actor);
+            const { count } = await service.deleteMany(actor);
 
             expect(count).toEqual(2);
         });
 
+        it('needs no permission (self-service) even with an empty/unrecognized filter', async () => {
+            seedOwn();
+            seedOther();
+
+            // an unrecognized filter key must NOT trigger an admin mass-delete;
+            // it falls through to the self path (deny-all actor still succeeds).
+            const actor = makeActor({ allow: false });
+            const { count } = await service.deleteMany(actor, { query: { filter: { foobar: 'x' } } });
+
+            expect(count).toEqual(1); // only the actor's own session
+        });
+
         it('throws for an identity-less actor', async () => {
             const actor = makeActor({ allow: true, identity: false });
-            await expect(service.deleteManyForActor(actor)).rejects.toBeDefined();
+            await expect(service.deleteMany(actor)).rejects.toBeDefined();
         });
     });
 
-    describe('deleteManyForOwner', () => {
-        const owner = { sub: otherUserId, subKind: IdentityType.USER };
+    describe('deleteMany (admin bulk revoke — target filter)', () => {
+        function adminQuery(userIds: string | string[]): Record<string, any> {
+            return { filter: { user_id: Array.isArray(userIds) ? userIds.join(',') : userIds } };
+        }
 
-        it('revokes every session of the target subject', async () => {
+        it('revokes every session matching filter[user_id]', async () => {
             const s1 = seedOther();
             const s2 = seedOther();
             seedOwn();
 
             const actor = makeActor({ allow: true });
-            const { count } = await service.deleteManyForOwner(actor, owner);
+            const { count } = await service.deleteMany(actor, { query: adminQuery(otherUserId) });
 
             expect(count).toEqual(2);
             const removed = repository.removeCalls.map((s) => s.id);
             expect(removed).toContain(s1.id);
             expect(removed).toContain(s2.id);
+        });
+
+        it('targets multiple subjects via a comma-separated filter[user_id]', async () => {
+            const thirdUserId = randomUUID();
+            const a = seedOther();
+            const b = repository.seed({
+                sub: thirdUserId,
+                sub_kind: IdentityType.USER,
+                user_id: thirdUserId,
+                realm_id: realmId,
+            });
+            seedOwn();
+
+            const actor = makeActor({ allow: true });
+            const { count } = await service.deleteMany(actor, { query: adminQuery([otherUserId, thirdUserId]) });
+
+            expect(count).toEqual(2);
+            const removed = repository.removeCalls.map((s) => s.id);
+            expect(removed).toContain(a.id);
+            expect(removed).toContain(b.id);
         });
 
         it('revokes only sessions within the actor realm reach (drops cross-realm)', async () => {
@@ -222,6 +258,7 @@ describe('SessionService', () => {
             const outOfReach = repository.seed({
                 sub: otherUserId,
                 sub_kind: IdentityType.USER,
+                user_id: otherUserId,
                 realm_id: otherRealmId,
             });
 
@@ -244,7 +281,7 @@ describe('SessionService', () => {
                 identity: { type: IdentityType.USER, data: { id: userId, realm_id: realmId } as User },
             };
 
-            const { count } = await service.deleteManyForOwner(actor, owner);
+            const { count } = await service.deleteMany(actor, { query: adminQuery(otherUserId) });
 
             expect(count).toEqual(2);
             const removed = repository.removeCalls.map((s) => s.id);
@@ -257,7 +294,9 @@ describe('SessionService', () => {
             seedOther();
 
             const actor = makeActor({ allow: false });
-            await expect(service.deleteManyForOwner(actor, owner)).rejects.toBeDefined();
+            await expect(
+                service.deleteMany(actor, { query: adminQuery(otherUserId) }),
+            ).rejects.toBeDefined();
             expect(repository.removeCalls).toHaveLength(0);
         });
 
@@ -265,7 +304,7 @@ describe('SessionService', () => {
             seedOwn();
 
             const actor = makeActor({ allow: true });
-            const { count } = await service.deleteManyForOwner(actor, owner);
+            const { count } = await service.deleteMany(actor, { query: adminQuery(otherUserId) });
 
             expect(count).toEqual(0);
             expect(repository.removeCalls).toHaveLength(0);

--- a/apps/server-core/test/unit/core/entities/session/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/session/service.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { BuiltInPolicyType } from '@authup/access';
 import type { Session, User } from '@authup/core-kit';
 import { IdentityType } from '@authup/core-kit';
 import type { ActorContext } from '@authup/server-kit';
@@ -194,6 +195,80 @@ describe('SessionService', () => {
         it('throws for an identity-less actor', async () => {
             const actor = makeActor({ allow: true, identity: false });
             await expect(service.deleteManyForActor(actor)).rejects.toBeDefined();
+        });
+    });
+
+    describe('deleteManyForOwner', () => {
+        const owner = { sub: otherUserId, subKind: IdentityType.USER };
+
+        it('revokes every session of the target subject', async () => {
+            const s1 = seedOther();
+            const s2 = seedOther();
+            seedOwn();
+
+            const actor = makeActor({ allow: true });
+            const { count } = await service.deleteManyForOwner(actor, owner);
+
+            expect(count).toEqual(2);
+            const removed = repository.removeCalls.map((s) => s.id);
+            expect(removed).toContain(s1.id);
+            expect(removed).toContain(s2.id);
+        });
+
+        it('revokes only sessions within the actor realm reach (drops cross-realm)', async () => {
+            const otherRealmId = randomUUID();
+            const inReach1 = seedOther();
+            const inReach2 = seedOther();
+            const outOfReach = repository.seed({
+                sub: otherUserId,
+                sub_kind: IdentityType.USER,
+                realm_id: otherRealmId,
+            });
+
+            // preEvaluate (gate) passes; per-session evaluate denies when the
+            // resource realm is outside the actor's own realm.
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.setBehavior((call) => {
+                if (call.method !== 'evaluate') {
+                    return;
+                }
+                const resourceRealm = call.ctx.data?.has(BuiltInPolicyType.REALM_MATCH) ?
+                    call.ctx.data.get(BuiltInPolicyType.REALM_MATCH) :
+                    undefined;
+                if (resourceRealm !== realmId) {
+                    throw new Error('out of realm reach');
+                }
+            });
+            const actor: ActorContext = {
+                permissionEvaluator: evaluator,
+                identity: { type: IdentityType.USER, data: { id: userId, realm_id: realmId } as User },
+            };
+
+            const { count } = await service.deleteManyForOwner(actor, owner);
+
+            expect(count).toEqual(2);
+            const removed = repository.removeCalls.map((s) => s.id);
+            expect(removed).toContain(inReach1.id);
+            expect(removed).toContain(inReach2.id);
+            expect(removed).not.toContain(outOfReach.id);
+        });
+
+        it('throws for an actor without the delete permission', async () => {
+            seedOther();
+
+            const actor = makeActor({ allow: false });
+            await expect(service.deleteManyForOwner(actor, owner)).rejects.toBeDefined();
+            expect(repository.removeCalls).toHaveLength(0);
+        });
+
+        it('returns count 0 when the target has no sessions', async () => {
+            seedOwn();
+
+            const actor = makeActor({ allow: true });
+            const { count } = await service.deleteManyForOwner(actor, owner);
+
+            expect(count).toEqual(0);
+            expect(repository.removeCalls).toHaveLength(0);
         });
     });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/session.spec.ts
@@ -113,12 +113,31 @@ describe('session', () => {
         const before = await suite.client.session.getMany({ filter: { user_id: user.id } });
         expect(before.data.length).toBeGreaterThanOrEqual(2);
 
-        const result = await suite.client.session.deleteMany({ userId: user.id });
+        const result = await suite.client.session.deleteMany({ filter: { user_id: user.id } });
         expect(result.count).toBeGreaterThanOrEqual(2);
 
         // every session of the target user is gone
         const after = await suite.client.session.getMany({ filter: { user_id: user.id } });
         expect(after.data).toHaveLength(0);
+    });
+
+    it('force-logs-out multiple users in one call via a comma filter', async () => {
+        const password = 'session-multi-user-pw';
+        const first = createFakeUser({ password });
+        const second = createFakeUser({ password });
+        const userA = await suite.client.user.create(first);
+        const userB = await suite.client.user.create(second);
+
+        await suite.client.token.createWithPassword({ username: first.name, password });
+        await suite.client.token.createWithPassword({ username: second.name, password });
+
+        const result = await suite.client.session.deleteMany({ filter: { user_id: [userA.id, userB.id] } });
+        expect(result.count).toBeGreaterThanOrEqual(2);
+
+        const afterA = await suite.client.session.getMany({ filter: { user_id: userA.id } });
+        const afterB = await suite.client.session.getMany({ filter: { user_id: userB.id } });
+        expect(afterA.data).toHaveLength(0);
+        expect(afterB.data).toHaveLength(0);
     });
 
     it('denies a non-privileged user from force-logging-out another user', async () => {
@@ -129,9 +148,9 @@ describe('session', () => {
         const login = await suite.client.token.createWithPassword({ username: fakeUser.name, password });
         const client = bearer(login.access_token);
 
-        // passing a target user_id takes the admin path → 403 (lacks SESSION_DELETE)
+        // a target filter takes the admin path → 403 (lacks SESSION_DELETE)
         await expectClientError(
-            () => client.session.deleteMany({ userId: randomUUID() }),
+            () => client.session.deleteMany({ filter: { user_id: randomUUID() } }),
             { status: 403 },
         );
 

--- a/apps/server-core/test/unit/http/controllers/entities/session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/session.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import {
     afterAll,
     beforeAll,
@@ -13,7 +14,7 @@ import {
     it,
 } from 'vitest';
 import { Client as HTTPClient } from '@authup/core-http-kit';
-import { createFakeUser } from '../../../../utils';
+import { createFakeUser, expectClientError } from '../../../../utils';
 import { createTestApplication } from '../../../../app';
 
 describe('session', () => {
@@ -98,5 +99,44 @@ describe('session', () => {
 
         // the user can revoke its own current session (@me)
         await client.session.delete(introspect.session_id!);
+    });
+
+    it('lets an admin force-logout a target user everywhere', async () => {
+        const password = 'session-target-user-pw';
+        const fakeUser = createFakeUser({ password });
+        const user = await suite.client.user.create(fakeUser);
+
+        // two sessions for the target user
+        await suite.client.token.createWithPassword({ username: fakeUser.name, password });
+        await suite.client.token.createWithPassword({ username: fakeUser.name, password });
+
+        const before = await suite.client.session.getMany({ filter: { user_id: user.id } });
+        expect(before.data.length).toBeGreaterThanOrEqual(2);
+
+        const result = await suite.client.session.deleteMany({ userId: user.id });
+        expect(result.count).toBeGreaterThanOrEqual(2);
+
+        // every session of the target user is gone
+        const after = await suite.client.session.getMany({ filter: { user_id: user.id } });
+        expect(after.data).toHaveLength(0);
+    });
+
+    it('denies a non-privileged user from force-logging-out another user', async () => {
+        const password = 'session-nonpriv-pw';
+        const fakeUser = createFakeUser({ password });
+        await suite.client.user.create(fakeUser);
+
+        const login = await suite.client.token.createWithPassword({ username: fakeUser.name, password });
+        const client = bearer(login.access_token);
+
+        // passing a target user_id takes the admin path → 403 (lacks SESSION_DELETE)
+        await expectClientError(
+            () => client.session.deleteMany({ userId: randomUUID() }),
+            { status: 403 },
+        );
+
+        // the no-arg self path is unaffected
+        const result = await client.session.deleteMany();
+        expect(result.count).toBeGreaterThanOrEqual(0);
     });
 });

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -120,6 +120,13 @@ export function createStore(context: StoreCreateContext) {
 
     // --------------------------------------------------------------------
 
+    // The id of the session backing the current access token. Sourced from the
+    // token introspection response so the UI can mark "this device" and avoid a
+    // confusing silent self-logout on the current row.
+    const sessionId = ref<string | null>(null);
+
+    // --------------------------------------------------------------------
+
     const realm = ref<RealmMinimal | null>(null);
     const realmId = computed<string | undefined>(() => (realm.value ? realm.value.id : undefined));
     const realmName = computed<string | undefined>(() => (realm.value ? realm.value.name : undefined));
@@ -165,6 +172,7 @@ export function createStore(context: StoreCreateContext) {
         setAccessTokenExpireDate(null);
         setRefreshToken(null);
         setUser(null);
+        sessionId.value = null;
         setRealm(null);
         setRealmManagement(null);
 
@@ -226,6 +234,10 @@ export function createStore(context: StoreCreateContext) {
                 if (response.exp) {
                     const expireDate = new Date(response.exp * 1000);
                     setAccessTokenExpireDate(expireDate);
+                }
+
+                if (response.session_id) {
+                    sessionId.value = response.session_id;
                 }
 
                 if (
@@ -412,5 +424,7 @@ export function createStore(context: StoreCreateContext) {
         user,
         userId,
         setUser,
+
+        sessionId,
     };
 }

--- a/packages/client-web-kit/test/unit/core/store/session-id.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/session-id.spec.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import { describe, expect, it } from 'vitest';
+import { createStore, createStoreDispatcher } from '../../../../src/core/store';
+
+function buildStore(sessionId?: string) {
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token/introspect': () => ({
+                exp: 9999999999,
+                ...(sessionId ? { session_id: sessionId } : {}),
+                realm_id: 'realm-1',
+                realm_name: 'master',
+                permissions: [],
+            }),
+            'GET /users/@me': () => ({ id: 'user-1', name: 'admin' }),
+            'POST /token/revoke': () => ({}),
+        },
+    });
+
+    const store = createStore({
+        httpClient,
+        dispatcher: createStoreDispatcher(),
+    });
+
+    return { store, httpClient };
+}
+
+describe('core/store/session-id', () => {
+    it('maps the introspection session_id onto the store sessionId ref', async () => {
+        const { store } = buildStore('sess-123');
+
+        expect(store.sessionId.value).toBeNull();
+
+        store.setAccessToken('abc');
+        await store.resolve();
+
+        expect(store.sessionId.value).toEqual('sess-123');
+    });
+
+    it('leaves sessionId null when introspection carries none', async () => {
+        const { store } = buildStore();
+
+        store.setAccessToken('abc');
+        await store.resolve();
+
+        expect(store.sessionId.value).toBeNull();
+    });
+
+    it('clears sessionId on logout', async () => {
+        const { store } = buildStore('sess-123');
+
+        store.setAccessToken('abc');
+        await store.resolve();
+        expect(store.sessionId.value).toEqual('sess-123');
+
+        await store.logout();
+        expect(store.sessionId.value).toBeNull();
+    });
+});

--- a/packages/core-http-kit/src/domains/entities/session/module.ts
+++ b/packages/core-http-kit/src/domains/entities/session/module.ts
@@ -31,9 +31,8 @@ export class SessionAPI extends BaseAPI implements ISessionAPI {
         return response.data;
     }
 
-    async deleteMany(options: { userId?: string } = {}): Promise<SessionDeleteManyResponse> {
-        const suffix = options.userId ? `?user_id=${encodeURIComponent(options.userId)}` : '';
-        const response = await this.client.delete(`sessions${suffix}`);
+    async deleteMany(data?: BuildInput<Session>): Promise<SessionDeleteManyResponse> {
+        const response = await this.client.delete(`sessions${buildQuery(data)}`);
 
         return response.data;
     }

--- a/packages/core-http-kit/src/domains/entities/session/module.ts
+++ b/packages/core-http-kit/src/domains/entities/session/module.ts
@@ -31,8 +31,9 @@ export class SessionAPI extends BaseAPI implements ISessionAPI {
         return response.data;
     }
 
-    async deleteMany(): Promise<SessionDeleteManyResponse> {
-        const response = await this.client.delete('sessions');
+    async deleteMany(options: { userId?: string } = {}): Promise<SessionDeleteManyResponse> {
+        const suffix = options.userId ? `?user_id=${encodeURIComponent(options.userId)}` : '';
+        const response = await this.client.delete(`sessions${suffix}`);
 
         return response.data;
     }

--- a/packages/core-http-kit/src/domains/entities/session/types.ts
+++ b/packages/core-http-kit/src/domains/entities/session/types.ts
@@ -21,12 +21,14 @@ export interface ISessionAPI {
     delete(id: Session['id']): Promise<EntityRecordResponse<Session>>;
 
     /**
-     * Revoke sessions in bulk.
+     * Revoke sessions in bulk (mirrors `getMany`'s query shape).
      *
      * - No argument → revoke every session of the current identity except the
      *   one this request authenticates with ("log out my other devices").
-     * - `{ userId }` → admin force-logout: revoke every session of the target
-     *   user on all devices (requires `SESSION_DELETE` + realm reach).
+     * - A target `filter` (e.g. `{ filter: { user_id } }`, `{ filter: { realm_id } }`)
+     *   → admin force-logout: revoke every matching session (requires
+     *   `SESSION_DELETE` + per-session realm reach). `filter[user_id]` accepts a
+     *   comma list to target multiple subjects at once.
      */
-    deleteMany(options?: { userId?: string }): Promise<SessionDeleteManyResponse>;
+    deleteMany(data?: BuildInput<Session>): Promise<SessionDeleteManyResponse>;
 }

--- a/packages/core-http-kit/src/domains/entities/session/types.ts
+++ b/packages/core-http-kit/src/domains/entities/session/types.ts
@@ -21,8 +21,12 @@ export interface ISessionAPI {
     delete(id: Session['id']): Promise<EntityRecordResponse<Session>>;
 
     /**
-     * Revoke every session of the current identity except the one this request
-     * authenticates with ("log out my other devices").
+     * Revoke sessions in bulk.
+     *
+     * - No argument → revoke every session of the current identity except the
+     *   one this request authenticates with ("log out my other devices").
+     * - `{ userId }` → admin force-logout: revoke every session of the target
+     *   user on all devices (requires `SESSION_DELETE` + realm reach).
      */
-    deleteMany(): Promise<SessionDeleteManyResponse>;
+    deleteMany(options?: { userId?: string }): Promise<SessionDeleteManyResponse>;
 }

--- a/packages/i18n/src/catalogs/de/app.ts
+++ b/packages/i18n/src/catalogs/de/app.ts
@@ -53,4 +53,11 @@ export const TranslatorTranslationAppGerman : NamespaceTranslations<`${Translato
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: 'Andere Geräte abmelden?',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'Dadurch werden alle anderen Sitzungen abgemeldet. Ihre aktuelle Sitzung bleibt aktiv.',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: '{{amount}} andere Sitzung(en) abgemeldet.',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL]: 'Überall abmelden',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_TITLE]: 'Diesen Benutzer überall abmelden?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION]: 'Dadurch werden alle Sitzungen dieses Benutzers auf allen Geräten abgemeldet.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_SUCCESS]: '{{amount}} Sitzung(en) abgemeldet.',
+
+    [TranslatorTranslationAppKey.SESSION_CURRENT]: 'Dieses Gerät',
 };

--- a/packages/i18n/src/catalogs/en/app.ts
+++ b/packages/i18n/src/catalogs/en/app.ts
@@ -53,4 +53,11 @@ export const TranslatorTranslationAppEnglish : NamespaceTranslations<`${Translat
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: 'Log out other devices?',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'This signs out all your other sessions. Your current session stays active.',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: 'Logged out {{amount}} other session(s).',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL]: 'Log out everywhere',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_TITLE]: 'Log this user out everywhere?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION]: 'This revokes every session of this user on all devices.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_SUCCESS]: 'Logged out {{amount}} session(s).',
+
+    [TranslatorTranslationAppKey.SESSION_CURRENT]: 'This device',
 };

--- a/packages/i18n/src/catalogs/es/app.ts
+++ b/packages/i18n/src/catalogs/es/app.ts
@@ -53,4 +53,11 @@ export const TranslatorTranslationAppSpanish : NamespaceTranslations<`${Translat
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: '¿Cerrar sesión en otros dispositivos?',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'Esto cierra todas tus otras sesiones. Tu sesión actual permanece activa.',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: '{{amount}} otra(s) sesión(es) cerradas.',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL]: 'Cerrar sesión en todas partes',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_TITLE]: '¿Cerrar la sesión de este usuario en todas partes?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION]: 'Esto revoca todas las sesiones de este usuario en todos los dispositivos.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_SUCCESS]: '{{amount}} sesión(es) cerradas.',
+
+    [TranslatorTranslationAppKey.SESSION_CURRENT]: 'Este dispositivo',
 };

--- a/packages/i18n/src/catalogs/fr/app.ts
+++ b/packages/i18n/src/catalogs/fr/app.ts
@@ -53,4 +53,11 @@ export const TranslatorTranslationAppFrench : NamespaceTranslations<`${Translato
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_TITLE]: 'Déconnecter les autres appareils ?',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION]: 'Cela déconnecte toutes vos autres sessions. Votre session actuelle reste active.',
     [TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_SUCCESS]: '{{amount}} autre(s) session(s) déconnectée(s).',
+
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL]: 'Déconnecter partout',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_TITLE]: 'Déconnecter cet utilisateur partout ?',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION]: 'Cela révoque toutes les sessions de cet utilisateur sur tous les appareils.',
+    [TranslatorTranslationAppKey.SESSION_REVOKE_ALL_SUCCESS]: '{{amount}} session(s) déconnectée(s).',
+
+    [TranslatorTranslationAppKey.SESSION_CURRENT]: 'Cet appareil',
 };

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -159,6 +159,13 @@ export enum TranslatorTranslationAppKey {
     SESSION_REVOKE_OTHERS_CONFIRM_TITLE = 'sessionRevokeOthersConfirmTitle',
     SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION = 'sessionRevokeOthersConfirmDescription',
     SESSION_REVOKE_OTHERS_SUCCESS = 'sessionRevokeOthersSuccess',
+
+    SESSION_REVOKE_ALL = 'sessionRevokeAll',
+    SESSION_REVOKE_ALL_CONFIRM_TITLE = 'sessionRevokeAllConfirmTitle',
+    SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION = 'sessionRevokeAllConfirmDescription',
+    SESSION_REVOKE_ALL_SUCCESS = 'sessionRevokeAllSuccess',
+
+    SESSION_CURRENT = 'sessionCurrent',
 }
 
 /**


### PR DESCRIPTION
Closes out the remaining plan-016 session-management (G2) items in two independent workstreams.

## Part A — Admin bulk session revocation ("log out user-X everywhere")

Previously an admin could only revoke another user's sessions one row at a time on `/users/:id/sessions`. This adds a single "force-logout" action, driven by the **same rapiq query filter** the list endpoint uses (not a bespoke param).

- **`DELETE /sessions` is discriminated by a recognized target filter** (`SESSION_FILTER_KEYS` = `id`, `sub`, `sub_kind`, `user_id`, `client_id`, `robot_id`, `realm_id` — the vocabulary `getMany` already filters on):
  - **No target filter →** self-service (unchanged): revoke every own session except the current one ("log out my other devices"). No permission. An unrecognized/empty filter falls through here too, so a typo can never trigger a mass delete.
  - **A target filter** (`?filter[user_id]=<uuid>`, a comma list for several subjects, or `?filter[realm_id]=…`) **→** admin force-logout: `SessionService.deleteManyByQuery` loads **every** matching session (unbounded — `findAllByQuery`, no pagination cap, since reusing the paginated `findMany` would silently truncate at `maxLimit`) and revokes each. Gated by `SESSION_DELETE` **plus a per-session `resourceRealmMatch`** (drop-unauthorized). Filter breadth **cannot escalate** — the actor only deletes what it's already authorized to; a `realm_admin` silently drops a target's out-of-realm sessions.
- A non-admin sending a target filter (even its own `user_id`) takes the admin path → `403`.
- **Typed client** mirrors `getMany`: `deleteMany(data?: BuildInput<Session>)` — `deleteMany()` (self) / `deleteMany({ filter: { user_id } })` (admin). `filter[user_id]` accepts an array → multi-subject in one call.
- **Admin UI** — a "Log out everywhere" button on `pages/users/[id]/sessions.vue`, gated on `SESSION_DELETE`, error-tone confirm, toasts the returned count.

## Part B — Current-session marking

Shows which row in the self sessions list is *this* device and prevents a confusing silent self-logout by deleting the current session individually.

- **Store** — `@authup/client-web-kit` now exposes a `sessionId` ref, sourced from the token-introspection `session_id` in `resolveToken` (cleared on logout).
- **Self page** — the current row gets a "This device" badge and its per-row delete button is omitted.

## i18n

`SESSION_REVOKE_ALL*` + `SESSION_CURRENT` keys across en/de/fr/es (locale-parity test enforced).

## Tests

- Service: self-service path (incl. unrecognized-filter fall-through) + admin bulk revoke (single, **multi-subject comma filter**, realm-scoped drop, 403, empty target).
- HTTP: admin force-logout end-to-end, multi-user comma filter, non-admin filter → 403, self path untouched.
- Kit store: `resolveToken` maps `session_id` onto `sessionId`; null when absent; cleared on logout.

Full build + `check:types` + eslint clean; server-core **1103 tests pass**, i18n parity, client-web-kit, core-http-kit green; client-web `nuxi typecheck` clean.