### PR TITLE
feat(client-web-kit): make entity form re-hydration reactive and edit-preserving

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1784,6 +1784,25 @@ integration:
   squared group edge (double border/notched seam). Where a real
   `<VCButton>` is intentional (e.g. `AFormInputListItem`'s
   warning-colored delete), square its inner edge with `rounded-l-none`.
+  **Entity hydration contract** (`assignFormProperties(form, entity,
+  { fields: v.fields })`, `core/form/properties.ts`): the helper assigns
+  only keys **declared in the form state** — the form owns its shape, and
+  copying every entity key leaks foreign properties into the state and
+  from there into submit payloads (a stale sibling-sub-form copy of
+  `name` used to clobber the edited value on the identity-provider
+  form's spread, #3222). With the validup `fields` accessor supplied,
+  hydration is **edit-preserving**: a `$dirty` field whose current value
+  differs from the incoming one is skipped (unsaved edit survives an
+  entity refresh), while a `$dirty` field whose value matches is
+  re-assigned and `$reset` (the edit got persisted, future syncs flow
+  again). Two supporting rules: `useUpdatedAt` must be passed a ref or
+  getter (`useUpdatedAt(() => props.entity)`) — passing `props.entity`
+  by value captures the object once and yields a watcher that never
+  fires; and user-input handlers must write through
+  `v.fields.<key>.$model.value` (never `form.<key> = ...`) so the edit
+  is dirty-tracked — direct `form` writes are reserved for hydration
+  defaults (`generateName()` fills, prop seeds) that deliberately stay
+  clean.
 - **Collections** — `defineEntityCollectionManager().render(...)`
   (`components/utility/entity/collection/module.ts`) composes `<VCList>`
   + `<VCListBody>` + `<VCListItem>` + `<VCListLoading>` + `<VCListEmpty>`

--- a/packages/client-web-kit/src/components/entities/client/AClientForm.vue
+++ b/packages/client-web-kit/src/components/entities/client/AClientForm.vue
@@ -111,7 +111,7 @@ export default defineComponent({
         const store = injectStore();
         const storeRefs = storeToRefs(store);
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
 
         const isNameFixed = computed(() => !!props.name && props.name.length > 0);
         const realmId = computed(() => (manager.data.value ?
@@ -133,7 +133,7 @@ export default defineComponent({
                 form.name = props.name;
             }
 
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             if (form.name.length === 0) {
                 form.name = generateName(nameSeed);
@@ -181,7 +181,7 @@ export default defineComponent({
 
             await manager.createOrUpdate(form);
 
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
         };
 
         const translationsClient = useTranslationsForNamespace(

--- a/packages/client-web-kit/src/components/entities/identity-provider-role/AIdentityProviderRoleAssignment.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider-role/AIdentityProviderRoleAssignment.vue
@@ -140,7 +140,7 @@ export default defineComponent({
         });
 
         if (manager.data.value) {
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
         }
 
         const handleSaveOrCreate = (e: Event) => {

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderBasicFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderBasicFields.vue
@@ -70,7 +70,7 @@ export default defineComponent({
         };
 
         function assign(data: Partial<IdentityProvider> = {}) {
-            assignFormProperties(form, data);
+            assignFormProperties(form, data, { fields: v.fields });
 
             if (isNameEmpty.value) {
                 form.name = generateName(nameSeed);
@@ -79,7 +79,7 @@ export default defineComponent({
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as IdentityProvider);
+        const updatedAt = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);
@@ -105,7 +105,7 @@ export default defineComponent({
         };
 
         const onNameUpdate = (value: string) => {
-            form.name = value;
+            v.fields.name.$model.value = value;
             update();
         };
 

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapConnectionFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapConnectionFields.vue
@@ -48,10 +48,10 @@ export default defineComponent({
 
         function init() {
             if (!props.entity) return;
-            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>);
+            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>, { fields: v.fields });
         }
 
-        const updated = useUpdatedAt(props.entity as IdentityProvider);
+        const updated = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updated, () => init());
 
         init();

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapCredentialsFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapCredentialsFields.vue
@@ -48,10 +48,10 @@ export default defineComponent({
 
         function init() {
             if (!props.entity) return;
-            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>);
+            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>, { fields: v.fields });
         }
 
-        const updated = useUpdatedAt(props.entity as IdentityProvider);
+        const updated = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updated, () => init());
         init();
 

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapGroupFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapGroupFields.vue
@@ -41,10 +41,10 @@ export default defineComponent({
 
         function init() {
             if (!props.entity) return;
-            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>);
+            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>, { fields: v.fields });
         }
 
-        const updated = useUpdatedAt(props.entity as IdentityProvider);
+        const updated = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updated, () => init());
         init();
 

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapUserFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderLdapUserFields.vue
@@ -40,10 +40,10 @@ export default defineComponent({
 
         function init() {
             if (!props.entity) return;
-            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>);
+            assignFormProperties(form, props.entity as Partial<LdapIdentityProvider>, { fields: v.fields });
         }
 
-        const updated = useUpdatedAt(props.entity as IdentityProvider);
+        const updated = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updated, () => init());
         init();
 

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
@@ -53,10 +53,10 @@ export default defineComponent({
         );
 
         function assign() {
-            assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>);
+            assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>, { fields: v.fields });
         }
 
-        const updatedAt = useUpdatedAt(props.entity as IdentityProvider);
+        const updatedAt = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updatedAt, () => assign());
         assign();
 

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2EndpointFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2EndpointFields.vue
@@ -64,23 +64,29 @@ export default defineComponent({
         const userInfoUrlField = v.fields.at<string | null>('user_info_url');
 
         function init() {
-            form.token_url = '';
-            form.authorize_url = '';
-            form.user_info_url = '';
+            // blank via the helper so an unsaved (dirty) edit survives an
+            // entity refresh instead of being wiped before the re-assign
+            assignFormProperties(form, {
+                token_url: null,
+                authorize_url: null,
+                user_info_url: null,
+            }, { fields: v.fields });
 
             if (!props.entity) return;
 
-            assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>);
+            assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>, { fields: v.fields });
         }
 
-        const updated = useUpdatedAt(props.entity as IdentityProvider);
+        const updated = useUpdatedAt(() => props.entity as IdentityProvider);
         onChange(updated, () => init());
 
         init();
 
         const handleDiscoveryLookup = (data: OpenIDProviderMetadata) => {
-            form.authorize_url = data.authorization_endpoint;
-            form.token_url = data.token_endpoint;
+            // through $model so the discovered values count as user edits
+            // (dirty) and survive a concurrent entity refresh
+            v.fields.authorize_url.$model.value = data.authorization_endpoint;
+            v.fields.token_url.$model.value = data.token_endpoint;
         };
 
         const translations = useTranslations([

--- a/packages/client-web-kit/src/components/entities/permission/APermissionForm.vue
+++ b/packages/client-web-kit/src/components/entities/permission/APermissionForm.vue
@@ -109,11 +109,11 @@ export default defineComponent({
                 null;
         });
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
         const isBuiltIn = computed(() => !!(manager.data.value && manager.data.value.built_in));
 
         function initForm() {
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             if (form.name.length === 0) {
                 form.name = generateName(nameSeed);

--- a/packages/client-web-kit/src/components/entities/policy/APolicyBasicForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/APolicyBasicForm.vue
@@ -98,12 +98,12 @@ export default defineComponent({
         );
 
         function assign(data: Partial<Policy> = {}) {
-            assignFormProperties(form, data);
+            assignFormProperties(form, data, { fields: v.fields });
         }
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);

--- a/packages/client-web-kit/src/components/entities/policy/attribute-names/AAttributeNamesPolicyForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/attribute-names/AAttributeNamesPolicyForm.vue
@@ -23,7 +23,7 @@ export default defineComponent({
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);

--- a/packages/client-web-kit/src/components/entities/policy/composite/ACompositePolicyForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/composite/ACompositePolicyForm.vue
@@ -102,7 +102,7 @@ export default defineComponent({
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);

--- a/packages/client-web-kit/src/components/entities/policy/date/ADatePolicyForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/date/ADatePolicyForm.vue
@@ -42,12 +42,12 @@ export default defineComponent({
         ]);
 
         function assign(data: Partial<DatePolicy> = {}) {
-            assignFormProperties(form, data as Record<string, unknown>);
+            assignFormProperties(form, data as Record<string, unknown>, { fields: v.fields });
         }
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);

--- a/packages/client-web-kit/src/components/entities/policy/identity/AIdentityPolicyForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/identity/AIdentityPolicyForm.vue
@@ -31,7 +31,7 @@ export default defineComponent({
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);

--- a/packages/client-web-kit/src/components/entities/policy/realm-match/ARealmMatchPolicyForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/realm-match/ARealmMatchPolicyForm.vue
@@ -37,17 +37,20 @@ export default defineComponent({
 
         function assign(input: Partial<RealmMatchPolicy> = {}) {
             const { attribute_name, ...data } = input;
-            assignFormProperties(form, data as Record<string, unknown>);
+            let names : string[] = [];
             if (attribute_name) {
-                form.attribute_name = typeof attribute_name === 'string' ? [attribute_name] : attribute_name;
-            } else {
-                form.attribute_name = [];
+                names = typeof attribute_name === 'string' ? [attribute_name] : attribute_name;
             }
+
+            assignFormProperties(form, {
+                ...data,
+                attribute_name: names,
+            } as Record<string, unknown>, { fields: v.fields });
         }
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);
@@ -60,7 +63,7 @@ export default defineComponent({
         };
 
         const handleAttributeNameChanged = (data: string[]) => {
-            form.attribute_name = data;
+            v.fields.attribute_name.$model.value = data;
             handleUpdated();
         };
 

--- a/packages/client-web-kit/src/components/entities/policy/time/ATimePolicyForm.vue
+++ b/packages/client-web-kit/src/components/entities/policy/time/ATimePolicyForm.vue
@@ -78,12 +78,12 @@ export default defineComponent({
         ]);
 
         function assign(data: Partial<TimePolicy> = {}) {
-            assignFormProperties(form, data as Record<string, unknown>);
+            assignFormProperties(form, data as Record<string, unknown>, { fields: v.fields });
         }
 
         setup.expose({ assign });
 
-        const updatedAt = useUpdatedAt(props.entity as Policy);
+        const updatedAt = useUpdatedAt(() => props.entity as Policy);
         onChange(updatedAt, () => assign(props.entity));
 
         assign(props.entity);

--- a/packages/client-web-kit/src/components/entities/realm/ARealmForm.vue
+++ b/packages/client-web-kit/src/components/entities/realm/ARealmForm.vue
@@ -71,12 +71,12 @@ export default defineComponent({
             { group: computed(() => (isEditing.value ? ValidatorGroup.UPDATE : ValidatorGroup.CREATE)) },
         );
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
         const isMaster = computed(() => manager.data.value &&
             manager.data.value.name === REALM_MASTER_NAME);
 
         function initForm() {
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             if (form.name.length === 0) {
                 form.name = generateName(nameSeed);

--- a/packages/client-web-kit/src/components/entities/robot/ARobotForm.vue
+++ b/packages/client-web-kit/src/components/entities/robot/ARobotForm.vue
@@ -78,7 +78,7 @@ export default defineComponent({
             { group: computed(() => (isEditing.value ? ValidatorGroup.UPDATE : ValidatorGroup.CREATE)) },
         );
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
 
         const isNameFixed = computed(() => !!props.name && props.name.length > 0);
         const isRealmLocked = computed(() => !!props.realmId);
@@ -89,7 +89,7 @@ export default defineComponent({
         );
 
         function initForm() {
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             // Apply caller-fixed props AFTER assign so the entity payload
             // can't overwrite a locked name / realm.
@@ -264,7 +264,7 @@ export default defineComponent({
                         <AToggleButton
                             :value="form.realm_id === pickerProps.data.id"
                             :is-busy="pickerProps.busy"
-                            @changed="(value: boolean) => { form.realm_id = value ? pickerProps.data.id : ''; }"
+                            @changed="(value: boolean) => { v.fields.realm_id.$model.value = value ? pickerProps.data.id : ''; }"
                         />
                     </template>
                 </ARealms>

--- a/packages/client-web-kit/src/components/entities/role/ARoleForm.vue
+++ b/packages/client-web-kit/src/components/entities/role/ARoleForm.vue
@@ -96,10 +96,10 @@ export default defineComponent({
                 null;
         });
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
 
         function initForm() {
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             if (form.name.length === 0) {
                 form.name = generateName(nameSeed);

--- a/packages/client-web-kit/src/components/entities/scope/AScopeForm.vue
+++ b/packages/client-web-kit/src/components/entities/scope/AScopeForm.vue
@@ -92,7 +92,7 @@ export default defineComponent({
                 null;
         });
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
 
         const isNameFixed = computed<boolean>(() => {
             if (!!props.name && props.name.length > 0) {
@@ -107,7 +107,7 @@ export default defineComponent({
                 form.name = props.name;
             }
 
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             if (form.name.length === 0) {
                 form.name = generateName(nameSeed);

--- a/packages/client-web-kit/src/components/entities/user/AUserForm.vue
+++ b/packages/client-web-kit/src/components/entities/user/AUserForm.vue
@@ -90,7 +90,7 @@ export default defineComponent({
             { group: computed(() => (isEditing.value ? ValidatorGroup.UPDATE : ValidatorGroup.CREATE)) },
         );
 
-        const updatedAt = useUpdatedAt(props.entity);
+        const updatedAt = useUpdatedAt(() => props.entity);
 
         const isRealmLocked = computed(() => !!props.realmId);
         const showRealmPicker = computed(() => props.canManage && !isRealmLocked.value);
@@ -103,7 +103,7 @@ export default defineComponent({
                 form.name_locked = manager.data.value.name_locked;
             }
 
-            assignFormProperties(form, manager.data.value);
+            assignFormProperties(form, manager.data.value, { fields: v.fields });
 
             if (form.name.length === 0) {
                 form.name = generateName(nameSeed);
@@ -306,7 +306,7 @@ export default defineComponent({
                         <AToggleButton
                             :value="form.realm_id === pickerProps.data.id"
                             :is-busy="pickerProps.busy"
-                            @changed="(value: boolean) => { form.realm_id = value ? pickerProps.data.id : ''; }"
+                            @changed="(value: boolean) => { v.fields.realm_id.$model.value = value ? pickerProps.data.id : ''; }"
                         />
                     </template>
                 </ARealms>

--- a/packages/client-web-kit/src/composables/updated-at.ts
+++ b/packages/client-web-kit/src/composables/updated-at.ts
@@ -5,18 +5,23 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { ComputedRef, MaybeRef } from 'vue';
-import { computed, isRef } from 'vue';
+import type { ComputedRef, MaybeRefOrGetter } from 'vue';
+import { computed, toValue } from 'vue';
 
 type ObjectLiteral = {
     updated_at: string | Date | undefined
 };
-export function useUpdatedAt<T extends ObjectLiteral>(input?: MaybeRef<T | null | undefined>) : ComputedRef<string | Date | undefined> {
-    return computed(() => {
-        if (isRef(input)) {
-            return input.value ? input.value.updated_at : undefined;
-        }
 
-        return input ? input.updated_at : undefined;
+/**
+ * Track an entity's `updated_at`. Pass a ref or getter
+ * (e.g. `() => props.entity`) — a plain value is accepted but yields a
+ * static computed: reading `props.entity` at the call site captures the
+ * object once, so a later prop replacement never triggers watchers.
+ */
+export function useUpdatedAt<T extends ObjectLiteral>(input?: MaybeRefOrGetter<T | null | undefined>) : ComputedRef<string | Date | undefined> {
+    return computed(() => {
+        const value = toValue(input);
+
+        return value ? value.updated_at : undefined;
     });
 }

--- a/packages/client-web-kit/src/core/form/index.ts
+++ b/packages/client-web-kit/src/core/form/index.ts
@@ -7,3 +7,4 @@
 
 export * from './defaults';
 export * from './properties';
+export * from './types';

--- a/packages/client-web-kit/src/core/form/properties.ts
+++ b/packages/client-web-kit/src/core/form/properties.ts
@@ -10,35 +10,36 @@ type PartialRecordWithNull<T extends Record<string, any>> = {
 };
 
 /**
- * Assign properties from input to src.
- * 'null' values will be transformed to an empty string.
+ * Hydrate form state from a data source (e.g. a loaded entity):
+ * assign `data`'s values onto `form`. 'null' values are transformed to an
+ * empty string so they bind cleanly to form inputs.
  *
- * Only keys already present in src are assigned — the form state owns its
- * shape. Copying every input key would leak unrelated entity properties
+ * Only keys already declared in `form` are assigned — the form state owns
+ * its shape. Copying every data key would leak unrelated entity properties
  * (id, timestamps, sibling sub-form fields, ...) into the form state and
  * from there into submit payloads, where a stale copy from one sub-form
  * can clobber an edited value from another.
  *
- * @param src
- * @param input
+ * @param form the form state to hydrate (mutated in place)
+ * @param data the data source to read values from
  */
 export function assignFormProperties<T extends Record<string, any>>(
-    src: T,
-    input: PartialRecordWithNull<T> = {},
+    form: T,
+    data: PartialRecordWithNull<T> = {},
 ) : T {
-    const keys : (keyof T)[] = Object.keys(src);
+    const keys : (keyof T)[] = Object.keys(form);
     for (const key of keys) {
-        if (!Object.prototype.hasOwnProperty.call(input, key)) {
+        if (!Object.prototype.hasOwnProperty.call(data, key)) {
             continue;
         }
 
-        const value = input[key];
+        const value = data[key];
         if (value === null) {
-            src[key] = '' as T[keyof T];
+            form[key] = '' as T[keyof T];
         } else {
-            src[key] = value as T[keyof T];
+            form[key] = value as T[keyof T];
         }
     }
 
-    return src;
+    return form;
 }

--- a/packages/client-web-kit/src/core/form/properties.ts
+++ b/packages/client-web-kit/src/core/form/properties.ts
@@ -13,6 +13,12 @@ type PartialRecordWithNull<T extends Record<string, any>> = {
  * Assign properties from input to src.
  * 'null' values will be transformed to an empty string.
  *
+ * Only keys already present in src are assigned — the form state owns its
+ * shape. Copying every input key would leak unrelated entity properties
+ * (id, timestamps, sibling sub-form fields, ...) into the form state and
+ * from there into submit payloads, where a stale copy from one sub-form
+ * can clobber an edited value from another.
+ *
  * @param src
  * @param input
  */
@@ -20,8 +26,12 @@ export function assignFormProperties<T extends Record<string, any>>(
     src: T,
     input: PartialRecordWithNull<T> = {},
 ) : T {
-    const keys : (keyof T)[] = Object.keys(input);
+    const keys : (keyof T)[] = Object.keys(src);
     for (const key of keys) {
+        if (!Object.prototype.hasOwnProperty.call(input, key)) {
+            continue;
+        }
+
         const value = input[key];
         if (value === null) {
             src[key] = '' as T[keyof T];

--- a/packages/client-web-kit/src/core/form/properties.ts
+++ b/packages/client-web-kit/src/core/form/properties.ts
@@ -5,9 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-type PartialRecordWithNull<T extends Record<string, any>> = {
-    [K in keyof T]?: T[K] | null
-};
+import { isEqual } from 'smob';
+import type { AssignFormPropertiesOptions, PartialRecordWithNull } from './types';
 
 /**
  * Hydrate form state from a data source (e.g. a loaded entity):
@@ -20,12 +19,18 @@ type PartialRecordWithNull<T extends Record<string, any>> = {
  * from there into submit payloads, where a stale copy from one sub-form
  * can clobber an edited value from another.
  *
+ * When `options.fields` is provided (the validup `fields` accessor bound
+ * to `form`), hydration preserves unsaved user edits — see
+ * {@link AssignFormPropertiesOptions}.
+ *
  * @param form the form state to hydrate (mutated in place)
  * @param data the data source to read values from
+ * @param options optional edit-preserving behavior
  */
 export function assignFormProperties<T extends Record<string, any>>(
     form: T,
     data: PartialRecordWithNull<T> = {},
+    options: AssignFormPropertiesOptions = {},
 ) : T {
     const keys : (keyof T)[] = Object.keys(form);
     for (const key of keys) {
@@ -34,11 +39,20 @@ export function assignFormProperties<T extends Record<string, any>>(
         }
 
         const value = data[key];
-        if (value === null) {
-            form[key] = '' as T[keyof T];
-        } else {
-            form[key] = value as T[keyof T];
+        const next = (value === null ? '' : value) as T[keyof T];
+
+        if (options.fields) {
+            const field = options.fields.at(key as string);
+            if (field.$dirty.value) {
+                if (!isEqual(form[key], next)) {
+                    continue;
+                }
+
+                field.$reset();
+            }
         }
+
+        form[key] = next;
     }
 
     return form;

--- a/packages/client-web-kit/src/core/form/types.ts
+++ b/packages/client-web-kit/src/core/form/types.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type PartialRecordWithNull<T extends Record<string, any>> = {
+    [K in keyof T]?: T[K] | null
+};
+
+/**
+ * Structural subset of `@validup/vue`'s `FieldsAccessor` — just what
+ * edit-preserving hydration needs (per-field dirty flag + reset).
+ */
+export type FormFieldsAccessor = {
+    at(path: string): {
+        $dirty: { value: boolean },
+        $reset: () => void,
+    },
+};
+
+export type AssignFormPropertiesOptions = {
+    /**
+     * The validup `fields` accessor of the composable bound to the form
+     * state (`v.fields`). When provided, hydration preserves unsaved
+     * user edits: a dirty field whose current value differs from the
+     * incoming one is skipped, while a dirty field whose value matches
+     * the incoming one is re-assigned and reset (the edit has been
+     * persisted, so subsequent syncs flow again).
+     */
+    fields?: FormFieldsAccessor,
+};

--- a/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { IdentityProvider } from '@authup/core-kit';
+import { IdentityProviderProtocol } from '@authup/core-kit';
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { FakeClient, FakeRequest } from '@authup/core-http-kit/testing';
+import { flushPromises, mount } from '@vue/test-utils';
+import vuecs from '@vuecs/core';
+import { createPinia } from 'pinia';
+import { describe, expect, it } from 'vitest';
+import AIdentityProviderOAuth2Form from '../../../../../src/components/entities/identity-provider/AIdentityProviderOAuth2Form.vue';
+import { ANameInput } from '../../../../../src/components/utility';
+import { install } from '../../../../../src/module';
+import type { Options } from '../../../../../src/types';
+
+const noop = () => undefined;
+
+function createEntity() : IdentityProvider {
+    return {
+        id: 'f0b1e948-4e69-4b7e-9f0c-1a2b3c4d5e6f',
+        name: 'old-name',
+        display_name: null,
+        protocol: IdentityProviderProtocol.OAUTH2,
+        preset: null,
+        enabled: true,
+        created_at: '2026-01-01T00:00:00.000Z',
+        updated_at: '2026-01-01T00:00:00.000Z',
+        realm_id: 'realm-1',
+        realm: {
+            id: 'realm-1',
+            name: 'master',
+            display_name: null,
+            description: null,
+            built_in: true,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+        },
+        // oauth2 extra attributes (EA) as returned by the API
+        client_id: 'client-id',
+        client_secret: 'client-secret',
+        token_url: 'https://idp.example.com/oauth/token',
+        authorize_url: 'https://idp.example.com/oauth/authorize',
+    } as IdentityProvider;
+}
+
+function mountForm(entity: IdentityProvider) {
+    const pinia = createPinia();
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /identity-providers/:id': (request: FakeRequest) => ({
+                ...entity,
+                ...(request.body as Record<string, any>),
+                updated_at: '2026-01-02T00:00:00.000Z',
+            }),
+        },
+    });
+
+    const options : Options = {
+        baseURL: 'http://fake.test',
+        httpClient,
+        pinia,
+        isServer: true,
+        cookieGet: noop,
+        cookieSet: noop,
+        cookieUnset: noop,
+    };
+
+    const wrapper = mount(AIdentityProviderOAuth2Form, {
+        props: { entity },
+        global: {
+            components: { VCIcon: { render: () => null } },
+            plugins: [
+                pinia,
+                [vuecs, {}],
+                [{ install }, options],
+            ],
+        },
+    });
+
+    return { wrapper, httpClient };
+}
+
+function findUpdateRequest(httpClient: FakeClient) : FakeRequest | undefined {
+    return httpClient.requests.find(
+        (request) => request.method === 'POST' &&
+            new URL(request.url, 'http://localhost').pathname.startsWith('/identity-providers/'),
+    );
+}
+
+describe('AIdentityProviderOAuth2Form', () => {
+    it('should submit a changed name on update', async () => {
+        const entity = createEntity();
+        const { wrapper, httpClient } = mountForm(entity);
+
+        await flushPromises();
+
+        const nameInput = wrapper.findComponent(ANameInput);
+        expect(nameInput.exists()).toBe(true);
+        expect(nameInput.props('modelValue')).toEqual('old-name');
+
+        nameInput.vm.$emit('update:modelValue', 'new-name');
+        await flushPromises();
+
+        await wrapper.find('form').trigger('submit');
+        await flushPromises();
+
+        const request = findUpdateRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({ name: 'new-name' });
+
+        // sub-form states must not leak unrelated entity properties into
+        // the payload (a stale `name` copied into the client/endpoint
+        // sub-forms previously clobbered the edited one on spread).
+        const body = request!.body as Record<string, any>;
+        expect(body).not.toHaveProperty('id');
+        expect(body).not.toHaveProperty('realm');
+        expect(body).not.toHaveProperty('created_at');
+        expect(body).not.toHaveProperty('updated_at');
+    });
+});

--- a/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
@@ -13,6 +13,7 @@ import { flushPromises, mount } from '@vue/test-utils';
 import vuecs from '@vuecs/core';
 import { createPinia } from 'pinia';
 import { describe, expect, it } from 'vitest';
+import AIdentityProviderBasicFields from '../../../../../src/components/entities/identity-provider/AIdentityProviderBasicFields.vue';
 import AIdentityProviderOAuth2Form from '../../../../../src/components/entities/identity-provider/AIdentityProviderOAuth2Form.vue';
 import { ANameInput } from '../../../../../src/components/utility';
 import { install } from '../../../../../src/module';
@@ -48,7 +49,7 @@ function createEntity() : IdentityProvider {
     } as IdentityProvider;
 }
 
-function mountForm(entity: IdentityProvider) {
+function mountComponent(component: any, entity: IdentityProvider) {
     const pinia = createPinia();
     const httpClient = createFakeClient({
         handlers: {
@@ -70,7 +71,7 @@ function mountForm(entity: IdentityProvider) {
         cookieUnset: noop,
     };
 
-    const wrapper = mount(AIdentityProviderOAuth2Form, {
+    const wrapper = mount(component, {
         props: { entity },
         global: {
             components: { VCIcon: { render: () => null } },
@@ -83,6 +84,10 @@ function mountForm(entity: IdentityProvider) {
     });
 
     return { wrapper, httpClient };
+}
+
+function mountForm(entity: IdentityProvider) {
+    return mountComponent(AIdentityProviderOAuth2Form, entity);
 }
 
 function findUpdateRequest(httpClient: FakeClient) : FakeRequest | undefined {
@@ -121,5 +126,65 @@ describe('AIdentityProviderOAuth2Form', () => {
         expect(body).not.toHaveProperty('realm');
         expect(body).not.toHaveProperty('created_at');
         expect(body).not.toHaveProperty('updated_at');
+    });
+});
+
+describe('AIdentityProviderBasicFields', () => {
+    it('should preserve an unsaved edit across an entity refresh and release it once persisted', async () => {
+        const entity = createEntity();
+        const { wrapper } = mountComponent(AIdentityProviderBasicFields, entity);
+
+        await flushPromises();
+
+        const nameInput = wrapper.findComponent(ANameInput);
+        const inputValues = () => wrapper
+            .findAll('input')
+            .map((i) => (i.element as HTMLInputElement).value);
+
+        expect(nameInput.props('modelValue')).toEqual('old-name');
+
+        // user edits the name (dirty), but does not submit
+        nameInput.vm.$emit('update:modelValue', 'new-name');
+        await flushPromises();
+
+        // external refresh: another session changed display_name
+        await wrapper.setProps({
+            entity: {
+                ...entity,
+                display_name: 'Renamed',
+                updated_at: '2026-01-03T00:00:00.000Z',
+            },
+        });
+        await flushPromises();
+
+        // the unsaved name edit survives, the clean field syncs
+        expect(nameInput.props('modelValue')).toEqual('new-name');
+        expect(inputValues()).toContain('Renamed');
+
+        // the entity catches up with the edit (own save persisted it)
+        await wrapper.setProps({
+            entity: {
+                ...entity,
+                name: 'new-name',
+                display_name: 'Renamed',
+                updated_at: '2026-01-04T00:00:00.000Z',
+            },
+        });
+        await flushPromises();
+
+        expect(nameInput.props('modelValue')).toEqual('new-name');
+
+        // a later refresh now flows again — the edit protection is released
+        await wrapper.setProps({
+            entity: {
+                ...entity,
+                name: 'third-name',
+                display_name: 'Renamed',
+                updated_at: '2026-01-05T00:00:00.000Z',
+            },
+        });
+        await flushPromises();
+
+        expect(nameInput.props('modelValue')).toEqual('third-name');
     });
 });


### PR DESCRIPTION
Stacked on #3222 (review only the last commit until that merges; base will be retargeted to `master` after).

## Problem

Two latent defects in the entity-form hydration contract, surfaced while root-causing #3222:

1. **Dead re-hydration watchers, kit-wide.** Every entity form called `useUpdatedAt(props.entity)` — reading `props.entity` in setup captures the object once, so the computed has no reactive dependency and the `onChange(updatedAt, ...)` re-hydration watcher never fired when the entity prop was replaced (post-save round-trip, socket update via the manager). Unnoticed because post-save form values usually already match what was saved.
2. **Entity refresh clobbers unsaved edits.** With the watchers made live, a plain entity-wins re-assign would wipe whatever the user is currently typing whenever another session saves the same entity.

## Fix

- `useUpdatedAt` accepts `MaybeRefOrGetter` (via `toValue`); all 21 call sites pass `() => props.entity`.
- `assignFormProperties(form, data, { fields: v.fields })` — with the validup `fields` accessor supplied, hydration is **edit-preserving**: a `$dirty` field whose current value differs from the incoming one is skipped (the unsaved edit survives), while a `$dirty` field whose value matches is re-assigned and `$reset` (the edit got persisted — subsequent syncs flow again). Value comparison via smob `isEqual` (arrays: realm-match `attribute_name`). Wired into all 20 hydration call sites.
- User-input handlers that wrote form state directly now go through `$model` so edits are dirty-tracked: identity-provider basic `name`, OAuth2 endpoint discovery lookup (+ its `init()` pre-blank now routes through the helper so it can't wipe a dirty field), realm-match attribute names, and the user/robot realm pickers. Direct `form` writes remain only for hydration defaults (`generateName()` fills, prop seeds) that deliberately stay clean.

## Verification

- New spec: edit the identity-provider name → external entity refresh (bumped `updated_at`, changed `display_name`) → the unsaved name survives while `display_name` syncs; once the entity carries the edited name, the protection releases and a later refresh flows.
- Full client-web-kit suite (91 tests), build, `vue-tsc` (src + tests), ESLint pass.
- `.agents/architecture.md` Forms bullet documents the hydration contract.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Form refreshes now preserve unsaved edits instead of unexpectedly overwriting them.
  * Forms correctly synchronize with newly saved entity data and reset stale edit states.
  * Entity updates and “last updated” tracking now respond reliably to refreshed data.
  * Form controls, including realm selection and OAuth2 discovery fields, consistently retain changes during validation and refreshes.
* **Documentation**
  * Added guidance describing form hydration and edit-preservation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->