### PR TITLE
fix(client-web-kit): unwrap realmIsRoot ref guards and keep permission-check realm id

### DIFF
--- a/packages/client-web-kit/src/components/entities/permission/APermissionForm.vue
+++ b/packages/client-web-kit/src/components/entities/permission/APermissionForm.vue
@@ -100,7 +100,7 @@ export default defineComponent({
         const storeRefs = storeToRefs(store);
 
         const realmId = computed(() => {
-            if (!storeRefs.realmIsRoot) {
+            if (!storeRefs.realmIsRoot.value) {
                 return storeRefs.realmId.value;
             }
 

--- a/packages/client-web-kit/src/components/entities/policy/APolicyBasicForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/APolicyBasicForm.vue
@@ -69,7 +69,7 @@ export default defineComponent({
 
         const isEditing = useIsEditing(entity);
         const realmId = computed(() => {
-            if (!storeRefs.realmIsRoot) {
+            if (!storeRefs.realmIsRoot.value) {
                 return storeRefs.realmId.value;
             }
 

--- a/packages/client-web-kit/src/components/entities/role/ARoleForm.vue
+++ b/packages/client-web-kit/src/components/entities/role/ARoleForm.vue
@@ -87,7 +87,7 @@ export default defineComponent({
         const storeRefs = storeToRefs(store);
 
         const realmId = computed(() => {
-            if (!storeRefs.realmIsRoot) {
+            if (!storeRefs.realmIsRoot.value) {
                 return storeRefs.realmId.value;
             }
 

--- a/packages/client-web-kit/src/components/entities/scope/AScopeForm.vue
+++ b/packages/client-web-kit/src/components/entities/scope/AScopeForm.vue
@@ -83,7 +83,7 @@ export default defineComponent({
         const storeRefs = storeToRefs(store);
 
         const realmId = computed(() => {
-            if (!storeRefs.realmIsRoot) {
+            if (!storeRefs.realmIsRoot.value) {
                 return storeRefs.realmId.value;
             }
 

--- a/packages/client-web-kit/src/core/permission-check/module.ts
+++ b/packages/client-web-kit/src/core/permission-check/module.ts
@@ -51,7 +51,7 @@ export function createPermissionCheckerReactiveFn(
                 }
 
                 if (storeRefs.realmName.value) {
-                    identity.realmId = storeRefs.realmName.value;
+                    identity.realmName = storeRefs.realmName.value;
                 }
             }
 

--- a/packages/client-web-kit/test/unit/core/permission-check/module.spec.ts
+++ b/packages/client-web-kit/test/unit/core/permission-check/module.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IdentityPolicyData, PermissionEvaluationContext } from '@authup/access';
+import { BuiltInPolicyType } from '@authup/access';
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { User } from '@authup/core-kit';
+import { flushPromises, mount } from '@vue/test-utils';
+import { createPinia, defineStore } from 'pinia';
+import { 
+    describe, 
+    expect, 
+    it, 
+    vi, 
+} from 'vitest';
+import type { Ref } from 'vue';
+import { defineComponent, h } from 'vue';
+import { createPermissionCheckerReactiveFn } from '../../../../src/core/permission-check';
+import type { Store } from '../../../../src/core/store';
+import { createStore, createStoreDispatcher } from '../../../../src/core/store';
+
+function buildStore() : Store {
+    const pinia = createPinia();
+    const storeFactory = defineStore('auth-test', () => createStore({
+        httpClient: createFakeClient({ handlers: {} }),
+        dispatcher: createStoreDispatcher(),
+    }));
+
+    return storeFactory(pinia);
+}
+
+async function runCheck(store: Store, ctx: PermissionEvaluationContext) : Promise<Ref<boolean>> {
+    let outcome!: Ref<boolean>;
+
+    mount(defineComponent({
+        setup() {
+            const checker = createPermissionCheckerReactiveFn({ store });
+            outcome = checker(ctx);
+
+            return () => h('div');
+        },
+    }));
+
+    await flushPromises();
+
+    return outcome;
+}
+
+describe('core/permission-check', () => {
+    it('should keep realm id and realm name on distinct identity fields', async () => {
+        const store = buildStore();
+        store.setUser({ id: 'user-id' } as User);
+        store.setRealm({ id: 'realm-id', name: 'master' });
+
+        const spy = vi.spyOn(store.permissionEvaluator, 'preEvaluateOneOf')
+            .mockResolvedValue(undefined);
+
+        const outcome = await runCheck(store, { name: 'user_read' });
+
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        const [evaluationContext] = spy.mock.calls[0];
+        expect(evaluationContext.data).toBeDefined();
+
+        const identity = evaluationContext.data!
+            .get<IdentityPolicyData>(BuiltInPolicyType.IDENTITY);
+        expect(identity).toEqual({
+            type: 'user',
+            id: 'user-id',
+            realmId: 'realm-id',
+            realmName: 'master',
+        });
+
+        expect(outcome.value).toBe(true);
+    });
+
+    it('should omit realm fields when the store has no realm', async () => {
+        const store = buildStore();
+        store.setUser({ id: 'user-id' } as User);
+
+        const spy = vi.spyOn(store.permissionEvaluator, 'preEvaluateOneOf')
+            .mockResolvedValue(undefined);
+
+        await runCheck(store, { name: 'user_read' });
+
+        expect(spy).toHaveBeenCalledTimes(1);
+
+        const [evaluationContext] = spy.mock.calls[0];
+        const identity = evaluationContext.data!
+            .get<IdentityPolicyData>(BuiltInPolicyType.IDENTITY);
+        expect(identity).toEqual({
+            type: 'user',
+            id: 'user-id',
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Two latent bugs in `@authup/client-web-kit` consumers of the kit store (plan-045 PR 5, adjacent bugs).

### 1. `!storeRefs.realmIsRoot` — missing `.value`, guard never fired

`AScopeForm.vue`, `ARoleForm.vue`, `APermissionForm.vue`, and `APolicyBasicForm.vue` share a realm-defaulting computed:

```ts
if (!storeRefs.realmIsRoot) {          // Ref object — always truthy, so this is always false
    return storeRefs.realmId.value;
}
return manager.data.value ? manager.data.value.realm_id : null;
```

`storeToRefs` yields a `Ref`, so `!storeRefs.realmIsRoot` is unconditionally `false` and the non-master pin never fired — every actor fell through to the entity-realm fallback. Fixed to `!storeRefs.realmIsRoot.value` in all four files; the props/entity fallback precedence is untouched.

**Behavior change:** a non-master-realm actor's scope/role/permission/policy forms now default `realm_id` to the actor's own realm as intended; master-realm actors keep the existing entity-realm fallback.

### 2. Permission check overwrote the realm id with the realm name

`createPermissionCheckerReactiveFn` (`core/permission-check/module.ts`) built the `IdentityPolicyData` as:

```ts
if (storeRefs.realmId.value) {
    identity.realmId = storeRefs.realmId.value;
}
if (storeRefs.realmName.value) {
    identity.realmId = storeRefs.realmName.value;   // clobbers the UUID with the name
}
```

`IdentityPolicyData` (`@authup/access`) has distinct `realmId` and `realmName` fields, and `RealmMatchPolicyEvaluator` consumes them separately (`attributeValue === identity.realmId || attributeValue === identity.realmName`, plus `realmScopeMatches(scope, resource, identity.realmId, identity.realmName)`). With the overwrite, `realmId` carried the name and `realmName` stayed unset, so a resource `realm_id` UUID matched **neither** field. Fixed to assign the name to `identity.realmName`.

## Test plan

- New `test/unit/core/permission-check/module.spec.ts`: seeds a pinia-backed store with user + realm, spies on `permissionEvaluator.preEvaluateOneOf`, and asserts the identity carries `realmId` (UUID) and `realmName` (name) on distinct fields, plus the no-realm case. Verified the spec fails against the unfixed module (`realmId: 'master'`) and passes with the fix.
- Form-component specs skipped (mount harness too heavy for a one-token truthiness fix); the guard shape is identical across all four files.
- `npm run test --workspace=packages/client-web-kit` — 11 files / 55 tests green.
- `npm run build -w packages/client-web-kit` + `vue-tsc --noEmit -p tsconfig.json` (only the pre-existing root-tsconfig `baseUrl` deprecation notice) green.
- ESLint clean on all changed files.