### PR TITLE
feat: configurable scope for oauth2/oidc identity providers

### DIFF
--- a/apps/server-core/src/core/identity/provider/authentication/presets/facebook.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/facebook.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractTokenPayload } from '@authup/server-kit';
+import { mergeOAuth2Scopes } from '@authup/specs';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../protocols/index.ts';
@@ -13,7 +14,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderFacebookAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = ctx.provider.scope || 'email';
+        ctx.provider.scope = mergeOAuth2Scopes('email', ctx.provider.scope);
         ctx.provider.authorize_url = 'https://graph.facebook.com/oauth/authorize';
         ctx.provider.token_url = 'https://graph.facebook.com/oauth/access_token';
         ctx.provider.user_info_url = 'https://graph.facebook.com/me?fields=id,name,email,first_name,last_name';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/facebook.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/facebook.ts
@@ -13,7 +13,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderFacebookAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = 'email';
+        ctx.provider.scope = ctx.provider.scope || 'email';
         ctx.provider.authorize_url = 'https://graph.facebook.com/oauth/authorize';
         ctx.provider.token_url = 'https://graph.facebook.com/oauth/access_token';
         ctx.provider.user_info_url = 'https://graph.facebook.com/me?fields=id,name,email,first_name,last_name';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/github.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/github.ts
@@ -13,7 +13,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderGithubAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = 'user:email';
+        ctx.provider.scope = ctx.provider.scope || 'user:email';
         ctx.provider.authorize_url = 'https://github.com/login/oauth/authorize';
         ctx.provider.token_url = 'https://github.com/login/oauth/access_token';
         ctx.provider.user_info_url = 'https://api.github.com/user';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/github.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/github.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractTokenPayload } from '@authup/server-kit';
+import { mergeOAuth2Scopes } from '@authup/specs';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../protocols/index.ts';
@@ -13,7 +14,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderGithubAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = ctx.provider.scope || 'user:email';
+        ctx.provider.scope = mergeOAuth2Scopes('user:email', ctx.provider.scope);
         ctx.provider.authorize_url = 'https://github.com/login/oauth/authorize';
         ctx.provider.token_url = 'https://github.com/login/oauth/access_token';
         ctx.provider.user_info_url = 'https://api.github.com/user';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/google.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/google.ts
@@ -15,7 +15,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderGoogleAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = 'openid profile email';
+        ctx.provider.scope = ctx.provider.scope || 'openid profile email';
         ctx.provider.authorize_url = 'https://accounts.google.com/o/oauth2/v2/auth';
         ctx.provider.token_url = 'https://oauth2.googleapis.com/token';
         ctx.provider.user_info_url = 'https://openidconnect.googleapis.com/v1/userinfo';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/google.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/google.ts
@@ -8,6 +8,7 @@
 import type { User } from '@authup/core-kit';
 import { extractTokenPayload } from '@authup/server-kit';
 import type { OpenIDTokenPayload } from '@authup/specs';
+import { mergeOAuth2Scopes } from '@authup/specs';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../protocols/index.ts';
@@ -15,7 +16,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderGoogleAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = ctx.provider.scope || 'openid profile email';
+        ctx.provider.scope = mergeOAuth2Scopes('openid profile email', ctx.provider.scope);
         ctx.provider.authorize_url = 'https://accounts.google.com/o/oauth2/v2/auth';
         ctx.provider.token_url = 'https://oauth2.googleapis.com/token';
         ctx.provider.user_info_url = 'https://openidconnect.googleapis.com/v1/userinfo';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/instagram.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/instagram.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractTokenPayload } from '@authup/server-kit';
+import { mergeOAuth2Scopes } from '@authup/specs';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../protocols/index.ts';
@@ -13,7 +14,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderInstagramAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = ctx.provider.scope || 'user_profile';
+        ctx.provider.scope = mergeOAuth2Scopes('user_profile', ctx.provider.scope);
         ctx.provider.authorize_url = 'https://api.instagram.com/oauth/authorize';
         ctx.provider.token_url = 'https://api.instagram.com/oauth/access_token';
         ctx.provider.user_info_url = 'https://graph.instagram.com/me?fields=id,username';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/instagram.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/instagram.ts
@@ -13,7 +13,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderInstagramAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = 'user_profile';
+        ctx.provider.scope = ctx.provider.scope || 'user_profile';
         ctx.provider.authorize_url = 'https://api.instagram.com/oauth/authorize';
         ctx.provider.token_url = 'https://api.instagram.com/oauth/access_token';
         ctx.provider.user_info_url = 'https://graph.instagram.com/me?fields=id,username';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/paypal.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/paypal.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractTokenPayload } from '@authup/server-kit';
+import { mergeOAuth2Scopes } from '@authup/specs';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../protocols/index.ts';
@@ -13,7 +14,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderPaypalAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = ctx.provider.scope || 'openid profile email';
+        ctx.provider.scope = mergeOAuth2Scopes('openid profile email', ctx.provider.scope);
         ctx.provider.authorize_url = 'https://www.paypal.com/signin/authorize';
         ctx.provider.token_url = 'https://api.paypal.com/v1/identity/openidconnect/tokenservice';
         ctx.provider.user_info_url = 'https://api.paypal.com/v1/oauth2/token/userinfo?schema=openid';

--- a/apps/server-core/src/core/identity/provider/authentication/presets/paypal.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/presets/paypal.ts
@@ -13,7 +13,7 @@ import { IdentityProviderOAuth2Authenticator } from '../protocols/index.ts';
 
 export class IdentityProviderPaypalAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
-        ctx.provider.scope = 'openid profile email';
+        ctx.provider.scope = ctx.provider.scope || 'openid profile email';
         ctx.provider.authorize_url = 'https://www.paypal.com/signin/authorize';
         ctx.provider.token_url = 'https://api.paypal.com/v1/identity/openidconnect/tokenservice';
         ctx.provider.user_info_url = 'https://api.paypal.com/v1/oauth2/token/userinfo?schema=openid';

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/module.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/module.ts
@@ -42,7 +42,7 @@ export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator
                 clientId: ctx.provider.client_id,
                 clientSecret: ctx.provider.client_secret,
                 redirectUri: `${ctx.options.baseURL}${buildIdentityProviderAuthorizeCallbackPath(ctx.provider.id)}`,
-                scope: ctx.provider.scope,
+                scope: ctx.provider.scope || undefined,
                 authorizationEndpoint: ctx.provider.authorize_url,
                 tokenEndpoint: ctx.provider.token_url,
                 userinfoEndpoint: ctx.provider.user_info_url || undefined,

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/open-id/module.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/open-id/module.ts
@@ -6,6 +6,7 @@
  */
 
 import { extractTokenPayload } from '@authup/server-kit';
+import { mergeOAuth2Scopes } from '@authup/specs';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../oauth2/index.ts';
@@ -14,7 +15,10 @@ import { IdentityProviderOAuth2Authenticator } from '../oauth2/index.ts';
 export class IdentityProviderOpenIDAuthenticator extends IdentityProviderOAuth2Authenticator {
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
         // OIDC requires the openid scope (Core §3.1.2.1)
-        ctx.provider.scope = ctx.provider.scope || 'openid profile email';
+        ctx.provider.scope = mergeOAuth2Scopes(
+            'openid',
+            ctx.provider.scope || 'openid profile email',
+        );
 
         super(ctx);
     }

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/open-id/module.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/open-id/module.ts
@@ -8,9 +8,17 @@
 import { extractTokenPayload } from '@authup/server-kit';
 import type { TokenGrantResponse } from '@hapic/oauth2';
 import type { IdentityProviderIdentity } from '../../../types.ts';
+import type { IdentityProviderOAuth2AuthenticatorContext } from '../oauth2/index.ts';
 import { IdentityProviderOAuth2Authenticator } from '../oauth2/index.ts';
 
 export class IdentityProviderOpenIDAuthenticator extends IdentityProviderOAuth2Authenticator {
+    constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
+        // OIDC requires the openid scope (Core §3.1.2.1)
+        ctx.provider.scope = ctx.provider.scope || 'openid profile email';
+
+        super(ctx);
+    }
+
     protected async buildIdentityWithTokenGrantResponse(input: TokenGrantResponse): Promise<IdentityProviderIdentity> {
         const payload = extractTokenPayload(input.access_token);
 

--- a/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
@@ -134,6 +134,15 @@ describe('IdentityProviderOpenIDAuthenticator', () => {
         const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
         expect(parsed.searchParams.get('scope')).toEqual('openid custom');
     });
+
+    it('should enforce the openid scope on a user-defined scope', () => {
+        const authenticator = new IdentityProviderOpenIDAuthenticator(
+            createAuthenticatorContext(createOpenIDProvider({ scope: 'profile custom' })),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.searchParams.get('scope')).toEqual('openid profile custom');
+    });
 });
 
 describe('IdentityProviderGoogleAuthenticator', () => {
@@ -147,9 +156,9 @@ describe('IdentityProviderGoogleAuthenticator', () => {
         expect(parsed.searchParams.get('scope')).toEqual('openid profile email');
     });
 
-    it('should keep a user-defined scope', () => {
+    it('should merge a user-defined scope with the preset scopes', () => {
         const authenticator = new IdentityProviderGoogleAuthenticator(
-            createAuthenticatorContext(createProvider({ scope: 'openid profile email https://www.googleapis.com/auth/calendar.readonly' })),
+            createAuthenticatorContext(createProvider({ scope: 'https://www.googleapis.com/auth/calendar.readonly' })),
         );
 
         const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));

--- a/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
@@ -5,14 +5,18 @@
  * view the LICENSE file that was distributed with this source code.
  */
 import { describe, expect, it } from 'vitest';
-import type { OAuth2IdentityProvider, Realm } from '@authup/core-kit';
+import type { OAuth2IdentityProvider, OpenIDIdentityProvider, Realm } from '@authup/core-kit';
 import { IdentityProviderProtocol } from '@authup/core-kit';
 import { createNanoID } from '@authup/kit';
 import { BadRequestError, isBadRequestError } from '@authup/errors';
 import type { IIdentityProviderAccountManager } from '../../../../../src/core';
-import { IdentityProviderOAuth2Authenticator } from '../../../../../src/core';
+import {
+    IdentityProviderGoogleAuthenticator,
+    IdentityProviderOAuth2Authenticator,
+    IdentityProviderOpenIDAuthenticator,
+} from '../../../../../src/core';
 
-function createAuthenticator(authorizeURL: string) {
+function createProvider(data: Partial<OAuth2IdentityProvider> = {}) : OAuth2IdentityProvider {
     const realm: Realm = {
         id: createNanoID(),
         name: 'master',
@@ -23,7 +27,7 @@ function createAuthenticator(authorizeURL: string) {
         updated_at: new Date().toISOString(),
     };
 
-    const provider: OAuth2IdentityProvider = {
+    return {
         id: createNanoID(),
         name: 'idp',
         display_name: null,
@@ -37,14 +41,31 @@ function createAuthenticator(authorizeURL: string) {
         client_id: 'client-id',
         client_secret: 'client-secret',
         token_url: 'https://idp.example.com/token',
-        authorize_url: authorizeURL,
+        authorize_url: 'https://idp.example.com/authorize',
+        ...data,
     };
+}
 
-    return new IdentityProviderOAuth2Authenticator({
+function createOpenIDProvider(data: Partial<OpenIDIdentityProvider> = {}) : OpenIDIdentityProvider {
+    return {
+        ...createProvider(),
+        protocol: IdentityProviderProtocol.OIDC,
+        ...data,
+    };
+}
+
+function createAuthenticatorContext(provider: OAuth2IdentityProvider | OpenIDIdentityProvider) {
+    return {
         options: { baseURL: 'https://authup.example.com/' },
         accountManager: {} as IIdentityProviderAccountManager,
         provider,
-    });
+    };
+}
+
+function createAuthenticator(authorizeURL: string) {
+    return new IdentityProviderOAuth2Authenticator(
+        createAuthenticatorContext(createProvider({ authorize_url: authorizeURL })),
+    );
 }
 
 describe('IdentityProviderOAuth2Authenticator', () => {
@@ -74,5 +95,65 @@ describe('IdentityProviderOAuth2Authenticator', () => {
         } catch (e) {
             expect(isBadRequestError(e)).toBeTruthy();
         }
+    });
+
+    it('should forward the configured scope to the redirect url', () => {
+        const authenticator = new IdentityProviderOAuth2Authenticator(
+            createAuthenticatorContext(createProvider({ scope: 'foo bar' })),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.searchParams.get('scope')).toEqual('foo bar');
+    });
+
+    it('should not send a scope parameter when no scope is configured', () => {
+        const authenticator = new IdentityProviderOAuth2Authenticator(
+            createAuthenticatorContext(createProvider({ scope: null })),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.searchParams.get('scope')).toBeNull();
+    });
+});
+
+describe('IdentityProviderOpenIDAuthenticator', () => {
+    it('should default to the openid scopes when no scope is configured', () => {
+        const authenticator = new IdentityProviderOpenIDAuthenticator(
+            createAuthenticatorContext(createOpenIDProvider()),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.searchParams.get('scope')).toEqual('openid profile email');
+    });
+
+    it('should keep a user-defined scope', () => {
+        const authenticator = new IdentityProviderOpenIDAuthenticator(
+            createAuthenticatorContext(createOpenIDProvider({ scope: 'openid custom' })),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.searchParams.get('scope')).toEqual('openid custom');
+    });
+});
+
+describe('IdentityProviderGoogleAuthenticator', () => {
+    it('should default to the preset scope when no scope is configured', () => {
+        const authenticator = new IdentityProviderGoogleAuthenticator(
+            createAuthenticatorContext(createProvider()),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.origin).toEqual('https://accounts.google.com');
+        expect(parsed.searchParams.get('scope')).toEqual('openid profile email');
+    });
+
+    it('should keep a user-defined scope', () => {
+        const authenticator = new IdentityProviderGoogleAuthenticator(
+            createAuthenticatorContext(createProvider({ scope: 'openid profile email https://www.googleapis.com/auth/calendar.readonly' })),
+        );
+
+        const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
+        expect(parsed.searchParams.get('scope'))
+            .toEqual('openid profile email https://www.googleapis.com/auth/calendar.readonly');
     });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
@@ -103,6 +103,7 @@ describe('src/http/controllers/identity-provider', () => {
     it('should update resource', async () => {
         oAuth2IdentityProvider.name = 'testa';
         oAuth2IdentityProvider.client_secret = 'start1234';
+        oAuth2IdentityProvider.scope = 'openid profile';
 
         const response = await suite.client
             .identityProvider

--- a/apps/server-core/test/utils/domains/identity-provider.ts
+++ b/apps/server-core/test/utils/domains/identity-provider.ts
@@ -22,6 +22,7 @@ export function createFakeOAuth2IdentityProvider(data: Partial<OAuth2IdentityPro
         client_secret: faker.string.alphanumeric({ length: 64 }),
         token_url: faker.internet.url(),
         authorize_url: faker.internet.url(),
+        scope: 'openid profile email',
         ...data,
     } satisfies Partial<OAuth2IdentityProvider>;
 }

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
@@ -12,6 +12,7 @@ import {
     TranslatorTranslationFieldKey,
     TranslatorTranslationNamespace,
 } from '@authup/i18n';
+import { splitOAuth2Scope } from '@authup/specs';
 import { assignFormProperties, useTranslations } from '../../../core';
 import { useValidup } from '@validup/vue';
 import type { PropType } from 'vue';
@@ -65,10 +66,7 @@ export default defineComponent({
         // state and is never undefined.
         const scopeField = v.fields.at<string | null>('scope');
 
-        const scopes = computed(() => {
-            const { value } = scopeField.$model;
-            return value ? value.split(/\s+/).filter((item) => item.length > 0) : [];
-        });
+        const scopes = computed(() => splitOAuth2Scope(scopeField.$model.value));
 
         function assign() {
             assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>, { fields: v.fields });

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
@@ -36,21 +36,32 @@ export default defineComponent({
     props: { entity: { type: Object as PropType<Partial<IdentityProvider>> } },
     emits: ['updated'],
     setup(props) {
-        const form = reactive({ client_id: '', client_secret: '' });
+        const form = reactive({
+            client_id: '', 
+            client_secret: '', 
+            scope: '', 
+        });
 
         const secretShow = ref(false);
 
         // Shared server-side validator, scoped to the keys this sub-form
         // owns via `pathsToInclude` — `client_id` stays required for every
         // OAuth2/OIDC flavor, `client_secret` optional (a secret-less
-        // public-client token exchange is a valid provider config). The
-        // remaining mounts (`preset`, endpoint URLs) belong to sibling
-        // sub-forms and are filtered out here.
+        // public-client token exchange is a valid provider config), `scope`
+        // optional (blank = protocol/preset default). The remaining mounts
+        // (`preset`, endpoint URLs) belong to sibling sub-forms and are
+        // filtered out here.
         const v = useValidup(
-            new IdentityProviderOAuth2AttributesValidator({ pathsToInclude: ['client_id', 'client_secret'] }),
+            new IdentityProviderOAuth2AttributesValidator({ pathsToInclude: ['client_id', 'client_secret', 'scope'] }),
             form,
             { name: 'client' },
         );
+
+        // `scope` is an optional key on `OAuth2IdentityProvider`, so the
+        // typed `fields` accessor yields `FieldState | undefined` under
+        // strict consumers — the dynamic `at()` accessor materialises the
+        // state and is never undefined.
+        const scopeField = v.fields.at<string | null>('scope');
 
         function assign() {
             assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>, { fields: v.fields });
@@ -70,6 +81,10 @@ export default defineComponent({
                 key: TranslatorTranslationFieldKey.CLIENT_SECRET,
             },
             {
+                namespace: TranslatorTranslationNamespace.FIELD,
+                key: TranslatorTranslationFieldKey.SCOPE,
+            },
+            {
                 namespace: TranslatorTranslationNamespace.ACTION,
                 key: TranslatorTranslationActionKey.SHOW,
             },
@@ -83,6 +98,7 @@ export default defineComponent({
 
         return {
             v,
+            scopeField,
             secretShow,
             secretToggleLabel,
             translations,
@@ -134,6 +150,20 @@ export default defineComponent({
                         </button>
                     </template>
                 </VCFormInput>
+            </VCFormGroup>
+        </IFieldValidation>
+        <IFieldValidation
+            v-slot="{ value }"
+            :field="scopeField"
+        >
+            <VCFormGroup :validation="value">
+                <template #label>
+                    {{ translations.scope }}
+                </template>
+                <VCFormInput
+                    v-model="scopeField.$model.value"
+                    placeholder="openid profile email"
+                />
             </VCFormGroup>
         </IFieldValidation>
     </div>

--- a/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
+++ b/packages/client-web-kit/src/components/entities/identity-provider/AIdentityProviderOAuth2ClientFields.vue
@@ -25,9 +25,11 @@ import { VCFormGroup, VCFormInput } from '@vuecs/forms';
 import { VCIcon } from '@vuecs/icon';
 import { onChange, useUpdatedAt } from '../../../composables';
 import { IFieldValidation } from '@ilingo/validup-vue';
+import { AFormInputList } from '../../utility';
 
 export default defineComponent({
     components: {
+        AFormInputList,
         VCFormGroup,
         VCFormInput,
         VCIcon,
@@ -62,6 +64,11 @@ export default defineComponent({
         // strict consumers — the dynamic `at()` accessor materialises the
         // state and is never undefined.
         const scopeField = v.fields.at<string | null>('scope');
+
+        const scopes = computed(() => {
+            const { value } = scopeField.$model;
+            return value ? value.split(/\s+/).filter((item) => item.length > 0) : [];
+        });
 
         function assign() {
             assignFormProperties(form, props.entity as Partial<OAuth2IdentityProvider>, { fields: v.fields });
@@ -99,6 +106,7 @@ export default defineComponent({
         return {
             v,
             scopeField,
+            scopes,
             secretShow,
             secretToggleLabel,
             translations,
@@ -152,19 +160,15 @@ export default defineComponent({
                 </VCFormInput>
             </VCFormGroup>
         </IFieldValidation>
-        <IFieldValidation
-            v-slot="{ value }"
-            :field="scopeField"
+        <AFormInputList
+            :names="scopes"
+            @changed="(value) => {
+                scopeField.$model.value = value.length === 0 ? '' : value.join(' ');
+            }"
         >
-            <VCFormGroup :validation="value">
-                <template #label>
-                    {{ translations.scope }}
-                </template>
-                <VCFormInput
-                    v-model="scopeField.$model.value"
-                    placeholder="openid profile email"
-                />
-            </VCFormGroup>
-        </IFieldValidation>
+            <template #label>
+                {{ translations.scope }}
+            </template>
+        </AFormInputList>
     </div>
 </template>

--- a/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
@@ -15,7 +15,7 @@ import { createPinia } from 'pinia';
 import { describe, expect, it } from 'vitest';
 import AIdentityProviderBasicFields from '../../../../../src/components/entities/identity-provider/AIdentityProviderBasicFields.vue';
 import AIdentityProviderOAuth2Form from '../../../../../src/components/entities/identity-provider/AIdentityProviderOAuth2Form.vue';
-import { ANameInput } from '../../../../../src/components/utility';
+import { AFormInputList, ANameInput } from '../../../../../src/components/utility';
 import { install } from '../../../../../src/module';
 import type { Options } from '../../../../../src/types';
 
@@ -46,6 +46,7 @@ function createEntity() : IdentityProvider {
         client_secret: 'client-secret',
         token_url: 'https://idp.example.com/oauth/token',
         authorize_url: 'https://idp.example.com/oauth/authorize',
+        scope: 'openid profile',
     } as IdentityProvider;
 }
 
@@ -128,16 +129,23 @@ describe('AIdentityProviderOAuth2Form', () => {
         expect(body).not.toHaveProperty('updated_at');
     });
 
-    it('should submit an entered scope on update', async () => {
+    it('should hydrate the scope list and submit a changed scope on update', async () => {
         const entity = createEntity();
         const { wrapper, httpClient } = mountForm(entity);
 
         await flushPromises();
 
-        const scopeInput = wrapper.find('input[placeholder="openid profile email"]');
-        expect(scopeInput.exists()).toBe(true);
+        // one list input per scope token
+        const scopeList = wrapper.findComponent(AFormInputList);
+        expect(scopeList.exists()).toBe(true);
 
-        await scopeInput.setValue('openid profile email custom');
+        const inputValues = wrapper
+            .findAll('input')
+            .map((i) => (i.element as HTMLInputElement).value);
+        expect(inputValues).toContain('openid');
+        expect(inputValues).toContain('profile');
+
+        scopeList.vm.$emit('changed', ['openid', 'profile', 'custom']);
         await flushPromises();
 
         await wrapper.find('form').trigger('submit');
@@ -145,7 +153,7 @@ describe('AIdentityProviderOAuth2Form', () => {
 
         const request = findUpdateRequest(httpClient);
         expect(request).toBeDefined();
-        expect(request!.body).toMatchObject({ scope: 'openid profile email custom' });
+        expect(request!.body).toMatchObject({ scope: 'openid profile custom' });
     });
 });
 

--- a/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
@@ -127,6 +127,26 @@ describe('AIdentityProviderOAuth2Form', () => {
         expect(body).not.toHaveProperty('created_at');
         expect(body).not.toHaveProperty('updated_at');
     });
+
+    it('should submit an entered scope on update', async () => {
+        const entity = createEntity();
+        const { wrapper, httpClient } = mountForm(entity);
+
+        await flushPromises();
+
+        const scopeInput = wrapper.find('input[placeholder="openid profile email"]');
+        expect(scopeInput.exists()).toBe(true);
+
+        await scopeInput.setValue('openid profile email custom');
+        await flushPromises();
+
+        await wrapper.find('form').trigger('submit');
+        await flushPromises();
+
+        const request = findUpdateRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({ scope: 'openid profile email custom' });
+    });
 });
 
 describe('AIdentityProviderBasicFields', () => {

--- a/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/identity-provider/oauth2-form.spec.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { IdentityProvider } from '@authup/core-kit';
+import type { IdentityProvider, OAuth2IdentityProvider } from '@authup/core-kit';
 import { IdentityProviderProtocol } from '@authup/core-kit';
 import { createFakeClient } from '@authup/core-http-kit/testing';
 import type { FakeClient, FakeRequest } from '@authup/core-http-kit/testing';
@@ -127,6 +127,22 @@ describe('AIdentityProviderOAuth2Form', () => {
         expect(body).not.toHaveProperty('realm');
         expect(body).not.toHaveProperty('created_at');
         expect(body).not.toHaveProperty('updated_at');
+    });
+
+    it('should submit with an empty scope (blank optional emitted as null)', async () => {
+        const entity = createEntity();
+        delete (entity as Partial<OAuth2IdentityProvider>).scope;
+
+        const { wrapper, httpClient } = mountForm(entity);
+
+        await flushPromises();
+
+        await wrapper.find('form').trigger('submit');
+        await flushPromises();
+
+        const request = findUpdateRequest(httpClient);
+        expect(request).toBeDefined();
+        expect((request!.body as Record<string, any>).scope ?? null).toBeNull();
     });
 
     it('should hydrate the scope list and submit a changed scope on update', async () => {

--- a/packages/core-kit/src/domains/identity-provider/oauth2/preset-validator.ts
+++ b/packages/core-kit/src/domains/identity-provider/oauth2/preset-validator.ts
@@ -44,5 +44,12 @@ export class IdentityProviderOAuth2PresetAttributesValidator extends Container<O
             createValidator(z.string().min(3).max(128).optional()
                 .nullable()),
         );
+
+        this.mount(
+            'scope',
+            { optional: true },
+            createValidator(z.string().min(3).max(2000).optional()
+                .nullable()),
+        );
     }
 }

--- a/packages/core-kit/src/domains/identity-provider/oauth2/types.ts
+++ b/packages/core-kit/src/domains/identity-provider/oauth2/types.ts
@@ -21,7 +21,7 @@ export interface OAuth2IdentityProviderBase {
 
     user_info_url?: string | null;
 
-    scope?: string;
+    scope?: string | null;
 }
 
 export interface OAuth2IdentityProvider extends IdentityProvider, OAuth2IdentityProviderBase {

--- a/packages/core-kit/src/domains/identity-provider/oauth2/validator.ts
+++ b/packages/core-kit/src/domains/identity-provider/oauth2/validator.ts
@@ -72,6 +72,7 @@ export class IdentityProviderOAuth2AttributesValidator extends Container<OAuth2I
 
         this.mount(
             'scope',
+            { optional: true },
             createValidator(z.string().min(3).max(2000).optional()
                 .nullable()),
         );

--- a/packages/i18n/src/catalogs/de/field.ts
+++ b/packages/i18n/src/catalogs/de/field.ts
@@ -60,6 +60,7 @@ export const TranslatorTranslationFieldGerman : NamespaceTranslations<`${Transla
     [TranslatorTranslationFieldKey.MEMBER_USER_ATTRIBUTE]: 'Mitglied-Benutzer-Attribut',
     [TranslatorTranslationFieldKey.CLIENT_ID]: 'Client-ID',
     [TranslatorTranslationFieldKey.CLIENT_SECRET]: 'Client-Secret',
+    [TranslatorTranslationFieldKey.SCOPE]: 'Scope',
     [TranslatorTranslationFieldKey.TOKEN]: 'Token',
     [TranslatorTranslationFieldKey.USER_INFO]: 'UserInfo',
     [TranslatorTranslationFieldKey.DISCOVERY]: 'Discovery',

--- a/packages/i18n/src/catalogs/en/field.ts
+++ b/packages/i18n/src/catalogs/en/field.ts
@@ -60,6 +60,7 @@ export const TranslatorTranslationFieldEnglish : NamespaceTranslations<`${Transl
     [TranslatorTranslationFieldKey.MEMBER_USER_ATTRIBUTE]: 'Member user attribute',
     [TranslatorTranslationFieldKey.CLIENT_ID]: 'Client ID',
     [TranslatorTranslationFieldKey.CLIENT_SECRET]: 'Client secret',
+    [TranslatorTranslationFieldKey.SCOPE]: 'Scope',
     [TranslatorTranslationFieldKey.TOKEN]: 'Token',
     [TranslatorTranslationFieldKey.USER_INFO]: 'UserInfo',
     [TranslatorTranslationFieldKey.DISCOVERY]: 'Discovery',

--- a/packages/i18n/src/catalogs/es/field.ts
+++ b/packages/i18n/src/catalogs/es/field.ts
@@ -60,6 +60,7 @@ export const TranslatorTranslationFieldSpanish : NamespaceTranslations<`${Transl
     [TranslatorTranslationFieldKey.MEMBER_USER_ATTRIBUTE]: 'Atributo de usuario miembro',
     [TranslatorTranslationFieldKey.CLIENT_ID]: 'ID de cliente',
     [TranslatorTranslationFieldKey.CLIENT_SECRET]: 'Secreto del cliente',
+    [TranslatorTranslationFieldKey.SCOPE]: 'Ámbito',
     [TranslatorTranslationFieldKey.TOKEN]: 'Token',
     [TranslatorTranslationFieldKey.USER_INFO]: 'UserInfo',
     [TranslatorTranslationFieldKey.DISCOVERY]: 'Descubrimiento',

--- a/packages/i18n/src/catalogs/fr/field.ts
+++ b/packages/i18n/src/catalogs/fr/field.ts
@@ -60,6 +60,7 @@ export const TranslatorTranslationFieldFrench : NamespaceTranslations<`${Transla
     [TranslatorTranslationFieldKey.MEMBER_USER_ATTRIBUTE]: 'Attribut d\'utilisateur membre',
     [TranslatorTranslationFieldKey.CLIENT_ID]: 'ID client',
     [TranslatorTranslationFieldKey.CLIENT_SECRET]: 'Secret du client',
+    [TranslatorTranslationFieldKey.SCOPE]: 'Portée',
     [TranslatorTranslationFieldKey.TOKEN]: 'Jeton',
     [TranslatorTranslationFieldKey.USER_INFO]: 'UserInfo',
     [TranslatorTranslationFieldKey.DISCOVERY]: 'Découverte',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -284,6 +284,7 @@ export enum TranslatorTranslationFieldKey {
     MEMBER_USER_ATTRIBUTE = 'memberUserAttribute',
     CLIENT_ID = 'clientId',
     CLIENT_SECRET = 'clientSecret',
+    SCOPE = 'scope',
     TOKEN = 'token',
     USER_INFO = 'userInfo',
     DISCOVERY = 'discovery',

--- a/packages/specs/src/oauth2/scope/helpers.ts
+++ b/packages/specs/src/oauth2/scope/helpers.ts
@@ -39,7 +39,7 @@ export function unwrapOAuth2Scope(input: string | string[]) : string[] {
 export function splitOAuth2Scope(...input: (string | string[] | null | undefined)[]) : string[] {
     return input
         .filter((el) : el is string | string[] => !!el)
-        .flatMap((el) => (Array.isArray(el) ? el : el.split(/\s+|,+/)))
+        .flatMap((el) => (Array.isArray(el) ? splitOAuth2Scope(...el) : el.split(/\s+|,+/)))
         .filter((item) => item.length > 0);
 }
 

--- a/packages/specs/src/oauth2/scope/helpers.ts
+++ b/packages/specs/src/oauth2/scope/helpers.ts
@@ -29,6 +29,23 @@ export function unwrapOAuth2Scope(input: string | string[]) : string[] {
 }
 
 /**
+ * Merge multiple scope representations into a single serialized scope
+ * string (union, first occurrence wins). Case is preserved — unlike
+ * {@link deserializeOAuth2Scope}, which canonicalizes for authup's own
+ * scopes — since external provider scopes may be case-sensitive.
+ *
+ * @param input
+ */
+export function mergeOAuth2Scopes(...input: (string | string[] | null | undefined)[]) : string {
+    const items = input
+        .filter((el) : el is string | string[] => !!el)
+        .flatMap((el) => (Array.isArray(el) ? el : el.split(/\s+|,+/)))
+        .filter((item) => item.length > 0);
+
+    return serializeOAuth2Scope([...new Set(items)]);
+}
+
+/**
  * Check if granted scope(s) cover required scop(e).
  *
  * @param granted

--- a/packages/specs/src/oauth2/scope/helpers.ts
+++ b/packages/specs/src/oauth2/scope/helpers.ts
@@ -29,20 +29,29 @@ export function unwrapOAuth2Scope(input: string | string[]) : string[] {
 }
 
 /**
+ * Split scope representation(s) into individual scopes, dropping empty
+ * items. Case is preserved — unlike {@link unwrapOAuth2Scope}, which
+ * canonicalizes for authup's own scopes — since external provider
+ * scopes may be case-sensitive.
+ *
+ * @param input
+ */
+export function splitOAuth2Scope(...input: (string | string[] | null | undefined)[]) : string[] {
+    return input
+        .filter((el) : el is string | string[] => !!el)
+        .flatMap((el) => (Array.isArray(el) ? el : el.split(/\s+|,+/)))
+        .filter((item) => item.length > 0);
+}
+
+/**
  * Merge multiple scope representations into a single serialized scope
- * string (union, first occurrence wins). Case is preserved — unlike
- * {@link deserializeOAuth2Scope}, which canonicalizes for authup's own
- * scopes — since external provider scopes may be case-sensitive.
+ * string (union, first occurrence wins). Case is preserved — see
+ * {@link splitOAuth2Scope}.
  *
  * @param input
  */
 export function mergeOAuth2Scopes(...input: (string | string[] | null | undefined)[]) : string {
-    const items = input
-        .filter((el) : el is string | string[] => !!el)
-        .flatMap((el) => (Array.isArray(el) ? el : el.split(/\s+|,+/)))
-        .filter((item) => item.length > 0);
-
-    return serializeOAuth2Scope([...new Set(items)]);
+    return serializeOAuth2Scope([...new Set(splitOAuth2Scope(...input))]);
 }
 
 /**

--- a/packages/specs/test/unit/oauth2/scope.spec.ts
+++ b/packages/specs/test/unit/oauth2/scope.spec.ts
@@ -16,6 +16,10 @@ describe('src/oauth2/scope/helpers', () => {
         expect(splitOAuth2Scope(undefined, '')).toEqual([]);
     });
 
+    it('should split array elements like string input', () => {
+        expect(splitOAuth2Scope(['openid profile', 'email'])).toEqual(['openid', 'profile', 'email']);
+    });
+
     it('should merge scopes with first occurrence winning', () => {
         expect(mergeOAuth2Scopes('openid profile email', 'openid custom'))
             .toEqual('openid profile email custom');

--- a/packages/specs/test/unit/oauth2/scope.spec.ts
+++ b/packages/specs/test/unit/oauth2/scope.spec.ts
@@ -6,9 +6,16 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { mergeOAuth2Scopes } from '../../../src';
+import { mergeOAuth2Scopes, splitOAuth2Scope } from '../../../src';
 
 describe('src/oauth2/scope/helpers', () => {
+    it('should split scopes preserving case', () => {
+        expect(splitOAuth2Scope('openid  User.Read')).toEqual(['openid', 'User.Read']);
+        expect(splitOAuth2Scope(null, ['openid'], 'profile,email'))
+            .toEqual(['openid', 'profile', 'email']);
+        expect(splitOAuth2Scope(undefined, '')).toEqual([]);
+    });
+
     it('should merge scopes with first occurrence winning', () => {
         expect(mergeOAuth2Scopes('openid profile email', 'openid custom'))
             .toEqual('openid profile email custom');

--- a/packages/specs/test/unit/oauth2/scope.spec.ts
+++ b/packages/specs/test/unit/oauth2/scope.spec.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { mergeOAuth2Scopes } from '../../../src';
+
+describe('src/oauth2/scope/helpers', () => {
+    it('should merge scopes with first occurrence winning', () => {
+        expect(mergeOAuth2Scopes('openid profile email', 'openid custom'))
+            .toEqual('openid profile email custom');
+    });
+
+    it('should preserve case', () => {
+        expect(mergeOAuth2Scopes('openid', 'User.Read'))
+            .toEqual('openid User.Read');
+    });
+
+    it('should ignore empty input', () => {
+        expect(mergeOAuth2Scopes('openid profile', null, undefined, ''))
+            .toEqual('openid profile');
+    });
+
+    it('should accept arrays and comma separated input', () => {
+        expect(mergeOAuth2Scopes(['openid', 'profile'], 'email,custom'))
+            .toEqual('openid profile email custom');
+    });
+
+    it('should return an empty string without input', () => {
+        expect(mergeOAuth2Scopes()).toEqual('');
+    });
+});


### PR DESCRIPTION
## Summary

There was no way to specify the OAuth2/OIDC `scope` for an external identity provider. The backend already carried a persisted `scope` attribute (typed, validated for non-preset providers, forwarded into the external authorize URL) — but nothing exposed it: the admin form had no input, the preset attributes validator stripped it, and every preset authenticator overwrote it unconditionally.

## Changes

- **client-web-kit** — `AIdentityProviderOAuth2ClientFields.vue` renders the scope as an `AFormInputList` (one input per scope token, add/remove), mirroring `AClientForm`'s `redirect_uri` list. Tokens are space-joined into the field validated through the shared `IdentityProviderOAuth2AttributesValidator` (via `pathsToInclude`). Rendered for custom OAuth2, custom OIDC, and preset providers alike.
- **specs** — new `mergeOAuth2Scopes` helper alongside the existing scope helpers: union with first occurrence winning, case-preserving (external provider scopes may be case-sensitive, e.g. Azure's `User.Read`, so it deliberately does not reuse `deserializeOAuth2Scope`'s lowercasing).
- **core-kit** — `IdentityProviderOAuth2PresetAttributesValidator` now accepts `scope`, so preset providers can persist an override too. Both scope mounts are flagged `{ optional: true }` — without it, the kit's blank `scope: ''` failed `min(3)` and blocked form submission (caught by the existing form component test).
- **server-core presets** (google, github, facebook, instagram, paypal) — **merge** their required scopes with a user-defined scope (`mergeOAuth2Scopes('<required>', ctx.provider.scope)`). The preset scopes are what the account manager needs to resolve a user (email, profile, ...), so they always survive; user-defined scopes are additive extras (e.g. adding `calendar.readonly` to Google).
- **server-core OIDC protocol** — always enforces the `openid` scope (Core §3.1.2.1) and defaults to `openid profile email` when no scope is configured. Behavior change for existing scope-less OIDC providers, but a scope-less OIDC request is out of spec and most IdPs reject it or won't issue an id_token.
- **i18n** — new `SCOPE` field key, translated in all four locales.

## Tests

- specs: `mergeOAuth2Scopes` unit tests (union order, case preservation, empty/array/comma input).
- Authenticator unit tests: scope forwarded into the redirect URL, omitted when unset, OIDC openid enforcement + default, Google preset merge (required scopes survive a user override).
- Kit component test: scope list hydrates one input per token; a changed list rides the update payload space-joined.
- HTTP integration spec round-trips `scope` through create/read/update (shared fake factory now carries a default scope).
- Full server-core suite, client-web-kit, core-kit, specs, and i18n locale-parity all pass; builds, lint, and `check:types` green. (One pre-existing local flake in `role-permission.spec.ts` — duplicate faker permission name under parallel spec files — passes in isolation, unrelated to this diff.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable OAuth2/OIDC scopes to identity provider settings.
  - Added a scope list editor for entering, reviewing, and updating scopes.
  - Preserved custom scopes while automatically including required provider scopes.
  - Added localized “Scope” labels in English, German, Spanish, and French.

- **Bug Fixes**
  - Empty or null scopes are now handled safely without sending invalid scope parameters.
  - OpenID Connect providers consistently include the required `openid` scope.

- **Tests**
  - Expanded coverage for scope editing, validation, merging, and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->