### PR TITLE
feat: retain the id_token in the kit store & round-trip client-web logout

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1226,12 +1226,17 @@ uses it: the page deliberately does **not** set `REQUIRED_LOGGED_OUT` (that meta
 makes the routing interceptor run `store.logout()` before the page's setup,
 discarding the id_token), captures `idToken`/`realmId` on mount, runs the
 local-only `store.logout()`, then hard-redirects to
-`buildEndSessionURL({ baseURL, idTokenHint, clientId: 'web', realmId,
+`buildEndSessionURL({ baseURL, idTokenHint, realmId,
 postLogoutRedirectUri: <origin>/login })`. With the hint the server revokes and
 bounces straight back; without it the server's confirm page returns to
-`/login`. `store.logout()` remains local-only — the round-trip is the chosen
-mechanism, **not** a `DELETE /sessions/@me` (which would collide with the #3191
-interactive-login session reuse → self-DoS of fresh logins).
+`/login`. **It passes NO `client_id`**: the id_token's `aud` is the client
+**UUID**, so a name-identified `client_id` (`web`) would fail the server's
+`aud` cross-check and clear `hintVerified` — silently disabling the revoke (the
+round-trip would always degrade to the confirm page). Omitting it lets the
+service resolve the client from the hint's sole `aud`. `store.logout()` remains
+local-only — the round-trip is the chosen mechanism, **not** a
+`DELETE /sessions/@me` (which would collide with the #3191 interactive-login
+session reuse → self-DoS of fresh logins).
 
 ## OAuth2 Token Endpoint Authentication
 

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1213,6 +1213,26 @@ the payload for this gate. **Residual (Keycloak parity):** a *leaked* valid
 id_token can force-logout its own session (annoyance, not privilege escalation)
 — mitigated by the sub-match + short id_token TTL.
 
+**Kit store retains the id_token; client-web round-trips through `/logout`
+(plan 042 items 8a + 8).** The `@authup/client-web-kit` store now keeps the
+grant response's `id_token` as an `idToken` ref (setter emits
+`StoreDispatcherEventName.ID_TOKEN_UPDATED`, cookie-persisted via
+`CookieName.ID_TOKEN`, cleared in `cleanup()`). `applyTokenGrantResponse`
+**retains** the existing value when a response carries none (a refresh grant
+returns no id_token) rather than clearing it. This gives every kit RP an
+`id_token_hint` to pass to the `end_session_endpoint` — without it they all
+degrade to the click-gated confirm page. `apps/client-web/pages/logout.vue`
+uses it: the page deliberately does **not** set `REQUIRED_LOGGED_OUT` (that meta
+makes the routing interceptor run `store.logout()` before the page's setup,
+discarding the id_token), captures `idToken`/`realmId` on mount, runs the
+local-only `store.logout()`, then hard-redirects to
+`buildEndSessionURL({ baseURL, idTokenHint, clientId: 'web', realmId,
+postLogoutRedirectUri: <origin>/login })`. With the hint the server revokes and
+bounces straight back; without it the server's confirm page returns to
+`/login`. `store.logout()` remains local-only — the round-trip is the chosen
+mechanism, **not** a `DELETE /sessions/@me` (which would collide with the #3191
+interactive-login session reuse → self-DoS of fresh logins).
+
 ## OAuth2 Token Endpoint Authentication
 
 The `/token` endpoint authenticates the calling client according to RFC 6749. Confidential clients MUST present a `client_secret`; public clients identify with `client_id` only.

--- a/apps/client-web/pages/logout.vue
+++ b/apps/client-web/pages/logout.vue
@@ -1,13 +1,47 @@
 <script lang="ts">
+/* global window */
+import { CLIENT_WEB_NAME } from '@authup/core-kit';
+import { buildEndSessionURL, injectStore } from '@authup/client-web-kit';
 import { defineNuxtComponent } from '#app';
-import { definePageMeta, navigateTo } from '#imports';
-import { LayoutKey } from '../config/layout';
+import { definePageMeta, onMounted, useRuntimeConfig } from '#imports';
 
 export default defineNuxtComponent({
-    async setup() {
-        definePageMeta({ [LayoutKey.REQUIRED_LOGGED_OUT]: true });
+    setup() {
+        // Deliberately NOT REQUIRED_LOGGED_OUT: that meta makes the routing
+        // interceptor run store.logout() before this page's setup, discarding
+        // the id_token needed for the round-trip. This page owns the sign-out.
+        definePageMeta({ layout: 'auth' });
 
-        await navigateTo({ path: '/login' });
+        const store = injectStore();
+        const runtimeConfig = useRuntimeConfig();
+
+        // Client-only (onMounted never runs during SSR — window is available).
+        onMounted(async () => {
+            // Capture the hint + realm BEFORE the local cleanup clears them.
+            const idTokenHint = store.idToken ?? undefined;
+            const { realmId } = store;
+
+            // Local token/cookie cleanup only (never a server session delete —
+            // that collides with #3191 interactive-login session reuse).
+            await store.logout();
+
+            // Hand off to authup's RP-Initiated Logout endpoint so the shared
+            // authup session is ended too. With the id_token hint the server
+            // revokes and bounces straight back to post_logout_redirect_uri;
+            // without it, the server's click-gated confirm page returns here.
+            window.location.href = buildEndSessionURL({
+                baseURL: runtimeConfig.public.apiUrl as string,
+                idTokenHint,
+                clientId: CLIENT_WEB_NAME,
+                realmId,
+                postLogoutRedirectUri: `${window.location.origin}/login`,
+            });
+        });
     },
 });
 </script>
+<template>
+    <div class="mx-auto w-full max-w-screen-lg px-4 text-center">
+        <span class="fa-solid fa-spinner fa-spin" />
+    </div>
+</template>

--- a/apps/client-web/pages/logout.vue
+++ b/apps/client-web/pages/logout.vue
@@ -1,6 +1,5 @@
 <script lang="ts">
 /* global window */
-import { CLIENT_WEB_NAME } from '@authup/core-kit';
 import { buildEndSessionURL, injectStore } from '@authup/client-web-kit';
 import { defineNuxtComponent } from '#app';
 import { definePageMeta, onMounted, useRuntimeConfig } from '#imports';
@@ -29,10 +28,15 @@ export default defineNuxtComponent({
             // authup session is ended too. With the id_token hint the server
             // revokes and bounces straight back to post_logout_redirect_uri;
             // without it, the server's click-gated confirm page returns here.
+            //
+            // Deliberately NO client_id: the id_token's `aud` is the client's
+            // UUID, so a name-identified client_id (`web`) would fail the
+            // server's aud cross-check and clear hintVerified — disabling the
+            // revoke. Omitting it lets the server resolve the client from the
+            // hint's sole aud and keep the hint verified.
             window.location.href = buildEndSessionURL({
                 baseURL: runtimeConfig.public.apiUrl as string,
                 idTokenHint,
-                clientId: CLIENT_WEB_NAME,
                 realmId,
                 postLogoutRedirectUri: `${window.location.origin}/login`,
             });

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -109,6 +109,22 @@ export function createStore(context: StoreCreateContext) {
 
     // --------------------------------------------------------------------
 
+    // The OIDC id_token from the last grant response. Retained (+ cookie
+    // persisted) so a downstream RP logout can pass it as `id_token_hint` to
+    // the authup `end_session_endpoint` — otherwise every kit RP degrades to
+    // the click-gated confirm page.
+    const idToken = ref<string | null>(null);
+    const setIdToken = (input: string | null) => {
+        idToken.value = input;
+
+        context.dispatcher.emit(
+            StoreDispatcherEventName.ID_TOKEN_UPDATED,
+            input,
+        );
+    };
+
+    // --------------------------------------------------------------------
+
     const user = ref<User | null>(null);
     const userId = computed<string | null>(() => (user.value ? user.value.id : null));
 
@@ -171,6 +187,7 @@ export function createStore(context: StoreCreateContext) {
         setAccessToken(null);
         setAccessTokenExpireDate(null);
         setRefreshToken(null);
+        setIdToken(null);
         setUser(null);
         sessionId.value = null;
         setRealm(null);
@@ -280,6 +297,12 @@ export function createStore(context: StoreCreateContext) {
             setRefreshToken(response.refresh_token);
         } else {
             setRefreshToken(null);
+        }
+
+        // A refresh grant response carries no id_token — keep the retained one
+        // rather than clearing it (the session is unchanged).
+        if (response.id_token) {
+            setIdToken(response.id_token);
         }
     };
 
@@ -409,6 +432,9 @@ export function createStore(context: StoreCreateContext) {
         setAccessTokenExpireDate,
         refreshToken,
         setRefreshToken,
+
+        idToken,
+        setIdToken,
 
         realm,
         realmId,

--- a/packages/client-web-kit/src/core/store/dispatcher/constants.ts
+++ b/packages/client-web-kit/src/core/store/dispatcher/constants.ts
@@ -20,6 +20,8 @@ export enum StoreDispatcherEventName {
 
     REFRESH_TOKEN_UPDATED = 'refreshTokenUpdated',
 
+    ID_TOKEN_UPDATED = 'idTokenUpdated',
+
     USER_UPDATED = 'userUpdated',
 
     REALM_UPDATED = 'realmUpdated',

--- a/packages/client-web-kit/src/core/store/dispatcher/types.ts
+++ b/packages/client-web-kit/src/core/store/dispatcher/types.ts
@@ -23,6 +23,7 @@ export type StoreDispatcherEvents = {
     [StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED]: Date | null,
 
     [StoreDispatcherEventName.REFRESH_TOKEN_UPDATED]: string | null,
+    [StoreDispatcherEventName.ID_TOKEN_UPDATED]: string | null,
     [StoreDispatcherEventName.USER_UPDATED]: User | null,
     [StoreDispatcherEventName.REALM_UPDATED]: RealmMinimal | null,
     [StoreDispatcherEventName.REALM_MANAGEMENT_UPDATED]: RealmMinimal | null,

--- a/packages/client-web-kit/src/core/store/install.ts
+++ b/packages/client-web-kit/src/core/store/install.ts
@@ -99,6 +99,11 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
                         store.setRefreshToken(value);
                     }
                     break;
+                case CookieName.ID_TOKEN:
+                    if (!store.idToken) {
+                        store.setIdToken(value);
+                    }
+                    break;
                 case CookieName.USER:
                     if (!store.user) {
                         store.setUser(value);
@@ -159,6 +164,17 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
                 cookieSet(CookieName.REFRESH_TOKEN, input, {});
             } else {
                 cookieUnset(CookieName.REFRESH_TOKEN, {});
+            }
+        },
+    );
+
+    storeDispatcher.on(
+        StoreDispatcherEventName.ID_TOKEN_UPDATED,
+        (input) => {
+            if (input) {
+                cookieSet(CookieName.ID_TOKEN, input, {});
+            } else {
+                cookieUnset(CookieName.ID_TOKEN, {});
             }
         },
     );

--- a/packages/client-web-kit/test/unit/core/store/id-token.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/id-token.spec.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import { describe, expect, it } from 'vitest';
+import { createStore, createStoreDispatcher } from '../../../../src/core/store';
+
+function buildStore() {
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token': () => ({
+                access_token: 'at',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: 'rt',
+                id_token: 'the-id-token',
+            }),
+            'POST /token/revoke': () => ({}),
+        },
+    });
+
+    const store = createStore({
+        httpClient,
+        dispatcher: createStoreDispatcher(),
+    });
+
+    return { store, httpClient };
+}
+
+describe('core/store/id-token', () => {
+    it('retains the grant response id_token', async () => {
+        const { store } = buildStore();
+
+        expect(store.idToken.value).toBeNull();
+
+        await store.login({ name: 'admin', password: 'start123' });
+
+        expect(store.idToken.value).toEqual('the-id-token');
+    });
+
+    it('clears the id_token on logout', async () => {
+        const { store } = buildStore();
+
+        await store.login({ name: 'admin', password: 'start123' });
+        expect(store.idToken.value).toEqual('the-id-token');
+
+        await store.logout();
+
+        expect(store.idToken.value).toBeNull();
+    });
+
+    it('keeps a retained id_token across a refresh grant response that carries none', async () => {
+        const { store } = buildStore();
+
+        store.setIdToken('previous-id-token');
+        // a refresh response has no id_token — the retained one must survive
+        store.applyTokenGrantResponse({
+            access_token: 'at2',
+            token_type: 'Bearer',
+            expires_in: 3600,
+            refresh_token: 'rt2',
+        });
+
+        expect(store.idToken.value).toEqual('previous-id-token');
+    });
+});

--- a/packages/core-http-kit/src/cookies.ts
+++ b/packages/core-http-kit/src/cookies.ts
@@ -9,6 +9,7 @@ export enum CookieName {
     ACCESS_TOKEN = 'access_token',
     ACCESS_TOKEN_EXPIRE_DATE = 'access_token_expire_date',
     REFRESH_TOKEN = 'refresh_token',
+    ID_TOKEN = 'id_token',
 
     USER = 'user',
     REALM = 'realm',


### PR DESCRIPTION
Plan 042 items **8a** + **8**. Independent of the server-core PRs (#3198–#3200) — branches off master.

## 8a — the kit store retains the id_token

`applyTokenGrantResponse` kept only the access/refresh tokens, so **no kit-based RP could pass an `id_token_hint`** to the new `end_session_endpoint` (#3196) — every logout degraded to the click-gated confirm page.

- new `idToken` ref + `setIdToken` setter emitting `StoreDispatcherEventName.ID_TOKEN_UPDATED`
- cookie persistence via a new `CookieName.ID_TOKEN` (`@authup/core-http-kit`) + the install-time read/write handlers, mirroring the access/refresh token pattern
- cleared in `cleanup()`
- `applyTokenGrantResponse` **retains** the existing id_token when a response carries none — a refresh grant returns no id_token, and the session is unchanged, so the hint must survive a token refresh

## 8 — client-web round-trips through `/logout`

`apps/client-web/pages/logout.vue` previously just `navigateTo('/login')` after the interceptor's local cleanup — the shared authup-origin session survived. Now the page owns the sign-out:

- it deliberately **drops `REQUIRED_LOGGED_OUT`** — that meta made the routing interceptor run `store.logout()` *before* the page's setup, discarding the id_token the round-trip needs
- on mount it captures `idToken`/`realmId`, runs the local-only `store.logout()`, then hard-redirects to `buildEndSessionURL({ baseURL, idTokenHint, clientId: 'web', realmId, postLogoutRedirectUri: <origin>/login })`
- with the hint, the server revokes the session and bounces straight back to `/login`; without it, the server's click-gated confirm page returns to `/login`

`store.logout()` stays **local-only** — the round-trip is the chosen mechanism, **not** a `DELETE /sessions/@me` (established in plan 041: that collides with the #3191 interactive-login session reuse → self-DoS of fresh logins).

## Tests

New `packages/client-web-kit/test/unit/core/store/id-token.spec.ts`: the grant response id_token is retained; cleared on logout; and a refresh-shaped response (no id_token) keeps the retained one. Full client-web-kit suite green (21), core-http-kit green (19), client-web `nuxi typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sign-out now keeps the login flow seamless by using the current session token during logout redirects.
  * The client app now shows a loading state while completing sign-out instead of immediately redirecting.

* **Bug Fixes**
  * Improved logout reliability by preserving the token needed for post-logout redirects.
  * Logout now clears local session data while still supporting the full sign-out round trip.

* **Documentation**
  * Updated architecture notes to describe the revised logout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->