### PR TITLE
feat: realm-bind the authorize and token flow

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1064,6 +1064,47 @@ Two-layer rejection:
 
 `AttributeNamesPolicyValidator` reads the policy's `names` field from extra-attributes (`policy_attributes`). For top-level policies bound directly to permissions, the policy is loaded as the root of a closure-table descendants tree. `EATreeRepository.findDescendantsTree()` calls `extendOneWithEA(entity)` after building the children — without that, the root entity's EA fields stay unloaded and the validator fails with "value_invalid". Both Layer 1 (`PermissionDatabaseProvider`) and Layer 2 (`bindings.ts`) depend on this fix.
 
+## Authorize Realm Binding (plan 041)
+
+The authenticated identity's realm MUST equal the client's realm — an identity
+cannot authorize (or redeem a code / refresh a token) against a client in
+another realm. Without this an identity with a lingering session for realm A,
+redirected to `/authorize` for realm B's `web` client (a downstream app's realm
+picker), silently minted realm-A tokens against realm B's client (confused
+deputy; the artifact carried realm-A `iss`/signing-key + realm-B `aud`).
+Enforced server-side at **three** points — the kit UI (realm-mismatch card in
+`Authorize.vue`) is UX only:
+
+1. **`POST /authorize` issuance** — `OAuth2Authorization.authorize()` throws
+   `OAuth2LoginRequiredError` (`ErrorCode.OAUTH_LOGIN_REQUIRED` / OIDC
+   `login_required`, HTTP 400, **no identity data in the body** — no
+   realm-enumeration oracle) when `identity.data.realm.id !== data.realm_id`
+   (the client realm the code-request verifier stamped).
+2. **`/token` code redemption** — the code verifier's `realmId` option (fed
+   `client.realm_id` by the HTTP authorize grant) rejects
+   `code.realm_id !== realmId` with `invalid_grant`. Covers codes minted outside
+   `authorize()` (identity-provider callback) and in-flight pre-deploy codes.
+3. **`/token` refresh parity** — a **public** client refreshing a token whose
+   `realm_id` differs from the client's realm → `invalid_grant` (kills legacy
+   cross-realm public-`web`-client refresh tokens). Confidential clients are
+   exempt — the secret proves identity, and the documented cross-realm password
+   grant (UUID user + master client) relies on that exemption.
+
+Deliberate breaking change: master-realm admins can no longer ride the built-in
+`web` client into other realms' apps. A name-identified client at `/authorize`
+now also requires a realm hint (`invalid_request` otherwise — every realm has a
+`web` client, so a bare name is ambiguous). All SSR auth pages emit
+`Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY`
+(clickjacking guard — the pages hydrate first-party session state, so click-
+gating is only a defense when framing is denied).
+
+Ending a lingering authup session on a downstream app's logout is **not** part
+of this gate — it belongs to standard OIDC RP-Initiated Logout
+(`end_session_endpoint`, plan 041 PR C), so kit and non-kit RPs share one
+mechanism. `store.logout()` stays local-only (token/cookie cleanup); it does not
+call `DELETE /sessions/@me` (that endpoint remains the session-management API for
+revoking a specific session from the sessions UI).
+
 ## OAuth2 Token Endpoint Authentication
 
 The `/token` endpoint authenticates the calling client according to RFC 6749. Confidential clients MUST present a `client_secret`; public clients identify with `client_id` only.

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/authorize.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/authorize.ts
@@ -56,6 +56,7 @@ export class HTTPOAuth2AuthorizeGrant extends OAuth2AuthorizeGrant implements IH
             codeVerifier,
             clientId: client.id,
             clientIsPublic: !client.is_confidential,
+            realmId: client.realm_id,
         });
 
         return this.runWith(entity, {

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/refresh_token.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/refresh_token.ts
@@ -67,6 +67,21 @@ export class HTTPOAuth2RefreshTokenGrant extends OAuth2RefreshTokenGrant impleme
             if (payload.client_id && payload.client_id !== client.id) {
                 throw OAuth2GrantError.invalid();
             }
+
+            // Realm parity for PUBLIC clients only: a public client may not
+            // refresh a token whose realm differs from the client's own realm.
+            // Kills cross-realm refresh tokens minted for a public `web` client
+            // before the authorize-side realm gate existed. Confidential clients
+            // are exempt — the client secret already proves identity, and the
+            // documented cross-realm password grant (UUID-identified user against
+            // a master-realm client) depends on that exemption.
+            if (
+                !client.is_confidential &&
+                payload.realm_id &&
+                payload.realm_id !== client.realm_id
+            ) {
+                throw OAuth2GrantError.invalid();
+            }
         } else if (payload.client_id) {
             // Token was issued to a specific client — that client MUST
             // re-authenticate (RFC 6749 §6 binding requirement).

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
@@ -14,7 +14,12 @@ import {
 import { URL } from 'node:url';
 
 import type { IAppEvent } from 'routup';
-import type { Client, OAuth2AuthorizationCodeRequest, Scope } from '@authup/core-kit';
+import type {
+    Client,
+    OAuth2AuthorizationCodeRequest,
+    Realm,
+    Scope,
+} from '@authup/core-kit';
 import { ForceUserLoggedInMiddleware } from '../../../middleware/index.ts';
 import { HTTPOAuth2Authorizer } from '../../../adapters/index.ts';
 import { renderUIPage } from '../../../ui/index.ts';
@@ -23,6 +28,8 @@ import type { IOAuth2AuthorizationCodeRequestVerifier } from '../../../../../cor
 import { OAuth2AuthorizationCodeRequestValidator } from '../../../../../core/index.ts';
 import type { AuthorizeControllerContext, AuthorizeControllerOptions } from './types.ts';
 import { sanitizeError } from '../../../../../utils/index.ts';
+
+type RealmSummary = Pick<Realm, 'id' | 'name' | 'display_name'>;
 
 @DController('/authorize')
 export class AuthorizeController {
@@ -88,6 +95,15 @@ export class AuthorizeController {
         let client : Client | undefined;
         let scopes : Scope[] | undefined;
 
+        // Target realm summary (the client's realm) — the UI names it in the
+        // realm-mismatch notice. codeRequest.realm_id is only the id.
+        let realm : RealmSummary | undefined;
+
+        // Whether the request redirect_uri matched a registered client pattern —
+        // the UI must not offer an automatic "return to application" redirect to
+        // an unverified (pattern-less-client) redirect_uri.
+        let redirectUriVerified = false;
+
         let error : Error | undefined;
 
         try {
@@ -97,6 +113,15 @@ export class AuthorizeController {
             const result = await this.codeRequestVerifier.verify(data);
             client = result.client;
             scopes = result.scopes;
+            redirectUriVerified = result.redirectUriVerified;
+
+            if (client.realm) {
+                realm = {
+                    id: client.realm.id,
+                    name: client.realm.name,
+                    display_name: client.realm.display_name,
+                };
+            }
 
             codeRequest = result.data;
         } catch (e) {
@@ -121,6 +146,8 @@ export class AuthorizeController {
                     error,
                     client,
                     scopes,
+                    realm,
+                    redirectUriVerified,
                     features: this.options.features,
                     requestPath: `${requestURL.pathname}${requestURL.search}`,
                 },

--- a/apps/server-core/src/adapters/http/ui/render.ts
+++ b/apps/server-core/src/adapters/http/ui/render.ts
@@ -101,6 +101,15 @@ export async function renderUIPage(event: IAppEvent, ctx: UIRenderContext): Prom
     body = rebasePublicAssetURLs(body, getURLBasePath(ctx.payload.config.baseURL));
 
     event.response.headers.set('content-type', 'text/html; charset=utf-8');
+
+    // Clickjacking guard: the SSR auth pages (login, consent, realm-mismatch,
+    // logout) mutate state behind explicit clicks and hydrate the logged-in
+    // session from first-party cookies. Framing them would make click-gating
+    // defeatable via overlay attacks, so deny embedding entirely. (Iframe-based
+    // silent renew is therefore unsupported — auth state is JS-readable anyway.)
+    event.response.headers.set('content-security-policy', "frame-ancestors 'none'");
+    event.response.headers.set('x-frame-options', 'DENY');
+
     return body;
 }
 

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -7,7 +7,7 @@
 
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
-import { isSimpleMatch } from '@authup/kit';
+import { isSimpleMatch, isUUID } from '@authup/kit';
 import {
     OAuth2AuthorizationResponseType,
     OAuth2ClientError,
@@ -52,6 +52,14 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
             throw OAuth2ClientError.invalid();
         }
 
+        // A name-identified client needs a realm hint to resolve deterministically
+        // — every realm has a built-in `web` client, so `client_id=web` without a
+        // realm would bind to an arbitrary realm's client (and, post realm-gate,
+        // produce a confusing mismatch against a random realm). Require the hint.
+        if (!isUUID(data.client_id) && !data.realm_id) {
+            throw OAuth2RequestError.malformed('A realm is required to resolve a client by name.');
+        }
+
         const client = await this.clientRepository.findOneByIdOrName(data.client_id, data.realm_id);
         if (!client) {
             throw OAuth2ClientError.invalid();
@@ -94,6 +102,10 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
             data.scope = scopeNames.join(' ');
         }
 
+        // Verified only when matched against a registered, non-null pattern. A
+        // pattern-less client leaves data.redirect_uri unchecked (any value
+        // passes) — flag it so consumers never auto-redirect to it.
+        const redirectUriVerified = !!(client.redirect_uri && data.redirect_uri);
         if (client.redirect_uri && data.redirect_uri) {
             const redirectUris = client.redirect_uri.split(',');
 
@@ -106,6 +118,7 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
             data,
             client,
             scopes,
+            redirectUriVerified,
         };
     }
 }

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/types.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/types.ts
@@ -18,7 +18,15 @@ export type OAuth2AuthorizationCodeRequestVerificationResult = {
     data: OAuth2AuthorizationCodeRequest,
 
     client: Client,
-    scopes: Scope[]
+    scopes: Scope[],
+
+    /**
+     * True when the request `redirect_uri` was matched against a registered,
+     * non-null client pattern. A pattern-less (null `redirect_uri`) client lets
+     * any supplied `redirect_uri` through unverified — consumers must NOT
+     * automatically redirect to it (open-redirect guard).
+     */
+    redirectUriVerified: boolean
 };
 
 export interface IOAuth2AuthorizationCodeRequestVerifier {

--- a/apps/server-core/src/core/oauth2/authorization/code/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code/verifier/module.ts
@@ -35,6 +35,15 @@ export class OAuth2AuthorizationCodeVerifier implements IOAuth2AuthorizationCode
             }
         }
 
+        // Realm binding (defense in depth): the code's realm (the authorizing
+        // identity's realm) must match the authenticated client's realm. Blocks
+        // redeeming a realm-A identity's code against a realm-B client — covers
+        // codes minted outside OAuth2Authorization.authorize() (identity-provider
+        // callback) and any in-flight codes issued before the authorize-side gate.
+        if (options.realmId && entity.realm_id && entity.realm_id !== options.realmId) {
+            throw OAuth2GrantError.invalid();
+        }
+
         if (entity.redirect_uri) {
             if (!options.redirectUri || entity.redirect_uri !== options.redirectUri) {
                 throw OAuth2GrantError.redirectUriMismatch();

--- a/apps/server-core/src/core/oauth2/authorization/code/verifier/types.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code/verifier/types.ts
@@ -12,6 +12,7 @@ export type IOAuth2AuthorizationCodeVerifyOptions = {
     codeVerifier?: string,
     clientId?: string,
     clientIsPublic?: boolean,
+    realmId?: string,
 };
 
 export interface IOAuth2AuthorizationCodeVerifier {

--- a/apps/server-core/src/core/oauth2/authorization/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/module.ts
@@ -11,6 +11,7 @@ import type { OAuth2TokenPayload } from '@authup/specs';
 import {
     OAuth2AuthorizationResponseType,
     OAuth2GrantError,
+    OAuth2LoginRequiredError,
     OAuth2RequestError,
     OAuth2ResponseTypeError,
     hasOAuth2Scopes,
@@ -83,6 +84,15 @@ export class OAuth2Authorization {
 
         if (!identity) {
             throw OAuth2RequestError.identityInvalid();
+        }
+
+        // Realm binding: the code-request verifier stamped data.realm_id with the
+        // resolved client's realm. The authenticated identity must belong to that
+        // same realm — otherwise a lingering session for realm A could silently
+        // mint a code/token for realm B's client (confused deputy). The error body
+        // deliberately carries no identity data (no realm-enumeration oracle).
+        if (data.realm_id && identity.data.realm.id !== data.realm_id) {
+            throw OAuth2LoginRequiredError.realmMismatch();
         }
 
         const payloadBaseNormalized : OAuth2TokenPayload = {

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -60,12 +60,26 @@ describe('OAuth2AuthorizationCodeRequestVerifier', () => {
         });
 
         it('should throw clientInvalid when client cannot be found', async () => {
+            // a UUID that resolves to nothing — a name would first trip the
+            // realm-hint requirement below
             await expect(
                 verifier.verify({
-                    client_id: 'unknown',
+                    client_id: randomUUID(),
                     response_type: OAuth2AuthorizationResponseType.CODE,
                 }),
             ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_CLIENT_INVALID }));
+        });
+
+        it('should throw requestInvalid when a name-identified client has no realm hint', async () => {
+            // every realm has a built-in `web` client, so a name without a realm
+            // is ambiguous — reject deterministically instead of matching an
+            // arbitrary realm's client.
+            await expect(
+                verifier.verify({
+                    client_id: 'web',
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_REQUEST_INVALID }));
         });
 
         it('should throw clientInactive when the client is inactive', async () => {

--- a/apps/server-core/test/unit/core/oauth2/authorization/code/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code/verifier/module.spec.ts
@@ -93,6 +93,25 @@ describe('OAuth2AuthorizationCodeVerifier', () => {
             ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_GRANT_INVALID }));
         });
 
+        it('should verify when realmId matches the code realm', async () => {
+            const code = repository.seed({ client_id: 'client-1', realm_id: 'realm-a' });
+            const result = await verifier.verify(code.id, { clientId: 'client-1', realmId: 'realm-a' });
+            expect(result.id).toBe(code.id);
+        });
+
+        it('should throw grantInvalid when realmId differs from the code realm', async () => {
+            const code = repository.seed({ client_id: 'client-1', realm_id: 'realm-a' });
+            await expect(
+                verifier.verify(code.id, { clientId: 'client-1', realmId: 'realm-b' }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_GRANT_INVALID }));
+        });
+
+        it('should ignore realmId when the code has no realm bound', async () => {
+            const code = repository.seed({ client_id: 'client-1' });
+            const result = await verifier.verify(code.id, { clientId: 'client-1', realmId: 'realm-b' });
+            expect(result.id).toBe(code.id);
+        });
+
         it('should throw grantInvalid when public client omits PKCE', async () => {
             const code = repository.seed({ client_id: 'client-1' });
             await expect(

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
@@ -11,8 +11,9 @@ import {
     expect,
     it,
 } from 'vitest';
-import type { Client, OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
+import type { Client, OAuth2AuthorizationCodeRequest, Realm } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
+import { Client as HTTPClient } from '@authup/core-http-kit';
 import {
     OAuth2AuthorizationCodeChallengeMethod,
     OAuth2AuthorizationResponseType,
@@ -23,6 +24,7 @@ import { buildOAuth2CodeChallenge, generateOAuth2CodeVerifier } from '../../../.
 import {
     createFakeClient,
     createFakeRealm,
+    createFakeUser,
     expectClientError,
     httpRequest,
 } from '../../../../../utils';
@@ -71,6 +73,28 @@ describe('grant-authorize', () => {
     afterAll(async () => {
         await suite.teardown();
     });
+
+    // Authorize now requires the acting user's realm to match the client realm,
+    // so a code for a non-master-realm client must be issued by a user in that
+    // realm (not the master admin). Creates a realm user, logs in, and returns
+    // an HTTP client bound to that user's bearer token.
+    const loginAsRealmUser = async (realm: Realm): Promise<HTTPClient> => {
+        const password = generateOAuth2CodeVerifier();
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password,
+        }));
+
+        const login = await suite.client.token.createWithPassword({
+            username: user.name,
+            password,
+            realm_id: realm.id,
+        });
+
+        const userClient = new HTTPClient({ baseURL: suite.baseURL });
+        userClient.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
+        return userClient;
+    };
 
     it('should build oauth2 code challenge', async () => {
         const codeVerifier = 'Li5PBcECIXmMuuDsWHjexHnr6LNK6BWKKkcuJaAjeSkeux7p';
@@ -462,8 +486,9 @@ describe('grant-authorize', () => {
             client_id: client.id,
         });
 
+        const userClient = await loginAsRealmUser(realm);
         const issueCode = async () => {
-            const response = await suite.client
+            const response = await userClient
                 .authorize
                 .confirm({
                     response_type: OAuth2AuthorizationResponseType.CODE,
@@ -517,6 +542,67 @@ describe('grant-authorize', () => {
         );
     });
 
+    it('should reject /authorize when the identity realm differs from the client realm', async () => {
+        // scenario 1: an identity logged in to realm A (here the master-realm
+        // admin) authorizing against a client in realm B must be rejected with
+        // login_required — otherwise a lingering session silently mints a
+        // cross-realm code/token (confused deputy).
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                realm_id: realm.id,
+                is_confidential: false,
+                secret: null,
+            }));
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: client.id,
+        });
+
+        const codeVerifier = generateOAuth2CodeVerifier();
+        const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
+
+        await expectClientError(
+            () => suite.client.authorize.confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: client.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                code_challenge: codeChallenge,
+                code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
+                state: generateOAuth2CodeVerifier(),
+            }),
+            {
+                status: 400,
+                code: ErrorCode.OAUTH_LOGIN_REQUIRED,
+                data: { error: OAuth2ErrorCode.LOGIN_REQUIRED },
+            },
+        );
+    });
+
+    it('should allow /authorize when the identity realm matches the client realm', async () => {
+        // control for the realm gate: a client in the actor's own (master) realm
+        // authorizes normally.
+        const codeVerifier = generateOAuth2CodeVerifier();
+        const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
+
+        const response = await suite.client
+            .authorize
+            .confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: publicClient.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                code_challenge: codeChallenge,
+                code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
+                state: generateOAuth2CodeVerifier(),
+            });
+
+        expect(new URL(response.url).searchParams.get('code')).toBeTruthy();
+    });
+
     it('should exchange a code for a name-identified public client scoped to its realm', async () => {
         const realm = await suite.client.realm.create(createFakeRealm());
         const client = await suite.client
@@ -535,7 +621,8 @@ describe('grant-authorize', () => {
         const codeVerifier = generateOAuth2CodeVerifier();
         const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
 
-        const response = await suite.client
+        const userClient = await loginAsRealmUser(realm);
+        const response = await userClient
             .authorize
             .confirm({
                 response_type: OAuth2AuthorizationResponseType.CODE,

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
@@ -294,6 +294,64 @@ describe('refresh-token', () => {
         expect(refreshed.access_token).toBeDefined();
     });
 
+    it('should reject refresh by a public client whose realm differs from the token realm', async () => {
+        // A no-client refresh token (master realm) presented with a PUBLIC client
+        // from another realm must be rejected — a public client may only refresh
+        // tokens of its own realm. Kills legacy cross-realm public-client refresh
+        // tokens minted before the authorize-side realm gate existed.
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const publicClient = await suite.client.client.create(createFakeClient({
+            realm_id: realm.id,
+            is_confidential: false,
+            secret: null,
+        }));
+
+        const login = await suite.client
+            .token
+            .createWithPassword({ username: 'admin', password: 'start123' });
+
+        await expectClientError(
+            () => suite.client.token.createWithRefreshToken({
+                refresh_token: login.refresh_token!,
+                client_id: publicClient.id,
+            }),
+            { status: 400, code: ErrorCode.OAUTH_GRANT_INVALID },
+        );
+    });
+
+    it('should allow refresh by a public client of the token\'s own realm', async () => {
+        // control for the parity guard above: same-realm public client refreshes
+        // a same-realm token normally.
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const publicClient = await suite.client.client.create(createFakeClient({
+            realm_id: realm.id,
+            is_confidential: false,
+            secret: null,
+        }));
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password: 'realm-public-refresh',
+        }));
+
+        const login = await suite.client
+            .token
+            .createWithPassword({
+                username: user.name,
+                password: 'realm-public-refresh',
+                realm_id: realm.id,
+            });
+
+        const refreshed = await suite.client
+            .token
+            .createWithRefreshToken({
+                refresh_token: login.refresh_token!,
+                client_id: publicClient.id,
+                realm_id: realm.id,
+            });
+
+        expect(refreshed.access_token).toBeDefined();
+    });
+
     it('should detect refresh-token replay and revoke the whole session family', async () => {
         const login = await suite.client
             .token

--- a/apps/server-core/ui/src/pages/authorize.vue
+++ b/apps/server-core/ui/src/pages/authorize.vue
@@ -6,13 +6,20 @@
   -->
 <script lang="ts">
 import { AAuthorize } from '@authup/client-web-kit';
-import type { Client, OAuth2AuthorizationCodeRequest, Scope } from '@authup/core-kit';
+import type {
+    Client,
+    OAuth2AuthorizationCodeRequest,
+    Realm,
+    Scope,
+} from '@authup/core-kit';
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import type { LinkProperties } from '@vuecs/link';
 import { useToast } from '@vuecs/overlays';
 import { computed, defineComponent } from 'vue';
 import { useBasePath } from '../base-path';
 import { injectPayload } from '../di';
+
+type RealmSummary = Pick<Realm, 'id' | 'name' | 'display_name'>;
 
 export default defineComponent({
     components: { AAuthorize },
@@ -22,6 +29,8 @@ export default defineComponent({
             error: Error | undefined,
             client: Client | undefined,
             scopes: Scope[] | undefined,
+            realm: RealmSummary | undefined,
+            redirectUriVerified: boolean | undefined,
             features: StatusResponseFeatures | undefined,
             requestPath: string | undefined
         }>();
@@ -76,6 +85,8 @@ export default defineComponent({
         :client="data.client"
         :scopes="data.scopes"
         :error="data.error"
+        :realm="data.realm"
+        :redirect-uri-verified="data.redirectUriVerified"
         :register-link="registerLink"
         :password-forgot-link="passwordForgotLink"
         @failed="handleFailed"

--- a/packages/client-web-kit/src/components/workflows/authorize/Authorize.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/Authorize.vue
@@ -5,7 +5,12 @@
   - view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
-import type { Client, OAuth2AuthorizationCodeRequest, Scope } from '@authup/core-kit';
+import type {
+    Client,
+    OAuth2AuthorizationCodeRequest,
+    Realm,
+    Scope,
+} from '@authup/core-kit';
 import { storeToRefs } from 'pinia';
 import type { PropType, VNodeChild } from 'vue';
 import {
@@ -20,6 +25,7 @@ import { injectHTTPClient, injectStore, useTranslation } from '../../../core';
 import AAuthShell from '../../utility/AAuthShell.vue';
 import LoginForm from '../login/LoginForm.vue';
 import AuthorizeForm from './AuthorizeForm.vue';
+import AuthorizeRealmMismatch from './AuthorizeRealmMismatch.vue';
 import AuthorizeText from './AuthorizeText.vue';
 
 const wrapChild = (child: VNodeChild) => h(
@@ -28,10 +34,13 @@ const wrapChild = (child: VNodeChild) => h(
     { default: () => child },
 );
 
+type RealmSummary = Pick<Realm, 'id' | 'name' | 'display_name'>;
+
 export default defineComponent({
     components: {
         AuthorizeText,
         AuthorizeForm,
+        AuthorizeRealmMismatch,
         LoginForm,
     },
     props: {
@@ -42,12 +51,20 @@ export default defineComponent({
         error: { type: Object as PropType<Error> },
         registerLink: { type: Object as PropType<LinkProperties> },
         passwordForgotLink: { type: Object as PropType<LinkProperties> },
+        realm: { type: Object as PropType<RealmSummary> },
+        redirectUriVerified: { type: Boolean, default: false },
     },
     emits: ['redirect', 'failed'],
     setup(props, { emit }) {
         const httpClient = injectHTTPClient();
         const store = injectStore();
-        const { loggedIn } = storeToRefs(store);
+        const { loggedIn, realmId } = storeToRefs(store);
+
+        // Local logout — the reactive loggedIn flip re-renders into the
+        // realm-pinned login form below.
+        const switchAccount = () => {
+            store.logout();
+        };
 
         const error = ref<Error | null>(null);
         const client = ref<Client | null>(null);
@@ -105,6 +122,29 @@ export default defineComponent({
                 }));
             }
 
+            // Realm binding (UX only — the server POST /authorize gate is
+            // authoritative). Wait until the store has resolved the signed-in
+            // identity's realm before deciding, so a built_in client's
+            // AuthorizeForm auto-consent (onMounted) can't fire before a
+            // mismatch is detected.
+            if (!realmId.value) {
+                return wrapChild(h(AuthorizeText, { message: loadingText.value }));
+            }
+
+            if (
+                props.codeRequest.realm_id &&
+                realmId.value !== props.codeRequest.realm_id
+            ) {
+                return wrapChild(h(AuthorizeRealmMismatch, {
+                    clientName: props.client?.name ?? '',
+                    targetRealmName: props.realm?.display_name || props.realm?.name || '',
+                    redirectUri: props.codeRequest.redirect_uri,
+                    state: props.codeRequest.state,
+                    redirectUriVerified: props.redirectUriVerified,
+                    onSwitch: switchAccount,
+                }));
+            }
+
             if (!client.value) {
                 return [];
             }
@@ -114,6 +154,7 @@ export default defineComponent({
                     codeRequest: props.codeRequest!,
                     client: client.value!,
                     scopes: props.scopes,
+                    onLoginRequired: switchAccount,
                 }),
                 fallback: () => h(AuthorizeText, { message: loadingText.value }),
             }));

--- a/packages/client-web-kit/src/components/workflows/authorize/AuthorizeForm.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/AuthorizeForm.vue
@@ -44,7 +44,8 @@ export default defineComponent({
             required: true,
         },
     },
-    setup(props) {
+    emits: ['loginRequired'],
+    setup(props, { emit }) {
         const httpClient = injectHTTPClient();
 
         const translationsDefault = useTranslations([
@@ -113,7 +114,17 @@ export default defineComponent({
                 if (typeof window !== 'undefined') {
                     window.location.href = url;
                 }
-            } catch {
+            } catch (e) {
+                // Server rejected the identity for this client (realm mismatch —
+                // e.g. a stale SSR bundle that skipped the client-side realm gate,
+                // or a race). Fall back to re-authentication rather than showing
+                // manual consent for a request the server will never accept.
+                const response = (e as { response?: { data?: { error?: unknown } } })?.response;
+                if (response?.data?.error === 'login_required') {
+                    emit('loginRequired');
+                    return;
+                }
+
                 autoConsentFailed.value = true;
             }
         };

--- a/packages/client-web-kit/src/components/workflows/authorize/AuthorizeRealmMismatch.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/AuthorizeRealmMismatch.vue
@@ -1,0 +1,136 @@
+<!--
+  - Copyright (c) 2026.
+  - Author Peter Placzek (tada5hi)
+  - For the full copyright and license information,
+  - view the LICENSE file that was distributed with this source code.
+  -->
+<script lang="ts">
+/* global window */
+import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import { VCButton } from '@vuecs/button';
+import { VCIcon } from '@vuecs/icon';
+import type { PropType } from 'vue';
+import { computed, defineComponent } from 'vue';
+import { useTranslation } from '../../../core';
+
+export default defineComponent({
+    components: { VCButton, VCIcon },
+    props: {
+        clientName: {
+            type: String,
+            required: true,
+        },
+        targetRealmName: {
+            type: String,
+            required: true,
+        },
+        redirectUri: { type: String as PropType<string | undefined> },
+        state: { type: String as PropType<string | undefined> },
+        // Only offer the "return to application" redirect when the request
+        // redirect_uri was matched against a registered client pattern
+        // (open-redirect guard for pattern-less clients).
+        redirectUriVerified: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    emits: ['switch'],
+    setup(props, { emit }) {
+        const title = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.REALM_MISMATCH_TITLE,
+        });
+
+        const text = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.REALM_MISMATCH_TEXT,
+            data: {
+                client: computed(() => props.clientName),
+                realm: computed(() => props.targetRealmName),
+            },
+        });
+
+        const signInLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.SIGN_IN_TO_REALM,
+            data: { realm: computed(() => props.targetRealmName) },
+        });
+
+        const returnLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.RETURN_TO_APP,
+        });
+
+        const canReturn = computed(() => props.redirectUriVerified && !!props.redirectUri);
+
+        const returnToApp = () => {
+            if (!canReturn.value || !props.redirectUri) {
+                return;
+            }
+
+            const url = new URL(props.redirectUri);
+            url.searchParams.set('error', 'access_denied');
+            url.searchParams.set(
+                'error_description',
+                'The resource owner or authorization server denied the request',
+            );
+            if (props.state) {
+                url.searchParams.set('state', props.state);
+            }
+
+            if (typeof window !== 'undefined') {
+                window.location.href = url.href;
+            }
+        };
+
+        return {
+            title,
+            text,
+            signInLabel,
+            returnLabel,
+            canReturn,
+            returnToApp,
+            switchAccount: () => emit('switch'),
+        };
+    },
+});
+</script>
+<template>
+    <div class="flex flex-col gap-2">
+        <div class="text-center">
+            <VCIcon
+                name="fa6-solid:right-left"
+                class="text-6xl text-info-600"
+            />
+        </div>
+        <div class="text-center">
+            <h1 class="font-bold">
+                {{ title }}
+            </h1>
+        </div>
+        <div class="text-center fs-6 px-3">
+            {{ text }}
+        </div>
+
+        <div class="flex flex-col gap-2 mt-2">
+            <VCButton
+                type="button"
+                color="primary"
+                class="w-full"
+                @click.prevent="switchAccount"
+            >
+                {{ signInLabel }}
+            </VCButton>
+            <VCButton
+                v-if="canReturn"
+                type="button"
+                color="neutral"
+                variant="soft"
+                class="w-full"
+                @click.prevent="returnToApp"
+            >
+                {{ returnLabel }}
+            </VCButton>
+        </div>
+    </div>
+</template>

--- a/packages/errors/src/constants.ts
+++ b/packages/errors/src/constants.ts
@@ -48,6 +48,7 @@ export enum ErrorCode {
     OAUTH_GRANT_INVALID = 'invalid_grant',
     OAUTH_GRANT_TYPE_UNSUPPORTED = 'unsupported_token_grant_type',
     OAUTH_REQUEST_INVALID = 'invalid_request',
+    OAUTH_LOGIN_REQUIRED = 'login_required',
     OAUTH_RESPONSE_TYPE_UNSUPPORTED = 'unsupported_response_type',
     OAUTH_SCOPE_INVALID = 'invalid_scope',
     OAUTH_SCOPE_INSUFFICIENT = 'insufficient_scope',

--- a/packages/i18n/src/catalogs/de/client.ts
+++ b/packages/i18n/src/catalogs/de/client.ts
@@ -73,4 +73,9 @@ export const TranslatorTranslationClientGerman : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Auswahl wird aktualisiert',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Aus der Auswahl entfernen',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Zur Auswahl hinzufügen',
+
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TITLE]: 'Mit einem anderen Konto anmelden',
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TEXT]: '{{client}} gehört zum Realm {{realm}}, aber Sie sind in einem anderen Realm angemeldet. Melden Sie sich mit einem {{realm}}-Konto an, um fortzufahren.',
+    [TranslatorTranslationClientKey.SIGN_IN_TO_REALM]: 'Bei {{realm}} anmelden',
+    [TranslatorTranslationClientKey.RETURN_TO_APP]: 'Zurück zur Anwendung',
 };

--- a/packages/i18n/src/catalogs/de/error.ts
+++ b/packages/i18n/src/catalogs/de/error.ts
@@ -42,6 +42,7 @@ export const TranslatorTranslationErrorGerman : NamespaceTranslations<`${ErrorCo
     [ErrorCode.OAUTH_GRANT_INVALID]: 'Die Autorisierungsfreigabe ist ungültig.',
     [ErrorCode.OAUTH_GRANT_TYPE_UNSUPPORTED]: 'Der Grant-Typ wird nicht unterstützt.',
     [ErrorCode.OAUTH_REQUEST_INVALID]: 'Die Anfrage ist ungültig.',
+    [ErrorCode.OAUTH_LOGIN_REQUIRED]: 'Sie müssen sich anmelden, um fortzufahren.',
     [ErrorCode.OAUTH_RESPONSE_TYPE_UNSUPPORTED]: 'Der Response-Typ wird nicht unterstützt.',
     [ErrorCode.OAUTH_SCOPE_INVALID]: 'Der angeforderte Bereich ist ungültig.',
     [ErrorCode.OAUTH_SCOPE_INSUFFICIENT]: 'Der gewährte Bereich reicht für diese Aktion nicht aus.',

--- a/packages/i18n/src/catalogs/en/client.ts
+++ b/packages/i18n/src/catalogs/en/client.ts
@@ -73,4 +73,9 @@ export const TranslatorTranslationClientEnglish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.ACCOUNT_ACTIVATED]: 'The account was successfully activated.',
     [TranslatorTranslationClientKey.PASSWORD_RESET_DONE]: 'The password was successfully reset.',
     [TranslatorTranslationClientKey.WORKFLOW_DISABLED]: 'This feature is not enabled.',
+
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TITLE]: 'Sign in with a different account',
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TEXT]: '{{client}} belongs to the {{realm}} realm, but you are signed in to a different realm. Sign in with a {{realm}} account to continue.',
+    [TranslatorTranslationClientKey.SIGN_IN_TO_REALM]: 'Sign in to {{realm}}',
+    [TranslatorTranslationClientKey.RETURN_TO_APP]: 'Return to application',
 };

--- a/packages/i18n/src/catalogs/en/error.ts
+++ b/packages/i18n/src/catalogs/en/error.ts
@@ -42,6 +42,7 @@ export const TranslatorTranslationErrorEnglish : NamespaceTranslations<`${ErrorC
     [ErrorCode.OAUTH_GRANT_INVALID]: 'The authorization grant is invalid.',
     [ErrorCode.OAUTH_GRANT_TYPE_UNSUPPORTED]: 'The grant type is not supported.',
     [ErrorCode.OAUTH_REQUEST_INVALID]: 'The request is invalid.',
+    [ErrorCode.OAUTH_LOGIN_REQUIRED]: 'You must sign in to continue.',
     [ErrorCode.OAUTH_RESPONSE_TYPE_UNSUPPORTED]: 'The response type is not supported.',
     [ErrorCode.OAUTH_SCOPE_INVALID]: 'The requested scope is invalid.',
     [ErrorCode.OAUTH_SCOPE_INSUFFICIENT]: 'The granted scope is insufficient for this action.',

--- a/packages/i18n/src/catalogs/es/client.ts
+++ b/packages/i18n/src/catalogs/es/client.ts
@@ -73,4 +73,9 @@ export const TranslatorTranslationClientSpanish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Actualizando selección',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Quitar de la selección',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Añadir a la selección',
+
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TITLE]: 'Inicia sesión con otra cuenta',
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TEXT]: '{{client}} pertenece al realm {{realm}}, pero has iniciado sesión en otro realm. Inicia sesión con una cuenta de {{realm}} para continuar.',
+    [TranslatorTranslationClientKey.SIGN_IN_TO_REALM]: 'Iniciar sesión en {{realm}}',
+    [TranslatorTranslationClientKey.RETURN_TO_APP]: 'Volver a la aplicación',
 };

--- a/packages/i18n/src/catalogs/es/error.ts
+++ b/packages/i18n/src/catalogs/es/error.ts
@@ -42,6 +42,7 @@ export const TranslatorTranslationErrorSpanish : NamespaceTranslations<`${ErrorC
     [ErrorCode.OAUTH_GRANT_INVALID]: 'La concesión de autorización no es válida.',
     [ErrorCode.OAUTH_GRANT_TYPE_UNSUPPORTED]: 'El tipo de concesión no es compatible.',
     [ErrorCode.OAUTH_REQUEST_INVALID]: 'La solicitud no es válida.',
+    [ErrorCode.OAUTH_LOGIN_REQUIRED]: 'Debes iniciar sesión para continuar.',
     [ErrorCode.OAUTH_RESPONSE_TYPE_UNSUPPORTED]: 'El tipo de respuesta no es compatible.',
     [ErrorCode.OAUTH_SCOPE_INVALID]: 'El ámbito solicitado no es válido.',
     [ErrorCode.OAUTH_SCOPE_INSUFFICIENT]: 'El ámbito concedido es insuficiente para esta acción.',

--- a/packages/i18n/src/catalogs/fr/client.ts
+++ b/packages/i18n/src/catalogs/fr/client.ts
@@ -73,4 +73,9 @@ export const TranslatorTranslationClientFrench : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.SELECTION_UPDATING]: 'Mise à jour de la sélection',
     [TranslatorTranslationClientKey.SELECTION_REMOVE]: 'Retirer de la sélection',
     [TranslatorTranslationClientKey.SELECTION_ADD]: 'Ajouter à la sélection',
+
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TITLE]: 'Connectez-vous avec un autre compte',
+    [TranslatorTranslationClientKey.REALM_MISMATCH_TEXT]: '{{client}} appartient au realm {{realm}}, mais vous êtes connecté à un autre realm. Connectez-vous avec un compte {{realm}} pour continuer.',
+    [TranslatorTranslationClientKey.SIGN_IN_TO_REALM]: 'Se connecter à {{realm}}',
+    [TranslatorTranslationClientKey.RETURN_TO_APP]: 'Retour à l\'application',
 };

--- a/packages/i18n/src/catalogs/fr/error.ts
+++ b/packages/i18n/src/catalogs/fr/error.ts
@@ -42,6 +42,7 @@ export const TranslatorTranslationErrorFrench : NamespaceTranslations<`${ErrorCo
     [ErrorCode.OAUTH_GRANT_INVALID]: 'L\'autorisation d\'accès est invalide.',
     [ErrorCode.OAUTH_GRANT_TYPE_UNSUPPORTED]: 'Le type d\'autorisation n\'est pas pris en charge.',
     [ErrorCode.OAUTH_REQUEST_INVALID]: 'La requête est invalide.',
+    [ErrorCode.OAUTH_LOGIN_REQUIRED]: 'Vous devez vous connecter pour continuer.',
     [ErrorCode.OAUTH_RESPONSE_TYPE_UNSUPPORTED]: 'Le type de réponse n\'est pas pris en charge.',
     [ErrorCode.OAUTH_SCOPE_INVALID]: 'La portée demandée est invalide.',
     [ErrorCode.OAUTH_SCOPE_INSUFFICIENT]: 'La portée accordée est insuffisante pour cette action.',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -104,6 +104,11 @@ export enum TranslatorTranslationClientKey {
     ACCOUNT_ACTIVATED = 'accountActivated',
     PASSWORD_RESET_DONE = 'passwordResetDone',
     WORKFLOW_DISABLED = 'workflowDisabled',
+
+    REALM_MISMATCH_TITLE = 'realmMismatchTitle',
+    REALM_MISMATCH_TEXT = 'realmMismatchText',
+    SIGN_IN_TO_REALM = 'signInToRealm',
+    RETURN_TO_APP = 'returnToApp',
 }
 
 /**

--- a/packages/specs/src/oauth2/constants.ts
+++ b/packages/specs/src/oauth2/constants.ts
@@ -58,4 +58,11 @@ export enum OAuth2ErrorCode {
     INSUFFICIENT_SCOPE = 'insufficient_scope',
 
     SERVER_ERROR = 'server_error',
+
+    /**
+     * OIDC Core 1.0 §3.1.2.6 — the End-User is required to authenticate.
+     * Used when the authenticated identity may not proceed with the
+     * authorization request (e.g. realm mismatch, or prompt=login/max_age).
+     */
+    LOGIN_REQUIRED = 'login_required',
 }

--- a/packages/specs/src/oauth2/error/index.ts
+++ b/packages/specs/src/oauth2/error/index.ts
@@ -8,6 +8,7 @@
 export * from './client';
 export * from './grant';
 export * from './grant-type';
+export * from './login-required';
 export * from './module';
 export * from './request';
 export * from './response-type';

--- a/packages/specs/src/oauth2/error/login-required.ts
+++ b/packages/specs/src/oauth2/error/login-required.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { ErrorCode, markInstanceof } from '@authup/errors';
+import type { AuthupErrorInput } from '@authup/errors';
+import { OAuth2ErrorCode } from '../constants';
+import { OAuth2Error, normalizeOAuth2ErrorInput } from './module.ts';
+
+export const OAUTH2_LOGIN_REQUIRED_ERROR_INSTANCE = Symbol.for('@authup/specs/OAuth2LoginRequiredError');
+
+export class OAuth2LoginRequiredError extends OAuth2Error {
+    constructor(input?: AuthupErrorInput) {
+        const options = normalizeOAuth2ErrorInput(input);
+        super({
+            code: ErrorCode.OAUTH_LOGIN_REQUIRED,
+            message: 'Authentication is required to continue.',
+            ...options,
+            data: {
+                error: OAuth2ErrorCode.LOGIN_REQUIRED,
+                ...(options.data ?? {}),
+            },
+        });
+        markInstanceof(this, OAUTH2_LOGIN_REQUIRED_ERROR_INSTANCE);
+    }
+
+    static realmMismatch() {
+        return new OAuth2LoginRequiredError({ message: 'Sign in with an account for the requested realm to continue.' });
+    }
+}


### PR DESCRIPTION
## Problem

A downstream app lets the user pick a realm and redirects to `/authorize` with that realm's client. If the browser still carries an authup session for **another** realm (e.g. the user logged in to RealmA earlier and logged out only in the downstream app — authup-origin cookies are untouched), authup silently continued as the RealmA identity: because every realm's `web` client is `built_in`, the consent step auto-submitted, and the server performed **no** identity-realm ↔ client-realm check. The downstream app asked for RealmB and received RealmA tokens — a confused deputy whose artifact carried a RealmA `iss`/signing-key with a RealmB `aud`.

## Fix

An identity may only authorize, redeem a code for, or refresh a token against a client in **its own realm**, enforced server-side at three independent points (the kit UI is UX only — the server is authoritative):

1. **`POST /authorize` issuance** — `OAuth2Authorization.authorize()` throws `login_required` (`OAUTH_LOGIN_REQUIRED`, HTTP 400, no identity data in the body — no realm-enumeration oracle) when the identity realm ≠ the client realm.
2. **`/token` code redemption** — the code verifier's new `realmId` option (fed `client.realm_id`) rejects `code.realm_id != client.realm_id` with `invalid_grant`. Covers identity-provider-callback codes and any in-flight pre-deploy codes.
3. **`/token` refresh parity** — a **public** client refreshing a token whose realm differs from the client's realm → `invalid_grant` (kills legacy cross-realm `web`-client refresh tokens). Confidential clients stay exempt — the secret proves identity, and the documented cross-realm password grant relies on it.

Also included:
- **Realm-mismatch UI** — the SSR `/authorize` page renders a "sign in to {realm}" / "return to application" card (the latter only when the `redirect_uri` matched a registered pattern) instead of auto-consenting, gated so a `built_in` client can't auto-consent before the store resolves the identity's realm.
- **Clickjacking guard** — all SSR auth pages send `Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY`.
- **Deterministic client resolution** — a name-identified client at `/authorize` now requires a realm hint (`invalid_request` otherwise); every realm has a `web` client, so a bare name was ambiguous.

## Testing

Full `apps/server-core` suite (1111 tests) green, plus `@authup/i18n` locale parity (77) and `@authup/client-web-kit` (11). New tests: scenario-1 reproduction (`login_required`) + same-realm control, the code-verifier realm branch, the refresh-parity reject + control, and the name-hint guard. Two pre-existing tests that minted codes via a cross-realm master-admin authorize were updated to authorize as a same-realm user (their fixture relied on the now-closed path).

## Breaking change

Master-realm admins can no longer authorize into another realm's app via the built-in `web` client. Previously-issued cross-realm artifacts were malformed (RealmA `iss`/key + RealmB `aud`), so intentional reliance is implausible — use realm-local accounts.

## Scope / follow-ups

This is PR A of the plan in `.agents/plans/041-authorize-session-binding.md`. It fully closes the cross-realm scenario. The account-switch UX (`prompt=select_account` + chooser) and cross-app logout via the standard `end_session_endpoint` are PRs B and C — the latter is the RP-agnostic mechanism that ends a lingering authup session on a downstream logout (kit and non-kit RPs alike), so this PR deliberately does not add a kit-specific session-delete to `store.logout()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added realm-aware sign-in handling, including a clearer “different realm” message and a way to switch accounts.
  * Auth screens now show the target realm and whether a redirect back to the app is safe.

* **Bug Fixes**
  * Prevented authorization, code exchange, and refresh flows from crossing realm boundaries in unsupported cases.
  * Added stronger protection for server-rendered auth pages against being embedded in other sites.

* **Chores**
  * Added new user-facing error messages and translations for multiple languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->