### PR TITLE
feat: add rp-initiated logout (end_session_endpoint)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1142,6 +1142,39 @@ session rather than a freshly-created fallback one (documented residual).
 `prompt_values_supported` and **fixes** `revocation_endpoint` from `…/token` to
 `…/token/revoke` (RFC 7009 — an RFC 7009 POST to `/token` never worked).
 
+### RP-Initiated Logout — `end_session_endpoint` (plan 041 PR C)
+
+`GET`/`POST /logout` (discovery `end_session_endpoint`, **no feature flag**) is
+the RP-agnostic session-termination mechanism — the intended way a downstream
+app (kit or non-kit) ends a lingering authup session on its own logout, so
+`store.logout()` never needs a kit-specific session delete. Core logic is
+`OAuth2EndSessionService` (`core/oauth2/end-session/`), wired via
+`createLogoutController`. Security posture (all enforced, unit-tested matrix):
+
+- **id_token_hint** is verified by `OAuth2TokenVerifier` with a new
+  `ignoreExpiry` option — signature, nbf and (crucially) **kind** still apply;
+  only `exp` is skipped (a logout hint is routinely expired). The option threads
+  down to server-kit's `verifyToken` (`validateExp: false`). A hint whose `kind
+  !== id_token` is **rejected** (access/refresh tokens also carry `session_id`,
+  so accepting them would let a leaked access token force a logout). `aud` vs
+  request `client_id` cross-checked when both present.
+- A signature-verified hint carrying `sid` → the referenced session is revoked
+  **immediately** (`ISessionManager.revoke`), but **only** after
+  `session.sub`/`sub_kind` match the hint's subject (never revoke someone else's
+  session). Without a hint the endpoint mutates nothing — the SSR page's sign-out
+  is a click-gated, bearer-authenticated `store.logout()`.
+- `post_logout_redirect_uri` is honored **only** when it is absolute http(s) AND
+  `isSimpleMatch`es a registered client `redirect_uri` pattern (open-redirect
+  guard); otherwise dropped, and `state` rides only alongside a validated
+  redirect. (A dedicated `post_logout_redirect_uri` client column + migration is
+  a deferred follow-up; today it validates against `redirect_uri` patterns.)
+
+The SSR page is `apps/server-core/ui/src/pages/logout.vue` → kit
+`AEndSessionForm`; the typed URL builder is `buildEndSessionURL` in
+`client-web-kit`. **Residual (Keycloak parity):** a *leaked* valid id_token can
+force-logout its session (annoyance, not privilege escalation) — mitigated by
+the sub-match + short id_token TTL.
+
 ## OAuth2 Token Endpoint Authentication
 
 The `/token` endpoint authenticates the calling client according to RFC 6749. Confidential clients MUST present a `client_secret`; public clients identify with `client_id` only.

--- a/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
@@ -106,6 +106,8 @@ export class RealmController {
 
             authorization_endpoint: resolveURL(baseURL, 'authorize'),
 
+            end_session_endpoint: resolveURL(baseURL, 'logout'),
+
             jwks_uri: resolveURL(baseURL, `realms/${entity.name}/jwks`),
 
             response_types_supported: [

--- a/apps/server-core/src/adapters/http/controllers/workflows/index.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/index.ts
@@ -8,6 +8,7 @@
 export * from './activate/index.ts';
 export * from './authorize/index.ts';
 export * from './jwks/index.ts';
+export * from './logout/index.ts';
 export * from './openid/index.ts';
 export * from './password-forgot/index.ts';
 export * from './password-reset/index.ts';

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/index.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/index.ts
@@ -5,8 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './authorize';
-export * from './end-session';
-export * from './login';
-export * from './password';
-export * from './register';
+export * from './module.ts';
+export * from './types.ts';

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    DContext,
+    DController,
+    DGet,
+    DPost,
+} from '@routup/decorators';
+import { URL } from 'node:url';
+import type { IAppEvent } from 'routup';
+import { sendRedirect } from 'routup';
+import type { IOAuth2EndSessionService } from '../../../../../core/index.ts';
+import { readFromLocations } from '../../../request/index.ts';
+import { renderUIPage } from '../../../ui/index.ts';
+import type { LogoutControllerContext, LogoutControllerOptions } from './types.ts';
+
+@DController('/logout')
+export class LogoutController {
+    protected options: LogoutControllerOptions;
+
+    protected endSessionService: IOAuth2EndSessionService;
+
+    constructor(ctx: LogoutControllerContext) {
+        this.options = ctx.options;
+        this.endSessionService = ctx.endSessionService;
+    }
+
+    @DGet('', [])
+    async serve(@DContext() event: IAppEvent): Promise<string | Response> {
+        return this.handle(event);
+    }
+
+    // OIDC RP-Initiated Logout allows form_post on the same endpoint.
+    @DPost('', [])
+    async execute(@DContext() event: IAppEvent): Promise<string | Response> {
+        return this.handle(event);
+    }
+
+    protected async handle(event: IAppEvent): Promise<string | Response> {
+        const merged = await readFromLocations(event, ['body', 'query']);
+
+        const result = await this.endSessionService.verify({
+            id_token_hint: merged.id_token_hint,
+            client_id: merged.client_id,
+            post_logout_redirect_uri: merged.post_logout_redirect_uri,
+            state: merged.state,
+            realm_id: merged.realm_id,
+            realm_name: merged.realm_name,
+        });
+
+        // A signature-verified id_token_hint proves possession — revoke the
+        // referenced session server-side immediately (only if it belongs to the
+        // hint's subject). Without a hint we mutate nothing; the SSR page's
+        // sign-out is a click-gated, bearer-authenticated action.
+        let serverRevoked = false;
+        if (result.hintVerified && result.sessionId && result.sub && result.subKind) {
+            serverRevoked = await this.endSessionService.revoke(
+                result.sessionId,
+                result.sub,
+                result.subKind,
+            );
+        }
+
+        // Redirect only to a validated post_logout_redirect_uri (open-redirect
+        // guard lives in the service). `state` rides only with a validated uri.
+        if (result.redirectUri) {
+            const url = new URL(result.redirectUri);
+            if (result.state) {
+                url.searchParams.set('state', result.state);
+            }
+
+            return sendRedirect(event, url.href);
+        }
+
+        const requestURL = new URL(event.request.url);
+
+        return renderUIPage(event, {
+            url: '/logout',
+            payload: {
+                config: { baseURL: this.options.baseURL },
+                data: {
+                    client: result.clientName ? { name: result.clientName } : undefined,
+                    hintVerified: result.hintVerified,
+                    // never reflect an unverified hint's claims
+                    hintSub: result.hintVerified ? result.sub : undefined,
+                    serverRevoked,
+                    requestPath: `${requestURL.pathname}${requestURL.search}`,
+                },
+            },
+        });
+    }
+}

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/types.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IOAuth2EndSessionService } from '../../../../../core/index.ts';
+
+export type LogoutControllerOptions = {
+    baseURL: string,
+};
+
+export type LogoutControllerContext = {
+    options: LogoutControllerOptions,
+    endSessionService: IOAuth2EndSessionService,
+};

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -105,6 +105,7 @@ import {
     ActivateController,
     AuthorizeController,
     JwkController,
+    LogoutController,
     OpenIDController,
     PasswordForgotController,
     PasswordResetController,
@@ -122,6 +123,7 @@ import {
     CredentialsAuthenticator,
     IdentityProviderRoleMappingService,
     OAuth2ClientAuthenticator,
+    OAuth2EndSessionService,
     PasswordRecoveryService,
     PermissionCheckerService,
     PermissionPolicyService,
@@ -189,6 +191,7 @@ export class HTTPControllerModule {
                 this.createPasswordForgotController(container),
                 this.createPasswordResetController(container),
                 this.createRegisterController(container),
+                this.createLogoutController(container),
 
                 this.createStatusController(container),
 
@@ -384,6 +387,26 @@ export class HTTPControllerModule {
                 features: this.buildUIFeatures(config),
             },
             service: this.createRegistrationService(container),
+        });
+    }
+
+    createLogoutController(container: IContainer) {
+        const config = container.resolve(ConfigInjectionKey);
+        const tokenVerifier = container.resolve(OAuth2InjectionToken.TokenVerifier);
+        const sessionManager = container.resolve(AuthenticationInjectionKey.SessionManager);
+        const clientRepository = container.resolve(OAuth2InjectionToken.ClientRepository);
+        const realmRepository = new RealmRepositoryAdapter(container.resolve<Repository<Realm>>(RealmEntity));
+
+        const endSessionService = new OAuth2EndSessionService({
+            tokenVerifier,
+            sessionManager,
+            clientRepository,
+            realmRepository,
+        });
+
+        return new LogoutController({
+            options: { baseURL: config.publicUrl },
+            endSessionService,
         });
     }
 

--- a/apps/server-core/src/core/oauth2/end-session/index.ts
+++ b/apps/server-core/src/core/oauth2/end-session/index.ts
@@ -5,8 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './authorize';
-export * from './end-session';
-export * from './login';
-export * from './password';
-export * from './register';
+export * from './service.ts';
+export * from './types.ts';

--- a/apps/server-core/src/core/oauth2/end-session/service.ts
+++ b/apps/server-core/src/core/oauth2/end-session/service.ts
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isSimpleMatch } from '@authup/kit';
+import { OAuth2TokenKind } from '@authup/specs';
+import type { IRealmRepository } from '../../entities/index.ts';
+import type { ISessionManager } from '../../authentication/index.ts';
+import type { IOAuth2ClientRepository } from '../client/index.ts';
+import type { IOAuth2TokenVerifier } from '../token/index.ts';
+import type {
+    IOAuth2EndSessionService,
+    OAuth2EndSessionRequest,
+    OAuth2EndSessionResult,
+    OAuth2EndSessionServiceContext,
+} from './types.ts';
+
+export class OAuth2EndSessionService implements IOAuth2EndSessionService {
+    protected tokenVerifier: IOAuth2TokenVerifier;
+
+    protected sessionManager: ISessionManager;
+
+    protected clientRepository: IOAuth2ClientRepository;
+
+    protected realmRepository: IRealmRepository;
+
+    constructor(ctx: OAuth2EndSessionServiceContext) {
+        this.tokenVerifier = ctx.tokenVerifier;
+        this.sessionManager = ctx.sessionManager;
+        this.clientRepository = ctx.clientRepository;
+        this.realmRepository = ctx.realmRepository;
+    }
+
+    async verify(data: OAuth2EndSessionRequest): Promise<OAuth2EndSessionResult> {
+        let hintVerified = false;
+        let sub: string | undefined;
+        let subKind: string | undefined;
+        let sessionId: string | undefined;
+        let audiences: string[] = [];
+
+        if (data.id_token_hint) {
+            try {
+                // Signature + kind are the anchors; exp is skipped (a logout hint
+                // is routinely expired) and the cache blocklist is irrelevant.
+                const payload = await this.tokenVerifier.verify(data.id_token_hint, {
+                    ignoreExpiry: true,
+                    skipActiveCheck: true,
+                });
+
+                // MUST be an id_token — access/refresh tokens also carry
+                // session_id, so accepting them would let a leaked access token
+                // act as a logout weapon.
+                if (payload.kind === OAuth2TokenKind.ID_TOKEN) {
+                    hintVerified = true;
+                    sub = payload.sub;
+                    subKind = payload.sub_kind;
+                    sessionId = payload.sid ?? payload.session_id ?? undefined;
+                    // aud may be a single string or an array (JWT spec).
+                    const { aud } = payload;
+                    if (Array.isArray(aud)) {
+                        audiences = aud.filter((entry): entry is string => typeof entry === 'string');
+                    } else if (typeof aud === 'string') {
+                        audiences = [aud];
+                    }
+                }
+            } catch {
+                // forged / unverifiable hint → stays unverified (no revoke)
+            }
+        }
+
+        // aud/client_id cross-check: when the request supplies a client_id and the
+        // hint carries an aud, the client_id MUST be one of the hint's audiences.
+        if (hintVerified && data.client_id && audiences.length > 0 && !audiences.includes(data.client_id)) {
+            hintVerified = false;
+            sub = undefined;
+            subKind = undefined;
+            sessionId = undefined;
+        }
+
+        // Resolve a single client for redirect validation: the request's
+        // client_id, else the hint's sole audience (ambiguous for a multi-aud hint).
+        const clientId = data.client_id ?? (audiences.length === 1 ? audiences[0] : undefined);
+
+        let clientName: string | undefined;
+        let redirectUri: string | undefined;
+
+        if (clientId) {
+            // Scope a name-identified client to the realm hint. No master
+            // fallback here (unlike /token): a bogus hint must NOT silently
+            // resolve a same-named client in master → null realm, and the
+            // repository fails closed on an unknown realm key.
+            const realm = await this.realmRepository.resolve(data.realm_id ?? data.realm_name, false);
+            const client = await this.clientRepository.findOneByIdOrName(clientId, realm?.id);
+            if (client) {
+                clientName = client.name;
+                if (
+                    data.post_logout_redirect_uri &&
+                    this.isValidPostLogoutRedirect(client.redirect_uri, data.post_logout_redirect_uri)
+                ) {
+                    redirectUri = data.post_logout_redirect_uri;
+                }
+            }
+        }
+
+        return {
+            hintVerified,
+            ...(hintVerified ? {
+                sub,
+                subKind,
+                sessionId,
+            } : {}),
+            ...(clientId ? { clientId } : {}),
+            ...(clientName ? { clientName } : {}),
+            ...(redirectUri ? { redirectUri, ...(data.state ? { state: data.state } : {}) } : {}),
+        };
+    }
+
+    async revoke(sessionId: string, sub: string, subKind: string): Promise<boolean> {
+        const session = await this.sessionManager.findOneById(sessionId);
+        if (!session) {
+            return false;
+        }
+
+        // Never revoke a session that does not belong to the hint's subject.
+        if (session.sub !== sub || session.sub_kind !== subKind) {
+            return false;
+        }
+
+        await this.sessionManager.revoke(sessionId);
+        return true;
+    }
+
+    /**
+     * A post-logout redirect is honored only when it is an absolute http(s) URL
+     * that matches a registered client redirect pattern (defense against open
+     * redirects to attacker-controlled URLs).
+     */
+    protected isValidPostLogoutRedirect(
+        registered: string | null | undefined,
+        candidate: string,
+    ): boolean {
+        let parsed: URL;
+        try {
+            parsed = new URL(candidate);
+        } catch {
+            return false;
+        }
+
+        if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+            return false;
+        }
+
+        if (!registered) {
+            return false;
+        }
+
+        return isSimpleMatch(candidate, registered.split(','));
+    }
+}

--- a/apps/server-core/src/core/oauth2/end-session/types.ts
+++ b/apps/server-core/src/core/oauth2/end-session/types.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IRealmRepository } from '../../entities/index.ts';
+import type { ISessionManager } from '../../authentication/index.ts';
+import type { IOAuth2ClientRepository } from '../client/index.ts';
+import type { IOAuth2TokenVerifier } from '../token/index.ts';
+
+export type OAuth2EndSessionRequest = {
+    id_token_hint?: string,
+    client_id?: string,
+    post_logout_redirect_uri?: string,
+    state?: string,
+    realm_id?: string,
+    realm_name?: string,
+};
+
+export type OAuth2EndSessionResult = {
+    /**
+     * True when a signature-verified id_token_hint proved possession. Only then
+     * are `sub` / `sessionId` populated and a server-side revoke authorized.
+     */
+    hintVerified: boolean,
+    sub?: string,
+    subKind?: string,
+    sessionId?: string,
+    clientId?: string,
+    clientName?: string,
+    /**
+     * The post-logout redirect — present ONLY when it matched a registered
+     * client pattern (open-redirect guard). `state` rides only alongside it.
+     */
+    redirectUri?: string,
+    state?: string,
+};
+
+export type OAuth2EndSessionServiceContext = {
+    tokenVerifier: IOAuth2TokenVerifier,
+    sessionManager: ISessionManager,
+    clientRepository: IOAuth2ClientRepository,
+    realmRepository: IRealmRepository,
+};
+
+export interface IOAuth2EndSessionService {
+    /**
+     * Verify the request (id_token_hint signature + kind + aud, redirect
+     * validation). Pure — performs no mutation.
+     */
+    verify(data: OAuth2EndSessionRequest): Promise<OAuth2EndSessionResult>;
+
+    /**
+     * Revoke the session ONLY when it belongs to the hint's subject.
+     * @returns whether a session was revoked.
+     */
+    revoke(sessionId: string, sub: string, subKind: string): Promise<boolean>;
+}

--- a/apps/server-core/src/core/oauth2/index.ts
+++ b/apps/server-core/src/core/oauth2/index.ts
@@ -7,6 +7,7 @@
 
 export * from './authorization/index.ts';
 export * from './client/index.ts';
+export * from './end-session/index.ts';
 export * from './grant-types/index.ts';
 export * from './key/index.ts';
 export * from './openid/index.ts';

--- a/apps/server-core/src/core/oauth2/token/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/token/verifier/module.ts
@@ -6,9 +6,9 @@
  */
 
 import {
-    type TokenECAlgorithm, 
-    type TokenRSAAlgorithm, 
-    extractTokenHeader, 
+    type TokenECAlgorithm,
+    type TokenRSAAlgorithm,
+    extractTokenHeader,
     verifyToken,
 } from '@authup/server-kit';
 import type { OAuth2TokenPayload } from '@authup/specs';
@@ -73,6 +73,7 @@ export class OAuth2TokenVerifier implements IOAuth2TokenVerifier {
                         type: JWKType.OCT,
                         key: key.decryption_key,
                     },
+                    { ignoreExpiry: options.ignoreExpiry },
                 );
                 break;
             }
@@ -92,6 +93,7 @@ export class OAuth2TokenVerifier implements IOAuth2TokenVerifier {
                                 []
                         ) as TokenECAlgorithm[],
                     },
+                    { ignoreExpiry: options.ignoreExpiry },
                 );
                 break;
             }
@@ -111,6 +113,7 @@ export class OAuth2TokenVerifier implements IOAuth2TokenVerifier {
                                 []
                         ) as TokenRSAAlgorithm[],
                     },
+                    { ignoreExpiry: options.ignoreExpiry },
                 );
             }
         }

--- a/apps/server-core/src/core/oauth2/token/verifier/types.ts
+++ b/apps/server-core/src/core/oauth2/token/verifier/types.ts
@@ -8,7 +8,13 @@
 import type { OAuth2TokenPayload } from '@authup/specs';
 
 export type OAuth2TokenVerifyOptions = {
-    skipActiveCheck?: boolean
+    skipActiveCheck?: boolean,
+    /**
+     * Skip ONLY the `exp` check (signature, issuer, nbf still enforced). For
+     * verifying an `id_token_hint` on RP-initiated logout, which is routinely
+     * expired by the time the user logs out.
+     */
+    ignoreExpiry?: boolean
 };
 
 export interface IOAuth2TokenVerifier {

--- a/apps/server-core/test/unit/core/oauth2/end-session/service.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/end-session/service.spec.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Client, Realm } from '@authup/core-kit';
+import type { OAuth2TokenPayload } from '@authup/specs';
+import { OAuth2SubKind, OAuth2TokenKind } from '@authup/specs';
+import {
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { OAuth2EndSessionService } from '../../../../../src/core/oauth2/end-session/service.ts';
+import type {
+    IOAuth2ClientRepository,
+    IOAuth2TokenVerifier,
+    IRealmRepository,
+} from '../../../../../src/core/index.ts';
+import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
+
+const realmId = randomUUID();
+const clientId = randomUUID();
+
+const client = {
+    id: clientId,
+    name: 'web',
+    realm_id: realmId,
+    redirect_uri: 'https://app.example.com/**',
+} as Client;
+
+const realmRepository = { resolve: async () => ({ id: realmId, name: 'master' } as Realm) } as unknown as IRealmRepository;
+
+const clientRepository = { findOneByIdOrName: async () => client } as unknown as IOAuth2ClientRepository;
+
+// A token-verifier stub whose behavior is set per test.
+function buildVerifier(behavior: () => Promise<OAuth2TokenPayload>): IOAuth2TokenVerifier {
+    return {
+        isInactive: async () => false,
+        verify: behavior,
+    };
+}
+
+describe('OAuth2EndSessionService', () => {
+    let sessionManager: FakeSessionManager;
+
+    const sub = randomUUID();
+    const sessionId = randomUUID();
+
+    const validPayload: OAuth2TokenPayload = {
+        kind: OAuth2TokenKind.ID_TOKEN,
+        sub,
+        sub_kind: OAuth2SubKind.USER,
+        sid: sessionId,
+        aud: clientId,
+    };
+
+    const buildService = (verify: () => Promise<OAuth2TokenPayload>) => new OAuth2EndSessionService({
+        tokenVerifier: buildVerifier(verify),
+        sessionManager,
+        clientRepository,
+        realmRepository,
+    });
+
+    beforeEach(() => {
+        sessionManager = new FakeSessionManager();
+    });
+
+    it('should verify a valid id_token_hint', async () => {
+        const service = buildService(async () => validPayload);
+        const result = await service.verify({ id_token_hint: 'valid', client_id: clientId });
+
+        expect(result.hintVerified).toBe(true);
+        expect(result.sub).toEqual(sub);
+        expect(result.sessionId).toEqual(sessionId);
+    });
+
+    it('should NOT verify a forged hint (signature failure)', async () => {
+        const service = buildService(async () => { throw new Error('bad signature'); });
+        const result = await service.verify({ id_token_hint: 'forged' });
+
+        expect(result.hintVerified).toBe(false);
+        expect(result.sub).toBeUndefined();
+        expect(result.sessionId).toBeUndefined();
+    });
+
+    it('should NOT verify a non-id_token (e.g. access token) presented as hint', async () => {
+        const service = buildService(async () => ({ ...validPayload, kind: OAuth2TokenKind.ACCESS }));
+        const result = await service.verify({ id_token_hint: 'access' });
+
+        expect(result.hintVerified).toBe(false);
+        expect(result.sessionId).toBeUndefined();
+    });
+
+    it('should NOT verify when aud and client_id mismatch', async () => {
+        const service = buildService(async () => validPayload);
+        const result = await service.verify({ id_token_hint: 'valid', client_id: randomUUID() });
+
+        expect(result.hintVerified).toBe(false);
+    });
+
+    it('should verify when client_id is one of a multi-valued aud', async () => {
+        const service = buildService(async () => ({ ...validPayload, aud: [clientId, randomUUID()] }));
+        const result = await service.verify({ id_token_hint: 'valid', client_id: clientId });
+
+        expect(result.hintVerified).toBe(true);
+    });
+
+    it('should NOT verify when client_id is absent from a multi-valued aud', async () => {
+        const service = buildService(async () => ({ ...validPayload, aud: [randomUUID(), randomUUID()] }));
+        const result = await service.verify({ id_token_hint: 'valid', client_id: clientId });
+
+        expect(result.hintVerified).toBe(false);
+    });
+
+    it('should honor a post_logout_redirect_uri matching a registered pattern', async () => {
+        const service = buildService(async () => validPayload);
+        const result = await service.verify({
+            id_token_hint: 'valid',
+            client_id: clientId,
+            post_logout_redirect_uri: 'https://app.example.com/after-logout',
+            state: 'xyz',
+        });
+
+        expect(result.redirectUri).toEqual('https://app.example.com/after-logout');
+        expect(result.state).toEqual('xyz');
+    });
+
+    it('should DROP an unregistered post_logout_redirect_uri (open-redirect guard)', async () => {
+        const service = buildService(async () => validPayload);
+        const result = await service.verify({
+            id_token_hint: 'valid',
+            client_id: clientId,
+            post_logout_redirect_uri: 'https://evil.example.com/steal',
+            state: 'xyz',
+        });
+
+        expect(result.redirectUri).toBeUndefined();
+        expect(result.state).toBeUndefined();
+    });
+
+    it('should DROP a non-http(s) post_logout_redirect_uri', async () => {
+        const service = buildService(async () => validPayload);
+        const result = await service.verify({
+            id_token_hint: 'valid',
+            client_id: clientId,
+            // eslint-disable-next-line no-script-url -- exercising the protocol guard
+            post_logout_redirect_uri: 'javascript:alert(1)',
+        });
+
+        expect(result.redirectUri).toBeUndefined();
+    });
+
+    it('should revoke the session when it belongs to the subject', async () => {
+        await sessionManager.create({
+            id: sessionId,
+            sub,
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: realmId,
+        });
+
+        const service = buildService(async () => validPayload);
+        const revoked = await service.revoke(sessionId, sub, OAuth2SubKind.USER);
+
+        expect(revoked).toBe(true);
+        expect(sessionManager.revokeCalls).toContain(sessionId);
+    });
+
+    it('should NOT revoke a session belonging to another subject', async () => {
+        await sessionManager.create({
+            id: sessionId,
+            sub: randomUUID(), // different subject
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: realmId,
+        });
+
+        const service = buildService(async () => validPayload);
+        const revoked = await service.revoke(sessionId, sub, OAuth2SubKind.USER);
+
+        expect(revoked).toBe(false);
+        expect(sessionManager.revokeCalls).toHaveLength(0);
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
@@ -82,4 +82,11 @@ describe('RealmController.getOpenIdConfiguration', () => {
             'select_account',
         ]);
     });
+
+    it('should advertise the end_session_endpoint', async () => {
+        const controller = createController(realm);
+        const config = await controller.getOpenIdConfiguration(realmId);
+
+        expect(config.end_session_endpoint).toEqual('https://auth.example.com/logout');
+    });
 });

--- a/apps/server-core/ui/src/app.ts
+++ b/apps/server-core/ui/src/app.ts
@@ -37,6 +37,7 @@ import './tailwind.css';
 import type { Router } from 'vue-router';
 import Activate from './pages/activate.vue';
 import Authorize from './pages/authorize.vue';
+import Logout from './pages/logout.vue';
 import PasswordForgot from './pages/password-forgot.vue';
 import PasswordReset from './pages/password-reset.vue';
 import Register from './pages/register.vue';
@@ -92,6 +93,10 @@ export function createApp(payload: HydrationPayload, options: CreateAppOptions =
             {
                 component: PasswordReset,
                 path: '/password-reset',
+            },
+            {
+                component: Logout,
+                path: '/logout',
             },
         ],
     });

--- a/apps/server-core/ui/src/pages/logout.vue
+++ b/apps/server-core/ui/src/pages/logout.vue
@@ -1,0 +1,33 @@
+<!--
+  - Copyright (c) 2026.
+  - Author Peter Placzek (tada5hi)
+  - For the full copyright and license information,
+  - view the LICENSE file that was distributed with this source code.
+  -->
+<script lang="ts">
+import { AAuthShell, AEndSessionForm } from '@authup/client-web-kit';
+import { defineComponent } from 'vue';
+import { injectPayload } from '../di';
+
+export default defineComponent({
+    components: {
+        AAuthShell,
+        AEndSessionForm,
+    },
+    setup() {
+        const payload = injectPayload<{
+            client?: { name: string },
+            hintVerified?: boolean,
+            hintSub?: string,
+            serverRevoked?: boolean,
+        }>();
+
+        return { data: payload.data };
+    },
+});
+</script>
+<template>
+    <AAuthShell>
+        <AEndSessionForm :server-revoked="data.serverRevoked" />
+    </AAuthShell>
+</template>

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -158,4 +158,25 @@ The resulting `id_token` includes the OIDC `auth_time` (the real authentication 
 
 #### Discovery
 
-Each realm exposes an OpenID Provider metadata document at `GET /realms/<realm>/.well-known/openid-configuration`, advertising the `authorization_endpoint`, `token_endpoint`, `revocation_endpoint` (`/token/revoke`), `jwks_uri`, and `prompt_values_supported`.
+Each realm exposes an OpenID Provider metadata document at `GET /realms/<realm>/.well-known/openid-configuration`, advertising the `authorization_endpoint`, `token_endpoint`, `revocation_endpoint` (`/token/revoke`), `end_session_endpoint` (`/logout`), `jwks_uri`, and `prompt_values_supported`.
+
+### 5. RP-Initiated Logout
+
+To end the Authup session when the user logs out of your application, redirect the browser to the `end_session_endpoint` ([OpenID Connect RP-Initiated Logout 1.0](https://openid.net/specs/openid-connect-rpinitiated-1_0.html)):
+
+```
+GET http://localhost:3001/logout
+  ?id_token_hint=THE_ID_TOKEN
+  &client_id=YOUR_CLIENT_ID
+  &post_logout_redirect_uri=https://app.example.com/after-logout
+  &state=RANDOM
+```
+
+| Parameter | Description |
+|---|---|
+| `id_token_hint` | An `id_token` previously issued to the user. When its signature verifies (an expired token is accepted) and its subject matches the referenced session, that session is revoked immediately without a confirmation prompt; a subject mismatch is ignored as a no-op. |
+| `client_id` | The client requesting logout. Cross-checked against the hint's `aud` when both are present. |
+| `post_logout_redirect_uri` | Where to redirect after logout. Honored only when it is an absolute `http(s)` URL matching one of the client's registered `redirect_uri` patterns (open-redirect guard); otherwise ignored. |
+| `state` | Opaque value echoed back on the redirect (only alongside a validated `post_logout_redirect_uri`). |
+
+Without a valid `id_token_hint`, `/logout` serves a page asking the user to confirm sign-out; no state is changed until they confirm.

--- a/packages/client-web-kit/src/components/workflows/end-session/AEndSessionForm.vue
+++ b/packages/client-web-kit/src/components/workflows/end-session/AEndSessionForm.vue
@@ -1,0 +1,116 @@
+<!--
+  - Copyright (c) 2026.
+  - Author Peter Placzek (tada5hi)
+  - For the full copyright and license information,
+  - view the LICENSE file that was distributed with this source code.
+  -->
+<script lang="ts">
+import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import { VCButton } from '@vuecs/button';
+import { VCIcon } from '@vuecs/icon';
+import {
+    defineComponent,
+    onMounted,
+    ref,
+} from 'vue';
+import { injectStore, useTranslation } from '../../../core';
+
+export default defineComponent({
+    components: { VCButton, VCIcon },
+    props: {
+        // A signature-verified id_token_hint already revoked the session
+        // server-side — this page just clears local state and confirms.
+        serverRevoked: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    setup(props) {
+        const store = injectStore();
+        const done = ref<boolean>(false);
+
+        const title = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE,
+        });
+        const text = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT,
+        });
+        const doneText = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.LOGOUT_DONE,
+        });
+        const signOutLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.SIGN_OUT,
+        });
+
+        // Always transition to the terminal state — a failed local cleanup must
+        // not strand the user on the pre-logout UI (in the serverRevoked path
+        // the server already ended the session).
+        const signOut = async () => {
+            try {
+                await store.logout();
+            } finally {
+                done.value = true;
+            }
+        };
+
+        onMounted(async () => {
+            // The server already ended the session (verified hint) — clear the
+            // local token/cookie state, then show the terminal notice (await so
+            // "done" isn't shown while local cleanup is still in flight).
+            if (props.serverRevoked) {
+                await signOut();
+            }
+        });
+
+        return {
+            done,
+            title,
+            text,
+            doneText,
+            signOutLabel,
+            signOut,
+        };
+    },
+});
+</script>
+<template>
+    <div class="flex flex-col gap-2">
+        <div class="text-center">
+            <VCIcon
+                :name="done ? 'fa6-solid:circle-check' : 'fa6-solid:right-from-bracket'"
+                class="text-6xl"
+                :class="done ? 'text-success-600' : 'text-info-600'"
+            />
+        </div>
+
+        <template v-if="done">
+            <div class="text-center fs-6 p-3">
+                {{ doneText }}
+            </div>
+        </template>
+        <template v-else>
+            <div class="text-center">
+                <h1 class="font-bold">
+                    {{ title }}
+                </h1>
+            </div>
+            <div class="text-center fs-6 px-3">
+                {{ text }}
+            </div>
+            <div class="mt-2">
+                <VCButton
+                    type="button"
+                    color="primary"
+                    class="w-full"
+                    @click.prevent="signOut"
+                >
+                    {{ signOutLabel }}
+                </VCButton>
+            </div>
+        </template>
+    </div>
+</template>

--- a/packages/client-web-kit/src/components/workflows/end-session/index.ts
+++ b/packages/client-web-kit/src/components/workflows/end-session/index.ts
@@ -5,8 +5,4 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './authorize';
-export * from './end-session';
-export * from './login';
-export * from './password';
-export * from './register';
+export { default as AEndSessionForm } from './AEndSessionForm.vue';

--- a/packages/client-web-kit/src/core/oauth2/authorization-request.ts
+++ b/packages/client-web-kit/src/core/oauth2/authorization-request.ts
@@ -104,3 +104,39 @@ export function buildAuthorizeURL(ctx: BuildAuthorizeURLContext): string {
 
     return `${base}/authorize?${params.toString()}`;
 }
+
+export type BuildEndSessionURLContext = {
+    baseURL: string,
+    idTokenHint?: string,
+    clientId?: string,
+    postLogoutRedirectUri?: string,
+    state?: string,
+    realmId?: string
+};
+
+/**
+ * Build an OIDC RP-Initiated Logout URL for the `end_session_endpoint`.
+ */
+export function buildEndSessionURL(ctx: BuildEndSessionURLContext): string {
+    const base = ctx.baseURL.replace(/\/+$/, '');
+
+    const params = new URLSearchParams();
+    if (ctx.idTokenHint) {
+        params.set('id_token_hint', ctx.idTokenHint);
+    }
+    if (ctx.clientId) {
+        params.set('client_id', ctx.clientId);
+    }
+    if (ctx.postLogoutRedirectUri) {
+        params.set('post_logout_redirect_uri', ctx.postLogoutRedirectUri);
+    }
+    if (ctx.state) {
+        params.set('state', ctx.state);
+    }
+    if (ctx.realmId) {
+        params.set('realm_id', ctx.realmId);
+    }
+
+    const qs = params.toString();
+    return `${base}/logout${qs ? `?${qs}` : ''}`;
+}

--- a/packages/i18n/src/catalogs/de/client.ts
+++ b/packages/i18n/src/catalogs/de/client.ts
@@ -82,4 +82,9 @@ export const TranslatorTranslationClientGerman : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Konto auswählen',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Als {{name}} fortfahren',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Anderes Konto verwenden',
+
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Abmelden',
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: 'Möchten Sie sich abmelden?',
+    [TranslatorTranslationClientKey.LOGOUT_DONE]: 'Sie wurden abgemeldet.',
+    [TranslatorTranslationClientKey.SIGN_OUT]: 'Abmelden',
 };

--- a/packages/i18n/src/catalogs/en/client.ts
+++ b/packages/i18n/src/catalogs/en/client.ts
@@ -82,4 +82,9 @@ export const TranslatorTranslationClientEnglish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Choose an account',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Continue as {{name}}',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Use another account',
+
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Sign out',
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: 'Do you want to sign out?',
+    [TranslatorTranslationClientKey.LOGOUT_DONE]: 'You have been signed out.',
+    [TranslatorTranslationClientKey.SIGN_OUT]: 'Sign out',
 };

--- a/packages/i18n/src/catalogs/es/client.ts
+++ b/packages/i18n/src/catalogs/es/client.ts
@@ -82,4 +82,9 @@ export const TranslatorTranslationClientSpanish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Elegir una cuenta',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Continuar como {{name}}',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Usar otra cuenta',
+
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Cerrar sesión',
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: '¿Quieres cerrar sesión?',
+    [TranslatorTranslationClientKey.LOGOUT_DONE]: 'Has cerrado sesión.',
+    [TranslatorTranslationClientKey.SIGN_OUT]: 'Cerrar sesión',
 };

--- a/packages/i18n/src/catalogs/fr/client.ts
+++ b/packages/i18n/src/catalogs/fr/client.ts
@@ -82,4 +82,9 @@ export const TranslatorTranslationClientFrench : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Choisir un compte',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Continuer en tant que {{name}}',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Utiliser un autre compte',
+
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Se déconnecter',
+    [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: 'Voulez-vous vous déconnecter ?',
+    [TranslatorTranslationClientKey.LOGOUT_DONE]: 'Vous avez été déconnecté.',
+    [TranslatorTranslationClientKey.SIGN_OUT]: 'Se déconnecter',
 };

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -113,6 +113,11 @@ export enum TranslatorTranslationClientKey {
     SELECT_ACCOUNT_TITLE = 'selectAccountTitle',
     CONTINUE_AS = 'continueAs',
     USE_ANOTHER_ACCOUNT = 'useAnotherAccount',
+
+    LOGOUT_CONFIRM_TITLE = 'logoutConfirmTitle',
+    LOGOUT_CONFIRM_TEXT = 'logoutConfirmText',
+    LOGOUT_DONE = 'logoutDone',
+    SIGN_OUT = 'signOut',
 }
 
 /**

--- a/packages/server-kit/src/crypto/json-web-token/verify/module.ts
+++ b/packages/server-kit/src/crypto/json-web-token/verify/module.ts
@@ -23,10 +23,15 @@ import type { TokenVerifyOptions } from './types';
 export async function verifyToken(
     token: string,
     context: TokenVerifyOptions,
+    options: { ignoreExpiry?: boolean } = {},
 ) : Promise<OAuth2TokenPayload> {
     let promise : Promise<JWTClaims> | undefined;
 
     let output : JWTClaims | undefined;
+
+    // Signature, nbf and issuer/kind checks always apply; only exp is skipped
+    // when explicitly requested (e.g. an id_token_hint on RP-initiated logout).
+    const validateExp = !options.ignoreExpiry;
 
     try {
         switch (context.type) {
@@ -65,6 +70,7 @@ export async function verifyToken(
                 promise = verify(token, key, {
                     algorithms,
                     validateNbf: true,
+                    validateExp,
                 });
                 break;
             }
@@ -88,6 +94,7 @@ export async function verifyToken(
                 promise = verify(token, key, {
                     algorithms,
                     validateNbf: true,
+                    validateExp,
                 });
             }
         }

--- a/packages/specs/src/openid/type.ts
+++ b/packages/specs/src/openid/type.ts
@@ -60,6 +60,11 @@ export type OpenIDProviderMetadata = {
     prompt_values_supported?: string[],
 
     /**
+     * OIDC RP-Initiated Logout 1.0 — the OP's end-session (logout) endpoint.
+     */
+    end_session_endpoint?: string,
+
+    /**
      * The OAuth 2.0 / OpenID Connect URL of the OP's Dynamic Client Registration Endpoint OpenID.Registration.
      */
     registration_endpoint?: string,


### PR DESCRIPTION
Stacked on #3195 (prompt surface). PR C of the plan in `.agents/plans/041-authorize-session-binding.md`. **Review/merge after #3195.**

## Problem

A downstream app that logs the user out locally had no standard way to also end the authup session — the "logout doesn't reach authup" half of the reported issue. This is deliberately *not* solved with a kit-specific `store.logout()` session delete (that stays local-only); the RP-agnostic answer is the OIDC standard `end_session_endpoint`.

## What this adds

`GET`/`POST /logout` (OIDC RP-Initiated Logout, advertised as `end_session_endpoint` in discovery, **no feature flag**). Core logic is `OAuth2EndSessionService`. It's the mechanism any RP — kit or non-kit React/other — redirects to on its own logout.

Security posture (all enforced, full unit-test matrix):

- **`id_token_hint`** is verified by the token verifier with a new **`ignoreExpiry`** option — signature, `nbf` and **`kind`** still apply; only `exp` is skipped (a logout hint is routinely expired). It threads down to server-kit's `verifyToken` (`validateExp: false`).
- A hint whose **`kind !== id_token` is rejected** — access/refresh tokens also carry `session_id`, so accepting them would let a leaked access token force a logout. `aud` is cross-checked against `client_id` when both are present.
- A verified hint carrying `sid` → the session is revoked **immediately**, but **only after** its `sub`/`sub_kind` match the hint's subject (never revoke someone else's session). Without a hint the endpoint mutates nothing — the SSR page's sign-out is a click-gated, bearer-authenticated `store.logout()`.
- **`post_logout_redirect_uri`** is honored only when it is absolute http(s) AND matches a registered client `redirect_uri` pattern (open-redirect guard); `state` rides only with a validated redirect, and an unverified hint's claims are never reflected.

Also: the SSR logout page (`AEndSessionForm` + `apps/server-core/ui/src/pages/logout.vue`), the discovery `end_session_endpoint`, and the typed `buildEndSessionURL`.

## Testing

Full `apps/server-core` suite (1136) + `@authup/server-kit` (10, the `verifyToken` change) + `@authup/i18n` parity + `@authup/client-web-kit` green. New `OAuth2EndSessionService` matrix: valid hint verified; forged hint rejected; **access-token-as-hint rejected** (kind check); `aud`/`client_id` mismatch rejected; registered redirect honored; unregistered + `javascript:` redirect dropped; sub-match revoke vs sub-mismatch no-revoke. Plus discovery `end_session_endpoint` assertion.

## Deferred follow-up

A dedicated `post_logout_redirect_uri` client column + migration + a `WebClientProvisioner` default + the client-web end-session round-trip — until then `/logout` validates against `redirect_uri` patterns.

## Residual (documented)

Keycloak parity: a *leaked* valid id_token can force-logout its own session (an annoyance, not privilege escalation) — mitigated by the sub-match requirement and the short id_token TTL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OIDC RP-initiated logout support, including a new logout endpoint, session verification/revocation flow, and logout redirect handling.
  * Exposed logout metadata in OpenID provider configuration so clients can discover the logout endpoint.
  * Added a logout page and confirmation form in the UI, with support for immediate sign-out when the session was already revoked.
  * Added logout URL building support for client-side sign-out redirects.

* **Bug Fixes**
  * Tightened redirect validation to allow only safe absolute HTTP(S) logout redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->