### PR TITLE
fix(client-web-kit): observe the promise-share wrapper's derived promise

### DIFF
--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -47,11 +47,15 @@ function createPromiseShareWrapperFn<F extends InputFn>(
             },
         );
 
-        promise.finally(() => {
+        // not .finally(): the derived promise it returns would reject
+        // unobserved whenever the shared promise rejects (unhandledrejection
+        // on every failed refresh/resolve).
+        const clear = () => {
             setTimeout(() => {
                 promise = undefined;
             }, 0);
-        });
+        };
+        promise.then(clear, clear);
 
         return promise;
     };

--- a/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { CookieName } from '@authup/core-http-kit';
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import { createPinia } from 'pinia';
+import { describe, expect, it } from 'vitest';
+import { createApp, h } from 'vue';
+import type { CookieOptions } from '../../../../src/types';
+import { injectStore, installStore } from '../../../../src/core/store';
+
+const GRANT_RESPONSE = {
+    access_token: 'at-1',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: 'rt-1',
+    id_token: 'idt-1',
+};
+
+const INTROSPECTION_RESPONSE = {
+    exp: 9999999999,
+    session_id: 'sess-1',
+    realm_id: 'realm-1',
+    realm_name: 'master',
+    permissions: [],
+};
+
+const USER_RESPONSE = { id: 'user-1', name: 'admin' };
+
+type CookieSetCall = {
+    key: string,
+    value: unknown,
+    options: CookieOptions
+};
+
+function buildApp(seed: Record<string, unknown> = {}) {
+    const jar = new Map<string, unknown>(Object.entries(seed));
+    const setCalls : CookieSetCall[] = [];
+    const unsetCalls : string[] = [];
+
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token': () => ({ ...GRANT_RESPONSE }),
+            'POST /token/introspect': () => ({ ...INTROSPECTION_RESPONSE }),
+            'GET /users/@me': () => ({ ...USER_RESPONSE }),
+            'POST /token/revoke': () => ({}),
+        },
+    });
+
+    const pinia = createPinia();
+    const app = createApp({ render: () => h('div') });
+    app.use(pinia);
+
+    installStore(app, {
+        httpClient,
+        pinia,
+        cookieGet: (key) => jar.get(key),
+        cookieSet: (key, value, options) => {
+            setCalls.push({
+                key, 
+                value, 
+                options, 
+            });
+            jar.set(key, value);
+        },
+        cookieUnset: (key) => {
+            unsetCalls.push(key);
+            jar.delete(key);
+        },
+    });
+
+    const store = injectStore(pinia, app);
+
+    return {
+        store, 
+        httpClient, 
+        setCalls, 
+        unsetCalls,
+    };
+}
+
+describe('core/store/install-cookies', () => {
+    it('hydrates the store from cookies synchronously at install time', () => {
+        const expireDate = '2099-01-01T00:00:00.000Z';
+        const { store, setCalls } = buildApp({
+            [CookieName.ACCESS_TOKEN]: 'cookie-at',
+            [CookieName.ACCESS_TOKEN_EXPIRE_DATE]: expireDate,
+            [CookieName.REFRESH_TOKEN]: 'cookie-rt',
+            [CookieName.ID_TOKEN]: 'cookie-idt',
+            [CookieName.USER]: { id: 'user-1', name: 'admin' },
+            [CookieName.REALM]: { id: 'realm-1', name: 'master' },
+            [CookieName.REALM_MANAGEMENT]: { id: 'realm-2', name: 'other' },
+        });
+
+        expect(store.cookiesRead).toBe(true);
+        expect(store.accessToken).toEqual('cookie-at');
+        expect(store.accessTokenExpireDate).toBeInstanceOf(Date);
+        expect((store.accessTokenExpireDate as Date).getTime()).toEqual(new Date(expireDate).getTime());
+        expect(store.refreshToken).toEqual('cookie-rt');
+        expect(store.idToken).toEqual('cookie-idt');
+        expect(store.user).toMatchObject({ id: 'user-1' });
+        expect(store.realm).toMatchObject({ id: 'realm-1' });
+        expect(store.realmManagement).toMatchObject({ id: 'realm-2' });
+
+        // hydration flips loggedIn before any network validation ran
+        expect(store.loggedIn).toBe(true);
+
+        // hydration re-emits the *_UPDATED events — the cookie listeners echo
+        // the restored values straight back into the jar
+        expect(setCalls.some(
+            (call) => call.key === CookieName.ACCESS_TOKEN && call.value === 'cookie-at',
+        )).toBe(true);
+    });
+
+    it('persists cookies on login — except the realm cookie (introspection bypasses setRealm)', async () => {
+        const { store, setCalls } = buildApp();
+
+        await store.login({ name: 'admin', password: 'start123' });
+
+        const keys = setCalls.map((call) => call.key);
+        expect(keys).toContain(CookieName.ACCESS_TOKEN);
+        expect(keys).toContain(CookieName.ACCESS_TOKEN_EXPIRE_DATE);
+        expect(keys).toContain(CookieName.REFRESH_TOKEN);
+        expect(keys).toContain(CookieName.ID_TOKEN);
+        expect(keys).toContain(CookieName.USER);
+        expect(keys).toContain(CookieName.REALM_MANAGEMENT);
+
+        // realm.value is written directly during introspection — REALM_UPDATED
+        // never fires, so the realm cookie is never persisted
+        expect(keys).not.toContain(CookieName.REALM);
+        expect(store.realm).toMatchObject({ id: 'realm-1' });
+
+        // the access-token cookie rides the grant-derived expire date
+        const accessTokenCall = setCalls.find((call) => call.key === CookieName.ACCESS_TOKEN);
+        expect(accessTokenCall).toBeDefined();
+        expect(accessTokenCall!.options.maxAge).toBeTypeOf('number');
+        expect(accessTokenCall!.options.maxAge!).toBeGreaterThan(0);
+        expect(accessTokenCall!.options.maxAge!).toBeLessThanOrEqual(3600);
+    });
+
+    it('unsets every cookie on logout', async () => {
+        const {
+            store, 
+            setCalls, 
+            unsetCalls, 
+        } = buildApp();
+
+        await store.login({ name: 'admin', password: 'start123' });
+        setCalls.length = 0;
+        unsetCalls.length = 0;
+
+        await store.logout();
+
+        expect(unsetCalls).toEqual([
+            CookieName.ACCESS_TOKEN,
+            CookieName.ACCESS_TOKEN_EXPIRE_DATE,
+            CookieName.REFRESH_TOKEN,
+            CookieName.ID_TOKEN,
+            CookieName.USER,
+            CookieName.REALM,
+            CookieName.REALM_MANAGEMENT,
+        ]);
+        expect(setCalls).toHaveLength(0);
+    });
+});

--- a/packages/client-web-kit/test/unit/core/store/lifecycle.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/lifecycle.spec.ts
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { FakeClient, FakeHandler, FakeRequest } from '@authup/core-http-kit/testing';
+import { describe, expect, it } from 'vitest';
+import { StoreDispatcherEventName, createStore, createStoreDispatcher } from '../../../../src/core/store';
+
+const GRANT_RESPONSE = {
+    access_token: 'at-1',
+    token_type: 'Bearer',
+    expires_in: 3600,
+    refresh_token: 'rt-1',
+    id_token: 'idt-1',
+};
+
+const INTROSPECTION_RESPONSE = {
+    exp: 9999999999,
+    session_id: 'sess-1',
+    realm_id: 'realm-1',
+    realm_name: 'master',
+    permissions: [],
+};
+
+const USER_RESPONSE = { id: 'user-1', name: 'admin' };
+
+const LIFECYCLE_EVENTS : string[] = [
+    StoreDispatcherEventName.LOGGING_IN,
+    StoreDispatcherEventName.LOGGED_IN,
+    StoreDispatcherEventName.LOGGING_OUT,
+    StoreDispatcherEventName.LOGGED_OUT,
+    StoreDispatcherEventName.SESSION_EXPIRED,
+    StoreDispatcherEventName.RESOLVING,
+    StoreDispatcherEventName.RESOLVED,
+];
+
+function buildStore(handlers: Record<string, FakeHandler> = {}) {
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token': () => ({ ...GRANT_RESPONSE }),
+            'POST /token/introspect': () => ({ ...INTROSPECTION_RESPONSE }),
+            'GET /users/@me': () => ({ ...USER_RESPONSE }),
+            'POST /token/revoke': () => ({}),
+            ...handlers,
+        },
+    });
+
+    const dispatcher = createStoreDispatcher();
+    const store = createStore({ httpClient, dispatcher });
+
+    const events : string[] = [];
+    dispatcher.on('*', (...args) => {
+        events.push(args[0]);
+    });
+
+    return {
+        store, 
+        httpClient, 
+        dispatcher, 
+        events,
+    };
+}
+
+function pathname(request: FakeRequest) : string {
+    return new URL(request.url, 'http://localhost').pathname;
+}
+
+function requestsTo(httpClient: FakeClient, method: string, path: string) : FakeRequest[] {
+    return httpClient.requests.filter(
+        (request) => request.method === method && pathname(request) === path,
+    );
+}
+
+describe('core/store/lifecycle', () => {
+    it('emits the documented event order on login and never REALM_UPDATED', async () => {
+        const { store, events } = buildStore();
+
+        await store.login({ name: 'admin', password: 'start123' });
+
+        expect(events).toEqual([
+            StoreDispatcherEventName.LOGGING_IN,
+            // applyTokenGrantResponse: expire date is set BEFORE the token
+            // (the cookie maxAge computation depends on that ordering)
+            StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED,
+            StoreDispatcherEventName.ACCESS_TOKEN_UPDATED,
+            StoreDispatcherEventName.REFRESH_TOKEN_UPDATED,
+            StoreDispatcherEventName.ID_TOKEN_UPDATED,
+            // introspection exp overwrites the grant-derived expire date
+            StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED,
+            StoreDispatcherEventName.REALM_MANAGEMENT_UPDATED,
+            StoreDispatcherEventName.USER_UPDATED,
+            StoreDispatcherEventName.LOGGED_IN,
+        ]);
+
+        // introspection writes realm.value directly, bypassing setRealm —
+        // REALM_UPDATED never fires with a non-null value
+        expect(events).not.toContain(StoreDispatcherEventName.REALM_UPDATED);
+        expect(store.realmId.value).toEqual('realm-1');
+    });
+
+    it('leaves LOGGING_IN dangling when the password grant fails', async () => {
+        const { store, events } = buildStore({
+            'POST /token': () => {
+                throw new Error('grant failed');
+            },
+        });
+
+        await expect(store.login({ name: 'admin', password: 'wrong' })).rejects.toThrow();
+
+        expect(events).toEqual([StoreDispatcherEventName.LOGGING_IN]);
+        expect(store.accessToken.value).toBeNull();
+        expect(store.loggedIn.value).toBe(false);
+    });
+
+    it('latches a failed introspection during login: token-only session, realm never resolves', async () => {
+        let introspectCalls = 0;
+        const { store, events } = buildStore({
+            'POST /token/introspect': () => {
+                introspectCalls += 1;
+                if (introspectCalls === 1) {
+                    throw new Error('introspection down');
+                }
+
+                return { ...INTROSPECTION_RESPONSE };
+            },
+        });
+
+        await expect(store.login({ name: 'admin', password: 'start123' })).rejects.toThrow();
+
+        // the token was applied before resolution — a half-built session remains
+        expect(store.loggedIn.value).toBe(true);
+        expect(events).not.toContain(StoreDispatcherEventName.LOGGED_IN);
+
+        // tokenResolved latched true before the failed call — resolve() never retries
+        await store.resolve();
+
+        expect(introspectCalls).toEqual(1);
+        expect(store.user.value).toMatchObject({ id: 'user-1' });
+        expect(store.realmId.value).toBeUndefined();
+        expect(store.sessionId.value).toBeNull();
+    });
+
+    it('logout is local-only: revokes both tokens, never touches the sessions API', async () => {
+        const {
+            store, 
+            httpClient, 
+            events, 
+        } = buildStore();
+
+        await store.login({ name: 'admin', password: 'start123' });
+        events.length = 0;
+        const requestCount = httpClient.requests.length;
+
+        await store.logout();
+
+        expect(events).toEqual([
+            StoreDispatcherEventName.LOGGING_OUT,
+            StoreDispatcherEventName.ACCESS_TOKEN_UPDATED,
+            StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED,
+            StoreDispatcherEventName.REFRESH_TOKEN_UPDATED,
+            StoreDispatcherEventName.ID_TOKEN_UPDATED,
+            StoreDispatcherEventName.USER_UPDATED,
+            StoreDispatcherEventName.REALM_UPDATED,
+            StoreDispatcherEventName.REALM_MANAGEMENT_UPDATED,
+            StoreDispatcherEventName.LOGGED_OUT,
+        ]);
+
+        const logoutRequests = httpClient.requests.slice(requestCount);
+        expect(logoutRequests).toHaveLength(2);
+        expect(logoutRequests.map((request) => pathname(request))).toEqual([
+            '/token/revoke',
+            '/token/revoke',
+        ]);
+        expect(logoutRequests[0].body).toMatchObject({ token: 'at-1' });
+        expect(logoutRequests[1].body).toMatchObject({ token: 'rt-1' });
+
+        expect(httpClient.requests.some(
+            (request) => pathname(request).startsWith('/sessions'),
+        )).toBe(false);
+    });
+
+    it('swallows revoke failures on logout', async () => {
+        const { store } = buildStore({
+            'POST /token/revoke': () => {
+                throw new Error('revoke down');
+            },
+        });
+
+        await store.login({ name: 'admin', password: 'start123' });
+        await store.logout();
+
+        expect(store.accessToken.value).toBeNull();
+        expect(store.user.value).toBeNull();
+    });
+
+    it('rejects and cleans up when the refresh grant fails: no RESOLVED', async () => {
+        const {
+            store, 
+            httpClient, 
+            events, 
+        } = buildStore({
+            'POST /token': () => {
+                throw new Error('invalid_grant');
+            },
+        });
+
+        store.setRefreshToken('rt-1');
+        events.length = 0;
+
+        await expect(store.resolve()).rejects.toThrow();
+
+        expect(events).toContain(StoreDispatcherEventName.RESOLVING);
+        expect(events).not.toContain(StoreDispatcherEventName.RESOLVED);
+        expect(store.refreshToken.value).toBeNull();
+
+        const tokenRequests = requestsTo(httpClient, 'POST', '/token');
+        expect(tokenRequests).toHaveLength(1);
+        expect(tokenRequests[0].body).toMatchObject({ grant_type: 'refresh_token' });
+
+        // cleanup captured the refresh token before nulling and revoked it
+        const revokeRequests = requestsTo(httpClient, 'POST', '/token/revoke');
+        expect(revokeRequests).toHaveLength(1);
+        expect(revokeRequests[0].body).toMatchObject({ token: 'rt-1' });
+    });
+
+    it('recovers via the refresh retry branch when introspection fails once', async () => {
+        let introspectCalls = 0;
+        const {
+            store, 
+            httpClient, 
+            events, 
+        } = buildStore({
+            'POST /token': (request) => {
+                expect((request.body as Record<string, string>).grant_type).toEqual('refresh_token');
+
+                return {
+                    access_token: 'at-2',
+                    token_type: 'Bearer',
+                    expires_in: 3600,
+                    refresh_token: 'rt-2',
+                };
+            },
+            'POST /token/introspect': () => {
+                introspectCalls += 1;
+                if (introspectCalls === 1) {
+                    throw new Error('introspection down');
+                }
+
+                return { ...INTROSPECTION_RESPONSE };
+            },
+        });
+
+        store.setAccessToken('at-0');
+        store.setRefreshToken('rt-0');
+        events.length = 0;
+
+        await store.resolve();
+
+        expect(introspectCalls).toEqual(2);
+        expect(store.accessToken.value).toEqual('at-2');
+        expect(store.refreshToken.value).toEqual('rt-2');
+        expect(store.realmId.value).toEqual('realm-1');
+        expect(store.user.value).toMatchObject({ id: 'user-1' });
+        expect(events.at(-1)).toEqual(StoreDispatcherEventName.RESOLVED);
+        expect(requestsTo(httpClient, 'POST', '/token')).toHaveLength(1);
+    });
+
+    it('emits RESOLVING and RESOLVED even with no session at all', async () => {
+        const {
+            store, 
+            httpClient, 
+            events, 
+        } = buildStore();
+
+        await store.resolve();
+
+        expect(events).toEqual([
+            StoreDispatcherEventName.RESOLVING,
+            StoreDispatcherEventName.RESOLVED,
+        ]);
+        expect(httpClient.requests).toHaveLength(0);
+    });
+
+    it('exchangeAuthorizationCode wipes the previous identity on success and emits no lifecycle events', async () => {
+        const {
+            store, 
+            httpClient, 
+            events, 
+        } = buildStore();
+
+        store.setAccessToken('old-at');
+        store.setRefreshToken('old-rt');
+        events.length = 0;
+
+        await store.exchangeAuthorizationCode('code-1', {
+            code_verifier: 'verifier-1',
+            redirect_uri: 'https://rp.example/callback',
+            client_id: 'client-1',
+            realm_id: 'realm-1',
+        });
+
+        const tokenRequests = requestsTo(httpClient, 'POST', '/token');
+        expect(tokenRequests).toHaveLength(1);
+        expect(tokenRequests[0].body).toMatchObject({
+            grant_type: 'authorization_code',
+            code: 'code-1',
+            code_verifier: 'verifier-1',
+            redirect_uri: 'https://rp.example/callback',
+            client_id: 'client-1',
+            realm_id: 'realm-1',
+        });
+
+        // cleanup on the SUCCESS path revokes the previous tokens
+        const revokeRequests = requestsTo(httpClient, 'POST', '/token/revoke');
+        expect(revokeRequests).toHaveLength(2);
+        expect(revokeRequests[0].body).toMatchObject({ token: 'old-at' });
+        expect(revokeRequests[1].body).toMatchObject({ token: 'old-rt' });
+
+        expect(store.accessToken.value).toEqual('at-1');
+        expect(store.idToken.value).toEqual('idt-1');
+        expect(store.user.value).toMatchObject({ id: 'user-1' });
+
+        expect(events.filter((event) => LIFECYCLE_EVENTS.includes(event))).toHaveLength(0);
+    });
+
+    it('leaves prior state intact when the code exchange fails', async () => {
+        const { store, httpClient } = buildStore({
+            'POST /token': () => {
+                throw new Error('invalid_grant');
+            },
+        });
+
+        store.setAccessToken('old-at');
+        store.setRefreshToken('old-rt');
+
+        await expect(store.exchangeAuthorizationCode('code-1')).rejects.toThrow();
+
+        expect(store.accessToken.value).toEqual('old-at');
+        expect(store.refreshToken.value).toEqual('old-rt');
+        expect(requestsTo(httpClient, 'POST', '/token/revoke')).toHaveLength(0);
+    });
+
+    it('retains the id_token across a refresh-grant resolve()', async () => {
+        const { store } = buildStore({
+            'POST /token': () => ({
+                access_token: 'at-2',
+                token_type: 'Bearer',
+                expires_in: 3600,
+                refresh_token: 'rt-2',
+            }),
+        });
+
+        store.setRefreshToken('rt-1');
+        store.setIdToken('previous-id-token');
+
+        await store.resolve();
+
+        expect(store.accessToken.value).toEqual('at-2');
+        expect(store.idToken.value).toEqual('previous-id-token');
+    });
+
+    it('populates sessionId through the login path', async () => {
+        const { store } = buildStore();
+
+        await store.login({ name: 'admin', password: 'start123' });
+
+        expect(store.sessionId.value).toEqual('sess-1');
+    });
+
+    it('shares one in-flight resolution across concurrent resolve() calls', async () => {
+        const { store, httpClient } = buildStore();
+
+        store.setAccessToken('at-1');
+
+        await Promise.all([store.resolve(), store.resolve()]);
+
+        expect(requestsTo(httpClient, 'POST', '/token/introspect')).toHaveLength(1);
+        expect(requestsTo(httpClient, 'GET', '/users/@me')).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
## Summary

Plan-045 PR 1 (characterization pass) — the new store lifecycle specs exposed a real defect, fixed here alongside the suite that caught it.

**Fix:** `createPromiseShareWrapperFn` (the dedup wrapper around `resolve()` / `refreshSession()`) attached its clear-callback via `.finally()` and dropped the derived promise. Whenever the shared promise rejected — any failed refresh or resolve — that derived promise rejected unobserved, producing an `unhandledrejection` alongside the properly handled one (console noise in browsers, and a potential process-level unhandled rejection during SSR with restored cookies). The callback now rides `.then(clear, clear)`, which never rejects. No behavioral change otherwise.

**Characterization tests** (`test/unit/core/store/lifecycle.spec.ts`, `install-cookies.spec.ts`) pin the store's current observable behavior ahead of the plan-045 auth-state redesign:

- login dispatcher event **order**, incl. expire-date-before-token and the missing `REALM_UPDATED` on introspection (the realm cookie is never persisted from that path)
- login failure modes: dangling `LOGGING_IN`; the `tokenResolved` latch that leaves a token-only session whose realm never resolves
- `logout()` local-only semantics: both token revokes, swallowed revoke failures, **no** `/sessions` request (plan-041 invariant)
- `resolve()`: refresh-failure cleanup (no `RESOLVED`), the refresh retry branch, the anonymous `RESOLVING`/`RESOLVED` no-op, promise-sharing across concurrent calls
- `exchangeAuthorizationCode`: success-path cleanup revoking the previous tokens with no lifecycle events; failure leaves prior state intact
- `id_token` retention across a refresh grant end-to-end
- `installStore` cookie bridge: synchronous hydration (incl. the write-back echo), per-event persistence on login, full unset on logout

## Test plan

- `npm run test --workspace=packages/client-web-kit` — 12 files, 69 tests green
- new specs type-checked strict via ad-hoc `vue-tsc --noEmit` (kit has no `check:types` script)
- `npm run build -w packages/client-web-kit` green