### PR TITLE
refactor(ui): adopt the store auth phase model (status / lastAuthOrigin)

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,78 @@
+# design-sync notes — authup/authup
+
+## The one thing to know first
+
+**This repo is outside the design-sync converter's envelope.** The component
+kit (`@authup/client-web-kit` + `@vuecs/*`) is **Vue 3**; Claude Design renders
+React only ("a non-React DS has nothing for the design agent to build with").
+There is no Storybook and no React surface anywhere in the monorepo. A faithful
+component sync is impossible without a reimplementation, which the skill
+forbids. **Do not run the converter scripts here.**
+
+The agreed fallback (user-approved 2026-07-12): a hand-authored
+**tokens-and-styles-only** sync — canonical design tokens + the plain-CSS layer
+of the kit's logged-out auth chrome, no component bundle, no `_ds_sync.json`
+anchor (honest omission for a hand-authored shape; every re-sync re-verifies,
+which is cheap at this size).
+
+## Target project — additive contract (IMPORTANT)
+
+`projectId` (pinned in config.json) is the user's **pre-existing, hand-built**
+"Authup Design System" project — re-adopted on explicit user choice, NOT
+created by this skill. It contains hand-authored content that must never be
+overwritten or deleted by a sync:
+
+- root `styles.css`, `colors_and_type.css`, `README.md`, `SKILL.md`
+- `preview/_base.css` and all pre-existing `preview/*.html` cards
+- `ui_kits/**`, `assets/**` (logo kit), `scraps/**`, design-canvas files
+
+Files **owned by this sync** (safe to rewrite on re-sync):
+
+- `tokens/authup-tokens.css` — canonical token sheet
+- `tokens/authup-auth-components.css` — verbatim kit auth-chrome CSS
+- `guidelines/repo-token-sync.md` — vocabulary + drift report
+- `preview/tokens-canonical-surfaces.html`, `preview/tokens-primary-ramp.html`,
+  `preview/components-auth-shell.html` — cards, group "Repo sync"
+- `_ds_needs_recompile` — refresh marker (write first as fence, re-arm last)
+
+## Re-sync procedure (custom shape)
+
+1. Re-derive the token sheet from:
+   `packages/client-web-theme/assets/css/index.css` (brand, surfaces, chrome,
+   vc bridge, primary ramp), `packages/client-web-kit-theme/assets/css/styles/
+   tokens.css` (kit component tokens), `.../styles/{auth,realm,picker,login}.css`
+   (verbatim component CSS), `client-web-theme/assets/css/styles/root.css`
+   (typography). Kit defaults overridden by app-level rebinds → emit the
+   winning value, note the kit default in a comment.
+2. Stage into `ds-bundle/` (gitignored). `ds-bundle/preview/_base.css` is a
+   LOCAL VERIFY COPY of the project's card base stylesheet — never upload it.
+3. Verify cards visually: serve ds-bundle with `python3 -m http.server`, then
+   screenshot with the playwright-cache headless shell
+   (`~/Library/Caches/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-mac-arm64/chrome-headless-shell
+   --headless --screenshot=… --window-size=WxH URL`). The Chrome extension MCP
+   was not connected on this machine.
+4. Cross-check every class/token named in the guidelines against the shipped
+   CSS (grep) before upload.
+5. `finalize_plan` with the exact owned paths above, `deletes: []`, then
+   sentinel → files → sentinel re-arm.
+
+## Gotchas learned
+
+- The kit component CSS assumes **Tailwind preflight**: standalone consumers
+  (and preview cards) need `* { box-sizing: border-box }` and
+  `a { text-decoration: none }` or the realm-search input overflows the auth
+  card and links render underlined.
+- The project's existing cards put the `@dsCard` marker on line 2 (after
+  `<!doctype html>`), use Google-Fonts links + relative `_base.css`; cross-dir
+  relative links (`../tokens/…`) are the converter norm and work.
+- The auth card is 460px max-width: three realm tiles wrap to two rows and
+  overflow a 520px-high card viewport — keep the demo grid to two tiles.
+- The project's hand-authored `colors_and_type.css` predates the Tailwind-v4
+  theme rework and has drifted (Bootstrap-blue `--authup-primary: #337ab7`,
+  chrome-never-flips model, `[data-theme]` toggle, missing chrome/kit tokens).
+  The drift report lives in `guidelines/repo-token-sync.md` (uploaded) and
+  `.design-sync/conventions.md` (committed master copy). Deliberately NOT
+  auto-fixed — their previews/ui_kits may depend on the old values; adopting
+  the canonical sheet is the user's / their design agent's call.
+- Dark mode: repo-canonical selector is the `.dark` class; the synced token
+  sheet also matches `[data-theme="dark"]` for the project's older previews.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,5 +1,8 @@
 {
     "projectId": "9f2a0d2f-fbf9-4f54-84c0-d1712aa73c6d",
+    "pkg": "@authup/client-web-theme",
     "shape": "custom",
-    "note": "Vue 3 design system — outside the design-sync converter's React-only envelope. Hand-authored tokens-and-styles enrichment of an existing, actively-used project; additive layout, never overwrite hand-authored root styles.css / README.md. See NOTES.md."
+    "note": "Vue 3 design system — outside the design-sync converter's React-only envelope; never run the converter here. Hand-authored tokens-and-styles enrichment of the user's pre-existing, hand-built project. Additive contract + re-sync procedure in NOTES.md.",
+    "lastSync": "2026-07-12",
+    "lastSyncCommit": "a6dca3c9a"
 }

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,99 @@
+# Repo token sync — canonical authup tokens
+
+Machine-derived from the `authup/authup` monorepo (commit `a6dca3c9a`, synced
+2026-07-12). When these files and a hand-authored file in this project
+disagree, **these files carry the shipped product's current values.**
+
+## What was synced
+
+| File | Contents | Source of truth in the repo |
+|---|---|---|
+| `tokens/authup-tokens.css` | All design tokens: brand accents, slate ramp, light+dark surfaces, flipping chrome model, vuecs semantic bridge, periwinkle primary ramp, auth/realm/picker/login component tokens, typography | `packages/client-web-theme/assets/css/index.css`, `packages/client-web-kit-theme/assets/css/styles/tokens.css`, `packages/client-web-theme/assets/css/styles/root.css` |
+| `tokens/authup-auth-components.css` | Verbatim component CSS for the logged-out chrome: `.a-auth-shell` (aurora + card), `.a-auth-gadget`, `.a-auth-back-link`, `.a-realm-grid` (tiles, search, skeleton, empty state), `.a-picker-item`, `.a-login-provider-box` | `packages/client-web-kit-theme/assets/css/styles/{auth,realm,picker,login}.css` |
+
+## How to build with it
+
+Load order: tokens first, then components (the components file `@import`s the
+tokens itself, so importing only it also works):
+
+```html
+<link rel="stylesheet" href="tokens/authup-auth-components.css">
+```
+
+- **Setup**: the kit CSS assumes Tailwind preflight — at minimum set
+  `* { box-sizing: border-box }` and `a { text-decoration: none }` globally,
+  or inputs/links inside the auth card render slightly off.
+- **Style via CSS custom properties** — `var(--authup-*)` for authup identity,
+  `var(--vc-color-*)` for the semantic layer (bg / fg / border / primary
+  ramp). Never hard-code a hex that has a token.
+- **Login-ish screens**: use the real classes — wrap in
+  `.a-auth-shell` → `.a-auth-shell-aurora` + `.a-auth-shell-card`; realm
+  pickers are `.a-realm-grid` > `.a-realm-grid-item` (with
+  `.a-realm-grid-item-name` / `-slug`).
+- **Dark mode**: add class `dark` (repo-canonical) or
+  `data-theme="dark"` (this project's older previews) on a root element.
+  Chrome tokens re-pin to the slate ramp; surfaces flip to the dark ramp
+  (`#16171a < #1f2024 < #26272c < #2d2f35 < #34373d`).
+- **Primary actions** paint `--vc-color-primary-600` (pure periwinkle) with
+  `--vc-color-on-primary` (#fff) text.
+
+Minimal idiomatic snippet:
+
+```html
+<div class="a-auth-shell">
+  <div class="a-auth-shell-aurora"></div>
+  <div class="a-auth-shell-card">
+    <h2 style="font-family: var(--authup-font-display); margin: 0;">Sign in</h2>
+    <div class="a-realm-grid">
+      <div class="a-realm-grid-item">
+        <span class="a-realm-grid-item-name">master</span>
+        <span class="a-realm-grid-item-slug">the admin realm</span>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Drift found vs this project's hand-authored `colors_and_type.css`
+
+The hand-authored extraction predates the repo's Tailwind-v4 theme rework.
+Where they disagree, the repo has moved on:
+
+1. **Primary is periwinkle, not Bootstrap blue.** `--authup-primary: #337ab7`
+   (+ hover/dark/info/success/warning/danger Bootstrap variants) no longer
+   exists in the repo. Primary = `#6d7fcc` with a `color-mix` ramp
+   (`--vc-color-primary-50…950`); status colors come from `@vuecs/design`'s
+   OKLCH semantic palettes, not authup-owned tokens.
+2. **The chrome now flips with the mode.** "Chrome stays slate in BOTH
+   themes" is outdated: light mode renders the header/sidebar/footer as a
+   light raised surface (`--authup-chrome-*` aliasing the semantic tokens);
+   only dark mode pins the slate ramp. New tokens: `--authup-chrome-bg`,
+   `-bg-elevated`, `-fg`, `-fg-muted`, `-border`,
+   `--authup-chrome-edge-shadow-{bottom,top,right}` (drop shadow in light,
+   recessed inset band in dark).
+3. **The signature title bar is periwinkle, not slate.** The 4px
+   `.title::before` bar paints `var(--authup-periwinkle)` in the repo
+   (`generics.css`), not `--authup-slate-800`.
+4. **Dark-mode selector is a `.dark` class**, toggled by the in-app switch
+   (Tailwind `@custom-variant`), not `[data-theme="dark"]` /
+   `prefers-color-scheme`. The synced token sheet supports both selectors.
+5. **New component token groups** absent from the old extraction:
+   `--authup-auth-*` (auth card, aurora, logo), `--authup-realm-grid-*`,
+   `--authup-picker-item-*`, `--authup-login-provider-*`.
+6. **Salmon narrowed.** `#ff5b5b` is now dropdown-hover text only, no longer
+   footer links.
+7. **Legacy `--authup-bg-*` aliases** (`--authup-bg-app`, `-content`, `-card`,
+   `-list`, `-list-active`, `-page`) don't exist in the repo — the
+   `--authup-surface-*` group is the only surface vocabulary.
+
+## What is deliberately NOT here
+
+- **Live components.** The kit (`@authup/client-web-kit`) is Vue 3; Claude
+  Design renders React, so no component bundle is synced. The CSS above is
+  the faithful, framework-neutral layer of the same components.
+- **The Tailwind utility layer and vuecs `<VC*>` class maps** — they require
+  a Tailwind JIT build against the app's sources and are not extractable as
+  static CSS.
+- **Fonts** — Asap + Nunito load from Google Fonts (this project's root
+  `styles.css` already does that; the repo's client-web uses
+  `@nuxtjs/google-fonts`).

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ authup.**.conf
 .nx
 coverage
 .agents/plans
+ds-bundle/

--- a/apps/client-web/components/header.vue
+++ b/apps/client-web/components/header.vue
@@ -9,6 +9,7 @@ import { TranslatorTranslationAppKey, TranslatorTranslationNamespace } from '@au
 import {
     AColorModeSwitcher,
     ALanguageSwitcherDropdown,
+    StoreAuthStatus,
     injectStore,
     useTranslationsForNamespace,
 } from '@authup/client-web-kit';
@@ -33,9 +34,11 @@ export default defineNuxtComponent({
     setup() {
         const store = injectStore();
         const {
-            loggedIn,
+            status,
             user,
         } = storeToRefs(store);
+
+        const authenticated = computed(() => status.value === StoreAuthStatus.AUTHENTICATED);
 
         const translationsApp = useTranslationsForNamespace(
             TranslatorTranslationNamespace.APP,
@@ -67,7 +70,7 @@ export default defineNuxtComponent({
         const { isDark } = useColorMode();
 
         return {
-            loggedIn,
+            authenticated,
             user,
             topItems,
             toggleNav,
@@ -135,7 +138,7 @@ export default defineNuxtComponent({
                         <li class="vc-nav-item">
                             <ALanguageSwitcherDropdown link-class-extra="vc-nav-link" />
                         </li>
-                        <template v-if="loggedIn && user">
+                        <template v-if="authenticated && user">
                             <li class="vc-nav-item">
                                 <a
                                     href="javascript:void(0)"

--- a/apps/client-web/components/sidebar.vue
+++ b/apps/client-web/components/sidebar.vue
@@ -9,6 +9,7 @@
 import { TranslatorTranslationAppKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { ITranslateT } from '@ilingo/vue';
 import {
+    StoreAuthStatus,
     injectHTTPClient,
     injectStore,
     injectTranslatorLocale,
@@ -25,10 +26,12 @@ export default defineNuxtComponent({
     setup() {
         const store = injectStore();
         const {
-            loggedIn,
+            status,
             accessTokenExpireDate: tokenExpireDate,
             realmManagement,
         } = storeToRefs(store);
+
+        const authenticated = computed(() => status.value === StoreAuthStatus.AUTHENTICATED);
 
         const tokenExpiresIn = computed(() => {
             if (!tokenExpireDate.value) {
@@ -53,7 +56,7 @@ export default defineNuxtComponent({
         const navigation = new Navigation(store, translate);
         const sideItems = () => navigation.getSideItems();
         const sideItemsWatch = [
-            () => store.loggedIn,
+            () => store.status,
             () => store.userId,
             () => store.realmManagement,
             () => locale.value,
@@ -69,7 +72,7 @@ export default defineNuxtComponent({
         );
 
         return {
-            loggedIn,
+            authenticated,
             tokenExpiresIn,
             docsUrl,
             realmManagement,
@@ -107,7 +110,7 @@ export default defineNuxtComponent({
 
             <div class="mt-auto">
                 <div
-                    v-if="loggedIn"
+                    v-if="authenticated"
                     class="session-info font-weight-light flex-col ms-3 me-3 mb-1 mt-auto"
                 >
                     <small>

--- a/apps/client-web/config/layout/module.ts
+++ b/apps/client-web/config/layout/module.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { type Store } from '@authup/client-web-kit';
+import { type Store, StoreAuthStatus } from '@authup/client-web-kit';
 import type { IdentityPolicyData } from '@authup/access';
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import type { NavigationItem } from '@vuecs/navigation';
@@ -65,7 +65,7 @@ export class Navigation {
 
     protected async reduceItem(item: NavigationItem<NavigationItemMeta>) : Promise<NavigationItem | undefined> {
         if (item.meta) {
-            const { loggedIn } = this.store;
+            const authenticated = this.store.status === StoreAuthStatus.AUTHENTICATED;
             let identity: IdentityPolicyData | undefined;
             if (this.store.userId) {
                 identity = {
@@ -77,7 +77,7 @@ export class Navigation {
             if (
                 typeof item.meta.requireLoggedIn !== 'undefined' &&
                     item.meta.requireLoggedIn &&
-                    !loggedIn
+                    !authenticated
             ) {
                 return undefined;
             }
@@ -85,7 +85,7 @@ export class Navigation {
             if (
                 typeof item.meta.requireLoggedOut !== 'undefined' &&
                     item.meta.requireLoggedOut &&
-                    loggedIn
+                    authenticated
             ) {
                 return undefined;
             }

--- a/docs/src/sdks/javascript/client-web-kit/session.md
+++ b/docs/src/sdks/javascript/client-web-kit/session.md
@@ -71,7 +71,8 @@ export default defineComponent({
     setup() {
         const store = injectStore();
         
-        console.log(store.loggedIn); // true
+        console.log(store.status); // 'unauthenticated' | 'authenticating' | 'restoring' | 'authenticated'
+        console.log(store.lastAuthOrigin); // 'login' | 'exchange' | 'restore' | null
         console.log(store.userId); // xxxx-xxxx-...
         console.log(store.realmId); // xxxx-xxxx-...
         console.log(store.realmName); // xxx
@@ -79,3 +80,9 @@ export default defineComponent({
     }
 })
 ```
+
+`status` is presence-derived: `authenticated` means access token, realm and user
+are all present (server-side validation stays `resolve()`'s job), while a
+refresh-token-only session reads `restoring` until `resolve()` settles it.
+The former `loggedIn` flag (a coarse "an access token exists" boolean) is
+deprecated — compare `status` against `StoreAuthStatus.AUTHENTICATED` instead.

--- a/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
+++ b/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
@@ -7,6 +7,7 @@
 
 import {
     type Store,
+    StoreAuthStatus,
     type StoreToRefs,
     clearAuthorizationRequest,
     injectStore,
@@ -183,7 +184,7 @@ export class RoutingInterceptor {
             return true;
         }
 
-        return !!this.storeRefs.loggedIn.value;
+        return this.storeRefs.status.value === StoreAuthStatus.AUTHENTICATED;
     }
 
     protected hasLoggedOutCondition(route: RouteLocationNormalized) {
@@ -197,7 +198,7 @@ export class RoutingInterceptor {
             return true;
         }
 
-        return !this.storeRefs.loggedIn.value;
+        return this.storeRefs.status.value !== StoreAuthStatus.AUTHENTICATED;
     }
 
     protected hasPermissionCondition(route: RouteLocationNormalized) {


### PR DESCRIPTION
## Summary

Adopts the plan-045 store auth phase model in authup's own downstream store consumers (checkbox 3 of #3220): the deprecated coarse `loggedIn` flag (bare access-token presence) is replaced with `status === StoreAuthStatus.AUTHENTICATED` (presence-derived: token + realm + user).

- **client-web-nuxt routing interceptor** — `validateLoggedInCondition` / `validateLoggedOutCondition` gate on `status`. Both run after `await store.resolve()` settles, so behavior is unchanged for settled sessions, while a token-only half-state no longer reads as logged in.
- **client-web chrome** — header, sidebar (incl. the nav-resolver watch source `() => store.loggedIn` → `() => store.status`), and the layout navigation reducer.
- **docs** — `session.md` meta example teaches `status` / `lastAuthOrigin` and documents the `loggedIn` deprecation.

Kit-internal usages of the frozen deprecated shims are deliberately untouched (emission semantics frozen per plan 045).

The hub (PrivateAIM/hub) and portal (dnpm-dip/portal) checkboxes of #3220 are delivered as companion PRs in those repos (same migration + lockstep `@authup/*` bump to v1.0.0-beta.52).

Refs #3220

## Verification

- `packages/client-web-nuxt` + `apps/client-web` build clean; ESLint clean
- `client-web-kit` component suite: 111/111 passing
- Checkbox 4 of #3220 (failed login leaves no half-session) audited in both downstream repos — no code relies on tokens surviving a failed `login()`/exchange

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication-state detection across headers, sidebars, navigation, and route handling.
  - Ensured user menus, session countdowns, protected navigation items, and access checks consistently reflect the current authenticated state.
  - Reduced incorrect UI visibility during authentication restoration or status transitions.

- **Documentation**
  - Updated session guidance to recommend the detailed authentication status and origin fields instead of the deprecated login flag.
  - Added documentation for design-token synchronization conventions and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->