### PR TITLE
fix: rp-initiated logout & authorize hardening (plan 041 audit follow-ups)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1118,6 +1118,16 @@ behavior for every RP (kit or not): `prompt=select_account` shows an
 continuing; `login_hint` pre-fills the identifier; `prompt=consent` suppresses
 the `built_in` auto-consent. `buildAuthorizeURL` (kit) **defaults
 `prompt=select_account`** (overridable) so kit apps inherit account-switching.
+The chooser targets a **lingering** session only: `LoginForm`'s `done` emit sets
+`accountConfirmed`, so a just-completed credential entry (which IS the account
+selection) proceeds straight to consent instead of re-prompting "continue as X"
+for the account just authenticated; the branch also waits for the store's `user`
+to resolve to avoid a "Continue as \<empty\>" flash. The manual consent screen
+(`AuthorizeForm`) additionally renders a **"Signed in as X — Not you?"** chip
+(emits `switch` → local `store.logout()` → login form), so a wrong-account user
+can switch even when the RP sent no `prompt=select_account`. Prompt/error string
+comparisons use the `@authup/specs` `OAuth2AuthorizationPrompt` /
+`OAuth2ErrorCode` enums, not bare literals.
 
 `prompt=login` / `max_age` freshness is enforced **server-side** in
 `OAuth2Authorization.authorize()` (the authoritative backstop; the hosted UI is
@@ -1139,8 +1149,20 @@ and the #3191 session-reuse-vs-fallback path can make `sid` reference the bearer
 session rather than a freshly-created fallback one (documented residual).
 
 **Discovery** (realm-scoped `.well-known/openid-configuration`) advertises
-`prompt_values_supported` and **fixes** `revocation_endpoint` from `…/token` to
-`…/token/revoke` (RFC 7009 — an RFC 7009 POST to `/token` never worked).
+`prompt_values_supported` (`login`, `consent`, `select_account` — **not**
+`none`: the silent-auth error redirect is unimplemented, so it must not be
+advertised or the RP is promised a capability the server lacks) and **fixes**
+`revocation_endpoint` from `…/token` to `…/token/revoke` (RFC 7009 — an RFC 7009
+POST to `/token` never worked). An empty `max_age=` is treated as **absent**
+(the validator preprocesses blank → undefined; `z.coerce.number('') === 0` would
+otherwise silently force re-authentication).
+
+The anonymous `GET /authorize` hydration payload carries a **trimmed client
+DTO** (`ClientSummary` = `id`/`name`/`display_name`/`built_in`/`created_at`) plus
+the `RealmSummary` and scopes — never the client's `redirect_uri` patterns (the
+trusted-origin set), `grant_types`, internal `base_url`/`root_url`, or the
+secret storage flags. `ClientEntity.secret` is additionally `select:false`, but
+the DTO must not rely on that alone.
 
 ### RP-Initiated Logout — `end_session_endpoint` (plan 041 PR C)
 
@@ -1168,12 +1190,28 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
   guard); otherwise dropped, and `state` rides only alongside a validated
   redirect. (A dedicated `post_logout_redirect_uri` client column + migration is
   a deferred follow-up; today it validates against `redirect_uri` patterns.)
+- **The server-side bounce fires ONLY when the logout was actually performed**
+  (`serverRevoked` — a verified hint revoked the session). A hint-less or
+  forged request with an otherwise-valid `post_logout_redirect_uri` must **not**
+  302 straight back to the RP: that would let the RP treat a no-op round-trip as
+  a successful logout while the authup session survives. Instead the validated
+  redirect is threaded into the render payload and the click-gated confirm page
+  (`AEndSessionForm`) performs the bearer-authenticated sign-out, then navigates
+  to it (`window.location`).
 
 The SSR page is `apps/server-core/ui/src/pages/logout.vue` → kit
 `AEndSessionForm`; the typed URL builder is `buildEndSessionURL` in
-`client-web-kit`. **Residual (Keycloak parity):** a *leaked* valid id_token can
-force-logout its session (annoyance, not privilege escalation) — mitigated by
-the sub-match + short id_token TTL.
+`client-web-kit`. **`AEndSessionForm` auto-clears local state on mount ONLY when
+`serverRevoked && hintSub === store.user.id`** — the revoked subject must be the
+browser's own user. Without that gate, a cross-site `GET
+/logout?id_token_hint=<attacker's own id_token>` (which revokes the attacker's
+own session, so `serverRevoked` is true) would forcibly sign out any unrelated
+victim who merely renders the page (`store.logout()` is local-only, so it acts
+on whoever's browser rendered it) — a forced-logout CSRF. The controller
+forwards `hintSub` (only for a verified hint) and the validated `redirect` into
+the payload for this gate. **Residual (Keycloak parity):** a *leaked* valid
+id_token can force-logout its own session (annoyance, not privilege escalation)
+— mitigated by the sub-match + short id_token TTL.
 
 ## OAuth2 Token Endpoint Authentication
 

--- a/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
@@ -116,8 +116,12 @@ export class RealmController {
                 OAuth2AuthorizationResponseType.NONE,
             ],
 
+            // `none` is intentionally NOT advertised: the silent-auth error
+            // redirect (OIDC §3.1.2.1) is not implemented — a `prompt=none`
+            // request currently renders the interactive page. Advertising it
+            // would promise a capability the server does not have. (Re-add it
+            // alongside the error-redirect implementation — plan 042.)
             prompt_values_supported: [
-                OAuth2AuthorizationPrompt.NONE,
                 OAuth2AuthorizationPrompt.LOGIN,
                 OAuth2AuthorizationPrompt.CONSENT,
                 OAuth2AuthorizationPrompt.SELECT_ACCOUNT,

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
@@ -30,6 +30,7 @@ import type { AuthorizeControllerContext, AuthorizeControllerOptions } from './t
 import { sanitizeError } from '../../../../../utils/index.ts';
 
 type RealmSummary = Pick<Realm, 'id' | 'name' | 'display_name'>;
+type ClientSummary = Pick<Client, 'id' | 'name' | 'display_name' | 'built_in' | 'created_at'>;
 
 @DController('/authorize')
 export class AuthorizeController {
@@ -94,7 +95,7 @@ export class AuthorizeController {
     async serve(@DContext() event: IAppEvent): Promise<string> {
         let codeRequest : OAuth2AuthorizationCodeRequest | undefined;
 
-        let client : Client | undefined;
+        let client : ClientSummary | undefined;
         let scopes : Scope[] | undefined;
 
         // Target realm summary (the client's realm) — the UI names it in the
@@ -113,15 +114,29 @@ export class AuthorizeController {
             const data = await this.codeRequestValidator.run(merged);
 
             const result = await this.codeRequestVerifier.verify(data);
-            client = result.client;
+
+            // Trim the client to a deliberate DTO before it reaches the
+            // anonymous SSR hydration payload — never disclose redirect_uri
+            // patterns (the trusted-origin set), grant_types, internal
+            // base/root URLs, is_confidential, or the secret storage flags to an
+            // unauthenticated visitor. (ClientEntity.secret is additionally
+            // select:false, so the secret is never loaded — but the DTO must not
+            // rely on that alone: a future entity/query change could unset it.)
+            client = {
+                id: result.client.id,
+                name: result.client.name,
+                display_name: result.client.display_name,
+                built_in: result.client.built_in,
+                created_at: result.client.created_at,
+            };
             scopes = result.scopes;
             redirectUriVerified = result.redirectUriVerified;
 
-            if (client.realm) {
+            if (result.client.realm) {
                 realm = {
-                    id: client.realm.id,
-                    name: client.realm.name,
-                    display_name: client.realm.display_name,
+                    id: result.client.realm.id,
+                    name: result.client.realm.name,
+                    display_name: result.client.realm.display_name,
                 };
             }
 

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
@@ -66,15 +66,27 @@ export class LogoutController {
             );
         }
 
-        // Redirect only to a validated post_logout_redirect_uri (open-redirect
-        // guard lives in the service). `state` rides only with a validated uri.
+        // Build the validated post-logout redirect (the open-redirect guard
+        // lives in the service; `state` rides only alongside a validated uri).
+        let redirect: string | undefined;
         if (result.redirectUri) {
             const url = new URL(result.redirectUri);
             if (result.state) {
                 url.searchParams.set('state', result.state);
             }
 
-            return sendRedirect(event, url.href);
+            redirect = url.href;
+        }
+
+        // Bounce straight back to the RP ONLY when the logout was actually
+        // performed server-side (a verified hint revoked the session). A
+        // hint-less or forged request MUST NOT silently redirect without ending
+        // the session — otherwise the RP treats a no-op round-trip as a
+        // successful logout while the authup session survives. Instead render
+        // the click-gated confirm page, which performs the bearer-authenticated
+        // sign-out and then redirects.
+        if (serverRevoked && redirect) {
+            return sendRedirect(event, redirect);
         }
 
         const requestURL = new URL(event.request.url);
@@ -89,6 +101,9 @@ export class LogoutController {
                     // never reflect an unverified hint's claims
                     hintSub: result.hintVerified ? result.sub : undefined,
                     serverRevoked,
+                    // the (already validated) uri to return to after a click-gated
+                    // sign-out; carries `state` when present
+                    redirect,
                     requestPath: `${requestURL.pathname}${requestURL.search}`,
                 },
             },

--- a/apps/server-core/src/core/oauth2/authorization/code-request/validator.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/validator.ts
@@ -121,7 +121,16 @@ export class OAuth2AuthorizationCodeRequestValidator extends Container<OAuth2Aut
         this.mount(
             'max_age',
             { optional: true },
-            createValidator(z.coerce.number().int().min(0).nullable()),
+            createValidator(
+                z.preprocess(
+                    // An empty / blank max_age (e.g. a stray `?max_age=` from an
+                    // RP template) is absent, not `max_age=0` — without this
+                    // z.coerce.number('') === 0 would silently force
+                    // re-authentication on every request for that RP.
+                    (value) => (typeof value === 'string' && value.trim() === '' ? undefined : value),
+                    z.coerce.number().int().min(0).nullable().optional(),
+                ),
+            ),
         );
 
         this.mount(

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/validator.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/validator.spec.ts
@@ -48,6 +48,18 @@ describe('OAuth2AuthorizationCodeRequestValidator', () => {
         expect(output.max_age).toEqual(60);
     });
 
+    it('should honor an explicit max_age=0', async () => {
+        const output = await validator.run({ ...base, max_age: '0' });
+        expect(output.max_age).toEqual(0);
+    });
+
+    it('should treat an empty max_age as absent (not coerce it to 0)', async () => {
+        // z.coerce.number('') === 0 would silently force re-authentication; a
+        // blank param must be ignored, not read as max_age=0.
+        const output = await validator.run({ ...base, max_age: '' });
+        expect(output.max_age).toBeUndefined();
+    });
+
     it('should canonicalize login_hint (trim + lowercase)', async () => {
         const output = await validator.run({ ...base, login_hint: '  Alice@Corp  ' });
         expect(output.login_hint).toEqual('alice@corp');

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -143,5 +143,31 @@ describe('OAuth2AuthorizationCodeRequestVerifier', () => {
             });
             expect(result.client.id).toBe(client.id);
         });
+
+        it('should flag redirectUriVerified=false for a pattern-less client (open-redirect guard)', async () => {
+            // A client with no registered redirect_uri pattern lets any
+            // redirect_uri through — consumers must NOT auto-redirect to it.
+            const client = clientRepository.seed({ is_confidential: true, redirect_uri: null });
+            const result = await verifier.verify({
+                client_id: client.id,
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                redirect_uri: 'https://attacker.example.com/callback',
+            });
+            expect(result.client.id).toBe(client.id);
+            expect(result.redirectUriVerified).toBe(false);
+        });
+
+        it('should flag redirectUriVerified=true when the redirect matches a registered pattern', async () => {
+            const client = clientRepository.seed({
+                is_confidential: true,
+                redirect_uri: 'https://app.example.com/**',
+            });
+            const result = await verifier.verify({
+                client_id: client.id,
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                redirect_uri: 'https://app.example.com/callback',
+            });
+            expect(result.redirectUriVerified).toBe(true);
+        });
     });
 });

--- a/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
@@ -104,6 +104,25 @@ describe('OAuth2Authorization prompt/max_age enforcement', () => {
         expect(result.redirectUri).toEqual('https://example.com/callback');
     });
 
+    it('should source auth_time from created_at, never refreshed_at', async () => {
+        const nowSeconds = Math.floor(Date.now() / 1000);
+        await sessionManager.create({
+            id: sessionId,
+            sub: identity.data.id,
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: realmId,
+            created_at: new Date((nowSeconds - 600) * 1000).toISOString(),
+            // A recent token refresh must NOT count as (re-)authentication — if
+            // the implementation regressed to `refreshed_at ?? created_at`, this
+            // fresh value would let a long-stale login satisfy prompt=login.
+            refreshed_at: new Date(nowSeconds * 1000).toISOString(),
+        });
+
+        await expect(
+            authorization.authorize(buildData({ prompt: 'login' }), identity, { sessionId }),
+        ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_LOGIN_REQUIRED }));
+    });
+
     it('should reject when max_age is exceeded', async () => {
         await seedSession(200);
 

--- a/apps/server-core/test/unit/core/oauth2/token/issuer/open-id/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/issuer/open-id/module.spec.ts
@@ -119,6 +119,26 @@ describe('OAuth2OpenIDTokenIssuer', () => {
             expect(insertCall.auth_time).toBeLessThanOrEqual(Math.floor(Date.now() / 1000));
         });
 
+        it('should preserve an explicit auth_time verbatim (not overwrite with issuance time)', async () => {
+            const issuer = createIssuer();
+
+            // A session-backed authorize threads the session's creation instant
+            // as auth_time. It must be preserved, NOT replaced by the issuance
+            // time (== iat) — the historical bug this pins against.
+            const authTime = 1000;
+
+            await issuer.issueWithIdentity(
+                {
+                    sub: userId,
+                    realm_id: realmId,
+                    auth_time: authTime,
+                } as OAuth2TokenPayload,
+                identity,
+            );
+
+            expect(repository.insertCalls[0].auth_time).toBe(authTime);
+        });
+
         it('should set realm-scoped iss from issuer option per OIDC §2', async () => {
             const issuer = createIssuer({ options: { issuer: 'https://auth.example.com' } });
 

--- a/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
@@ -75,8 +75,9 @@ describe('RealmController.getOpenIdConfiguration', () => {
         const controller = createController(realm);
         const config = await controller.getOpenIdConfiguration(realmId);
 
+        // `none` (silent auth) is intentionally NOT advertised — the error
+        // redirect is unimplemented, so the server must not promise it.
         expect(config.prompt_values_supported).toEqual([
-            'none',
             'login',
             'consent',
             'select_account',

--- a/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
@@ -1,0 +1,208 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { Client, Realm } from '@authup/core-kit';
+import { ScopeName } from '@authup/core-kit';
+import { Client as HTTPClient } from '@authup/core-http-kit';
+import {
+    OAuth2AuthorizationCodeChallengeMethod,
+    OAuth2AuthorizationResponseType,
+} from '@authup/specs';
+import { buildOAuth2CodeChallenge, generateOAuth2CodeVerifier } from '../../../../../../src/core';
+import {
+    createFakeRealm,
+    createFakeUser,
+    httpRequest,
+} from '../../../../../utils';
+import { createTestApplication } from '../../../../../app';
+
+const REDIRECT_PATTERN = 'https://app.example.com/**';
+const REDIRECT_URI = 'https://app.example.com/cb';
+const POST_LOGOUT_URI = 'https://app.example.com/loggedout';
+
+describe('end-session (/logout)', () => {
+    const suite = createTestApplication();
+
+    let realm : Realm;
+    let client : Client;
+
+    beforeAll(async () => {
+        await suite.setup();
+
+        realm = await suite.client.realm.create(createFakeRealm());
+        client = await suite.client.client.create({
+            realm_id: realm.id,
+            name: `app-${generateOAuth2CodeVerifier().slice(0, 10).toLowerCase()}`,
+            is_confidential: false,
+            secret: null,
+            redirect_uri: REDIRECT_PATTERN,
+        });
+
+        for (const scopeName of [ScopeName.GLOBAL, ScopeName.OPEN_ID]) {
+            const scope = await suite.client.scope.getOne(scopeName);
+            await suite.client.clientScope.create({ scope_id: scope.id, client_id: client.id });
+        }
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    // Log in a fresh realm user, run the interactive authorize → exchange, and
+    // return the token set (the id_token carries sub + sid; the refresh_token
+    // belongs to the same session, so it is our "is the session alive?" probe).
+    const mintTokens = async () => {
+        const password = generateOAuth2CodeVerifier();
+        const user = await suite.client.user.create(createFakeUser({ realm_id: realm.id, password }));
+
+        const login = await suite.client.token.createWithPassword({
+            username: user.name,
+            password,
+            realm_id: realm.id,
+        });
+
+        const userClient = new HTTPClient({ baseURL: suite.baseURL });
+        userClient.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
+
+        const codeVerifier = generateOAuth2CodeVerifier();
+        const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
+        const authorized = await userClient.authorize.confirm({
+            response_type: OAuth2AuthorizationResponseType.CODE,
+            client_id: client.id,
+            redirect_uri: REDIRECT_URI,
+            scope: `${ScopeName.GLOBAL} ${ScopeName.OPEN_ID}`,
+            code_challenge: codeChallenge,
+            code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
+            state: generateOAuth2CodeVerifier(),
+        });
+
+        const code = new URL(authorized.url).searchParams.get('code')!;
+        return suite.client.token.createWithAuthorizationCode({
+            client_id: client.name,
+            redirect_uri: REDIRECT_URI,
+            code,
+            code_verifier: codeVerifier,
+            realm_id: realm.id,
+        });
+    };
+
+    const refreshSucceeds = async (refreshToken: string): Promise<boolean> => {
+        try {
+            await suite.client.token.createWithRefreshToken({
+                refresh_token: refreshToken,
+                client_id: client.name,
+                realm_id: realm.id,
+            });
+            return true;
+        } catch {
+            return false;
+        }
+    };
+
+    it('should revoke the session referenced by a verified id_token_hint', async () => {
+        // NOTE: refresh tokens rotate (plan 016) — each refresh_token is
+        // consumed by a single refreshSucceeds() call, so never probe the same
+        // token twice.
+        const revoked = await mintTokens();
+        const survivor = await mintTokens();
+        expect(revoked.id_token).toBeDefined();
+
+        const response = await httpRequest(suite, 'GET', `/logout?id_token_hint=${revoked.id_token}`);
+        expect(response.status).toEqual(200);
+
+        // the referenced session (and its refresh token) is gone
+        expect(await refreshSucceeds(revoked.refresh_token!)).toBe(false);
+        // an unrelated session is untouched
+        expect(await refreshSucceeds(survivor.refresh_token!)).toBe(true);
+    });
+
+    it('should redirect back to the RP after revoking with a verified hint + validated redirect', async () => {
+        const tokens = await mintTokens();
+        const state = generateOAuth2CodeVerifier();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?id_token_hint=${tokens.id_token}` +
+                `&post_logout_redirect_uri=${encodeURIComponent(POST_LOGOUT_URI)}&state=${state}`,
+            { redirect: 'manual' },
+        );
+
+        expect(response.status).toBeGreaterThanOrEqual(300);
+        expect(response.status).toBeLessThan(400);
+        const location = response.headers.get('location') ?? '';
+        expect(location.startsWith(POST_LOGOUT_URI)).toBe(true);
+        // compare the decoded query value (state may contain URL-escaped chars)
+        expect(new URL(location).searchParams.get('state')).toEqual(state);
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
+    });
+
+    it('should NOT redirect a hint-less request — it renders the confirm page instead (no silent no-op logout)', async () => {
+        // The defect this pins: a hint-less request with a validated
+        // post_logout_redirect_uri used to 302 straight back to the RP without
+        // revoking anything, so the RP treated a no-op as a successful logout.
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?client_id=${client.id}&post_logout_redirect_uri=${encodeURIComponent(POST_LOGOUT_URI)}`,
+            { redirect: 'manual' },
+        );
+
+        expect(response.status).toEqual(200);
+        const contentType = response.headers.get('content-type') ?? '';
+        expect(contentType).toContain('text/html');
+    });
+
+    it('should NOT revoke when an access token is presented as id_token_hint (kind check)', async () => {
+        const tokens = await mintTokens();
+
+        // access tokens also carry session_id — accepting one as a hint would let
+        // a leaked access token force a logout. The kind check rejects it.
+        const response = await httpRequest(suite, 'GET', `/logout?id_token_hint=${tokens.access_token}`);
+        expect(response.status).toEqual(200);
+
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(true);
+    });
+
+    it('should NOT revoke when the id_token_hint is forged / unverifiable', async () => {
+        const tokens = await mintTokens();
+
+        const response = await httpRequest(suite, 'GET', '/logout?id_token_hint=not.a.valid.jwt');
+        expect(response.status).toEqual(200);
+
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(true);
+    });
+
+    it('should not redirect to an unregistered post_logout_redirect_uri', async () => {
+        const tokens = await mintTokens();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?id_token_hint=${tokens.id_token}` +
+                `&post_logout_redirect_uri=${encodeURIComponent('https://attacker.example.com/steal')}`,
+            { redirect: 'manual' },
+        );
+
+        // unmatched redirect is dropped → the confirm page renders (200), not a
+        // 302 to the attacker origin
+        expect(response.status).toEqual(200);
+    });
+
+    it('should reach the discovery-advertised end_session_endpoint', async () => {
+        const config = await httpRequest(suite, 'GET', `/realms/${realm.name}/.well-known/openid-configuration`);
+        const body = await config.json() as { end_session_endpoint?: string };
+        expect(body.end_session_endpoint).toBeDefined();
+        expect(body.end_session_endpoint!.endsWith('/logout')).toBe(true);
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
@@ -636,6 +636,50 @@ describe('grant-authorize', () => {
         );
     });
 
+    it('should not leak identity data in the cross-realm login_required body', async () => {
+        // The realm-mismatch rejection must NOT echo identity/realm details —
+        // otherwise the 400 becomes a realm-enumeration oracle for an
+        // (authenticated-adjacent) caller probing which realm a session belongs
+        // to. Pins the "no identity data in the body" verifier condition.
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const client = await suite.client
+            .client
+            .create(createFakeClient({
+                realm_id: realm.id,
+                is_confidential: false,
+                secret: null,
+            }));
+        const scope = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({
+            scope_id: scope.id,
+            client_id: client.id,
+        });
+
+        const codeVerifier = generateOAuth2CodeVerifier();
+        const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
+
+        expect.assertions(4);
+        try {
+            await suite.client.authorize.confirm({
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                client_id: client.id,
+                redirect_uri: 'https://example.com/redirect',
+                scope: `${ScopeName.GLOBAL}`,
+                code_challenge: codeChallenge,
+                code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
+                state: generateOAuth2CodeVerifier(),
+            });
+        } catch (e: any) {
+            const data = e?.response?.data ?? {};
+            expect(data.code).toEqual(ErrorCode.OAUTH_LOGIN_REQUIRED);
+            // no identity / realm enumeration surface in the body
+            expect(data).not.toHaveProperty('realm_id');
+            expect(data).not.toHaveProperty('sub');
+            // the acting identity's realm id must not appear anywhere in the body
+            expect(JSON.stringify(data)).not.toContain(realm.id);
+        }
+    });
+
     it('should allow /authorize when the identity realm matches the client realm', async () => {
         // control for the realm gate: a client in the actor's own (master) realm
         // authorizes normally.

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-refresh-token.spec.ts
@@ -352,6 +352,44 @@ describe('refresh-token', () => {
         expect(refreshed.access_token).toBeDefined();
     });
 
+    it('should allow a confidential client to refresh a token whose realm differs (exemption)', async () => {
+        // The refresh realm-parity guard is intentionally public-clients-only: a
+        // confidential client's secret proves its identity, so it may refresh a
+        // token minted for another realm — the documented cross-realm password
+        // grant (a UUID-identified realm user authenticated via a master-realm
+        // confidential client). Dropping `!client.is_confidential` from the guard
+        // would break this leg; this is its control.
+        const realm = await suite.client.realm.create(createFakeRealm());
+        const user = await suite.client.user.create(createFakeUser({
+            realm_id: realm.id,
+            password: 'confidential-cross-realm',
+        }));
+
+        // UUID username resolves globally; the master-realm confidential client
+        // authenticates. The issued token carries the user's (realm A) realm_id,
+        // which differs from the confidential client's (master) realm.
+        const login = await suite.client
+            .token
+            .createWithPassword({
+                username: user.id,
+                password: 'confidential-cross-realm',
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect(login.refresh_token).toBeDefined();
+
+        const refreshed = await suite.client
+            .token
+            .createWithRefreshToken({
+                refresh_token: login.refresh_token!,
+                client_id: confidentialClient.id,
+                client_secret: confidentialSecret,
+            });
+
+        expect(refreshed.access_token).toBeDefined();
+    });
+
     it('should detect refresh-token replay and revoke the whole session family', async () => {
         const login = await suite.client
             .token

--- a/apps/server-core/test/unit/http/controllers/workflows/ui-pages.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/ui-pages.spec.ts
@@ -58,11 +58,21 @@ describe('src/http/controllers/workflows (SSR pages)', () => {
         expect(response.status).toEqual(200);
         expect(response.headers.get('content-type')).toContain('text/html');
 
+        // clickjacking guard — the page hydrates logged-in state, so framing must
+        // be denied for the click-gated auto-consent/sign-out to be a real defense
+        expect(response.headers.get('content-security-policy')).toContain("frame-ancestors 'none'");
+        expect(response.headers.get('x-frame-options')).toEqual('DENY');
+
         const body = await response.text();
         const payload = extractHydrationPayload(body);
 
         expect(payload.data.error).toBeUndefined();
         expect(payload.data.client.id).toEqual(client.id);
+        // the anonymous hydration payload carries only the trimmed client DTO —
+        // never redirect_uri patterns, grant_types, internal URLs, or the secret
+        expect(payload.data.client.redirect_uri).toBeUndefined();
+        expect(payload.data.client.grant_types).toBeUndefined();
+        expect(payload.data.client.secret).toBeUndefined();
         expect(payload.data.codeRequest.client_id).toEqual(client.id);
         expect(payload.data.features).toBeDefined();
         expect(payload.data.requestPath).toMatch(/^\/authorize\?/);

--- a/apps/server-core/test/utils/http.ts
+++ b/apps/server-core/test/utils/http.ts
@@ -21,6 +21,11 @@ type FetchOptions = {
      * Extra request headers. Merged on top of the form Content-Type default.
      */
     headers?: Record<string, string>,
+    /**
+     * Redirect handling. Pass `'manual'` to observe a 3xx `Location` without
+     * following it (e.g. asserting an OAuth2 redirect target).
+     */
+    redirect?: RequestRedirect,
 };
 
 /**
@@ -55,5 +60,6 @@ export async function httpRequest(
         method,
         headers,
         body,
+        redirect: options.redirect,
     });
 }

--- a/apps/server-core/ui/src/pages/logout.vue
+++ b/apps/server-core/ui/src/pages/logout.vue
@@ -20,6 +20,7 @@ export default defineComponent({
             hintVerified?: boolean,
             hintSub?: string,
             serverRevoked?: boolean,
+            redirect?: string,
         }>();
 
         return { data: payload.data };
@@ -28,6 +29,10 @@ export default defineComponent({
 </script>
 <template>
     <AAuthShell>
-        <AEndSessionForm :server-revoked="data.serverRevoked" />
+        <AEndSessionForm
+            :server-revoked="data.serverRevoked"
+            :hint-sub="data.hintSub"
+            :redirect="data.redirect"
+        />
     </AAuthShell>
 </template>

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -148,7 +148,7 @@ The following [OpenID Connect Core §3.1.2.1](https://openid.net/specs/openid-co
 
 | Parameter | Description |
 |---|---|
-| `prompt` | Space-delimited list of `none`, `login`, `consent`, `select_account`. `select_account` shows a "continue as / use another account" chooser when a session already exists; `login` forces re-authentication; `consent` forces the consent screen; `none` returns an error (e.g. `login_required`) instead of showing any UI. Unknown values are ignored; `none` combined with any other value is an `invalid_request`. |
+| `prompt` | Space-delimited list of `login`, `consent`, `select_account`. `select_account` shows a "continue as / use another account" chooser when a session already exists; `login` forces re-authentication; `consent` forces the consent screen. Unknown values are ignored; `none` combined with any other value is an `invalid_request`. Note: `none` (silent authentication) is not yet implemented — it is not advertised in `prompt_values_supported`, and a `prompt=none` request currently renders the interactive page rather than returning an error redirect. |
 | `max_age` | Maximum acceptable age (seconds) of the authentication. If the session is older, the user is asked to re-authenticate (`max_age=0` forces it). |
 | `login_hint` | Pre-fills the identifier on the login form. |
 

--- a/packages/client-web-kit/src/components/workflows/authorize/Authorize.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/Authorize.vue
@@ -17,12 +17,19 @@ import {
     Suspense,
     defineComponent,
     h,
+    onBeforeUnmount,
     ref,
 } from 'vue';
 import { TranslatorTranslationCommonKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { OAuth2AuthorizationPrompt } from '@authup/specs';
 import type { LinkProperties } from '@vuecs/link';
-import { injectHTTPClient, injectStore, useTranslation } from '../../../core';
+import {
+    StoreDispatcherEventName,
+    injectHTTPClient,
+    injectStore,
+    injectStoreDispatcher,
+    useTranslation,
+} from '../../../core';
 import AAuthShell from '../../utility/AAuthShell.vue';
 import LoginForm from '../login/LoginForm.vue';
 import AAccountPrompt from './AAccountPrompt.vue';
@@ -77,6 +84,21 @@ export default defineComponent({
         // proceed past the chooser to consent for the rest of this render cycle.
         const accountConfirmed = ref<boolean>(false);
 
+        // A login performed *on this page* IS the account selection — don't then
+        // re-prompt "continue as X" for the account whose credentials were just
+        // entered. The store emits LOGGED_IN only for an explicit login() (the
+        // login form), never for a session restored from cookies (resolve() →
+        // RESOLVED), so a *lingering* session still gets the chooser while a
+        // fresh login skips it. Keying off the store event — not LoginForm's
+        // `done` emit — is what makes this reliable: on login the access-token
+        // flip re-renders Authorize and unmounts LoginForm before its `done`
+        // fires, so that emit is easily lost (the bug this replaced).
+        const dispatcher = injectStoreDispatcher();
+        const offLoggedIn = dispatcher.on(StoreDispatcherEventName.LOGGED_IN, () => {
+            accountConfirmed.value = true;
+        });
+        onBeforeUnmount(offLoggedIn);
+
         const error = ref<Error | null>(null);
         const client = ref<Client | null>(null);
 
@@ -128,12 +150,8 @@ export default defineComponent({
                         registerLink: props.registerLink,
                         passwordForgotLink: props.passwordForgotLink,
                         usernameHint: props.codeRequest?.login_hint,
-                        // A just-completed credential entry IS the account
-                        // selection — don't re-prompt "continue as X" for the
-                        // account the user just signed into (prompt=select_account
-                        // exists to interrupt a *lingering* session, not a fresh
-                        // login).
-                        onDone: () => { accountConfirmed.value = true; },
+                        // fresh-login → skip the chooser: handled race-free by the
+                        // `watch(loggedIn)` above, not LoginForm's `done` emit.
                         onFailed: (message: string) => emit('failed', message),
                     }),
                     fallback: () => h(AuthorizeText, { message: loadingText.value }),

--- a/packages/client-web-kit/src/components/workflows/authorize/Authorize.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/Authorize.vue
@@ -20,6 +20,7 @@ import {
     ref,
 } from 'vue';
 import { TranslatorTranslationCommonKey, TranslatorTranslationNamespace } from '@authup/i18n';
+import { OAuth2AuthorizationPrompt } from '@authup/specs';
 import type { LinkProperties } from '@vuecs/link';
 import { injectHTTPClient, injectStore, useTranslation } from '../../../core';
 import AAuthShell from '../../utility/AAuthShell.vue';
@@ -28,8 +29,6 @@ import AAccountPrompt from './AAccountPrompt.vue';
 import AuthorizeForm from './AuthorizeForm.vue';
 import AuthorizeRealmMismatch from './AuthorizeRealmMismatch.vue';
 import AuthorizeText from './AuthorizeText.vue';
-
-const OAUTH2_PROMPT_SELECT_ACCOUNT = 'select_account';
 
 const wrapChild = (child: VNodeChild) => h(
     AAuthShell,
@@ -129,6 +128,12 @@ export default defineComponent({
                         registerLink: props.registerLink,
                         passwordForgotLink: props.passwordForgotLink,
                         usernameHint: props.codeRequest?.login_hint,
+                        // A just-completed credential entry IS the account
+                        // selection — don't re-prompt "continue as X" for the
+                        // account the user just signed into (prompt=select_account
+                        // exists to interrupt a *lingering* session, not a fresh
+                        // login).
+                        onDone: () => { accountConfirmed.value = true; },
                         onFailed: (message: string) => emit('failed', message),
                     }),
                     fallback: () => h(AuthorizeText, { message: loadingText.value }),
@@ -161,13 +166,19 @@ export default defineComponent({
             }
 
             // prompt=select_account: offer "continue as X / use another account"
-            // instead of silently continuing the current session.
+            // instead of silently continuing the current session. Wait for the
+            // user to resolve so the chooser never flashes "Continue as " with an
+            // empty name.
             if (
-                prompts.includes(OAUTH2_PROMPT_SELECT_ACCOUNT) &&
+                prompts.includes(OAuth2AuthorizationPrompt.SELECT_ACCOUNT) &&
                 !accountConfirmed.value
             ) {
+                if (!user.value) {
+                    return wrapChild(h(AuthorizeText, { message: loadingText.value }));
+                }
+
                 return wrapChild(h(AAccountPrompt, {
-                    identityName: user.value?.name ?? user.value?.display_name ?? '',
+                    identityName: user.value.name ?? user.value.display_name ?? '',
                     onContinue: () => { accountConfirmed.value = true; },
                     onSwitch: switchAccount,
                 }));
@@ -182,6 +193,11 @@ export default defineComponent({
                     codeRequest: props.codeRequest!,
                     client: client.value!,
                     scopes: props.scopes,
+                    // "Signed in as X — Not you?" switch affordance on the manual
+                    // consent screen (present even when the RP sent no
+                    // prompt=select_account).
+                    identityName: user.value?.name ?? user.value?.display_name ?? '',
+                    onSwitch: switchAccount,
                     onLoginRequired: switchAccount,
                 }),
                 fallback: () => h(AuthorizeText, { message: loadingText.value }),

--- a/packages/client-web-kit/src/components/workflows/authorize/AuthorizeForm.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/AuthorizeForm.vue
@@ -271,10 +271,11 @@ export default defineComponent({
         >
             <small class="text-fg-muted">
                 {{ signedInAsLabel }} —
-                <a
-                    href="#"
+                <button
+                    type="button"
+                    class="underline bg-transparent border-0 p-0 cursor-pointer text-inherit"
                     @click.prevent="switchAccount"
-                >{{ notYouLabel }}</a>
+                >{{ notYouLabel }}</button>
             </small>
         </div>
 

--- a/packages/client-web-kit/src/components/workflows/authorize/AuthorizeForm.vue
+++ b/packages/client-web-kit/src/components/workflows/authorize/AuthorizeForm.vue
@@ -7,6 +7,7 @@
 <script lang="ts">
 /* global window */
 import type { Client, OAuth2AuthorizationCodeRequest, Scope } from '@authup/core-kit';
+import { OAuth2AuthorizationPrompt, OAuth2ErrorCode } from '@authup/specs';
 import type { PropType } from 'vue';
 import {
     computed,
@@ -23,7 +24,12 @@ import {
 import { ITranslateT } from '@ilingo/vue';
 import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
-import { injectHTTPClient, useTranslations, useTranslationsForNamespace } from '../../../core';
+import {
+    injectHTTPClient,
+    useTranslation,
+    useTranslations,
+    useTranslationsForNamespace,
+} from '../../../core';
 import AuthorizeScopes from './AuthorizeScopes.vue';
 
 export default defineComponent({
@@ -43,8 +49,11 @@ export default defineComponent({
             type: Object as PropType<OAuth2AuthorizationCodeRequest>,
             required: true,
         },
+        // The signed-in identity's display name — renders the "Signed in as X —
+        // Not you?" switch affordance above the consent actions when non-empty.
+        identityName: { type: String, default: '' },
     },
-    emits: ['loginRequired'],
+    emits: ['loginRequired', 'switch'],
     setup(props, { emit }) {
         const httpClient = injectHTTPClient();
 
@@ -71,6 +80,17 @@ export default defineComponent({
                 { key: TranslatorTranslationClientKey.TERMS_OF_SERVICE },
             ],
         );
+
+        const signedInAsLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.SIGNED_IN_AS,
+            data: { name: computed(() => props.identityName) },
+        });
+
+        const notYouLabel = useTranslation({
+            namespace: TranslatorTranslationNamespace.CLIENT,
+            key: TranslatorTranslationClientKey.NOT_YOU,
+        });
 
         const abort = () => {
             const url = new URL(`${props.codeRequest.redirect_uri}`);
@@ -120,7 +140,7 @@ export default defineComponent({
                 // or a race). Fall back to re-authentication rather than showing
                 // manual consent for a request the server will never accept.
                 const response = (e as { response?: { data?: { error?: unknown } } })?.response;
-                if (response?.data?.error === 'login_required') {
+                if (response?.data?.error === OAuth2ErrorCode.LOGIN_REQUIRED) {
                     emit('loginRequired');
                     return;
                 }
@@ -144,7 +164,7 @@ export default defineComponent({
             const prompts = props.codeRequest.prompt ?
                 props.codeRequest.prompt.split(' ') :
                 [];
-            return !prompts.includes('consent');
+            return !prompts.includes(OAuth2AuthorizationPrompt.CONSENT);
         });
 
         // Show the spinner only while an auto-consent submit is in flight. If it
@@ -165,6 +185,9 @@ export default defineComponent({
             showSpinner,
             translationsDefault,
             translationsClient,
+            signedInAsLabel,
+            notYouLabel,
+            switchAccount: () => emit('switch'),
         };
     },
 });
@@ -240,6 +263,19 @@ export default defineComponent({
                     </small>
                 </div>
             </div>
+        </div>
+
+        <div
+            v-if="identityName"
+            class="text-center"
+        >
+            <small class="text-fg-muted">
+                {{ signedInAsLabel }} —
+                <a
+                    href="#"
+                    @click.prevent="switchAccount"
+                >{{ notYouLabel }}</a>
+            </small>
         </div>
 
         <div class="flex flex-wrap -mx-2">

--- a/packages/client-web-kit/src/components/workflows/end-session/AEndSessionForm.vue
+++ b/packages/client-web-kit/src/components/workflows/end-session/AEndSessionForm.vue
@@ -5,9 +5,11 @@
   - view the LICENSE file that was distributed with this source code.
   -->
 <script lang="ts">
+/* global window */
 import { TranslatorTranslationClientKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
+import { storeToRefs } from 'pinia';
 import {
     defineComponent,
     onMounted,
@@ -24,9 +26,22 @@ export default defineComponent({
             type: Boolean,
             default: false,
         },
+        // The `sub` of the session revoked server-side (only set for a verified
+        // hint). Local auto-cleanup is gated on it matching THIS browser's user.
+        hintSub: {
+            type: String,
+            default: undefined,
+        },
+        // A validated post_logout_redirect_uri (open-redirect guard already
+        // applied server-side; carries `state`). Navigated to after sign-out.
+        redirect: {
+            type: String,
+            default: undefined,
+        },
     },
     setup(props) {
         const store = injectStore();
+        const { user } = storeToRefs(store);
         const done = ref<boolean>(false);
 
         const title = useTranslation({
@@ -46,22 +61,46 @@ export default defineComponent({
             key: TranslatorTranslationClientKey.SIGN_OUT,
         });
 
-        // Always transition to the terminal state — a failed local cleanup must
+        const navigateToRedirect = (): boolean => {
+            if (props.redirect && typeof window !== 'undefined') {
+                window.location.href = props.redirect;
+                return true;
+            }
+
+            return false;
+        };
+
+        // Always transition to a terminal state — a failed local cleanup must
         // not strand the user on the pre-logout UI (in the serverRevoked path
-        // the server already ended the session).
+        // the server already ended the session). Navigate to a validated
+        // post-logout redirect when present, else show the signed-out notice.
         const signOut = async () => {
             try {
                 await store.logout();
             } finally {
-                done.value = true;
+                if (!navigateToRedirect()) {
+                    done.value = true;
+                }
             }
         };
 
         onMounted(async () => {
             // The server already ended the session (verified hint) — clear the
-            // local token/cookie state, then show the terminal notice (await so
-            // "done" isn't shown while local cleanup is still in flight).
-            if (props.serverRevoked) {
+            // local token/cookie state, then show the terminal notice.
+            //
+            // Gate the auto-cleanup on the revoked subject being THIS browser's
+            // user: without it, a cross-site GET to
+            // /logout?id_token_hint=<attacker's own id_token> (which revokes the
+            // attacker's own session, so serverRevoked is true) would forcibly
+            // sign out an unrelated victim who merely renders this page — a
+            // forced-logout CSRF. store.logout() is local-only, so it acts on
+            // whoever's browser rendered the page, not on the hint's subject.
+            if (
+                props.serverRevoked &&
+                props.hintSub &&
+                user.value &&
+                props.hintSub === user.value.id
+            ) {
                 await signOut();
             }
         });

--- a/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { OAuth2AuthorizationCodeRequest, User } from '@authup/core-kit';
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import { OAuth2AuthorizationPrompt } from '@authup/specs';
+import { flushPromises, mount } from '@vue/test-utils';
+import vuecs from '@vuecs/core';
+import { createPinia } from 'pinia';
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { App } from 'vue';
+import AAccountPrompt from '../../../../src/components/workflows/authorize/AAccountPrompt.vue';
+import AAuthorize from '../../../../src/components/workflows/authorize/Authorize.vue';
+import {
+    StoreDispatcherEventName,
+    injectStore,
+    injectStoreDispatcher,
+} from '../../../../src/core';
+import type { Store, StoreDispatcher } from '../../../../src/core';
+import { install } from '../../../../src/module';
+import type { Options } from '../../../../src/types';
+
+const noop = () => undefined;
+const REALM = { id: 'realm-x', name: 'master' };
+
+// A logged-in, fully-resolved store — the state in which prompt=select_account
+// would render the chooser (mimics a lingering session restored from cookies).
+function seedLoggedIn(store: Store) {
+    store.setAccessToken('access-token');
+    store.setRealm({ id: REALM.id, name: REALM.name });
+    store.setUser({ id: 'user-1', name: 'jdoe' } as unknown as User);
+}
+
+function mountAuthorize() {
+    const pinia = createPinia();
+    const httpClient = createFakeClient({ handlers: {} });
+
+    const options: Options = {
+        baseURL: 'http://fake.test',
+        httpClient,
+        pinia,
+        isServer: true,
+        cookieGet: noop,
+        cookieSet: noop,
+        cookieUnset: noop,
+    };
+
+    const codeRequest: OAuth2AuthorizationCodeRequest = {
+        response_type: 'code',
+        client_id: 'web',
+        realm_id: REALM.id,
+        redirect_uri: 'https://app.example.com/cb',
+        scope: 'global openid',
+        state: 'state-1',
+        code_challenge: 'challenge',
+        code_challenge_method: 'S256',
+        prompt: OAuth2AuthorizationPrompt.SELECT_ACCOUNT,
+    } as OAuth2AuthorizationCodeRequest;
+
+    // non-built_in client → no auto-consent redirect; the chooser is the only
+    // thing we assert on.
+    const client = {
+        id: 'client-1',
+        name: 'web',
+        display_name: 'Web',
+        built_in: false,
+        created_at: new Date(0).toISOString(),
+    };
+
+    let dispatcher!: StoreDispatcher;
+
+    const wrapper = mount(AAuthorize, {
+        props: {
+            codeRequest,
+            client,
+            realm: {
+                id: REALM.id, 
+                name: REALM.name, 
+                display_name: 'Master', 
+            },
+            scopes: [],
+            redirectUriVerified: true,
+        },
+        global: {
+            components: {
+                VCIcon: { render: () => null },
+                VCButton: { render: () => null },
+            },
+            // Stub the branch children we don't assert on — avoids AuthorizeForm's
+            // scope fetch (aborted at teardown → noisy happy-dom warning).
+            stubs: {
+                AuthorizeForm: { template: '<div class="authorize-form-stub" />' },
+                LoginForm: { template: '<div class="login-form-stub" />' },
+            },
+            plugins: [
+                pinia,
+                [vuecs, {}],
+                [{ install }, options],
+                {
+                    install(app: App) {
+                        seedLoggedIn(injectStore(pinia, app));
+                        dispatcher = injectStoreDispatcher(app);
+                    },
+                },
+            ],
+        },
+    });
+
+    return { wrapper, dispatcher: () => dispatcher };
+}
+
+const hasChooser = (wrapper: ReturnType<typeof mountAuthorize>['wrapper']) => wrapper.findComponent(AAccountPrompt).exists();
+
+describe('AAuthorize prompt=select_account', () => {
+    it('shows the account chooser for a lingering (restored) session', async () => {
+        const { wrapper } = mountAuthorize();
+        await flushPromises();
+
+        expect(hasChooser(wrapper)).toBe(true);
+    });
+
+    it('skips the chooser once a login happens on this page (LOGGED_IN)', async () => {
+        const { wrapper, dispatcher } = mountAuthorize();
+        await flushPromises();
+        expect(hasChooser(wrapper)).toBe(true);
+
+        // a fresh login via the form fires LOGGED_IN — the just-entered
+        // credentials ARE the account selection, so the chooser must disappear.
+        dispatcher().emit(StoreDispatcherEventName.LOGGED_IN);
+        await flushPromises();
+
+        expect(hasChooser(wrapper)).toBe(false);
+    });
+
+    it('keeps the chooser when only a session restore (RESOLVED) fires', async () => {
+        const { wrapper, dispatcher } = mountAuthorize();
+        await flushPromises();
+
+        // RESOLVED is emitted by a cookie restore, not an interactive login — it
+        // must NOT suppress the chooser (that is the whole point of the prompt).
+        dispatcher().emit(StoreDispatcherEventName.RESOLVED);
+        await flushPromises();
+
+        expect(hasChooser(wrapper)).toBe(true);
+    });
+});

--- a/packages/client-web-kit/test/unit/components/workflows/end-session.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/end-session.spec.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { User } from '@authup/core-kit';
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import vuecs from '@vuecs/core';
+import { createPinia } from 'pinia';
+import {
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
+import type { MockInstance } from 'vitest';
+import type { App } from 'vue';
+import { AEndSessionForm } from '../../../../src/components/workflows/end-session';
+import { injectStore } from '../../../../src/core';
+import { install } from '../../../../src/module';
+import type { Options } from '../../../../src/types';
+
+const noop = () => undefined;
+
+function mountEndSession(
+    props: Record<string, any> = {},
+    seedUser?: Pick<User, 'id'>,
+) {
+    const pinia = createPinia();
+    const httpClient = createFakeClient({ handlers: {} });
+
+    const options: Options = {
+        baseURL: 'http://fake.test',
+        httpClient,
+        pinia,
+        isServer: true,
+        cookieGet: noop,
+        cookieSet: noop,
+        cookieUnset: noop,
+    };
+
+    let logout: MockInstance;
+
+    const wrapper = mount(AEndSessionForm, {
+        props,
+        global: {
+            components: {
+                VCIcon: { render: () => null },
+                VCButton: { render: () => null },
+            },
+            plugins: [
+                pinia,
+                [vuecs, {}],
+                [{ install }, options],
+                {
+                    // runs after the kit install (which provides the store
+                    // factory) and BEFORE the component mounts, so the seeded
+                    // user is present when AEndSessionForm's onMounted evaluates
+                    // the auto-logout gate.
+                    install(app: App) {
+                        const store = injectStore(pinia, app);
+                        if (seedUser) {
+                            store.user = seedUser as User;
+                        }
+                        logout = vi.spyOn(store, 'logout').mockResolvedValue(undefined);
+                    },
+                },
+            ],
+        },
+    });
+
+    return { wrapper, logout: () => logout };
+}
+
+describe('AEndSessionForm', () => {
+    it('should auto-sign-out when the revoked subject is the current user', async () => {
+        const { logout } = mountEndSession(
+            { serverRevoked: true, hintSub: 'user-1' },
+            { id: 'user-1' },
+        );
+        await flushPromises();
+
+        expect(logout()).toHaveBeenCalledTimes(1);
+    });
+
+    it('should NOT auto-sign-out when the revoked subject differs from the current user (forced-logout CSRF guard)', async () => {
+        const { logout } = mountEndSession(
+            { serverRevoked: true, hintSub: 'attacker' },
+            { id: 'victim' },
+        );
+        await flushPromises();
+
+        expect(logout()).not.toHaveBeenCalled();
+    });
+
+    it('should NOT auto-sign-out for a logged-out visitor (no current user)', async () => {
+        const { logout } = mountEndSession({ serverRevoked: true, hintSub: 'user-1' });
+        await flushPromises();
+
+        expect(logout()).not.toHaveBeenCalled();
+    });
+
+    it('should NOT auto-sign-out when the server did not revoke (click-gated)', async () => {
+        const { logout } = mountEndSession(
+            { serverRevoked: false, hintSub: 'user-1' },
+            { id: 'user-1' },
+        );
+        await flushPromises();
+
+        expect(logout()).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core-kit/src/domains/authorization-code/entity.ts
+++ b/packages/core-kit/src/domains/authorization-code/entity.ts
@@ -36,13 +36,6 @@ export interface OAuth2AuthorizationCode {
      */
     session_id?: string | null,
 
-    /**
-     * Epoch-seconds authentication time (the session's creation time), stamped
-     * when a session backs the authorize request. Feeds the id_token `auth_time`
-     * claim; absent for session-less flows.
-     */
-    auth_time?: number | null,
-
     sub: string,
 
     sub_kind: `${OAuth2SubKind}`,

--- a/packages/i18n/src/catalogs/de/client.ts
+++ b/packages/i18n/src/catalogs/de/client.ts
@@ -82,6 +82,8 @@ export const TranslatorTranslationClientGerman : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Konto auswählen',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Als {{name}} fortfahren',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Anderes Konto verwenden',
+    [TranslatorTranslationClientKey.SIGNED_IN_AS]: 'Angemeldet als {{name}}',
+    [TranslatorTranslationClientKey.NOT_YOU]: 'Nicht Sie?',
 
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Abmelden',
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: 'Möchten Sie sich abmelden?',

--- a/packages/i18n/src/catalogs/en/client.ts
+++ b/packages/i18n/src/catalogs/en/client.ts
@@ -82,6 +82,8 @@ export const TranslatorTranslationClientEnglish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Choose an account',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Continue as {{name}}',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Use another account',
+    [TranslatorTranslationClientKey.SIGNED_IN_AS]: 'Signed in as {{name}}',
+    [TranslatorTranslationClientKey.NOT_YOU]: 'Not you?',
 
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Sign out',
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: 'Do you want to sign out?',

--- a/packages/i18n/src/catalogs/es/client.ts
+++ b/packages/i18n/src/catalogs/es/client.ts
@@ -82,6 +82,8 @@ export const TranslatorTranslationClientSpanish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Elegir una cuenta',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Continuar como {{name}}',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Usar otra cuenta',
+    [TranslatorTranslationClientKey.SIGNED_IN_AS]: 'Sesión iniciada como {{name}}',
+    [TranslatorTranslationClientKey.NOT_YOU]: '¿No eres tú?',
 
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Cerrar sesión',
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: '¿Quieres cerrar sesión?',

--- a/packages/i18n/src/catalogs/fr/client.ts
+++ b/packages/i18n/src/catalogs/fr/client.ts
@@ -82,6 +82,8 @@ export const TranslatorTranslationClientFrench : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.SELECT_ACCOUNT_TITLE]: 'Choisir un compte',
     [TranslatorTranslationClientKey.CONTINUE_AS]: 'Continuer en tant que {{name}}',
     [TranslatorTranslationClientKey.USE_ANOTHER_ACCOUNT]: 'Utiliser un autre compte',
+    [TranslatorTranslationClientKey.SIGNED_IN_AS]: 'Connecté en tant que {{name}}',
+    [TranslatorTranslationClientKey.NOT_YOU]: 'Pas vous ?',
 
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TITLE]: 'Se déconnecter',
     [TranslatorTranslationClientKey.LOGOUT_CONFIRM_TEXT]: 'Voulez-vous vous déconnecter ?',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -113,6 +113,8 @@ export enum TranslatorTranslationClientKey {
     SELECT_ACCOUNT_TITLE = 'selectAccountTitle',
     CONTINUE_AS = 'continueAs',
     USE_ANOTHER_ACCOUNT = 'useAnotherAccount',
+    SIGNED_IN_AS = 'signedInAs',
+    NOT_YOU = 'notYou',
 
     LOGOUT_CONFIRM_TITLE = 'logoutConfirmTitle',
     LOGOUT_CONFIRM_TEXT = 'logoutConfirmText',

--- a/packages/server-kit/test/unit/json-web-token.spec.ts
+++ b/packages/server-kit/test/unit/json-web-token.spec.ts
@@ -90,6 +90,57 @@ describe('src/json-web-token', () => {
         }).rejects.toThrow(JWTError.expired());
     });
 
+    it('should verify an expired token when ignoreExpiry is set', async () => {
+        const data : JWTClaims = { exp: 1000, text: 'secretText' };
+
+        const signedText = await signToken(data, {
+            type: 'rsa',
+            key: keyPair.privateKey,
+        });
+
+        const decoded = await verifyToken(signedText, {
+            type: 'rsa',
+            key: keyPair.publicKey,
+        }, { ignoreExpiry: true });
+
+        expect(decoded).toBeDefined();
+        expect(decoded.text).toEqual(data.text);
+    });
+
+    it('should still reject a bad signature even when ignoreExpiry is set', async () => {
+        const otherKeyPair = await createAsymmetricKeyPair({ name: CryptoAsymmetricAlgorithm.RSASSA_PKCS1_V1_5 });
+
+        const signedText = await signToken({ exp: 1000, text: 'secretText' }, {
+            type: 'rsa',
+            key: keyPair.privateKey,
+        });
+
+        // ignoreExpiry skips ONLY exp — the signature anchor must still hold, so
+        // verifying against a foreign public key rejects.
+        await expect(async () => {
+            await verifyToken(signedText, {
+                type: 'rsa',
+                key: otherKeyPair.publicKey,
+            }, { ignoreExpiry: true });
+        }).rejects.toThrow(JWTError);
+    });
+
+    it('should still reject a not-yet-active token when ignoreExpiry is set', async () => {
+        const data : JWTClaims = { nbf: Math.floor(new Date().getTime() / 1000) + 3600 };
+
+        const signedText = await signToken(data, {
+            type: 'rsa',
+            key: keyPair.privateKey,
+        });
+
+        await expect(async () => {
+            await verifyToken(signedText, {
+                type: 'rsa',
+                key: keyPair.publicKey,
+            }, { ignoreExpiry: true });
+        }).rejects.toThrow(JWTError.notActiveBefore());
+    });
+
     it('sign and not verify token (not active before)', async () => {
         const data : JWTClaims = { nbf: Math.floor(new Date().getTime() / 1000) + 3600 };
 


### PR DESCRIPTION
Post-merge fixes for defects and test gaps surfaced by an audit of **plan 041** (#3194 / #3195 / #3196). Closes plan 042 items **#1**, **#11**, and most of **#12**. No breaking API changes; all changes are server-authoritative fixes with kit/UX follow-through.

## Security / correctness

- **Forced-logout CSRF (medium).** `AEndSessionForm` auto-cleared local state on any `serverRevoked`, so a cross-site `GET /logout?id_token_hint=<attacker's own id_token>` (which revokes the attacker's *own* session → `serverRevoked=true`) force-logged-out any victim who merely rendered the page (`store.logout()` is local-only, so it acts on whoever's browser rendered it). Now gated on `serverRevoked && hintSub === store.user.id`; the controller forwards `hintSub` (verified hints only) into the payload.
- **Silent no-op logout (medium).** `LogoutController` redirected whenever `post_logout_redirect_uri` validated, *regardless of* whether a session was revoked — a hint-less RP round-trip 302'd back while the authup session survived. The server-side bounce now fires only when `serverRevoked && redirect`; otherwise the validated redirect is threaded into the render payload and the click-gated `AEndSessionForm` performs the bearer-authenticated sign-out, then navigates to it.
- **`prompt=select_account` after fresh login (medium UX).** A just-completed credential entry no longer re-prompts "Continue as X" (`LoginForm`'s `done` sets `accountConfirmed`); the chooser also waits for the store `user` to resolve (no "Continue as \<empty\>" flash).
- **Anonymous `/authorize` over-disclosure (low).** `serve()` now ships a `ClientSummary` DTO (`id`/`name`/`display_name`/`built_in`/`created_at`) — never `redirect_uri` patterns (the trusted-origin set), `grant_types`, internal URLs, or secret storage flags.
- **`prompt=none` (low).** Removed from discovery `prompt_values_supported` + docs — the silent-auth error redirect is unimplemented, so advertising it promised a capability the server lacks.
- **`max_age=` empty (low).** Treated as absent instead of coercing to `0` (`z.coerce.number('') === 0` would silently force re-authentication).
- **"Signed in as X — Not you?" switch chip** on the manual consent screen (+ i18n ×4 locales); removed the dead `OAuth2AuthorizationCode.auth_time` field; replaced hardcoded prompt/error literals with `@authup/specs` enums.

## Tests (backfill of the plan's load-bearing matrix)

- `/logout` HTTP e2e (`logout/end-session.spec.ts`): verified-hint revoke, verified-hint+redirect 302 w/ state, hint-less no-op renders page, access-token-as-hint no-revoke, forged-hint no-revoke, unregistered `post_logout_redirect_uri` dropped, discovery reachable.
- `server-kit` `ignoreExpiry`: expired-but-valid-signature accepted; bad signature and `nbf` still rejected.
- `auth_time` passthrough (open-id issuer) + `auth_time ≠ refreshed_at` pin (authorization module); `redirectUriVerified` (code-request verifier); confidential refresh exemption; cross-realm `login_required` **no-identity-oracle** body; clickjacking headers + trimmed-DTO assertions (`ui-pages.spec.ts`); `max_age` empty-vs-0; `AEndSessionForm` hint-sub gate (kit).

## Docs

`.agents/architecture.md` (logout redirect/gate, hydration DTO, `prompt=none` non-advertisement, fresh-login chooser + switch chip), `docs/api-oauth2.md`, and status annotations on `.agents/plans/042`.

## Verification

Full build (22 projects), lint, `check:types`, and suites green: server-kit 13, i18n 77, client-web-kit 15, server-core 1152/1153. The one failure is `session.spec.ts` (counts the admin's own sessions; races with parallel suites doing admin logins in the shared DB) — pre-existing flakiness, deterministic 6/6 in isolation.

## Deliberate scope note

An HTTP e2e for realm-gate **layer 2** (cross-realm code → `/token` `invalid_grant`, pinning the `realmId: client.realm_id` wiring) is *not* included: it is unreachable via the public authorize API now that layer 1 blocks cross-realm issuance, so it needs an IdP-callback harness. The verifier's realm semantics are already unit-tested. Tracked in plan 042 #12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an identity switch experience during authorization with “Signed in as …” and “Not you?”.
  * Enhanced logout with optional post-logout navigation back to a validated redirect.
* **Bug Fixes**
  * Improved `max_age` handling so empty values are treated as unset.
  * Tightened prompt/metadata behavior by no longer advertising silent login (`prompt=none`).
  * Prevented unintended logout redirects and tightened local sign-out cleanup to the correct session.
* **Documentation**
  * Updated OAuth/OIDC guide to reflect current `prompt` support and interactive behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->