### PR TITLE
refactor(client-web-kit): extract error-context normalization into core/error module

### DIFF
--- a/packages/client-web-kit/src/core/error/index.ts
+++ b/packages/client-web-kit/src/core/error/index.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export * from './module';
+export * from './types';

--- a/packages/client-web-kit/src/core/error/module.ts
+++ b/packages/client-web-kit/src/core/error/module.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isObject } from '@authup/kit';
+import type { ErrorContext } from './types';
+
+/**
+ * Pull the structured `{ code, data, message, issues, status }` out of whatever
+ * the caller caught. An authup server error arrives as a hapic `ClientError`
+ * whose `response.data` is the serialized error body (`AuthupError.toJSON`
+ * flattens `code` + `data` onto the top level and carries the validup
+ * `issues`); a directly-thrown `AuthupError` or plain `Error` exposes the
+ * same fields on itself. Duck-typed on purpose — no hapic import (it is not a
+ * declared dependency, and its `isClientError` guard is `instanceof`-based, so
+ * it would miss a non-hapic-instance error), works for both transports.
+ */
+export function extractErrorContext(error: unknown): ErrorContext {
+    if (!isObject(error)) {
+        return { message: typeof error === 'string' ? error : undefined };
+    }
+
+    const self = error as Record<string, any>;
+    const { response } = self;
+    const body: Record<string, any> = isObject(response) && isObject(response.data) ?
+        response.data :
+        self;
+
+    const status = isObject(response) && typeof response.status === 'number' ?
+        response.status :
+        undefined;
+
+    // The server-side body `message` is the most specific human string; the
+    // transport error's own `message` (e.g. hapic's "Request failed") is only
+    // the last resort.
+    let message: string | undefined;
+    if (typeof body.message === 'string') {
+        message = body.message;
+    } else if (typeof self.message === 'string') {
+        message = self.message;
+    }
+
+    return {
+        code: typeof body.code === 'string' ? body.code : undefined,
+        data: body,
+        message,
+        // Only validation (`BAD_REQUEST`) errors carry issues; a coded
+        // business error serializes an empty array.
+        issues: Array.isArray(body.issues) && body.issues.length > 0 ? body.issues : undefined,
+        status,
+    };
+}

--- a/packages/client-web-kit/src/core/error/types.ts
+++ b/packages/client-web-kit/src/core/error/types.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Issue } from 'validup';
+
+export type ErrorContext = {
+    code?: string;
+    data?: Record<string, any>;
+    message?: string;
+    issues?: Issue[];
+    /**
+     * The HTTP status of the transport error (a hapic `ClientError`'s
+     * `response.status`), when the error arrived over HTTP. Absent for a
+     * directly-thrown / non-HTTP error.
+     */
+    status?: number;
+};

--- a/packages/client-web-kit/src/core/index.ts
+++ b/packages/client-web-kit/src/core/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './constants';
+export * from './error';
 export * from './http-client';
 export * from './inject';
 export * from './provide';

--- a/packages/client-web-kit/src/core/translator/error.ts
+++ b/packages/client-web-kit/src/core/translator/error.ts
@@ -5,70 +5,10 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isObject } from '@authup/kit';
 import { TranslatorTranslationNamespace } from '@authup/i18n';
 import { injectIlingo, injectLocale } from '@ilingo/vue';
 import { translateIssues } from '@ilingo/validup';
-import type { Issue } from 'validup';
-
-export type ErrorContext = {
-    code?: string;
-    data?: Record<string, any>;
-    message?: string;
-    issues?: Issue[];
-    /**
-     * The HTTP status of the transport error (a hapic `ClientError`'s
-     * `response.status`), when the error arrived over HTTP. Absent for a
-     * directly-thrown / non-HTTP error.
-     */
-    status?: number;
-};
-
-/**
- * Pull the structured `{ code, data, message, issues, status }` out of whatever
- * the caller caught. An authup server error arrives as a hapic `ClientError`
- * whose `response.data` is the serialized error body (`AuthupError.toJSON`
- * flattens `code` + `data` onto the top level and carries the validup
- * `issues`); a directly-thrown `AuthupError` or plain `Error` exposes the
- * same fields on itself. Duck-typed on purpose — no hapic import (it is not a
- * declared dependency, and its `isClientError` guard is `instanceof`-based, so
- * it would miss a non-hapic-instance error), works for both transports.
- */
-export function extractErrorContext(error: unknown): ErrorContext {
-    if (!isObject(error)) {
-        return { message: typeof error === 'string' ? error : undefined };
-    }
-
-    const self = error as Record<string, any>;
-    const { response } = self;
-    const body: Record<string, any> = isObject(response) && isObject(response.data) ?
-        response.data :
-        self;
-
-    const status = isObject(response) && typeof response.status === 'number' ?
-        response.status :
-        undefined;
-
-    // The server-side body `message` is the most specific human string; the
-    // transport error's own `message` (e.g. hapic's "Request failed") is only
-    // the last resort.
-    let message: string | undefined;
-    if (typeof body.message === 'string') {
-        message = body.message;
-    } else if (typeof self.message === 'string') {
-        message = self.message;
-    }
-
-    return {
-        code: typeof body.code === 'string' ? body.code : undefined,
-        data: body,
-        message,
-        // Only validation (`BAD_REQUEST`) errors carry issues; a coded
-        // business error serializes an empty array.
-        issues: Array.isArray(body.issues) && body.issues.length > 0 ? body.issues : undefined,
-        status,
-    };
-}
+import { extractErrorContext } from '../error';
 
 /**
  * Resolve a caught error to a localized, user-facing message.

--- a/packages/client-web-kit/test/unit/core/error/module.spec.ts
+++ b/packages/client-web-kit/test/unit/core/error/module.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { extractErrorContext } from '../../../../src/core/translator/error';
+import { extractErrorContext } from '../../../../src/core/error';
 
 describe('extractErrorContext', () => {
     describe('non-object input', () => {


### PR DESCRIPTION
Implements plan 046: `extractErrorContext` + `ErrorContext` move out of `core/translator/error.ts` into a dedicated `core/error/` module (`types.ts` / `module.ts` / `index.ts` per repo convention).

`core/translator/error.ts` had fused two unrelated concerns: `useErrorTranslator()` (a genuine translation concern) and `extractErrorContext()` (a generic "normalize a caught authup error into `{ code, data, message, issues, status }`" primitive). Since #3203/#3204 gave the extractor a second, non-translation consumer (`AuthorizeForm.vue` inspecting `status` / `data.error` for the dead-bearer + prompt=none fallbacks), the placement became a real smell. It is deliberately **not** placed under `core/http-client/` — the extractor also normalizes directly-thrown non-HTTP errors (which is why it duck-types instead of importing hapic).

- Pure relocation — no logic or shape change; `useErrorTranslator()` stays in `core/translator/` and imports from `../error`.
- `core/index.ts` re-exports `./error`, so the public surface (`import { extractErrorContext } from '@authup/client-web-kit'`) is unchanged; `AuthorizeForm.vue` already imported via the `core` barrel.
- The `extractErrorContext` spec moves to `test/unit/core/error/module.spec.ts`, mirroring the new source location.

Verification:
- `nx run @authup/client-web-kit:build` (tsdown + vue-tsc types) ✔
- `npm run test --workspace=packages/client-web-kit` — 53/53 ✔ (incl. the #3211 `extractErrorContext` / dead-bearer edge cases)
- `rg "from .*translator/error" packages apps` — no deep-path consumers remain ✔

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a shared utility for extracting structured context from errors, including messages, error codes, status information, data, and validation issues.
  * Made the error context functionality available through the core package exports.

* **Improvements**
  * Error translation now uses the shared error context for localized validation and server error messages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->