### PR TITLE
fix: harden mfa verify path - atomic attempt counter + stamp-first unit of work

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1814,8 +1814,9 @@ user's nested route is a 404 (no existence oracle).
 **Enforcement — two chokepoints, both server-side:**
 
 1. **Interactive `/authorize`**: the proof is session-bound — `auth_sessions.mfa_at`
-   is stamped by `POST /authenticators/challenge` (bearer-scoped;
-   `ISessionManager.markMfaVerified`) or by the password grant's `otp` param.
+   is stamped by `POST /authenticators/challenge` (bearer-scoped; via the
+   verify `onVerified` hook, see *Verify unit of work* below) or by the
+   password grant's `otp` param.
    `OAuth2Authorization.authorizeInner` (ctx `mfaChallengeProvider`, the
    `IUserAuthenticatorChallengeProvider` seam) throws `OAuth2MfaRequiredError`
    (`ErrorCode.OAUTH_MFA_REQUIRED` / wire `error: mfa_required` — a dedicated
@@ -1838,9 +1839,30 @@ user's nested route is a 404 (no existence oracle).
    the token endpoint. WebAuthn cannot ride a single POST — it stays
    interactive-only (documented boundary).
 
+**Verify unit of work (#3237)**: `UserAuthenticatorService.verify()`
+serializes its read-verify-save critical section per user via a cache lock
+(`mfaVerifyLock:<user_id>`, the atomic `ICache.add` set-if-absent — Redis
+`SET … NX`, single-tick memory adapter) so a factor is consumed exactly once
+under concurrency; a held lock bails `false` without penalty, and a cache
+outage fails open for factors with a persisted anti-replay backstop (TOTP
+step-counter, recovery `used_at`) but closed for EMAIL (cache-only
+single-use). Consumption is ordered **stamp-first**: the optional
+`UserAuthenticatorVerifyContext.onVerified` hook — the challenge controller
+stamps `session.mfa_at` (`ISessionManager.markMfaVerified`) inside it — runs
+after the factor matched but BEFORE the consumption persists (the device-row
+save; the email-code / webauthn-challenge cache drops are deferred to the
+same success block), so a session-stamp failure aborts the verify with
+nothing consumed — never a burned single-use code without a completed MFA.
+The accepted residual is the inverse window (consumption fails AFTER the
+hook): a stamped session plus a still-valid code.
+
 **Brute-force**: per-account exponential backoff inside
-`UserAuthenticatorService.verify`/`confirm` — cache-keyed
-(`mfaAttempt:<user_id>`) `min(300, 1·2^(n−1))`s lock, reset on success, 429
+`UserAuthenticatorService.verify`/`confirm` — the failed-attempt count is a
+raw number bumped via the atomic `ICache.increment` (Redis `INCRBY`,
+single-tick memory adapter) under `mfaAttempt:<user_id>` (TTL = 1h window),
+with the lockout deadline under `mfaThrottle:<user_id>` (TTL = the lock), so
+concurrent failures — verify or confirm — never under-count the
+`min(300, 1·2^(n−1))`s lock; reset on success, 429
 `MfaThrottledError` (`ErrorCode.MFA_ATTEMPT_THROTTLED`, `retryAfter` in the
 body). Config: `mfaEnabled` / `mfaRequired` / `mfaEncryptionKey`
 (`MFA_ENABLED` / `MFA_REQUIRED` / `MFA_ENCRYPTION_KEY`; `mfaRequired` requires

--- a/apps/server-core/src/adapters/http/controllers/workflows/authenticator-challenge/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authenticator-challenge/module.ts
@@ -109,6 +109,16 @@ export class AuthenticatorChallengeController {
             throw new BadRequestError('A kind and response must be provided.');
         }
 
+        // Bind the proof to the backing session — the /authorize backstop
+        // reads session.mfa_at. The session id is server-derived (stashed
+        // by the authorization middleware), never client input. The stamp
+        // runs INSIDE the verify unit of work (before the code consumption
+        // persists), so a stamp failure never burns a single-use code.
+        const sessionId = useRequestSessionId(event);
+        const session = sessionId ?
+            await this.sessionManager.findOneById(sessionId) :
+            null;
+
         const verified = await this.service.verify(
             identity.id,
             {
@@ -119,21 +129,15 @@ export class AuthenticatorChallengeController {
                 ipAddress: getRequestIP(event, { trustProxy: true }) ?? null,
                 userAgent: getRequestHeader(event, 'user-agent') ?? null,
                 clientId: identity.clientId,
+                ...(session ? {
+                    onVerified: async () => {
+                        await this.sessionManager.markMfaVerified(session);
+                    },
+                } : {}),
             },
         );
         if (!verified) {
             throw new EntityCredentialsInvalidError();
-        }
-
-        // Bind the proof to the backing session — the /authorize backstop
-        // reads session.mfa_at. The session id is server-derived (stashed
-        // by the authorization middleware), never client input.
-        const sessionId = useRequestSessionId(event);
-        if (sessionId) {
-            const session = await this.sessionManager.findOneById(sessionId);
-            if (session) {
-                await this.sessionManager.markMfaVerified(session);
-            }
         }
 
         return { verified: true };

--- a/apps/server-core/src/core/entities/user-authenticator/constants.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/constants.ts
@@ -5,7 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+// Failed-attempt counter — a raw number bumped via the cache's atomic
+// increment, so concurrent failures (verify or confirm) never under-count
+// the exponential backoff. The lockout deadline lives under its own prefix.
 export const USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX = 'mfaAttempt';
+export const USER_AUTHENTICATOR_THROTTLE_CACHE_PREFIX = 'mfaThrottle';
 
 // Per-user lock serializing concurrent verify critical sections so a factor
 // (recovery code / TOTP step) is consumed exactly once. The TTL only bounds a

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -62,6 +62,7 @@ import {
     USER_AUTHENTICATOR_EMAIL_SEND_CACHE_PREFIX,
     USER_AUTHENTICATOR_EMAIL_SEND_COOLDOWN,
     USER_AUTHENTICATOR_RECOVERY_CODE_COUNT,
+    USER_AUTHENTICATOR_THROTTLE_CACHE_PREFIX,
     USER_AUTHENTICATOR_TOTP_ALGORITHM,
     USER_AUTHENTICATOR_TOTP_DIGITS,
     USER_AUTHENTICATOR_TOTP_PERIOD,
@@ -87,11 +88,6 @@ import type {
     UserAuthenticatorWebauthnParameters,
 } from './types.ts';
 import type { WebauthnContext } from './webauthn.ts';
-
-type AttemptState = {
-    count: number,
-    lockedUntil: number,
-};
 
 type EmailCodeState = {
     hash: string,
@@ -665,9 +661,6 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
                         if (parameters) {
                             device.parameters = JSON.stringify({ ...parameters, counter: newCounter });
                         }
-                        await this.cache.drop(
-                            this.buildWebauthnCacheKey(USER_AUTHENTICATOR_WEBAUTHN_AUTH_CACHE_PREFIX, userId),
-                        );
                         matched = device;
                     }
                 }
@@ -683,8 +676,30 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
                 return false;
             }
 
+            // Bind the proof to the caller's aggregate (the session mfa_at
+            // stamp) BEFORE any consumption persists: a hook failure aborts
+            // the verify with nothing consumed — never a burned single-use
+            // code without a completed MFA. The residual (a failure AFTER the
+            // hook) leaves a stamped session plus a still-valid code — a
+            // bounded server-error window, not a lost factor.
+            if (ctx.onVerified) {
+                await ctx.onVerified();
+            }
+
             matched.last_used_at = new Date().toISOString();
             await this.repository.save(matched);
+
+            // cache-borne single-use artifacts (email code, webauthn challenge
+            // nonce) are consumed only once the unit of work committed — the
+            // verify lock keeps the deferral race-free.
+            if (input.kind === UserAuthenticatorKind.EMAIL) {
+                await this.cache.drop(this.buildEmailCodeCacheKey(userId));
+            }
+            if (input.kind === UserAuthenticatorKind.WEBAUTHN) {
+                await this.cache.drop(
+                    this.buildWebauthnCacheKey(USER_AUTHENTICATOR_WEBAUTHN_AUTH_CACHE_PREFIX, userId),
+                );
+            }
 
             await this.resetAttempts(userId);
 
@@ -820,13 +835,10 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             return false;
         }
 
-        if (!await compare(response.trim(), state.hash)) {
-            return false;
-        }
-
-        // single-use — drop the code once consumed
-        await this.cache.drop(key);
-        return true;
+        // single-use — but the drop is deferred to the verify success block,
+        // AFTER the onVerified hook ran, so a hook failure does not burn the
+        // code (the verify lock keeps the deferral race-free).
+        return compare(response.trim(), state.hash);
     }
 
     // ------------------------------------------------------------------
@@ -1011,6 +1023,13 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         });
     }
 
+    protected buildThrottleCacheKey(userId: string): string {
+        return buildCacheKey({
+            prefix: USER_AUTHENTICATOR_THROTTLE_CACHE_PREFIX,
+            key: userId,
+        });
+    }
+
     protected buildEmailCodeCacheKey(userId: string): string {
         return buildCacheKey({
             prefix: USER_AUTHENTICATOR_EMAIL_CODE_CACHE_PREFIX,
@@ -1058,29 +1077,44 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
     }
 
     protected async assertNotThrottled(userId: string): Promise<void> {
-        const state = await this.cache.get<AttemptState>(this.buildAttemptCacheKey(userId));
-        if (state && state.lockedUntil > Date.now()) {
-            throw new MfaThrottledError({ retryAfter: Math.ceil((state.lockedUntil - Date.now()) / 1_000) });
+        const lockedUntil = await this.cache.get<number>(this.buildThrottleCacheKey(userId));
+        if (typeof lockedUntil === 'number' && lockedUntil > Date.now()) {
+            throw new MfaThrottledError({ retryAfter: Math.ceil((lockedUntil - Date.now()) / 1_000) });
         }
     }
 
     protected async bumpAttempts(userId: string): Promise<void> {
         const key = this.buildAttemptCacheKey(userId);
-        const state = (await this.cache.get<AttemptState>(key)) ?? { count: 0, lockedUntil: 0 };
 
-        state.count += 1;
+        // Atomic increment — concurrent failures (verify OR confirm) each get
+        // a distinct count, so the exponential backoff never under-counts.
+        let count : number;
+        try {
+            count = await this.cache.increment(key, 1, { ttl: USER_AUTHENTICATOR_ATTEMPT_WINDOW * 1_000 });
+        } catch {
+            // a non-numeric value at the key (legacy JSON state) — reset and
+            // re-count; a genuine cache outage rethrows from the drop.
+            await this.cache.drop(key);
+            count = await this.cache.increment(key, 1, { ttl: USER_AUTHENTICATOR_ATTEMPT_WINDOW * 1_000 });
+        }
 
         const delay = Math.min(
             USER_AUTHENTICATOR_ATTEMPT_LOCK_MAX,
-            USER_AUTHENTICATOR_ATTEMPT_LOCK_FACTOR * (2 ** (state.count - 1)),
+            USER_AUTHENTICATOR_ATTEMPT_LOCK_FACTOR * (2 ** (count - 1)),
         );
-        state.lockedUntil = Date.now() + (delay * 1_000);
 
-        await this.cache.set(key, state, { ttl: USER_AUTHENTICATOR_ATTEMPT_WINDOW * 1_000 });
+        await this.cache.set(
+            this.buildThrottleCacheKey(userId),
+            Date.now() + (delay * 1_000),
+            { ttl: delay * 1_000 },
+        );
     }
 
     protected async resetAttempts(userId: string): Promise<void> {
-        await this.cache.drop(this.buildAttemptCacheKey(userId));
+        await this.cache.dropMany([
+            this.buildAttemptCacheKey(userId),
+            this.buildThrottleCacheKey(userId),
+        ]);
     }
 
     // ------------------------------------------------------------------

--- a/apps/server-core/src/core/entities/user-authenticator/types.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/types.ts
@@ -161,6 +161,14 @@ export type UserAuthenticatorVerifyContext = {
     ipAddress?: string | null,
     userAgent?: string | null,
     clientId?: string | null,
+    /**
+     * Runs inside the verify critical section once the factor matched,
+     * BEFORE the consumption (TOTP step / recovery used_at / email code)
+     * is persisted. A throw aborts the verify without consuming the factor
+     * — the seam for binding the proof to another aggregate (the session
+     * mfa_at stamp) so a stamp failure never burns a single-use code.
+     */
+    onVerified?: () => Promise<void>,
 };
 
 /**

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -27,6 +27,7 @@ import { FakePermissionEvaluator } from '@authup/server-test-kit';
 import { MailTemplateRenderer } from '../../../../../src/core/mail/index.ts';
 import { UserAuthenticatorService } from '../../../../../src/core/entities/user-authenticator/service.ts';
 import {
+    USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX,
     USER_AUTHENTICATOR_VERIFY_LOCK_CACHE_PREFIX,
     USER_AUTHENTICATOR_WEBAUTHN_AUTH_CACHE_PREFIX,
     USER_AUTHENTICATOR_WEBAUTHN_REG_CACHE_PREFIX,
@@ -332,6 +333,111 @@ describe('UserAuthenticatorService', () => {
                 response: totpCode(enrolled.secret!),
             });
             expect(verified).toBeTruthy();
+        });
+
+        it('counts concurrent failures atomically (#3237)', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+
+            expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: '000000' })).toBeFalsy();
+
+            const count = await cache.get(
+                buildCacheKey({ prefix: USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX, key: userId }),
+            );
+            expect(count).toBe(1);
+        });
+
+        it('recovers from a legacy (non-numeric) attempt-counter value', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+
+            // a pre-upgrade deployment stored the state as a JSON object
+            const key = buildCacheKey({ prefix: USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX, key: userId });
+            await cache.set(key, { count: 3, lockedUntil: 0 }, {});
+
+            expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: '000000' })).toBeFalsy();
+
+            // the legacy value was dropped and the count restarted
+            expect(await cache.get(key)).toBe(1);
+        });
+    });
+
+    describe('verify unit of work (#3237)', () => {
+        it('does not consume a recovery code when the onVerified hook fails', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
+            const [code] = enrolled.codes!;
+
+            await expect(service.verify(
+                userId,
+                { kind: UserAuthenticatorKind.RECOVERY, response: code },
+                { onVerified: async () => { throw new Error('session stamp failed'); } },
+            )).rejects.toThrow('session stamp failed');
+
+            // nothing was consumed (and no penalty applied) — the same code
+            // completes the challenge once the stamp works again.
+            expect(await service.verify(userId, { kind: UserAuthenticatorKind.RECOVERY, response: code })).toBeTruthy();
+        });
+
+        it('does not consume the TOTP step when the onVerified hook fails', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+
+            const code = totpCode(enrolled.secret!);
+            await expect(service.verify(
+                userId,
+                { kind: UserAuthenticatorKind.TOTP, response: code },
+                { onVerified: async () => { throw new Error('session stamp failed'); } },
+            )).rejects.toThrow('session stamp failed');
+
+            expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: code })).toBeTruthy();
+        });
+
+        it('does not burn an email code when the onVerified hook fails', async () => {
+            userRepository.seed({
+                id: userId,
+                name: 'test-user',
+                email: 'user@example.com',
+                realm_id: realmId,
+            } as Partial<User>);
+            await service.enroll({ kind: UserAuthenticatorKind.EMAIL }, makeActor());
+            await service.sendChallenge(userId, UserAuthenticatorKind.EMAIL);
+            const code = /(\d{6})/.exec(mailClient.sent[0].text ?? '')![1];
+
+            await expect(service.verify(
+                userId,
+                { kind: UserAuthenticatorKind.EMAIL, response: code },
+                { onVerified: async () => { throw new Error('session stamp failed'); } },
+            )).rejects.toThrow('session stamp failed');
+
+            expect(await service.verify(userId, { kind: UserAuthenticatorKind.EMAIL, response: code })).toBeTruthy();
+
+            // still single-use once actually consumed
+            expect(await service.verify(userId, { kind: UserAuthenticatorKind.EMAIL, response: code })).toBeFalsy();
+        });
+
+        it('runs the onVerified hook on success only, never on a failed code', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
+            const [code] = enrolled.codes!;
+
+            let calls = 0;
+            const onVerified = async () => { calls += 1; };
+
+            expect(await service.verify(
+                userId,
+                { kind: UserAuthenticatorKind.RECOVERY, response: 'not-a-code' },
+                { onVerified },
+            )).toBeFalsy();
+            expect(calls).toBe(0);
+
+            // wait out the 1s lock from the failed attempt
+            await new Promise((resolve) => { setTimeout(resolve, 1_100); });
+
+            expect(await service.verify(
+                userId,
+                { kind: UserAuthenticatorKind.RECOVERY, response: code },
+                { onVerified },
+            )).toBeTruthy();
+            expect(calls).toBe(1);
         });
     });
 

--- a/packages/server-kit/src/cache/adapters/memory.ts
+++ b/packages/server-kit/src/cache/adapters/memory.ts
@@ -58,6 +58,19 @@ export class MemoryCache implements ICache {
         return true;
     }
 
+    async increment(key: string, value = 1, options: CacheSetOptions = {}): Promise<number> {
+        // The read + write run in a single synchronous tick (no await
+        // between), so this is atomic within the single-threaded process.
+        const current = this.instance.get(key);
+        if (typeof current !== 'undefined' && typeof current !== 'number') {
+            throw new Error(`The value at key ${key} is not a number.`);
+        }
+
+        const output = (current ?? 0) + value;
+        this.instance.set(key, output, { ttl: options.ttl });
+        return output;
+    }
+
     async drop(key: string): Promise<void> {
         this.instance.delete(key);
     }

--- a/packages/server-kit/src/cache/adapters/redis.ts
+++ b/packages/server-kit/src/cache/adapters/redis.ts
@@ -64,6 +64,18 @@ export class RedisCache implements ICache {
         return result === 'OK';
     }
 
+    async increment(key: string, value = 1, options: CacheSetOptions = {}): Promise<number> {
+        // INCRBY is atomic; the follow-up PEXPIRE only (re)arms the expiry,
+        // so an interleaved concurrent increment is harmless. Rejects when
+        // the key holds a non-integer value.
+        const output = await this.client.incrby(key, value);
+        if (options.ttl) {
+            await this.client.pexpire(key, options.ttl);
+        }
+
+        return output;
+    }
+
     async drop(key: string): Promise<void> {
         await this.jsonAdapter.drop(key);
     }

--- a/packages/server-kit/src/cache/types.ts
+++ b/packages/server-kit/src/cache/types.ts
@@ -34,6 +34,17 @@ export interface ICache {
      */
     add(key: string, value: any, options?: CacheSetOptions) : Promise<boolean>;
 
+    /**
+     * Atomically increment the numeric value stored at the key by `value`
+     * (default 1), treating an absent key as 0, and return the
+     * post-increment value. A ttl (re)arms the key's expiry on every call —
+     * the building block for a sliding-window counter (attempt throttling).
+     * Concurrent increments never lose an update — atomic on Redis
+     * (`INCRBY`) and on the in-process memory adapter. Rejects when the key
+     * holds a non-numeric value.
+     */
+    increment(key: string, value?: number, options?: CacheSetOptions) : Promise<number>;
+
     has(key: string) : Promise<boolean>;
 
     get<T = unknown>(key: string): Promise<T | null>;

--- a/packages/server-kit/test/unit/cache-memory.spec.ts
+++ b/packages/server-kit/test/unit/cache-memory.spec.ts
@@ -35,4 +35,49 @@ describe('src/cache/adapters/memory', () => {
             expect(await cache.add('lock', 1)).toBe(true);
         });
     });
+
+    describe('increment (atomic counter)', () => {
+        it('creates an absent key at the increment value', async () => {
+            const cache = new MemoryCache();
+
+            expect(await cache.increment('counter')).toBe(1);
+            expect(await cache.get('counter')).toBe(1);
+        });
+
+        it('returns the post-increment value on every call', async () => {
+            const cache = new MemoryCache();
+
+            expect(await cache.increment('counter')).toBe(1);
+            expect(await cache.increment('counter')).toBe(2);
+            expect(await cache.increment('counter', 3)).toBe(5);
+        });
+
+        it('never loses an update under concurrent increments', async () => {
+            const cache = new MemoryCache();
+
+            const outputs = await Promise.all(
+                Array.from({ length: 10 }, () => cache.increment('counter')),
+            );
+
+            expect(await cache.get('counter')).toBe(10);
+            expect(new Set(outputs).size).toBe(10);
+        });
+
+        it('rejects when the key holds a non-numeric value', async () => {
+            const cache = new MemoryCache();
+            await cache.set('counter', { count: 1 }, {});
+
+            await expect(cache.increment('counter')).rejects.toThrow();
+        });
+
+        it('restarts at zero once the key is dropped', async () => {
+            const cache = new MemoryCache();
+
+            await cache.increment('counter');
+            await cache.increment('counter');
+            await cache.drop('counter');
+
+            expect(await cache.increment('counter')).toBe(1);
+        });
+    });
 });


### PR DESCRIPTION
Closes #3237 — items **#3** (attempt-counter race) and **#4** (recovery-consume + session-stamp atomicity); items #1/#2 were already delivered in #3232.

## #3 — atomic attempt counter

- `ICache` gains an `increment(key, value?, { ttl })` primitive: Redis `INCRBY` (+ `PEXPIRE` re-arming the window), single-synchronous-tick read/write on the memory adapter. Rejects on a non-numeric value.
- `UserAuthenticatorService` drops the get-modify-set `AttemptState` JSON: the failed-attempt count is a raw number bumped atomically under `mfaAttempt:<user_id>` (TTL = 1h window), the lockout deadline lives under `mfaThrottle:<user_id>` (TTL = the lock). Concurrent failures — `verify` **or** `confirm`, which runs outside the verify lock — each get a distinct count, so the exponential backoff can no longer be under-counted.
- A legacy JSON value at the counter key (in-flight throttle state from a pre-upgrade deployment, bounded by the 1h TTL) is dropped and re-counted instead of erroring.

## #4 — session stamp inside the verify unit of work

- `UserAuthenticatorVerifyContext` gains an `onVerified` hook that `verify()` runs after the factor matched but **before** any consumption persists — the issue's "defer code consumption until the session stamp succeeds" option.
- The challenge controller resolves the backing session up front and stamps `mfa_at` inside the hook instead of after `verify()` returns.
- The email-code / webauthn-challenge cache drops move out of the match loop into the success block (race-free: the per-user verify lock serializes the critical section, and EMAIL already fails closed when no lock can be taken).
- Net effect: a session-stamp failure aborts the verify with **nothing consumed** — no more burned recovery/email codes without a completed MFA. Accepted residual (documented): if persisting the consumption fails *after* the stamp, the session is stamped and the code stays valid — a bounded server-error window rather than a lost factor.

## Tests / docs

- server-kit: 5 new `increment` cases (creation, post-increment value, concurrent no-lost-update, non-numeric rejection, restart after drop).
- server-core service spec: hook-failure non-consumption for recovery/TOTP/email, hook-runs-on-success-only, atomic-count assertion, legacy-counter recovery.
- Full server-core suite (140 files / 1494 tests), server-kit suite, `check:types`, and lint all green.
- `.agents/architecture.md`: new *Verify unit of work (#3237)* paragraph (also documents the previously undocumented verify lock) + updated *Brute-force* paragraph.