### PR TITLE
feat: drop implicit & hybrid oauth2 response types

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1105,6 +1105,19 @@ mechanism. `store.logout()` stays local-only (token/cookie cleanup); it does not
 call `DELETE /sessions/@me` (that endpoint remains the session-management API for
 revoking a specific session from the sessions UI).
 
+### Response types — code only (plan 042 item 3)
+
+`response_type=code` is the **only** supported response type (OAuth 2.1
+posture). The implicit/hybrid response types (`token`, `id_token`, `none`) are
+rejected by the code-request validator (a `response_type` issue → 400) and,
+defense in depth, by `OAuth2Authorization.authorize()`
+(`unsupported_response_type`). The authorization response never carries tokens
+— an openid-scoped code stores its id_token on the code blob and the `/token`
+exchange returns it. Discovery `response_types_supported` advertises only
+`code`. Consequently the code-request verifier requires PKCE + `state` for
+public clients **unconditionally** (the former `willIssueCode` gate is gone —
+every verified request issues a code).
+
 ### OIDC prompt surface & id_token claims (plan 041 PR B)
 
 `/authorize` accepts the OIDC Core §3.1.2.1 params `prompt`

--- a/apps/client-web/pages/clients/[id]/url.vue
+++ b/apps/client-web/pages/clients/[id]/url.vue
@@ -50,7 +50,7 @@ export default defineNuxtComponent({
         const generatedUrl = computed(() => {
             const link = new URL('authorize', config.public.apiUrl);
             link.searchParams.set('client_id', props.entity.id);
-            link.searchParams.set('response_type', 'token');
+            link.searchParams.set('response_type', 'code');
 
             if (scopes.value.length > 0) {
                 link.searchParams.set('scope', scopes.value.join(' '));

--- a/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/realm/module.ts
@@ -110,10 +110,10 @@ export class RealmController {
 
             jwks_uri: resolveURL(baseURL, `realms/${entity.name}/jwks`),
 
+            // OAuth 2.1 posture: the authorization endpoint issues codes
+            // only — implicit/hybrid response types were dropped (plan 042).
             response_types_supported: [
                 OAuth2AuthorizationResponseType.CODE,
-                OAuth2AuthorizationResponseType.TOKEN,
-                OAuth2AuthorizationResponseType.NONE,
             ],
 
             // `none` is intentionally NOT advertised: the silent-auth error

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
@@ -56,7 +56,6 @@ export class AuthorizeController {
 
         this.authorizer = new HTTPOAuth2Authorizer({
             codeRequestVerifier: this.codeRequestVerifier,
-            accessTokenIssuer: ctx.accessTokenIssuer,
             openIdTokenIssuer: ctx.openIdTokenIssuer,
             codeIssuer: ctx.codeIssuer,
             identityResolver: ctx.identityResolver,
@@ -78,14 +77,6 @@ export class AuthorizeController {
 
         if (result.authorizationCode) {
             url.searchParams.set('code', result.authorizationCode);
-        }
-
-        if (result.accessToken) {
-            url.searchParams.set('access_token', result.accessToken);
-        }
-
-        if (result.idToken) {
-            url.searchParams.set('id_token', result.idToken);
         }
 
         return { url: url.href };

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/types.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/types.ts
@@ -11,7 +11,6 @@ import type {
     IOAuth2AuthorizationCodeIssuer,
     IOAuth2AuthorizationCodeRequestVerifier,
     IOAuth2OpenIDTokenIssuer,
-    IOAuth2TokenIssuer,
     ISessionManager,
 } from '../../../../../core/index.ts';
 
@@ -28,7 +27,6 @@ export type AuthorizeControllerOptions = {
 export type AuthorizeControllerContext = {
     options: AuthorizeControllerOptions,
 
-    accessTokenIssuer: IOAuth2TokenIssuer,
     openIdTokenIssuer: IOAuth2OpenIDTokenIssuer,
 
     codeIssuer: IOAuth2AuthorizationCodeIssuer,

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -225,7 +225,6 @@ export class HTTPControllerModule {
 
     createAuthorize(container: IContainer) {
         const config = container.resolve(ConfigInjectionKey);
-        const accessTokenIssuer = container.resolve(OAuth2InjectionToken.AccessTokenIssuer);
         const openIdTokenIssuer = container.resolve(OAuth2InjectionToken.OpenIDTokenIssuer);
 
         const codeIssuer = container.resolve(OAuth2InjectionToken.AuthorizationCodeIssuer);
@@ -241,7 +240,6 @@ export class HTTPControllerModule {
                 promptLoginMaxAge: config.promptLoginMaxAge,
             },
 
-            accessTokenIssuer,
             openIdTokenIssuer,
 
             codeIssuer,

--- a/apps/server-core/src/core/oauth2/authorization/code-request/validator.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/validator.ts
@@ -29,18 +29,21 @@ export class OAuth2AuthorizationCodeRequestValidator extends Container<OAuth2Aut
                     .string()
                     .nonempty()
                     .check((ctx) => {
-                        const availableResponseTypes = Object.values(OAuth2AuthorizationResponseType);
-                        const responseTypes = ctx.value.split(' ') as OAuth2AuthorizationResponseType[];
+                        // OAuth 2.1 posture: the authorization endpoint issues
+                        // codes only — the implicit/hybrid response types
+                        // (token, id_token, none) are not supported.
+                        const responseTypes = ctx.value.split(' ').filter(Boolean);
 
-                        for (const responseType of responseTypes) {
-                            if (!availableResponseTypes.includes(responseType)) {
-                                const error = OAuth2ResponseTypeError.unsupported();
-                                ctx.issues.push({
-                                    input: responseType,
-                                    code: 'custom',
-                                    message: error.message,
-                                });
-                            }
+                        const invalid = responseTypes.length !== 1 ||
+                            responseTypes[0] !== OAuth2AuthorizationResponseType.CODE;
+
+                        if (invalid) {
+                            const error = OAuth2ResponseTypeError.unsupported();
+                            ctx.issues.push({
+                                input: ctx.value,
+                                code: 'custom',
+                                message: error.message,
+                            });
                         }
 
                         return z.NEVER;

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -9,7 +9,6 @@ import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
 import { isSimpleMatch, isUUID } from '@authup/kit';
 import {
-    OAuth2AuthorizationResponseType,
     OAuth2ClientError,
     OAuth2GrantError,
     OAuth2RequestError,
@@ -23,13 +22,6 @@ import type {
     OAuth2AuthorizationCodeRequestVerificationResult,
     OAuth2AuthorizationCodeRequestVerifierContext,
 } from './types.ts';
-
-function willIssueCode(responseType: string | undefined): boolean {
-    if (!responseType) {
-        return false;
-    }
-    return responseType.split(' ').includes(OAuth2AuthorizationResponseType.CODE);
-}
 
 export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2AuthorizationCodeRequestVerifier {
     protected clientRepository: IOAuth2ClientRepository;
@@ -69,12 +61,11 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
             throw OAuth2ClientError.inactive();
         }
 
-        // Public clients MUST use PKCE for the code flow (RFC 7636 §4.4.1,
-        // OAuth 2.1). Without PKCE a public client's code flow has no second
-        // factor — anyone who intercepts the redirect can redeem the code at
-        // /token. Only enforce when an authorization code will actually be
-        // issued; implicit/id_token-only flows don't involve a code.
-        if (!client.is_confidential && !data.code_challenge && willIssueCode(data.response_type)) {
+        // Public clients MUST use PKCE (RFC 7636 §4.4.1, OAuth 2.1). Without
+        // PKCE a public client's code flow has no second factor — anyone who
+        // intercepts the redirect can redeem the code at /token. The code flow
+        // is the only supported response type, so this holds unconditionally.
+        if (!client.is_confidential && !data.code_challenge) {
             throw OAuth2RequestError.malformed('PKCE code_challenge is required for public clients.');
         }
 
@@ -82,7 +73,7 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
         // initiating session and prevent CSRF (RFC 6749 §10.12). Confidential
         // clients are exempt because the /token exchange already authenticates
         // them via client_secret.
-        if (!client.is_confidential && !data.state && willIssueCode(data.response_type)) {
+        if (!client.is_confidential && !data.state) {
             throw OAuth2RequestError.malformed('state is required for public clients in the code flow.');
         }
 

--- a/apps/server-core/src/core/oauth2/authorization/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/module.ts
@@ -17,7 +17,7 @@ import {
     OAuth2ResponseTypeError,
     hasOAuth2Scopes,
 } from '@authup/specs';
-import type { IOAuth2OpenIDTokenIssuer, IOAuth2TokenIssuer } from '../token/index.ts';
+import type { IOAuth2OpenIDTokenIssuer } from '../token/index.ts';
 import type { IOAuth2AuthorizationCodeIssuer } from './code/index.ts';
 import { buildOAuth2TokenHash } from './helpers.ts';
 import type {
@@ -31,8 +31,6 @@ import type { ISessionManager } from '../../authentication/index.ts';
 const DEFAULT_PROMPT_LOGIN_MAX_AGE = 60;
 
 export class OAuth2Authorization {
-    protected accessTokenIssuer : IOAuth2TokenIssuer;
-
     protected openIdTokenIssuer : IOAuth2OpenIDTokenIssuer;
 
     protected codeIssuer : IOAuth2AuthorizationCodeIssuer;
@@ -44,7 +42,6 @@ export class OAuth2Authorization {
     protected promptLoginMaxAge : number;
 
     constructor(ctx: OAuth2AuthorizationManagerContext) {
-        this.accessTokenIssuer = ctx.accessTokenIssuer;
         this.openIdTokenIssuer = ctx.openIdTokenIssuer;
         this.codeIssuer = ctx.codeIssuer;
         this.identityResolver = ctx.identityResolver;
@@ -64,8 +61,9 @@ export class OAuth2Authorization {
         identity: Identity,
         options: OAuth2AuthorizationOptions = {},
     ) : Promise<OAuth2AuthorizationResult> {
-        const availableResponseTypes : string[] = Object.values(OAuth2AuthorizationResponseType);
-
+        // OAuth 2.1 posture: only the authorization-code response type is
+        // supported — implicit/hybrid (token, id_token, none) were dropped
+        // (plan 042 item 3). Defense in depth behind the request validator.
         let responseTypes : string[] = [];
         if (data.response_type) {
             responseTypes = Array.isArray(data.response_type) ?
@@ -73,14 +71,14 @@ export class OAuth2Authorization {
                 data.response_type.split(' ');
         }
 
-        const enabledResponseTypes : Record<string, boolean> = {};
-
         for (const responseType of responseTypes) {
-            if (!availableResponseTypes.includes(responseType)) {
+            if (responseType !== OAuth2AuthorizationResponseType.CODE) {
                 throw OAuth2ResponseTypeError.unsupported();
-            } else {
-                enabledResponseTypes[responseType] = true;
             }
+        }
+
+        if (!responseTypes.includes(OAuth2AuthorizationResponseType.CODE)) {
+            throw OAuth2ResponseTypeError.unsupported();
         }
 
         if (!data.redirect_uri) {
@@ -147,54 +145,31 @@ export class OAuth2Authorization {
             ...(data.nonce ? { nonce: data.nonce } : {}),
         };
 
-        let codeEntity : OAuth2AuthorizationCode | undefined;
+        const codeEntity : OAuth2AuthorizationCode = await this.codeIssuer.issue(
+            data,
+            identity,
+            { sessionId: options.sessionId },
+        );
 
-        if (enabledResponseTypes[OAuth2AuthorizationResponseType.TOKEN]) {
-            const [token] = await this.accessTokenIssuer.issue(payloadBaseNormalized);
+        output.authorizationCode = codeEntity.id;
 
-            output.accessToken = token;
-        }
-
-        if (enabledResponseTypes[OAuth2AuthorizationResponseType.CODE]) {
-            codeEntity = await this.codeIssuer.issue(
-                data,
-                identity,
-                { sessionId: options.sessionId },
-            );
-
-            output.authorizationCode = codeEntity.id;
-        }
-
-        const needsIdToken = enabledResponseTypes[OAuth2AuthorizationResponseType.ID_TOKEN] ||
-            (data.scope && hasOAuth2Scopes(data.scope, ScopeName.OPEN_ID));
-
-        if (needsIdToken) {
+        // An openid-scoped code carries its id_token on the code blob — the
+        // /token exchange returns it alongside the access token.
+        if (data.scope && hasOAuth2Scopes(data.scope, ScopeName.OPEN_ID)) {
             const idTokenPayload : OAuth2TokenPayload = {
                 ...payloadBaseNormalized,
                 // OIDC id_token claims: real authentication time + session id.
                 auth_time: authTime,
                 ...(options.sessionId ? { sid: options.sessionId } : {}),
+                c_hash: await buildOAuth2TokenHash(codeEntity.id),
             };
-
-            if (output.accessToken) {
-                idTokenPayload.at_hash = await buildOAuth2TokenHash(output.accessToken);
-            }
-            if (output.authorizationCode) {
-                idTokenPayload.c_hash = await buildOAuth2TokenHash(output.authorizationCode);
-            }
 
             const [token] = await this.openIdTokenIssuer.issueWithIdentity(
                 idTokenPayload,
                 identity,
             );
 
-            if (enabledResponseTypes[OAuth2AuthorizationResponseType.ID_TOKEN]) {
-                output.idToken = token;
-            }
-
-            if (codeEntity) {
-                await this.codeIssuer.updateIdToken(codeEntity, token);
-            }
+            await this.codeIssuer.updateIdToken(codeEntity, token);
         }
 
         return output;

--- a/apps/server-core/src/core/oauth2/authorization/types.ts
+++ b/apps/server-core/src/core/oauth2/authorization/types.ts
@@ -5,13 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { IOAuth2OpenIDTokenIssuer, IOAuth2TokenIssuer } from '../token/index.ts';
+import type { IOAuth2OpenIDTokenIssuer } from '../token/index.ts';
 import type { IOAuth2AuthorizationCodeIssuer } from './code/index.ts';
 import type { IIdentityResolver } from '../../identity/index.ts';
 import type { ISessionManager } from '../../authentication/index.ts';
 
 export type OAuth2AuthorizationManagerContext = {
-    accessTokenIssuer: IOAuth2TokenIssuer,
     openIdTokenIssuer: IOAuth2OpenIDTokenIssuer,
     codeIssuer: IOAuth2AuthorizationCodeIssuer,
     identityResolver: IIdentityResolver,
@@ -25,8 +24,6 @@ export type OAuth2AuthorizationManagerContext = {
 
 export type OAuth2AuthorizationResult = {
     authorizationCode?: string,
-    accessToken?: string,
-    idToken?: string,
 
     redirectUri: string,
     state?: string

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -135,13 +135,12 @@ describe('OAuth2AuthorizationCodeRequestVerifier', () => {
             expect(result.client.id).toBe(client.id);
         });
 
-        it('should not require state for public clients in implicit flow', async () => {
+        it('should require PKCE for public clients regardless of response_type (code-only pipeline)', async () => {
             const client = clientRepository.seed({ is_confidential: false });
-            const result = await verifier.verify({
+            await expect(verifier.verify({
                 client_id: client.id,
                 response_type: OAuth2AuthorizationResponseType.TOKEN,
-            });
-            expect(result.client.id).toBe(client.id);
+            })).rejects.toThrow();
         });
 
         it('should flag redirectUriVerified=false for a pattern-less client (open-redirect guard)', async () => {

--- a/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Identity } from '@authup/core-kit';
+import type { Identity, OAuth2AuthorizationCode } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
 import { ErrorCode } from '@authup/errors';
 import { OAuth2AuthorizationResponseType, OAuth2SubKind } from '@authup/specs';
@@ -21,23 +21,21 @@ import type {
     IIdentityResolver,
     IOAuth2AuthorizationCodeIssuer,
     IOAuth2OpenIDTokenIssuer,
-    IOAuth2TokenIssuer,
 } from '../../../../../src/core/index.ts';
 import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
 
-// response_type=none + scope=global reaches the prompt/max_age gate without
-// invoking any issuer, so these stubs must never be called.
+// response_type=code + scope=global exercises the prompt/max_age gate; only
+// the code issuer fires — openid issuance (scope-gated) must never be called.
 const notCalled = (name: string) => async () => {
     throw new Error(`${name} should not be called`);
 };
 
-const accessTokenIssuer = { issue: notCalled('accessTokenIssuer.issue') } as unknown as IOAuth2TokenIssuer;
 const openIdTokenIssuer = {
     issue: notCalled('openIdTokenIssuer.issue'),
     issueWithIdentity: notCalled('openIdTokenIssuer.issueWithIdentity'),
 } as unknown as IOAuth2OpenIDTokenIssuer;
 const codeIssuer = {
-    issue: notCalled('codeIssuer.issue'),
+    issue: async () => ({ id: randomUUID() } as OAuth2AuthorizationCode),
     updateIdToken: notCalled('codeIssuer.updateIdToken'),
 } as unknown as IOAuth2AuthorizationCodeIssuer;
 const identityResolver = { resolve: async () => null } as unknown as IIdentityResolver;
@@ -58,7 +56,7 @@ describe('OAuth2Authorization prompt/max_age enforcement', () => {
     } as unknown as Identity;
 
     const buildData = (extra: Record<string, any> = {}) => ({
-        response_type: OAuth2AuthorizationResponseType.NONE,
+        response_type: OAuth2AuthorizationResponseType.CODE,
         client_id: randomUUID(),
         realm_id: realmId,
         redirect_uri: 'https://example.com/callback',
@@ -80,7 +78,6 @@ describe('OAuth2Authorization prompt/max_age enforcement', () => {
     beforeEach(() => {
         sessionManager = new FakeSessionManager();
         authorization = new OAuth2Authorization({
-            accessTokenIssuer,
             openIdTokenIssuer,
             codeIssuer,
             identityResolver,
@@ -149,5 +146,22 @@ describe('OAuth2Authorization prompt/max_age enforcement', () => {
         // no session seeded / no sessionId → auth_time = now → passes
         const result = await authorization.authorize(buildData({ prompt: 'login', max_age: 0 }), identity, {});
         expect(result.redirectUri).toEqual('https://example.com/callback');
+    });
+
+    it.each([
+        ['token'],
+        ['id_token'],
+        ['none'],
+        ['code token'],
+        ['id_token token'],
+    ])('should reject the dropped response type "%s" (OAuth 2.1)', async (responseType) => {
+        await expect(
+            authorization.authorize(buildData({ response_type: responseType }), identity, {}),
+        ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_RESPONSE_TYPE_UNSUPPORTED }));
+    });
+
+    it('should issue an authorization code for response_type=code', async () => {
+        const result = await authorization.authorize(buildData(), identity, {});
+        expect(result.authorizationCode).toBeDefined();
     });
 });

--- a/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
@@ -5,22 +5,16 @@
  * view the LICENSE file that was distributed with this source code.
  */
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
-import type { OAuth2TokenPayload } from '@authup/specs';
-import {
-    OAuth2AuthorizationResponseType,
-    OAuth2SubKind,
-    OAuth2TokenKind,
-} from '@authup/specs';
-import { extractTokenPayload } from '@authup/server-kit';
-import { createFakeClient } from '../../../../utils';
+import { OAuth2AuthorizationResponseType } from '@authup/specs';
+import { createFakeClient, expectClientError } from '../../../../utils';
 import { createTestApplication } from '../../../../app';
 
 describe('src/http/controllers/token', () => {
@@ -67,75 +61,45 @@ describe('src/http/controllers/token', () => {
         expect(url.searchParams.get('id_token')).toBeFalsy();
     });
 
-    it('should authorize with response_type: id_token', async () => {
-        const response = await suite.client
-            .authorize
-            .confirm({
+    // OAuth 2.1 posture: the authorization endpoint issues codes only — the
+    // implicit/hybrid response types were dropped (plan 042 item 3). Tokens in
+    // the redirect URL leaked via history, proxy logs, and Referer.
+    it.each([
+        [`${OAuth2AuthorizationResponseType.ID_TOKEN}`],
+        [`${OAuth2AuthorizationResponseType.TOKEN}`],
+        [`${OAuth2AuthorizationResponseType.ID_TOKEN} ${OAuth2AuthorizationResponseType.TOKEN}`],
+        [`${OAuth2AuthorizationResponseType.CODE} ${OAuth2AuthorizationResponseType.TOKEN}`],
+        [`${OAuth2AuthorizationResponseType.NONE}`],
+    ])('should reject the dropped response_type: %s', async (responseType) => {
+        await expectClientError(
+            () => suite.client.authorize.confirm({
                 ...payload,
-                response_type: `${OAuth2AuthorizationResponseType.ID_TOKEN}`,
-            });
-
-        expect(response.url).toBeDefined();
-
-        const url = new URL(response.url);
-        expect(url.searchParams.get('access_token')).toBeFalsy();
-        expect(url.searchParams.get('code')).toBeFalsy();
-        expect(url.searchParams.get('id_token')).toBeDefined();
-
-        const tokenPayload = extractTokenPayload(url.searchParams.get('id_token')!) as OAuth2TokenPayload;
-        expect(tokenPayload).toBeDefined();
-
-        expect(tokenPayload.kind).toEqual(OAuth2TokenKind.ID_TOKEN);
-        expect(tokenPayload.realm_id).toBeDefined();
-        expect(tokenPayload.realm_name).toBeDefined();
-        expect(tokenPayload.sub).toBeDefined();
-        expect(tokenPayload.sub_kind).toEqual(OAuth2SubKind.USER);
-
-        // verify claims
-        expect(tokenPayload.name).toBeDefined();
-        expect(tokenPayload.nickname).toBeDefined();
-        expect(tokenPayload.email).toBeDefined();
-        expect(tokenPayload.email_verified).toBeDefined();
+                response_type: responseType,
+            }),
+            { status: 400 },
+        );
     });
 
-    it('should authorize with response_type: token', async () => {
-        const response = await suite.client
-            .authorize
-            .confirm({
+    it('should reject an unknown response_type with a response_type issue', async () => {
+        expect.assertions(2);
+        try {
+            await suite.client.authorize.confirm({
                 ...payload,
-                response_type: `${OAuth2AuthorizationResponseType.TOKEN}`,
+                response_type: 'garbage',
             });
-
-        expect(response.url).toBeDefined();
-
-        const url = new URL(response.url);
-        expect(url.searchParams.get('access_token')).toBeDefined();
-        expect(url.searchParams.get('code')).toBeFalsy();
-        expect(url.searchParams.get('id_token')).toBeFalsy();
-
-        const tokenPayload = extractTokenPayload(url.searchParams.get('access_token')!) as OAuth2TokenPayload;
-        expect(tokenPayload).toBeDefined();
-
-        expect(tokenPayload.kind).toEqual(OAuth2TokenKind.ACCESS);
-        expect(tokenPayload.realm_id).toBeDefined();
-        expect(tokenPayload.realm_name).toBeDefined();
-        expect(tokenPayload.sub).toBeDefined();
-        expect(tokenPayload.sub_kind).toEqual(OAuth2SubKind.USER);
+        } catch (e) {
+            const { response } = (e as { response?: { status?: number, data?: { issues?: { path: string[] }[] } } });
+            expect(response?.status).toEqual(400);
+            expect(response?.data?.issues?.some(
+                (issue) => issue.path.includes('response_type'),
+            )).toBe(true);
+        }
     });
 
-    it('should authorize with response_type: id_token & token', async () => {
-        const response = await suite.client
-            .authorize
-            .confirm({
-                ...payload,
-                response_type: `${OAuth2AuthorizationResponseType.ID_TOKEN} ${OAuth2AuthorizationResponseType.TOKEN}`,
-            });
+    it('should NOT advertise implicit/hybrid response types in discovery', async () => {
+        const configuration = await fetch(`${suite.baseURL}/realms/master/.well-known/openid-configuration`);
+        const body = await configuration.json() as { response_types_supported: string[] };
 
-        expect(response.url).toBeDefined();
-
-        const url = new URL(response.url);
-        expect(url.searchParams.get('access_token')).toBeDefined();
-        expect(url.searchParams.get('code')).toBeFalsy();
-        expect(url.searchParams.get('id_token')).toBeDefined();
+        expect(body.response_types_supported).toEqual([OAuth2AuthorizationResponseType.CODE]);
     });
 });

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -130,6 +130,8 @@ curl -X POST 'http://localhost:3001/token' \
 
 Browser-based applications redirect the user to Authup's hosted `/authorize` page, which handles login and consent. On success the browser is redirected back to the `redirect_uri` with a `code`, which is then exchanged at `/token` (`grant_type=authorization_code`). Public clients must use PKCE (`code_challenge` / `code_verifier`) and `state`.
 
+`response_type=code` is the **only** supported response type (OAuth 2.1 posture): the implicit and hybrid response types (`token`, `id_token`, `none`) are rejected with `unsupported_response_type` — tokens are never delivered via the redirect URL. RPs still relying on implicit must migrate to the code flow with PKCE.
+
 #### Authorize request
 
 ```


### PR DESCRIPTION
Plan 042 item **3**. Decided with the plan: fix the "implicit tokens land in the redirect **query** string" defect (RFC 6749 §4.2.2 requires the fragment) at the source — by dropping the implicit/hybrid response types entirely, per the OAuth 2.1 draft (which removes the implicit grant) and RFC 9700 (OAuth 2.0 Security BCP: implicit MUST NOT be used).

## What changes

- **`response_type=code` is the only supported response type.** The code-request validator rejects `token`, `id_token`, `none`, and any hybrid combination; `OAuth2Authorization.authorize()` enforces the same as defense in depth (`unsupported_response_type`).
- **The authorization response never carries tokens.** `confirm()` loses its `access_token`/`id_token` `searchParams` writes — previously those tokens leaked via browser history, proxy/access logs, and `Referer` (compounding the id_token-hint replay surface, see #3198). An openid-scoped code still mints its id_token onto the code blob (with `c_hash`); the `/token` exchange returns it — unchanged.
- **Discovery** `response_types_supported` now advertises only `code` (previously `code`, `token`, `none`).
- **Verifier tightened:** PKCE + `state` for public clients are now unconditional — the `willIssueCode` gate is dead code with a code-only pipeline (every call site is validator-guarded, including the identity-provider flow, which validates the embedded code request before verifying).
- `OAuth2AuthorizationResult` loses `accessToken`/`idToken`; the now-unused `accessTokenIssuer` was removed from the authorize controller/authorization contexts and wiring.
- client-web's client **URL generator** page now emits `response_type=code`.

## Error surface

At the HTTP layer a dropped response type yields the standard 400 validation shape (a `response_type` issue carrying the `unsupported_response_type` message) — consistent with how every other invalid `/authorize` parameter has always behaved. The precise OAuth2 error object is thrown by the core module (unit-tested). A spec-conformant *error redirect* back to the RP is deliberately not part of this PR — that redirect infrastructure lands with the `prompt=none` work (plan 042 item 10).

## Tests

- unit: rejection matrix (`token`, `id_token`, `none`, `code token`, `id_token token`) + code-issuance assertion in `authorization/module.spec.ts` (spec reworked onto `response_type=code` with a working code-issuer stub)
- unit: verifier spec's "implicit flow skips state" test flipped to a rejection pin
- e2e: `authorize.spec.ts` rewritten — code flow still works, each dropped type 400s with a `response_type` issue, and discovery advertises only `code`

Full server-core suite green (1163 tests; the known pre-existing `grant-authorize` FK flake documented in #3198 surfaced once across four runs, on an untouched code path).

**BREAKING:** any third-party RP using the implicit or hybrid flow against authup must migrate to the authorization code flow with PKCE. Authup's own kit, client-web, SSR pages, and federated IdP flow have always used the code flow — no first-party impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in now uses authorization code flow only, with updated client links and discovery metadata to reflect the supported response type.
  * Public clients must always use PKCE and provide a state value.

* **Bug Fixes**
  * Redirects no longer include access or ID tokens.
  * Unsupported or implicit/hybrid response types are now rejected consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->