### PR TITLE
fix: scope the id_token_hint exp-bypass so an expired token cannot poison the claims cache

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1241,7 +1241,14 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
 - **id_token_hint** is verified by `OAuth2TokenVerifier` with a new
   `ignoreExpiry` option — signature, nbf and (crucially) **kind** still apply;
   only `exp` is skipped (a logout hint is routinely expired). The option threads
-  down to server-kit's `verifyToken` (`validateExp: false`). A hint whose `kind
+  down to server-kit's `verifyToken` (`validateExp: false`). The `ignoreExpiry`
+  verify path **must NOT populate the shared signature-keyed claims cache**
+  (`OAuth2TokenVerifier.verify` skips `saveWithSignature` when `ignoreExpiry` is
+  set): otherwise an expired token re-caches with `buildTTL`'s 1h fallback (a
+  past `exp` → non-positive ttl → 3600s) and the cache-first branch returns it
+  with no `exp` re-check on every later verify — so `/token/introspect` would
+  report an expired token as `active` for up to an hour (RFC 7662). The
+  exp-bypass stays scoped to the single end-session call. A hint whose `kind
   !== id_token` is **rejected** (access/refresh tokens also carry `session_id`,
   so accepting them would let a leaked access token force a logout). `aud` vs
   request `client_id` cross-checked when both present — note the id_token `aud`

--- a/apps/server-core/src/core/oauth2/token/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/token/verifier/module.ts
@@ -122,7 +122,17 @@ export class OAuth2TokenVerifier implements IOAuth2TokenVerifier {
             throw JWTError.payloadPropertyInvalid('jti');
         }
 
-        await this.tokenRepository.saveWithSignature(payload, token);
+        // Never populate the shared signature-keyed claims cache on the
+        // exp-ignoring path. An expired token verified with `ignoreExpiry`
+        // (the RP-initiated-logout id_token_hint) would otherwise be re-cached
+        // with buildTTL's 1h fallback (a past exp yields a non-positive ttl),
+        // and the cache-first branch above returns it with no exp re-check on
+        // every subsequent verify — so `/token/introspect` would report an
+        // expired token as active for up to an hour (RFC 7662). Keep the
+        // exp-bypass scoped to this single call.
+        if (!options.ignoreExpiry) {
+            await this.tokenRepository.saveWithSignature(payload, token);
+        }
 
         if (!options.skipActiveCheck) {
             const isInactive = await this.isInactive(payload.jti);

--- a/apps/server-core/test/unit/core/helpers/fake-oauth2-openid-token-issuer.ts
+++ b/apps/server-core/test/unit/core/helpers/fake-oauth2-openid-token-issuer.ts
@@ -24,10 +24,10 @@ export class FakeOAuth2OpenIDTokenIssuer implements IOAuth2OpenIDTokenIssuer {
         this.issueCalls.push(input);
         const jti = randomUUID();
         return [`id-token-${jti}`, {
-            ...input, 
-            jti, 
-            exp: this.exp, 
-        } as OAuth2TokenPayload];
+            ...input,
+            jti,
+            exp: this.exp,
+        }];
     }
 
     async issueWithIdentity(

--- a/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
@@ -5,22 +5,40 @@
  * view the LICENSE file that was distributed with this source code.
  */
 import { describe, expect, it } from 'vitest';
-import type { OAuth2IdentityProvider } from '@authup/core-kit';
+import type { OAuth2IdentityProvider, Realm } from '@authup/core-kit';
 import { IdentityProviderProtocol } from '@authup/core-kit';
 import { createNanoID } from '@authup/kit';
 import { BadRequestError, isBadRequestError } from '@authup/errors';
 import type { IIdentityProviderAccountManager } from '../../../../../src/core';
 import { IdentityProviderOAuth2Authenticator } from '../../../../../src/core';
 
-function createAuthenticator(authorizeURL: unknown) {
-    const provider = {
+function createAuthenticator(authorizeURL: string) {
+    const realm: Realm = {
         id: createNanoID(),
+        name: 'master',
+        display_name: null,
+        description: null,
+        built_in: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+    };
+
+    const provider: OAuth2IdentityProvider = {
+        id: createNanoID(),
+        name: 'idp',
+        display_name: null,
         protocol: IdentityProviderProtocol.OAUTH2,
+        preset: null,
+        enabled: true,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+        realm_id: realm.id,
+        realm,
         client_id: 'client-id',
         client_secret: 'client-secret',
         token_url: 'https://idp.example.com/token',
         authorize_url: authorizeURL,
-    } as OAuth2IdentityProvider;
+    };
 
     return new IdentityProviderOAuth2Authenticator({
         options: { baseURL: 'https://authup.example.com/' },

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -23,12 +23,39 @@ class FakeClientRepository implements IOAuth2ClientRepository {
     private clients: Client[] = [];
 
     seed(client: Partial<Client>): Client {
-        const entity = {
+        const now = new Date().toISOString();
+        const realmId = randomUUID();
+        const entity: Client = {
             id: randomUUID(),
             active: true,
+            built_in: false,
             is_confidential: false,
+            name: 'client',
+            display_name: null,
+            description: null,
+            secret: null,
+            secret_hashed: false,
+            secret_encrypted: false,
+            redirect_uri: null,
+            post_logout_redirect_uri: null,
+            grant_types: null,
+            scope: null,
+            base_url: null,
+            root_url: null,
+            created_at: now,
+            updated_at: now,
+            realm_id: realmId,
+            realm: {
+                id: realmId,
+                name: 'master',
+                display_name: null,
+                description: null,
+                built_in: true,
+                created_at: now,
+                updated_at: now,
+            },
             ...client,
-        } as Client;
+        };
         this.clients.push(entity);
         return entity;
     }

--- a/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Identity, OAuth2AuthorizationCode } from '@authup/core-kit';
+import type { Identity } from '@authup/core-kit';
 import { ScopeName } from '@authup/core-kit';
 import { ErrorCode } from '@authup/errors';
 import { OAuth2AuthorizationResponseType, OAuth2SubKind } from '@authup/specs';
@@ -27,16 +27,18 @@ import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
 // No id_token is minted here anymore (that moved to the /token exchange), so no
 // openid-issuer stub is needed.
 const issueCalls: OAuth2AuthorizationCodeIssuerOptions[] = [];
-const codeIssuer = {
-    issue: async (
-        _input: unknown,
-        _identity: unknown,
-        options: OAuth2AuthorizationCodeIssuerOptions = {},
-    ) => {
+const codeIssuer: IOAuth2AuthorizationCodeIssuer = {
+    issue: async (_input, _identity, options = {}) => {
         issueCalls.push(options);
-        return { id: randomUUID() } as OAuth2AuthorizationCode;
+        return {
+            id: randomUUID(),
+            sub: randomUUID(),
+            sub_kind: OAuth2SubKind.USER,
+            realm_id: randomUUID(),
+            realm_name: 'master',
+        };
     },
-} as unknown as IOAuth2AuthorizationCodeIssuer;
+};
 
 describe('OAuth2Authorization prompt/max_age enforcement', () => {
     const realmId = randomUUID();
@@ -45,13 +47,40 @@ describe('OAuth2Authorization prompt/max_age enforcement', () => {
     let sessionManager: FakeSessionManager;
     let authorization: OAuth2Authorization;
 
-    const identity = {
+    const identity: Identity = {
         type: OAuth2SubKind.USER,
         data: {
             id: randomUUID(),
-            realm: { id: realmId, name: 'master' },
+            name: 'user',
+            name_locked: false,
+            first_name: null,
+            last_name: null,
+            display_name: null,
+            email: 'user@example.com',
+            password: null,
+            avatar: null,
+            cover: null,
+            reset_hash: null,
+            reset_at: null,
+            reset_expires: null,
+            status: null,
+            status_message: null,
+            active: true,
+            activate_hash: null,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+            realm_id: realmId,
+            realm: {
+                id: realmId,
+                name: 'master',
+                display_name: null,
+                description: null,
+                built_in: true,
+                created_at: new Date().toISOString(),
+                updated_at: new Date().toISOString(),
+            },
         },
-    } as unknown as Identity;
+    };
 
     const buildData = (extra: Record<string, any> = {}) => ({
         response_type: OAuth2AuthorizationResponseType.CODE,

--- a/apps/server-core/test/unit/core/oauth2/end-session/service.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/end-session/service.spec.ts
@@ -19,24 +19,49 @@ import { OAuth2EndSessionService } from '../../../../../src/core/oauth2/end-sess
 import type {
     IOAuth2ClientRepository,
     IOAuth2TokenVerifier,
-    IRealmRepository,
 } from '../../../../../src/core/index.ts';
 import { FakeSessionManager } from '../../helpers/fake-session-manager.ts';
+import { FakeRealmRepository } from '../../entities/realm/fake-repository.ts';
 
 const realmId = randomUUID();
 const clientId = randomUUID();
 
-const client = {
+const realm: Realm = {
+    id: realmId,
+    name: 'master',
+    display_name: null,
+    description: null,
+    built_in: true,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+};
+
+const client: Client = {
     id: clientId,
+    active: true,
+    built_in: true,
+    is_confidential: false,
     name: 'web',
-    realm_id: realmId,
+    display_name: null,
+    description: null,
+    secret: null,
+    secret_hashed: false,
+    secret_encrypted: false,
     redirect_uri: 'https://app.example.com/**',
     post_logout_redirect_uri: 'https://app.example.com/**',
-} as Client;
+    grant_types: null,
+    scope: null,
+    base_url: null,
+    root_url: null,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    realm_id: realmId,
+    realm,
+};
 
-const realmRepository = { resolve: async () => ({ id: realmId, name: 'master' } as Realm) } as unknown as IRealmRepository;
+const realmRepository = new FakeRealmRepository();
 
-const clientRepository = { findOneByIdOrName: async () => client } as unknown as IOAuth2ClientRepository;
+const clientRepository: IOAuth2ClientRepository = { findOneByIdOrName: async () => client };
 
 // A token-verifier stub whose behavior is set per test.
 function buildVerifier(behavior: () => Promise<OAuth2TokenPayload>): IOAuth2TokenVerifier {
@@ -179,15 +204,15 @@ describe('OAuth2EndSessionService', () => {
     it('should validate against post_logout_redirect_uri, NOT redirect_uri (dedicated column)', async () => {
         // a client whose login redirect_uri would match but whose dedicated
         // post-logout allow-list does NOT — the redirect must be dropped
-        const narrowClient = {
+        const narrowClient: Client = {
             ...client,
             redirect_uri: 'https://app.example.com/**',
             post_logout_redirect_uri: 'https://app.example.com/only-here/**',
-        } as Client;
+        };
         const service = new OAuth2EndSessionService({
             tokenVerifier: buildVerifier(async () => validPayload),
             sessionManager,
-            clientRepository: { findOneByIdOrName: async () => narrowClient } as unknown as IOAuth2ClientRepository,
+            clientRepository: { findOneByIdOrName: async () => narrowClient },
             realmRepository,
         });
 

--- a/apps/server-core/test/unit/core/oauth2/token/issuer/open-id/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/issuer/open-id/module.spec.ts
@@ -7,7 +7,6 @@
 
 import { randomUUID } from 'node:crypto';
 import type { Identity, Realm, User } from '@authup/core-kit';
-import type { OAuth2TokenPayload } from '@authup/specs';
 import { JWTError, OAuth2SubKind, OAuth2TokenKind } from '@authup/specs';
 import {
     beforeEach,
@@ -26,20 +25,39 @@ describe('OAuth2OpenIDTokenIssuer', () => {
     const userId = randomUUID();
     const clientId = randomUUID();
 
-    const user = {
+    const realm: Realm = {
+        id: realmId,
+        name: 'master',
+        display_name: null,
+        description: null,
+        built_in: true,
+        created_at: '2025-01-01T00:00:00.000Z',
+        updated_at: '2025-01-01T00:00:00.000Z',
+    };
+
+    const user: User = {
         id: userId,
         name: 'jdoe',
+        name_locked: false,
         first_name: 'John',
         last_name: 'Doe',
         display_name: 'John Doe',
         email: 'john@example.com',
+        password: null,
+        avatar: null,
+        cover: null,
+        reset_hash: null,
+        reset_at: null,
+        reset_expires: null,
+        status: null,
+        status_message: null,
         active: true,
+        activate_hash: null,
+        created_at: '2025-01-01T00:00:00.000Z',
+        updated_at: '2025-01-01T00:00:00.000Z',
         realm_id: realmId,
-        realm: {
-            id: realmId,
-            name: 'master',
-        } as Realm,
-    } as User;
+        realm,
+    };
 
     const identity: Identity = {
         type: OAuth2SubKind.USER,
@@ -69,8 +87,8 @@ describe('OAuth2OpenIDTokenIssuer', () => {
             resolver.setIdentity(identity);
             const issuer = createIssuer({ identityResolver: resolver });
 
-            await expect(issuer.issue({ sub: userId } as OAuth2TokenPayload)).rejects.toThrow(JWTError);
-            await expect(issuer.issue({ sub_kind: OAuth2SubKind.USER } as OAuth2TokenPayload)).rejects.toThrow(JWTError);
+            await expect(issuer.issue({ sub: userId })).rejects.toThrow(JWTError);
+            await expect(issuer.issue({ sub_kind: OAuth2SubKind.USER })).rejects.toThrow(JWTError);
         });
 
         it('should throw when identity cannot be resolved', async () => {
@@ -79,7 +97,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
             await expect(issuer.issue({
                 sub: userId,
                 sub_kind: OAuth2SubKind.USER,
-            } as OAuth2TokenPayload)).rejects.toThrow(JWTError);
+            })).rejects.toThrow(JWTError);
         });
 
         it('should resolve identity and issue token', async () => {
@@ -91,7 +109,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                 sub: userId,
                 sub_kind: OAuth2SubKind.USER,
                 realm_id: realmId,
-            } as OAuth2TokenPayload);
+            });
             expect(token).toBe('signed-id-token');
         });
     });
@@ -105,7 +123,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                 {
                     sub: userId,
                     realm_id: realmId,
-                } as OAuth2TokenPayload,
+                },
                 identity,
             );
 
@@ -132,7 +150,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                     sub: userId,
                     realm_id: realmId,
                     auth_time: authTime,
-                } as OAuth2TokenPayload,
+                },
                 identity,
             );
 
@@ -148,7 +166,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                     realm_id: realmId,
                     realm_name: 'master',
                     client_id: clientId,
-                } as OAuth2TokenPayload,
+                },
                 identity,
             );
 
@@ -165,7 +183,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                     sub: userId,
                     realm_id: realmId,
                     client_id: clientId,
-                } as OAuth2TokenPayload,
+                },
                 identity,
             );
 
@@ -182,7 +200,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                     sub: userId,
                     realm_id: realmId,
                     client_id: clientId,
-                } as OAuth2TokenPayload,
+                },
                 identity,
             );
 
@@ -198,7 +216,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
                 {
                     sub: userId,
                     realm_id: realmId,
-                } as OAuth2TokenPayload,
+                },
                 identity,
             );
 

--- a/apps/server-core/test/unit/core/oauth2/token/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/verifier/module.spec.ts
@@ -25,12 +25,32 @@ vi.mock('@authup/server-kit', () => ({
     verifyToken: vi.fn(),
 }));
 
-function createKey(type: string, overrides: Partial<Key> = {}): Key {
+const TIMESTAMP = '2026-01-01T00:00:00.000Z';
+
+function createKey(type: `${JWKType}`, overrides: Partial<Key> = {}): Key {
+    const realmId = randomUUID();
+
     return {
         id: randomUUID(),
         type,
+        signature_algorithm: 'RS256',
+        priority: 0,
+        decryption_key: null,
+        encryption_key: null,
+        created_at: TIMESTAMP,
+        updated_at: TIMESTAMP,
+        realm_id: realmId,
+        realm: {
+            id: realmId,
+            name: 'master',
+            display_name: null,
+            description: null,
+            built_in: true,
+            created_at: TIMESTAMP,
+            updated_at: TIMESTAMP,
+        },
         ...overrides,
-    } as unknown as Key;
+    };
 }
 
 function createPayload(overrides: Partial<OAuth2TokenPayload> = {}): OAuth2TokenPayload {
@@ -38,7 +58,7 @@ function createPayload(overrides: Partial<OAuth2TokenPayload> = {}): OAuth2Token
         jti: randomUUID(),
         sub: 'u1',
         ...overrides,
-    } as OAuth2TokenPayload;
+    };
 }
 
 describe('OAuth2TokenVerifier', () => {
@@ -77,7 +97,7 @@ describe('OAuth2TokenVerifier', () => {
 
         it('should throw JWTError when cached payload has no jti', async () => {
             const tokenRepo = new FakeOAuth2TokenRepository();
-            tokenRepo.seedSignature('cached-token', { sub: 'u1' } as OAuth2TokenPayload);
+            tokenRepo.seedSignature('cached-token', { sub: 'u1' });
             const verifier = new OAuth2TokenVerifier(new FakeOAuth2KeyRepository(), tokenRepo);
 
             await expect(verifier.verify('cached-token')).rejects.toThrow(JWTError);
@@ -122,7 +142,7 @@ describe('OAuth2TokenVerifier', () => {
 
         it('should verify OCT token and cache result', async () => {
             const payload = createPayload();
-            const key = createKey(JWKType.OCT, { decryption_key: 'secret' } as any);
+            const key = createKey(JWKType.OCT, { decryption_key: 'secret' });
             const tokenRepo = new FakeOAuth2TokenRepository();
             extractTokenHeader.mockReturnValue({ kid: key.id });
             verifyToken.mockResolvedValue(payload);
@@ -138,7 +158,7 @@ describe('OAuth2TokenVerifier', () => {
             // would report the expired token as valid/active for buildTTL's 1h
             // fallback, e.g. /token/introspect returning active:true (RFC 7662).
             const payload = createPayload({ exp: Math.floor(Date.now() / 1000) - 3600 });
-            const key = createKey(JWKType.OCT, { decryption_key: 'secret' } as any);
+            const key = createKey(JWKType.OCT, { decryption_key: 'secret' });
             const tokenRepo = new FakeOAuth2TokenRepository();
             extractTokenHeader.mockReturnValue({ kid: key.id });
             verifyToken.mockResolvedValue(payload);
@@ -153,7 +173,7 @@ describe('OAuth2TokenVerifier', () => {
         });
 
         it('should throw JWKError when OCT key has no decryption_key', async () => {
-            const key = createKey(JWKType.OCT, { decryption_key: null } as any);
+            const key = createKey(JWKType.OCT, { decryption_key: null });
             extractTokenHeader.mockReturnValue({ kid: key.id });
 
             const verifier = new OAuth2TokenVerifier(new FakeOAuth2KeyRepository(key), new FakeOAuth2TokenRepository());
@@ -165,7 +185,7 @@ describe('OAuth2TokenVerifier', () => {
             const key = createKey(JWKType.EC, {
                 encryption_key: 'ec-public-key',
                 signature_algorithm: 'ES256',
-            } as any);
+            });
             extractTokenHeader.mockReturnValue({ kid: key.id });
             verifyToken.mockResolvedValue(payload);
 
@@ -174,7 +194,7 @@ describe('OAuth2TokenVerifier', () => {
         });
 
         it('should throw JWKError when EC key has no encryption_key', async () => {
-            const key = createKey(JWKType.EC, { encryption_key: null } as any);
+            const key = createKey(JWKType.EC, { encryption_key: null });
             extractTokenHeader.mockReturnValue({ kid: key.id });
 
             const verifier = new OAuth2TokenVerifier(new FakeOAuth2KeyRepository(key), new FakeOAuth2TokenRepository());
@@ -186,7 +206,7 @@ describe('OAuth2TokenVerifier', () => {
             const key = createKey(JWKType.RSA, {
                 encryption_key: 'rsa-public-key',
                 signature_algorithm: 'RS256',
-            } as any);
+            });
             extractTokenHeader.mockReturnValue({ kid: key.id });
             verifyToken.mockResolvedValue(payload);
 
@@ -195,9 +215,9 @@ describe('OAuth2TokenVerifier', () => {
         });
 
         it('should throw JWTError when verified payload has no jti', async () => {
-            const key = createKey(JWKType.OCT, { decryption_key: 'secret' } as any);
+            const key = createKey(JWKType.OCT, { decryption_key: 'secret' });
             extractTokenHeader.mockReturnValue({ kid: key.id });
-            verifyToken.mockResolvedValue({ sub: 'u1' } as OAuth2TokenPayload);
+            verifyToken.mockResolvedValue({ sub: 'u1' });
 
             const verifier = new OAuth2TokenVerifier(new FakeOAuth2KeyRepository(key), new FakeOAuth2TokenRepository());
             await expect(verifier.verify('raw-token')).rejects.toThrow(JWTError);
@@ -205,7 +225,7 @@ describe('OAuth2TokenVerifier', () => {
 
         it('should check active status after crypto verification', async () => {
             const payload = createPayload();
-            const key = createKey(JWKType.OCT, { decryption_key: 'secret' } as any);
+            const key = createKey(JWKType.OCT, { decryption_key: 'secret' });
             const tokenRepo = new FakeOAuth2TokenRepository();
             await tokenRepo.setInactive(payload.jti!);
             extractTokenHeader.mockReturnValue({ kid: key.id });
@@ -218,7 +238,7 @@ describe('OAuth2TokenVerifier', () => {
 
         it('should skip active check in crypto path when skipActiveCheck is true', async () => {
             const payload = createPayload();
-            const key = createKey(JWKType.OCT, { decryption_key: 'secret' } as any);
+            const key = createKey(JWKType.OCT, { decryption_key: 'secret' });
             const tokenRepo = new FakeOAuth2TokenRepository();
             await tokenRepo.setInactive(payload.jti!);
             extractTokenHeader.mockReturnValue({ kid: key.id });

--- a/apps/server-core/test/unit/core/oauth2/token/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/verifier/module.spec.ts
@@ -132,6 +132,26 @@ describe('OAuth2TokenVerifier', () => {
             expect(tokenRepo.saveWithSignatureCalls).toContainEqual({ payload, signature: 'raw-token' });
         });
 
+        it('should NOT populate the signature cache when ignoreExpiry is set', async () => {
+            // Regression: an expired id_token_hint verified with ignoreExpiry must
+            // not be re-cached — otherwise the cache-first branch (no exp re-check)
+            // would report the expired token as valid/active for buildTTL's 1h
+            // fallback, e.g. /token/introspect returning active:true (RFC 7662).
+            const payload = createPayload({ exp: Math.floor(Date.now() / 1000) - 3600 });
+            const key = createKey(JWKType.OCT, { decryption_key: 'secret' } as any);
+            const tokenRepo = new FakeOAuth2TokenRepository();
+            extractTokenHeader.mockReturnValue({ kid: key.id });
+            verifyToken.mockResolvedValue(payload);
+
+            const verifier = new OAuth2TokenVerifier(new FakeOAuth2KeyRepository(key), tokenRepo);
+            expect(
+                await verifier.verify('expired-hint', { ignoreExpiry: true, skipActiveCheck: true }),
+            ).toBe(payload);
+
+            expect(tokenRepo.saveWithSignatureCalls).toHaveLength(0);
+            expect(await tokenRepo.findOneBySignature('expired-hint')).toBeNull();
+        });
+
         it('should throw JWKError when OCT key has no decryption_key', async () => {
             const key = createKey(JWKType.OCT, { decryption_key: null } as any);
             extractTokenHeader.mockReturnValue({ kid: key.id });

--- a/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-openid.spec.ts
@@ -18,20 +18,35 @@ import { RealmController } from '../../../../../src/adapters/http/controllers/en
 import type { KeyEntity } from '../../../../../src/adapters/database/domains/index.ts';
 
 function createController(realm: Realm, baseURL = 'https://auth.example.com') {
-    const service: Pick<IRealmService, 'getOne'> = { getOne: async () => realm };
+    const notImplemented = async () => {
+        throw new Error('not implemented');
+    };
+    const service: IRealmService = {
+        getOne: async () => realm,
+        getMany: notImplemented,
+        create: notImplemented,
+        update: notImplemented,
+        save: notImplemented,
+        delete: notImplemented,
+    };
     return new RealmController({
         options: { baseURL },
-        service: service as IRealmService,
+        service,
         keyRepository: {} as Repository<KeyEntity>,
     });
 }
 
 describe('RealmController.getOpenIdConfiguration', () => {
     const realmId = randomUUID();
-    const realm = {
+    const realm: Realm = {
         id: realmId,
         name: 'master',
-    } as Realm;
+        display_name: null,
+        description: null,
+        built_in: true,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+    };
 
     it('should construct issuer from realm name (matching the JWT iss claim format)', async () => {
         const controller = createController(realm);

--- a/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
@@ -249,7 +249,7 @@ describe('end-session (/logout)', () => {
 
     it('should reach the discovery-advertised end_session_endpoint', async () => {
         const config = await httpRequest(suite, 'GET', `/realms/${realm.name}/.well-known/openid-configuration`);
-        const body = await config.json() as { end_session_endpoint?: string };
+        const body: { end_session_endpoint?: string } = await config.json();
         expect(body.end_session_endpoint).toBeDefined();
         expect(body.end_session_endpoint!.endsWith('/logout')).toBe(true);
     });

--- a/apps/server-core/test/unit/http/controllers/workflows/oidc-conformance.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/oidc-conformance.spec.ts
@@ -107,7 +107,7 @@ describe('OIDC conformance smoke', () => {
         // discovery endpoints are built from publicUrl (not the random test
         // port), so fetch the JWKS from the running test server directly.
         const response = await fetch(`${suite.baseURL}/realms/${REALM_MASTER_NAME}/jwks`);
-        const body = await response.json() as { keys: Record<string, any>[] };
+        const body: { keys: Record<string, any>[] } = await response.json();
 
         expect(Array.isArray(body.keys)).toBe(true);
         expect(body.keys.length).toBeGreaterThan(0);
@@ -159,11 +159,7 @@ describe('OIDC conformance smoke', () => {
         });
 
         expect(tokens.id_token).toBeDefined();
-        const payload = decodeJwtPayload(tokens.id_token!) as OAuth2TokenPayload & {
-            iss?: string, 
-            aud?: string, 
-            iat?: number 
-        };
+        const payload: OAuth2TokenPayload = decodeJwtPayload(tokens.id_token!);
 
         // OIDC Core §2 REQUIRED id_token claims
         expect(payload.kind).toEqual(OAuth2TokenKind.ID_TOKEN);

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize-realm-gate.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize-realm-gate.spec.ts
@@ -74,13 +74,13 @@ describe('grant-authorize realm gate (layer 2)', () => {
 
         // mint a code for realm-B's client, but authorized by a realm-A identity
         // (realm_id is taken from the identity → realm A)
-        const identity = {
+        const identity: Identity = {
             type: IdentityType.USER,
             data: {
-                id: user.id,
-                realm: { id: realmA.id, name: realmA.name },
+                ...user,
+                realm: realmA,
             },
-        } as unknown as Identity;
+        };
 
         const code = await codeIssuer.issue(
             {
@@ -114,13 +114,13 @@ describe('grant-authorize realm gate (layer 2)', () => {
         const codeVerifier = generateOAuth2CodeVerifier();
         const codeChallenge = await buildOAuth2CodeChallenge(codeVerifier);
 
-        const identity = {
+        const identity: Identity = {
             type: IdentityType.USER,
             data: {
-                id: user.id,
-                realm: { id: realmB.id, name: realmB.name },
+                ...user,
+                realm: realmB,
             },
-        } as unknown as Identity;
+        };
 
         const code = await codeIssuer.issue(
             {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-authorize.spec.ts
@@ -20,6 +20,7 @@ import {
     OAuth2ErrorCode,
 } from '@authup/specs';
 import { ErrorCode } from '@authup/errors';
+import { isClientError } from 'hapic';
 import { buildOAuth2CodeChallenge, generateOAuth2CodeVerifier } from '../../../../../../src/core';
 import {
     createFakeClient,
@@ -674,8 +675,8 @@ describe('grant-authorize', () => {
                 code_challenge_method: OAuth2AuthorizationCodeChallengeMethod.SHA_256,
                 state: generateOAuth2CodeVerifier(),
             });
-        } catch (e: any) {
-            const data = e?.response?.data ?? {};
+        } catch (e) {
+            const data = (isClientError(e) ? e.response?.data : undefined) ?? {};
             expect(data.code).toEqual(ErrorCode.OAUTH_LOGIN_REQUIRED);
             // no identity / realm enumeration surface in the body
             expect(data).not.toHaveProperty('realm_id');

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-idp-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-idp-authorize.spec.ts
@@ -221,7 +221,7 @@ describe('identity-provider authorization code grant', () => {
                 code: authupCode!,
             });
 
-        let error: any;
+        let error: unknown;
 
         try {
             await suite.client

--- a/packages/client-web-kit/test/unit/components/workflows/authorize-form-silent.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize-form-silent.spec.ts
@@ -30,16 +30,39 @@ const codeRequest: OAuth2AuthorizationCodeRequest = {
     redirect_uri: 'https://app.example.com/cb',
     scope: 'global openid',
     state: 'state-1',
-} as OAuth2AuthorizationCodeRequest;
+};
 
 // built_in → auto-consent fires the POST /authorize on mount.
-const client = {
+const client: Client = {
     id: 'client-1',
+    active: true,
+    built_in: true,
+    is_confidential: false,
     name: 'web',
     display_name: 'Web',
-    built_in: true,
+    description: null,
+    secret: null,
+    secret_hashed: false,
+    secret_encrypted: false,
+    redirect_uri: null,
+    post_logout_redirect_uri: null,
+    grant_types: null,
+    scope: null,
+    base_url: null,
+    root_url: null,
     created_at: new Date(0).toISOString(),
-} as Client;
+    updated_at: new Date(0).toISOString(),
+    realm_id: 'realm-x',
+    realm: {
+        id: 'realm-x',
+        name: 'master',
+        display_name: null,
+        description: null,
+        built_in: true,
+        created_at: new Date(0).toISOString(),
+        updated_at: new Date(0).toISOString(),
+    },
+};
 
 // a non-login_required failure (transient 500 / network blip)
 const failHandler: FakeHandler = () => { throw new Error('boom'); };

--- a/packages/client-web-kit/test/unit/components/workflows/authorize-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize-form.spec.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Client, OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
+import type { Client, OAuth2AuthorizationCodeRequest, Realm } from '@authup/core-kit';
 import { createFakeClient } from '@authup/core-http-kit/testing';
 import { OAuth2ErrorCode } from '@authup/specs';
 import { flushPromises, mount } from '@vue/test-utils';
@@ -25,16 +25,43 @@ const codeRequest: OAuth2AuthorizationCodeRequest = {
     redirect_uri: 'https://app.example.com/cb',
     scope: 'global openid',
     state: 'state-1',
-} as OAuth2AuthorizationCodeRequest;
+};
+
+const now = new Date(0).toISOString();
+
+const realm: Realm = {
+    id: 'realm-x',
+    name: 'master',
+    display_name: null,
+    description: null,
+    built_in: true,
+    created_at: now,
+    updated_at: now,
+};
 
 // built_in → auto-consent fires the POST /authorize on mount.
-const client = {
+const client: Client = {
     id: 'client-1',
+    active: true,
+    built_in: true,
+    is_confidential: false,
     name: 'web',
     display_name: 'Web',
-    built_in: true,
-    created_at: new Date(0).toISOString(),
-} as Client;
+    description: null,
+    secret: null,
+    secret_hashed: false,
+    secret_encrypted: false,
+    redirect_uri: null,
+    post_logout_redirect_uri: null,
+    grant_types: null,
+    scope: null,
+    base_url: null,
+    root_url: null,
+    created_at: now,
+    updated_at: now,
+    realm_id: 'realm-x',
+    realm,
+};
 
 function mountForm(authorizeHandler: () => unknown) {
     const pinia = createPinia();
@@ -77,11 +104,10 @@ function mountForm(authorizeHandler: () => unknown) {
 }
 
 // A hapic ClientError-shaped rejection.
-const httpError = (status: number, data: Record<string, any> = {}) => {
-    const error = new Error(`HTTP ${status}`);
-    (error as unknown as { response: unknown }).response = { status, data };
-    return error;
-};
+const httpError = (status: number, data: Record<string, any> = {}) => Object.assign(
+    new Error(`HTTP ${status}`),
+    { response: { status, data } },
+);
 
 describe('AuthorizeForm dead-bearer resilience', () => {
     it('emits loginRequired on a 401 (dead/expired bearer)', async () => {

--- a/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { OAuth2AuthorizationCodeRequest, User } from '@authup/core-kit';
+import type { Client, OAuth2AuthorizationCodeRequest, User } from '@authup/core-kit';
 import { createFakeClient } from '@authup/core-http-kit/testing';
 import { OAuth2AuthorizationPrompt } from '@authup/specs';
 import { flushPromises, mount } from '@vue/test-utils';
@@ -39,7 +39,40 @@ const REALM = { id: 'realm-x', name: 'master' };
 function seedLoggedIn(store: Store, realmId = REALM.id) {
     store.setAccessToken('access-token');
     store.setRealm({ id: realmId, name: REALM.name });
-    store.setUser({ id: 'user-1', name: 'jdoe' } as unknown as User);
+
+    const now = new Date(0).toISOString();
+    const user: User = {
+        id: 'user-1',
+        name: 'jdoe',
+        name_locked: false,
+        first_name: null,
+        last_name: null,
+        display_name: null,
+        email: 'jdoe@example.com',
+        password: null,
+        avatar: null,
+        cover: null,
+        reset_hash: null,
+        reset_at: null,
+        reset_expires: null,
+        status: null,
+        status_message: null,
+        active: true,
+        activate_hash: null,
+        created_at: now,
+        updated_at: now,
+        realm_id: realmId,
+        realm: {
+            id: realmId,
+            name: REALM.name,
+            display_name: null,
+            description: null,
+            built_in: false,
+            created_at: now,
+            updated_at: now,
+        },
+    };
+    store.setUser(user);
 }
 
 type MountOverrides = {
@@ -82,14 +115,38 @@ function mountAuthorize(overrides: MountOverrides = {}) {
         code_challenge: 'challenge',
         code_challenge_method: 'S256',
         prompt,
-    } as OAuth2AuthorizationCodeRequest;
+    };
 
-    const client = {
+    const clientTimestamp = new Date(0).toISOString();
+    const client: Client = {
         id: 'client-1',
+        active: true,
+        built_in: clientBuiltIn,
+        is_confidential: false,
         name: 'web',
         display_name: 'Web',
-        built_in: clientBuiltIn,
-        created_at: new Date(0).toISOString(),
+        description: null,
+        secret: null,
+        secret_hashed: false,
+        secret_encrypted: false,
+        redirect_uri: null,
+        post_logout_redirect_uri: null,
+        grant_types: null,
+        scope: null,
+        base_url: null,
+        root_url: null,
+        created_at: clientTimestamp,
+        updated_at: clientTimestamp,
+        realm_id: REALM.id,
+        realm: {
+            id: REALM.id,
+            name: REALM.name,
+            display_name: null,
+            description: null,
+            built_in: false,
+            created_at: clientTimestamp,
+            updated_at: clientTimestamp,
+        },
     };
 
     let dispatcher!: StoreDispatcher;

--- a/packages/client-web-kit/test/unit/components/workflows/end-session.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/end-session.spec.ts
@@ -25,6 +25,40 @@ import type { Options } from '../../../../src/types';
 
 const noop = () => undefined;
 
+function createUser(overrides: Pick<User, 'id'>): User {
+    return {
+        id: overrides.id,
+        name: 'user',
+        name_locked: false,
+        first_name: null,
+        last_name: null,
+        display_name: null,
+        email: 'user@example.com',
+        password: null,
+        avatar: null,
+        cover: null,
+        reset_hash: null,
+        reset_at: null,
+        reset_expires: null,
+        status: null,
+        status_message: null,
+        active: true,
+        activate_hash: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        realm_id: 'realm-1',
+        realm: {
+            id: 'realm-1',
+            name: 'master',
+            display_name: null,
+            description: null,
+            built_in: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+    };
+}
+
 function mountEndSession(
     props: Record<string, any> = {},
     seedUser?: Pick<User, 'id'>,
@@ -63,7 +97,7 @@ function mountEndSession(
                     install(app: App) {
                         const store = injectStore(pinia, app);
                         if (seedUser) {
-                            store.user = seedUser as User;
+                            store.user = createUser(seedUser);
                         }
                         logout = vi.spyOn(store, 'logout').mockResolvedValue(undefined);
                     },


### PR DESCRIPTION
## Problem

An expired `id_token` verified through the RP-initiated-logout `ignoreExpiry` path poisons the shared claims cache, so `/token/introspect` reports an already-expired token as `active` for up to an hour — an RFC 7662 violation.

Root cause chain:

1. `OAuth2EndSessionService.verify()` calls `tokenVerifier.verify(hint, { ignoreExpiry: true, skipActiveCheck: true })` — `core/oauth2/end-session/service.ts:53`.
2. `ignoreExpiry` → `verifyToken(..., { validateExp: false })`, so an already-expired token passes crypto verification.
3. `OAuth2TokenVerifier.verify()` then `saveWithSignature(payload, token)` **unconditionally** — `core/oauth2/token/verifier/module.ts:125`.
4. `buildTTL(exp)` for a past `exp` computes `ttl ≤ 0` and falls back to `3_600 * 1000` (1h) — `app/modules/oauth2/repositories/token/repository.ts:143`.
5. The cache-first branch of `verify()` returns the cached payload with **no `exp` re-check** (only `jti` + optional `isInactive`) — `verifier/module.ts:38-52`. `/token/introspect` (which calls `verify` with `skipActiveCheck: true`) then derives `active` solely from `isInactive(jti)`, which the logout flow never sets.

Result: after a `/logout` carrying an expired `id_token_hint` (default `endSessionHintGracePeriod=0` honors any expired hint), that token — and any expired token submitted on an `ignoreExpiry` path — introspects as `active: true` for ~1h.

## Fix

Skip `saveWithSignature` when `options.ignoreExpiry` is set, so the exp-bypass stays scoped to the single end-session call and never leaks into the shared signature-keyed claims cache.

The only `ignoreExpiry` caller is `OAuth2EndSessionService.verify`, which uses the returned payload directly and never relied on the cache write — no behavioral loss.

## Tests

- New regression test in `verifier/module.spec.ts` — an expired token verified with `ignoreExpiry` is not written to the cache and is not retrievable by signature.
- Targeted verifier + end-session specs green (33/33); full server-core suite green.

## Notes

Found during a deep review of the plan 041/042 OAuth2/OIDC + RP-logout change set. Remaining low/info follow-ups from that review are tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token verification so expiry-bypassed checks no longer re-save expired tokens into shared cache, preventing them from being treated as active later.
  * Restricted the expiry bypass to the single logout verification flow, reducing the chance of unintended reuse.

* **Documentation**
  * Clarified the logout verification guidance to highlight the cache-related security requirement.

* **Tests**
  * Added a regression test covering expired token verification with expiry bypass enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->