### PR TITLE
test(client-web-kit): cover extractErrorContext and AuthorizeForm dead-bearer edge cases

### DIFF
--- a/packages/client-web-kit/test/unit/components/workflows/authorize-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize-form.spec.ts
@@ -137,4 +137,37 @@ describe('AuthorizeForm dead-bearer resilience', () => {
         // the manual-consent UI (with its scope list) renders as the retry path
         expect(wrapper.find('.scopes-stub').exists()).toBe(true);
     });
+
+    it('does NOT emit loginRequired on a non-401 error carrying a different OAuth2 error code', async () => {
+        // guards against a loose check that treats any body `error` field as
+        // login_required — only the LOGIN_REQUIRED code (or a 401) qualifies.
+        const wrapper = mountForm(() => {
+            throw httpError(400, { error: OAuth2ErrorCode.INVALID_REQUEST });
+        });
+        await flushPromises();
+
+        expect(wrapper.emitted('loginRequired')).toBeFalsy();
+        expect(wrapper.find('.scopes-stub').exists()).toBe(true);
+    });
+
+    it('emits loginRequired on a 401 even when the body carries an unrelated error code (status wins)', async () => {
+        const wrapper = mountForm(() => {
+            throw httpError(401, { error: OAuth2ErrorCode.INVALID_REQUEST });
+        });
+        await flushPromises();
+
+        expect(wrapper.emitted('loginRequired')).toBeTruthy();
+        expect(wrapper.find('.scopes-stub').exists()).toBe(false);
+    });
+
+    it('does NOT emit loginRequired for a non-HTTP rejection (no response envelope)', async () => {
+        // a directly-thrown/non-transport error (no `.response`) has no status
+        // and no body `.error` — extractErrorContext yields both as undefined,
+        // so it must fall back to manual consent, not re-authentication.
+        const wrapper = mountForm(() => { throw new Error('boom'); });
+        await flushPromises();
+
+        expect(wrapper.emitted('loginRequired')).toBeFalsy();
+        expect(wrapper.find('.scopes-stub').exists()).toBe(true);
+    });
 });

--- a/packages/client-web-kit/test/unit/core/translator/error.spec.ts
+++ b/packages/client-web-kit/test/unit/core/translator/error.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { extractErrorContext } from '../../../../src/core/translator/error';
+
+describe('extractErrorContext', () => {
+    describe('non-object input', () => {
+        it('wraps a string error as the message, with no status', () => {
+            expect(extractErrorContext('boom')).toEqual({ message: 'boom' });
+        });
+
+        it('returns an empty context for a nullish/primitive error', () => {
+            expect(extractErrorContext(undefined)).toEqual({ message: undefined });
+            expect(extractErrorContext(null)).toEqual({ message: undefined });
+            expect(extractErrorContext(42)).toEqual({ message: undefined });
+        });
+    });
+
+    describe('HTTP transport error (hapic ClientError shape)', () => {
+        it('extracts status, code, data and message from response.data', () => {
+            const error = {
+                message: 'Request failed',
+                response: {
+                    status: 401,
+                    data: {
+                        code: 'unauthorized',
+                        message: 'Bearer expired',
+                        error: 'login_required',
+                        issues: [],
+                    },
+                },
+            };
+
+            const ctx = extractErrorContext(error);
+
+            expect(ctx.status).toBe(401);
+            expect(ctx.code).toBe('unauthorized');
+            // the server-side body message wins over the transport's own message
+            expect(ctx.message).toBe('Bearer expired');
+            expect(ctx.data).toMatchObject({ error: 'login_required' });
+            // an empty issues array is treated as "no issues"
+            expect(ctx.issues).toBeUndefined();
+        });
+
+        it('keeps a non-empty issues array', () => {
+            const issues = [{ path: 'name', message: 'is required' }];
+            const error = {
+                response: {
+                    status: 400,
+                    data: { code: 'bad_request', issues },
+                },
+            };
+
+            expect(extractErrorContext(error).issues).toEqual(issues);
+        });
+
+        it('falls back to the transport message when the body object has none', () => {
+            // response.data is a real object, but it carries no `message`; the
+            // resolved message must fall through to the transport error's own.
+            const error = {
+                message: 'Request failed',
+                response: {
+                    status: 403,
+                    data: { code: 'permission_denied' },
+                },
+            };
+
+            const ctx = extractErrorContext(error);
+
+            expect(ctx.status).toBe(403);
+            expect(ctx.code).toBe('permission_denied');
+            expect(ctx.message).toBe('Request failed');
+        });
+
+        it('reads status even when response.data is not an object (falls back to self as body)', () => {
+            const error = {
+                message: 'Request failed',
+                response: {
+                    status: 500,
+                    data: undefined,
+                },
+            };
+
+            const ctx = extractErrorContext(error);
+
+            expect(ctx.status).toBe(500);
+            // no usable body on response.data, so self is used as the body —
+            // self.message becomes the resolved message.
+            expect(ctx.message).toBe('Request failed');
+            expect(ctx.code).toBeUndefined();
+        });
+
+        it('leaves status undefined when response.status is not a number', () => {
+            const error = {
+                response: {
+                    status: '401',
+                    data: { code: 'unauthorized' },
+                },
+            };
+
+            expect(extractErrorContext(error).status).toBeUndefined();
+        });
+
+        it('leaves status undefined when there is no response at all', () => {
+            const error = { message: 'network down' };
+
+            const ctx = extractErrorContext(error);
+
+            expect(ctx.status).toBeUndefined();
+            expect(ctx.message).toBe('network down');
+        });
+
+        it('leaves status undefined when response is not an object', () => {
+            const error = { response: 'not-an-object', message: 'weird' };
+
+            const ctx = extractErrorContext(error);
+
+            expect(ctx.status).toBeUndefined();
+            expect(ctx.message).toBe('weird');
+        });
+    });
+
+    describe('directly-thrown error (no transport envelope)', () => {
+        it('reads code/data/message/issues off the error itself, with no status', () => {
+            const error = {
+                code: 'entity_conflict',
+                message: 'Already exists',
+                issues: [{ path: 'email', message: 'taken' }],
+            };
+
+            const ctx = extractErrorContext(error);
+
+            expect(ctx.status).toBeUndefined();
+            expect(ctx.code).toBe('entity_conflict');
+            expect(ctx.message).toBe('Already exists');
+            expect(ctx.issues).toEqual(error.issues);
+            expect(ctx.data).toBe(error);
+        });
+
+        it('ignores a non-string code', () => {
+            const error = { code: 42, message: 'oops' };
+
+            expect(extractErrorContext(error).code).toBeUndefined();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Adds unit-test coverage for two `@authup/client-web-kit` surfaces involved in the plan-042 dead-bearer / error-handling work. Distilled and extended from a CodeRabbit UTG draft (`coderabbitai/utg/1ab54ca`), keeping only the parts that add real coverage and merging them into the existing, strongly-typed specs.

### `core/translator/error.ts` — new spec for `extractErrorContext`

This exported pure function had **no** tests. The new `test/unit/core/translator/error.spec.ts` covers every branch:

- **non-object input** — string wrapped as `message`; nullish/primitive → empty context.
- **HTTP transport envelope** (hapic `ClientError` shape) — status/code/data/message extraction from `response.data`; server body `message` wins over the transport message; **falls back to the transport message when the body object carries none**; empty `issues: []` elided while a non-empty array is kept; `status` left `undefined` when `response.status` isn't a number, when there's no `response`, and when `response` isn't an object.
- **directly-thrown error** — code/data/message/issues read off the error itself with no status; non-string `code` ignored.

### `components/workflows/authorize/AuthorizeForm.vue` — 3 new dead-bearer cases

Extends the existing `AuthorizeForm dead-bearer resilience` suite (verified against the real component logic — `status === 401 || data?.error === LOGIN_REQUIRED`):

- a non-401 error carrying a **different** OAuth2 code (`invalid_request`) does **not** re-authenticate (guards a loose "any body `error`" check);
- a `401` wins even when the body carries an unrelated code (status wins);
- a non-HTTP rejection (no `response` envelope) falls back to manual consent, not re-auth.

## Verification

- `npm run test -w packages/client-web-kit` — **10 files, 53 tests pass** (17 in the two touched specs).
- ESLint clean on both files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for error parsing and login-required handling.
  * Verified that status codes take precedence over error payloads when deciding whether to prompt for login.
  * Added checks for non-HTTP failures and fallback consent flows.
  * Improved validation of error message, status, code, and issue extraction across multiple error shapes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->