### PR TITLE
fix(client-web-kit): restrict assignFormProperties to declared form keys

### DIFF
--- a/packages/client-web-kit/src/core/form/properties.ts
+++ b/packages/client-web-kit/src/core/form/properties.ts
@@ -10,35 +10,36 @@ type PartialRecordWithNull<T extends Record<string, any>> = {
 };
 
 /**
- * Assign properties from input to src.
- * 'null' values will be transformed to an empty string.
+ * Hydrate form state from a data source (e.g. a loaded entity):
+ * assign `data`'s values onto `form`. 'null' values are transformed to an
+ * empty string so they bind cleanly to form inputs.
  *
- * Only keys already present in src are assigned — the form state owns its
- * shape. Copying every input key would leak unrelated entity properties
+ * Only keys already declared in `form` are assigned — the form state owns
+ * its shape. Copying every data key would leak unrelated entity properties
  * (id, timestamps, sibling sub-form fields, ...) into the form state and
  * from there into submit payloads, where a stale copy from one sub-form
  * can clobber an edited value from another.
  *
- * @param src
- * @param input
+ * @param form the form state to hydrate (mutated in place)
+ * @param data the data source to read values from
  */
 export function assignFormProperties<T extends Record<string, any>>(
-    src: T,
-    input: PartialRecordWithNull<T> = {},
+    form: T,
+    data: PartialRecordWithNull<T> = {},
 ) : T {
-    const keys : (keyof T)[] = Object.keys(src);
+    const keys : (keyof T)[] = Object.keys(form);
     for (const key of keys) {
-        if (!Object.prototype.hasOwnProperty.call(input, key)) {
+        if (!Object.prototype.hasOwnProperty.call(data, key)) {
             continue;
         }
 
-        const value = input[key];
+        const value = data[key];
         if (value === null) {
-            src[key] = '' as T[keyof T];
+            form[key] = '' as T[keyof T];
         } else {
-            src[key] = value as T[keyof T];
+            form[key] = value as T[keyof T];
         }
     }
 
-    return src;
+    return form;
 }

--- a/packages/client-web-kit/src/core/form/properties.ts
+++ b/packages/client-web-kit/src/core/form/properties.ts
@@ -13,6 +13,12 @@ type PartialRecordWithNull<T extends Record<string, any>> = {
  * Assign properties from input to src.
  * 'null' values will be transformed to an empty string.
  *
+ * Only keys already present in src are assigned — the form state owns its
+ * shape. Copying every input key would leak unrelated entity properties
+ * (id, timestamps, sibling sub-form fields, ...) into the form state and
+ * from there into submit payloads, where a stale copy from one sub-form
+ * can clobber an edited value from another.
+ *
  * @param src
  * @param input
  */
@@ -20,8 +26,12 @@ export function assignFormProperties<T extends Record<string, any>>(
     src: T,
     input: PartialRecordWithNull<T> = {},
 ) : T {
-    const keys : (keyof T)[] = Object.keys(input);
+    const keys : (keyof T)[] = Object.keys(src);
     for (const key of keys) {
+        if (!Object.prototype.hasOwnProperty.call(input, key)) {
+            continue;
+        }
+
         const value = input[key];
         if (value === null) {
             src[key] = '' as T[keyof T];

--- a/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IdentityProvider } from '@authup/core-kit';
+import { IdentityProviderProtocol } from '@authup/core-kit';
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { FakeClient, FakeRequest } from '@authup/core-http-kit/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import vuecs from '@vuecs/core';
+import { createPinia } from 'pinia';
+import { describe, expect, it } from 'vitest';
+import AIdentityProviderOAuth2Form from '../../../../../src/components/entities/identity-provider/AIdentityProviderOAuth2Form.vue';
+import { ANameInput } from '../../../../../src/components/utility';
+import { install } from '../../../../../src/module';
+import type { Options } from '../../../../../src/types';
+
+const noop = () => undefined;
+
+function createEntity() : IdentityProvider {
+    return {
+        id: 'f0b1e948-4e69-4b7e-9f0c-1a2b3c4d5e6f',
+        name: 'old-name',
+        display_name: null,
+        protocol: IdentityProviderProtocol.OAUTH2,
+        preset: null,
+        enabled: true,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        realm_id: 'realm-1',
+        realm: {
+            id: 'realm-1',
+            name: 'master',
+            display_name: null,
+            description: null,
+            built_in: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        // oauth2 extra attributes (EA) as returned by the API
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+        token_url: 'https://idp.example.com/oauth/token',
+        authorize_url: 'https://idp.example.com/oauth/authorize',
+    } as IdentityProvider;
+}
+
+function mountForm(entity: IdentityProvider) {
+    const pinia = createPinia();
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /identity-providers/:id': (request: FakeRequest) => ({
+                ...entity,
+                ...(request.body as Record<string, any>),
+                updated_at: '2026-01-02T00:00:00.000Z',
+            }),
+        },
+    });
+
+    const options : Options = {
+        baseURL: 'http://fake.test',
+        httpClient,
+        pinia,
+        isServer: true,
+        cookieGet: noop,
+        cookieSet: noop,
+        cookieUnset: noop,
+    };
+
+    const wrapper = mount(AIdentityProviderOAuth2Form, {
+        props: { entity },
+        global: {
+            components: { VCIcon: { render: () => null } },
+            plugins: [
+                pinia,
+                [vuecs, {}],
+                [{ install }, options],
+            ],
+        },
+    });
+
+    return { wrapper, httpClient };
+}
+
+function findUpdateRequest(httpClient: FakeClient) : FakeRequest | undefined {
+    return httpClient.requests.find(
+        (request) => request.method === 'POST' &&
+            new URL(request.url, 'http://localhost').pathname.startsWith('/identity-providers/'),
+    );
+}
+
+describe('AIdentityProviderOAuth2Form', () => {
+    it('should submit a changed name on update', async () => {
+        const entity = createEntity();
+        const { wrapper, httpClient } = mountForm(entity);
+
+        await flushPromises();
+
+        const nameInput = wrapper.findComponent(ANameInput);
+        expect(nameInput.exists()).toBe(true);
+        expect(nameInput.props('modelValue')).toEqual('old-name');
+
+        nameInput.vm.$emit('update:modelValue', 'new-name');
+        await flushPromises();
+
+        await wrapper.find('form').trigger('submit');
+        await flushPromises();
+
+        const request = findUpdateRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({ name: 'new-name' });
+
+        // sub-form states must not leak unrelated entity properties into
+        // the payload (a stale `name` copied into the client/endpoint
+        // sub-forms previously clobbered the edited one on spread).
+        const body = request!.body as Record<string, any>;
+        expect(body).not.toHaveProperty('id');
+        expect(body).not.toHaveProperty('realm');
+        expect(body).not.toHaveProperty('created_at');
+        expect(body).not.toHaveProperty('updated_at');
+    });
+});


### PR DESCRIPTION
## Problem

Renaming an identity provider in `AIdentityProviderForm` and submitting had no effect — the old name was sent to the backend.

## Root cause

`assignFormProperties` copied **every** key of the input entity into a form's reactive state, not just the keys the form declares. Each identity-provider sub-form (`AIdentityProviderBasicFields`, `...OAuth2ClientFields`, `...OAuth2EndpointFields`, and the five LDAP field groups) calls it with the whole entity, so the client/endpoint sub-form states silently absorbed a stale copy of `name` (plus `id`, `realm`, timestamps, ...).

On submit, the parent form spreads the sub-form results in order `basic → client → endpoint`, so the stale `name` from the later sub-forms clobbered the edited value from the basic sub-form. The whole entity also leaked into every entity form's request payload (harmless server-side — validators strip unmounted keys — but wrong).

## Fix

`assignFormProperties` now assigns only keys already declared in the form state. Audited all 20 call sites: every form pre-declares its full key set in `reactive({...})` and nothing reads the previously-leaked keys.

## Verification

- New regression spec `test/unit/components/entities/identity-provider/oauth2-form.spec.ts` mounts the OAuth2 form with an entity, edits the name, submits, and asserts the request body carries the new name and no leaked entity properties — failed with `name: 'old-name'` before the fix.
- Full client-web-kit suite (90 tests), build, `vue-tsc`, and ESLint pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form updates now submit only fields supported by the form, preventing unrelated or stale entity properties from being included.
  * OAuth2 identity provider updates now send only the changed values, improving update reliability.

* **Tests**
  * Added coverage to verify that identity provider updates exclude unrelated properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->