### PR TITLE
fix: make MFA login work + stop admins planting a user's second factor

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1811,6 +1811,19 @@ requires the `USER_AUTHENTICATOR_READ/CREATE/UPDATE/DELETE` permissions
 with per-row `resourceRealmMatch` gates. A foreign device id under the wrong
 user's nested route is a 404 (no existence oracle).
 
+**Enrollment FOR another user is email-only, even for a privileged actor
+(`UserAuthenticatorService.enroll`, `BadRequestError` otherwise).** Every other
+kind would let the enroller hold a factor it controls: TOTP/recovery return the
+seed/codes in the enroll response, and a WebAuthn ceremony can be completed on
+the *enroller's own* authenticator (the server can't tell whose device signed).
+Only EMAIL is safe — its code is mailed to the user's own (verified) mailbox, so
+the enroller obtains nothing. So `USER_AUTHENTICATOR_CREATE` on another user is
+effectively "enable email OTP"; an admin **resets** a user's other factors by
+DELETING them and the user re-enrolls (matching Keycloak/Okta/Authentik, which
+never expose a user's factor secret to an admin). The kit `AUserAuthenticatorEnroll`
+mirrors this — when `userId !== '@me'` it offers only the email button
+(`canOfferKind`).
+
 **Enforcement — two chokepoints, both server-side:**
 
 1. **Interactive `/authorize`**: the proof is session-bound — `auth_sessions.mfa_at`

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1831,13 +1831,32 @@ user's nested route is a 404 (no existence oracle).
    with a confirmed device must send a valid `otp` form parameter (TOTP or
    recovery code, classified by shape via
    `guessUserAuthenticatorKindByResponse`: all-digits → totp) or the grant
-   throws `mfa_required`. On success the created session is stamped
-   (`mfa_at`), so the subsequent SSR `POST /authorize` passes the backstop.
-   Users *without* a device pass through (they could never enroll otherwise) —
-   `mfaRequired` (configure-inline) is enforced at `/authorize`
+   throws `mfa_required` (the error `data.kinds` carries the challengeable kinds
+   so a client can pick the right step). On success the created session is
+   stamped (`mfa_at`), so the subsequent SSR `POST /authorize` passes the
+   backstop. Users *without* a device pass through (they could never enroll
+   otherwise) — `mfaRequired` (configure-inline) is enforced at `/authorize`
    (`enrollmentRequired` → the hosted UI routes to inline enrollment), not at
    the token endpoint. WebAuthn cannot ride a single POST — it stays
    interactive-only (documented boundary).
+
+**The password grant is the single MFA chokepoint for credential login — the
+hosted `LoginForm` drives the `otp`, NOT a post-login challenge.** `store.login`
+(and `StoreLoginContext`) carry an optional `otp`, forwarded on the
+`createWithPassword` body. `LoginForm` catches `mfa_required` from the
+credentials-only submit, transitions to a second-factor step, and *resubmits the
+same credentials WITH the code* — so a token is never issued before the factor is
+verified (fail-closed; a credential-only bearer would be a full-API MFA bypass).
+The step reads the error's `kinds`: TOTP/recovery render a code field;
+email/webauthn (which cannot complete in one POST — email needs a send, webauthn
+needs an interactive ceremony against a live session) render the server message
+instead. **Known boundary:** a user whose ONLY confirmed factor is email or
+webauthn cannot complete a *fresh* interactive login this way; that requires a
+pre-MFA session (a session created before enrollment, or a federated-IdP
+callback) so the `/authorize` backstop + `POST /authenticators/challenge` path
+applies. `challenge(userId, { issueMaterial })` lets the enforcement chokepoints
+(authorize backstop, password grant) read the requirement flags without minting
+the webauthn nonce (issued only by the interactive status endpoint).
 
 **Verify unit of work (#3237)**: `UserAuthenticatorService.verify()`
 serializes its read-verify-save critical section per user via a cache lock

--- a/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
+++ b/apps/server-core/src/adapters/http/adapters/oauth2/grant-types/password.ts
@@ -150,14 +150,21 @@ export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2G
             return undefined;
         }
 
-        const status = await this.userAuthenticatorService.challenge(user.id);
+        // requirement flags + kinds only — no webauthn material on the token path.
+        const status = await this.userAuthenticatorService.challenge(user.id, { issueMaterial: false });
         if (!status.required) {
             return undefined;
         }
 
         const otp = readStringField(body, 'otp');
         if (!otp) {
-            throw OAuth2MfaRequiredError.challengeRequired();
+            // carry the challengeable kinds so a client (the hosted login form)
+            // can tell whether a single-POST factor (totp/recovery) is on offer
+            // or the user must complete an interactive challenge (email/webauthn).
+            throw new OAuth2MfaRequiredError({
+                message: 'Complete a second-factor challenge to continue.',
+                data: { kinds: status.kinds },
+            });
         }
 
         const verified = await this.userAuthenticatorService.verify(
@@ -173,7 +180,10 @@ export class HTTPPasswordGrant extends PasswordGrantType implements IHTTPOAuth2G
             },
         );
         if (!verified) {
-            throw new OAuth2MfaRequiredError({ message: 'The provided second factor is not valid.' });
+            throw new OAuth2MfaRequiredError({
+                message: 'The provided second factor is not valid.',
+                data: { kinds: status.kinds },
+            });
         }
 
         return new Date().toISOString();

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -617,10 +617,13 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             return false;
         }
         // Lock acquisition fails open (cache down → 'unavailable') so a cache
-        // outage cannot brick MFA login. That is only safe for factors with a
-        // PERSISTED anti-replay backstop (TOTP step-counter / recovery used_at).
-        // EMAIL single-use rides entirely on the lock + cache drop with no
-        // persisted backstop, so without a real lock it must fail closed —
+        // outage cannot brick MFA login. TOTP/recovery proceed because they carry
+        // a PERSISTED anti-replay backstop (TOTP step-counter / recovery used_at)
+        // — note this bounds SEQUENTIAL replay only; two verifies of the same
+        // still-valid code racing during an outage can both read-then-write and
+        // both pass (an accepted, narrow residual, since each still needs a valid
+        // code). EMAIL single-use rides entirely on the lock + cache drop with no
+        // persisted backstop, so without a real lock it MUST fail closed —
         // otherwise concurrent verifies could both consume one code.
         if (lock === 'unavailable' && input.kind === UserAuthenticatorKind.EMAIL) {
             return false;
@@ -923,12 +926,15 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         return this.repository.hasConfirmedByUser(userId);
     }
 
-    async challenge(userId: string): Promise<UserAuthenticatorChallengeStatus> {
+    async challenge(
+        userId: string,
+        options: { issueMaterial?: boolean } = {},
+    ): Promise<UserAuthenticatorChallengeStatus> {
         if (!this.options.enabled) {
             return {
-                required: false, 
-                enrollmentRequired: false, 
-                kinds: [], 
+                required: false,
+                enrollmentRequired: false,
+                kinds: [],
             };
         }
 
@@ -945,7 +951,11 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         // WebAuthn needs server-issued request options as the challenge — build
         // them (and store the nonce) when the subject holds a webauthn factor.
-        if (kinds.includes(UserAuthenticatorKind.WEBAUTHN) && this.options.webauthn) {
+        // Skipped when the caller only needs the requirement flags (issueMaterial
+        // false): the enforcement chokepoints must not rotate an in-flight
+        // ceremony's nonce nor run this extra query on every request.
+        const issueMaterial = options.issueMaterial ?? true;
+        if (issueMaterial && kinds.includes(UserAuthenticatorKind.WEBAUTHN) && this.options.webauthn) {
             const credentials = (await this.repository.findAllWithSecretsByUser(userId, {
                 kind: UserAuthenticatorKind.WEBAUTHN,
                 confirmed: true,

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -244,6 +244,24 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         const user = await this.resolveTargetUser(validated.user_id, actor, validated);
 
+        // Only EMAIL may be provisioned FOR another user: its code is mailed to
+        // the user's own (already-verified) mailbox, so the enroller never
+        // obtains a factor it controls. Every other kind would let an admin plant
+        // a second factor they hold, defeating MFA — TOTP/recovery return the
+        // seed/codes to the caller, and a WebAuthn ceremony can be completed on
+        // the enroller's OWN authenticator (the server can't tell whose device
+        // signed). Those are self-enrollment only (Keycloak/Okta/Authentik don't
+        // hand a user's factor secret to an admin either); an admin resets another
+        // user's MFA by DELETING it, and the user re-enrolls.
+        const isSelfEnrollment = !!actor.identity &&
+            actor.identity.type === IdentityType.USER &&
+            actor.identity.data.id === user.id;
+        if (!isSelfEnrollment && validated.kind !== UserAuthenticatorKind.EMAIL) {
+            throw new BadRequestError(
+                `A ${validated.kind} authenticator can only be enrolled by the account owner.`,
+            );
+        }
+
         switch (validated.kind) {
             case UserAuthenticatorKind.TOTP: {
                 return this.enrollTotp(user, validated.name ?? null);

--- a/apps/server-core/src/core/entities/user-authenticator/types.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/types.ts
@@ -171,12 +171,24 @@ export type UserAuthenticatorVerifyContext = {
     onVerified?: () => Promise<void>,
 };
 
+export type UserAuthenticatorChallengeOptions = {
+    /**
+     * Issue kind-specific challenge material as a side effect (e.g. mint +
+     * cache the WebAuthn request nonce). Only the interactive status endpoint
+     * needs it; the enforcement chokepoints (authorize backstop, password
+     * grant) read `required`/`enrollmentRequired`/`kinds` only and pass
+     * `false` so they don't rotate an in-flight ceremony's nonce or run the
+     * extra query on every request. Defaults to `true`.
+     */
+    issueMaterial?: boolean,
+};
+
 /**
  * The login-time seam: computes whether (and how) a subject must be
  * challenged. Consumed by the authorize backstop and the password grant.
  */
 export interface IUserAuthenticatorChallengeProvider {
-    challenge(userId: string): Promise<UserAuthenticatorChallengeStatus>;
+    challenge(userId: string, options?: UserAuthenticatorChallengeOptions): Promise<UserAuthenticatorChallengeStatus>;
 }
 
 export interface IUserAuthenticatorService extends IUserAuthenticatorChallengeProvider {

--- a/apps/server-core/src/core/entities/user-authenticator/webauthn.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/webauthn.ts
@@ -14,6 +14,7 @@ import {
 import { isoBase64URL } from '@simplewebauthn/server/helpers';
 import type {
     AuthenticationResponseJSON,
+    AuthenticatorTransportFuture,
     RegistrationResponseJSON,
 } from '@simplewebauthn/server';
 import type { UserAuthenticatorWebauthnParameters } from './types.ts';
@@ -26,8 +27,23 @@ export type WebauthnContext = {
 
 export type WebauthnCredentialRef = {
     id: string,
+    // persisted as a plain string[] on the credential row (JSON column); the
+    // SimpleWebAuthn API narrows it to its transport string-literal union.
     transports?: string[],
 };
+
+// The SimpleWebAuthn option objects are serialized verbatim to the browser
+// (navigator.credentials.*). They cross the wire as an opaque JSON blob, so the
+// public DTO deliberately keeps them as `Record<string, unknown>` rather than
+// leaking @simplewebauthn/server types into the shared HTTP contract — hence the
+// single boundary conversion below.
+function asOpaqueOptions(options: object): Record<string, unknown> {
+    return options as unknown as Record<string, unknown>;
+}
+
+function asTransports(transports?: string[]): AuthenticatorTransportFuture[] | undefined {
+    return transports as AuthenticatorTransportFuture[] | undefined;
+}
 
 export async function buildWebauthnRegistrationOptions(
     ctx: WebauthnContext,
@@ -42,7 +58,7 @@ export async function buildWebauthnRegistrationOptions(
         attestationType: 'none',
         excludeCredentials: existing.map((credential) => ({
             id: credential.id,
-            transports: credential.transports as never,
+            transports: asTransports(credential.transports),
         })),
         authenticatorSelection: {
             residentKey: 'discouraged',
@@ -51,7 +67,7 @@ export async function buildWebauthnRegistrationOptions(
     });
 
     return {
-        options: options as unknown as Record<string, unknown>,
+        options: asOpaqueOptions(options),
         challenge: options.challenge,
     };
 }
@@ -93,12 +109,12 @@ export async function buildWebauthnAuthenticationOptions(
         userVerification: 'preferred',
         allowCredentials: credentials.map((credential) => ({
             id: credential.id,
-            transports: credential.transports as never,
+            transports: asTransports(credential.transports),
         })),
     });
 
     return {
-        options: options as unknown as Record<string, unknown>,
+        options: asOpaqueOptions(options),
         challenge: options.challenge,
     };
 }
@@ -119,7 +135,7 @@ export async function verifyWebauthnAuthentication(
             id: credential.credential_id,
             publicKey: isoBase64URL.toBuffer(credential.public_key),
             counter: credential.counter,
-            transports: credential.transports as never,
+            transports: asTransports(credential.transports),
         },
     });
 

--- a/apps/server-core/src/core/oauth2/authorization/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/module.ts
@@ -193,7 +193,12 @@ export class OAuth2Authorization {
         // fails closed while the user holds a confirmed device. A user without
         // a device under mfaRequired is routed to inline enrollment.
         if (this.mfaChallengeProvider && identity.type === IdentityType.USER) {
-            const challenge = await this.mfaChallengeProvider.challenge(identity.data.id);
+            // requirement flags only — the interactive challenge material (the
+            // webauthn nonce) is issued by the status endpoint, not this backstop.
+            const challenge = await this.mfaChallengeProvider.challenge(
+                identity.data.id,
+                { issueMaterial: false },
+            );
             if (challenge.required && !session?.mfa_at) {
                 throw OAuth2MfaRequiredError.challengeRequired();
             }

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -175,19 +175,52 @@ describe('UserAuthenticatorService', () => {
             }
         });
 
-        it('allows a privileged actor to enroll another user', async () => {
+        // Every kind except email would hand the enroller a factor it controls:
+        // totp/recovery return the seed/codes, and a webauthn ceremony can be
+        // completed on the enroller's own authenticator. Those are
+        // self-enrollment only even for a privileged actor — an admin resets
+        // another user's MFA by deleting it.
+        it.each([
+            UserAuthenticatorKind.TOTP,
+            UserAuthenticatorKind.RECOVERY,
+            UserAuthenticatorKind.WEBAUTHN,
+        ])(
+            'refuses a privileged actor enrolling a %s factor for another user',
+            async (kind) => {
+                userRepository.seed({
+                    id: otherUserId,
+                    name: 'other',
+                    realm_id: realmId,
+                } as Partial<User>);
+
+                expect.assertions(2);
+                try {
+                    await service.enroll({ kind, user_id: otherUserId }, makeActor());
+                } catch (e) {
+                    expect(isAuthupError(e)).toBeTruthy();
+                    expect((e as { code?: string }).code).toEqual(ErrorCode.BAD_REQUEST);
+                }
+            },
+        );
+
+        // Email is the one exception: its code is mailed to the user's own
+        // mailbox, so provisioning it for another user discloses no secret to
+        // the enroller — a privileged actor may still enable it.
+        it('allows a privileged actor to enroll email for another user', async () => {
             userRepository.seed({
-                id: otherUserId, 
-                name: 'other', 
-                realm_id: realmId, 
+                id: otherUserId,
+                name: 'other',
+                email: 'other@example.com',
+                realm_id: realmId,
             } as Partial<User>);
 
             const result = await service.enroll(
-                { kind: UserAuthenticatorKind.TOTP, user_id: otherUserId },
+                { kind: UserAuthenticatorKind.EMAIL, user_id: otherUserId },
                 makeActor(),
             );
 
             expect(result.entity.user_id).toEqual(otherUserId);
+            expect(result.entity.confirmed).toBeTruthy();
         });
     });
 

--- a/apps/server-core/test/unit/http/controllers/entities/user-authenticator.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user-authenticator.spec.ts
@@ -45,22 +45,48 @@ describe('src/http/controllers/user-authenticator', () => {
         return { id: user.id, client };
     }
 
-    it('lets an admin manage another user\'s devices', async () => {
-        const { id: userId } = await createUserBearer('admin-managed-pw');
+    it('lets an admin list and reset another user\'s devices', async () => {
+        const { id: userId, client: userClient } = await createUserBearer('admin-managed-pw');
 
-        const enrolled = await suite.client.userAuthenticator.enroll(userId, { kind: UserAuthenticatorKind.RECOVERY });
+        // secret-bearing factors are self-enrollment only — the user enrolls
+        // their own recovery set (the admin never sees the codes).
+        const enrolled = await userClient.userAuthenticator.enroll('@me', { kind: UserAuthenticatorKind.RECOVERY });
         expect(enrolled.codes).toHaveLength(10);
         expect(enrolled.entity.user_id).toEqual(userId);
 
+        // the admin can list it (secrets nulled) ...
         const list = await suite.client.userAuthenticator.getMany(userId);
         expect(list.data).toHaveLength(1);
         expect(list.data[0].codes ?? null).toBeNull();
 
+        // ... and reset it by deleting (the sanctioned admin management path)
         const deleted = await suite.client.userAuthenticator.delete(userId, enrolled.entity.id);
         expect(deleted.id).toEqual(enrolled.entity.id);
 
         const after = await suite.client.userAuthenticator.getMany(userId);
         expect(after.data).toHaveLength(0);
+    });
+
+    it('refuses an admin enrolling an owner-controlled factor for another user', async () => {
+        const { id: userId } = await createUserBearer('admin-enroll-block-pw');
+
+        // totp/recovery would disclose the seed/codes to the admin, and a
+        // webauthn ceremony can be completed on the admin's own authenticator —
+        // all three are self-enrollment only.
+        for (const kind of [
+            UserAuthenticatorKind.TOTP,
+            UserAuthenticatorKind.RECOVERY,
+            UserAuthenticatorKind.WEBAUTHN,
+        ]) {
+            await expectClientError(
+                () => suite.client.userAuthenticator.enroll(userId, { kind }),
+                { status: 400 },
+            );
+        }
+
+        // nothing was created on the target
+        const list = await suite.client.userAuthenticator.getMany(userId);
+        expect(list.data).toHaveLength(0);
     });
 
     it('denies a non-privileged user access to a foreign user\'s devices', async () => {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-mfa.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-mfa.spec.ts
@@ -96,6 +96,9 @@ describe('src/http/controllers/token (password grant + authorize MFA)', () => {
         const withoutOtpBody = await withoutOtp.json();
         expect(withoutOtpBody.code).toEqual(ErrorCode.OAUTH_MFA_REQUIRED);
         expect(withoutOtpBody.error).toEqual(OAuth2ErrorCode.MFA_REQUIRED);
+        // the challengeable kinds ride the error so the hosted login form can
+        // present the right second-factor step (single-POST otp vs interactive).
+        expect(withoutOtpBody.kinds).toEqual([UserAuthenticatorKind.TOTP]);
 
         // 4) ... and accepts password + otp. Use the PREVIOUS step's code (valid
         // via the ±1 window) so the consumed step stays behind the challenge

--- a/packages/client-web-kit/src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue
+++ b/packages/client-web-kit/src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue
@@ -80,6 +80,21 @@ export default defineComponent({
             () => (props.kind as `${UserAuthenticatorKind}` | null),
         );
 
+        // Only email can be provisioned FOR another user — totp/recovery/webauthn
+        // are owner-controlled (self-enrollment only) and the server rejects them
+        // on a non-self target, so an admin managing a different user is offered
+        // email alone (they reset the rest by deleting the user's devices).
+        const managingOther = computed<boolean>(() => props.userId !== '@me');
+        const canOfferKind = (kind: `${UserAuthenticatorKind}`): boolean => {
+            if (forcedKind.value && forcedKind.value !== kind) {
+                return false;
+            }
+            if (managingOther.value && kind !== UserAuthenticatorKind.EMAIL) {
+                return false;
+            }
+            return true;
+        };
+
         const reset = () => {
             enrollment.value = null;
             enrollmentKind.value = null;
@@ -184,6 +199,7 @@ export default defineComponent({
             enrollmentKind,
             confirmCode,
             forcedKind,
+            canOfferKind,
             enroll,
             confirm,
             reset,
@@ -214,28 +230,28 @@ export default defineComponent({
 
             <div class="flex flex-col gap-2">
                 <VCButton
-                    v-if="!forcedKind || forcedKind === UserAuthenticatorKind.TOTP"
+                    v-if="canOfferKind(UserAuthenticatorKind.TOTP)"
                     :disabled="busy"
                     color="primary"
                     :label="translations.mfaEnrollTotp"
                     @click="enroll(UserAuthenticatorKind.TOTP)"
                 />
                 <VCButton
-                    v-if="!forcedKind || forcedKind === UserAuthenticatorKind.WEBAUTHN"
+                    v-if="canOfferKind(UserAuthenticatorKind.WEBAUTHN)"
                     :disabled="busy"
                     color="neutral"
                     :label="translations.mfaEnrollWebauthn"
                     @click="enroll(UserAuthenticatorKind.WEBAUTHN)"
                 />
                 <VCButton
-                    v-if="!forcedKind || forcedKind === UserAuthenticatorKind.EMAIL"
+                    v-if="canOfferKind(UserAuthenticatorKind.EMAIL)"
                     :disabled="busy"
                     color="neutral"
                     :label="translations.mfaEnrollEmail"
                     @click="enroll(UserAuthenticatorKind.EMAIL)"
                 />
                 <VCButton
-                    v-if="!forcedKind || forcedKind === UserAuthenticatorKind.RECOVERY"
+                    v-if="canOfferKind(UserAuthenticatorKind.RECOVERY)"
                     :disabled="busy"
                     color="neutral"
                     :label="translations.mfaEnrollRecovery"

--- a/packages/client-web-kit/src/components/workflows/login/LoginForm.vue
+++ b/packages/client-web-kit/src/components/workflows/login/LoginForm.vue
@@ -10,7 +10,8 @@ import {
     watch,
 } from 'vue';
 import type { IdentityProvider, OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
-import { IdentityProviderProtocol } from '@authup/core-kit';
+import { IdentityProviderProtocol, UserAuthenticatorKind } from '@authup/core-kit';
+import { ErrorCode } from '@authup/errors';
 import { useValidup } from '@validup/vue';
 import {
     TranslatorTranslationActionKey,
@@ -20,6 +21,7 @@ import {
     TranslatorTranslationNamespace,
 } from '@authup/i18n';
 import {
+    extractErrorContext,
     injectHTTPClient,
     injectStore,
     useTranslations,
@@ -30,6 +32,7 @@ import { Container } from 'validup';
 import { z } from 'zod';
 import type { BuildInput } from 'rapiq';
 import { VCButton } from '@vuecs/button';
+import { VCAlert } from '@vuecs/elements';
 import { VCFormGroup, VCFormInput, useSubmitButton } from '@vuecs/forms';
 import type { LinkProperties } from '@vuecs/link';
 import { VCLink } from '@vuecs/link';
@@ -66,6 +69,7 @@ export default defineComponent({
         AIdentityProviders,
         AIdentityProviderIcon,
         VCButton,
+        VCAlert,
         VCFormGroup,
         VCFormInput,
         VCLink,
@@ -122,11 +126,43 @@ export default defineComponent({
                 namespace: TranslatorTranslationNamespace.CLIENT,
                 key: TranslatorTranslationClientKey.FORGOT_PASSWORD,
             },
+            {
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.MFA_TITLE,
+            },
+            {
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.MFA_CHALLENGE_INTRO,
+            },
+            {
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.MFA_CODE,
+            },
+            {
+                namespace: TranslatorTranslationNamespace.CLIENT,
+                key: TranslatorTranslationClientKey.MFA_VERIFY,
+            },
         ]);
 
         const translate = useTranslator();
 
         const busy = ref(false);
+
+        // Second-factor step (plan 049). The password grant rejects an
+        // MFA-enrolled user's credential-only login with `mfa_required`; rather
+        // than surface that as a dead-end failure, transition to a code step
+        // and resubmit the same credentials WITH the `otp`. Only the single-POST
+        // factors (TOTP / recovery code) can complete here — email/webauthn need
+        // an interactive challenge against a live session, so a user holding
+        // only those is shown the server's message instead of a code field.
+        const otp = ref('');
+        const mfaRequired = ref(false);
+        const mfaKinds = ref<`${UserAuthenticatorKind}`[]>([]);
+        const mfaMessage = ref<string | null>(null);
+
+        const mfaHasCodeFactor = computed<boolean>(() => mfaKinds.value.length === 0 ||
+            mfaKinds.value.includes(UserAuthenticatorKind.TOTP) ||
+            mfaKinds.value.includes(UserAuthenticatorKind.RECOVERY));
 
         const identityProviderQuery: Ref<BuildInput<IdentityProvider>> = ref({});
         const resetIdentityProviderQuery = () => {
@@ -176,17 +212,58 @@ export default defineComponent({
                 return;
             }
 
+            // once in the second-factor step, require a code before resubmitting
+            if (mfaRequired.value && (!mfaHasCodeFactor.value || !otp.value.trim())) {
+                return;
+            }
+
             busy.value = true;
+            mfaMessage.value = null;
 
             try {
                 await store.login({
                     name: form.name,
                     password: form.password,
                     realmId: form.realm_id,
+                    ...(mfaRequired.value && otp.value.trim() ? { otp: otp.value.trim() } : {}),
                 });
 
                 emit('done');
             } catch (e: unknown) {
+                const ctx = extractErrorContext(e);
+
+                if (ctx.code === ErrorCode.OAUTH_MFA_REQUIRED) {
+                    const kinds = Array.isArray(ctx.data?.kinds) ?
+                        ctx.data?.kinds as `${UserAuthenticatorKind}`[] :
+                        [];
+                    const hasCodeFactor = kinds.length === 0 ||
+                        kinds.includes(UserAuthenticatorKind.TOTP) ||
+                        kinds.includes(UserAuthenticatorKind.RECOVERY);
+
+                    // Entering a CODE step (from the credentials view) is silent —
+                    // the message only surfaces on a later rejection/throttle. A
+                    // step with no single-POST factor (email/webauthn only) shows
+                    // the server's explanation right away, since there is no field.
+                    mfaMessage.value = mfaRequired.value || !hasCodeFactor ?
+                        (ctx.message ?? null) :
+                        null;
+                    mfaKinds.value = kinds;
+                    mfaRequired.value = true;
+                    otp.value = '';
+                    return;
+                }
+
+                // A non-mfa error while completing the second factor (e.g. a
+                // throttle) keeps the step so the user can retry; a failure at
+                // the credentials stage is the normal login failure.
+                if (mfaRequired.value) {
+                    mfaMessage.value = ctx.message ?? await translate({
+                        namespace: TranslatorTranslationNamespace.CLIENT,
+                        key: TranslatorTranslationClientKey.LOGIN_FAILED,
+                    });
+                    return;
+                }
+
                 emit('failed', e instanceof Error ?
                     e.message :
                     await translate({
@@ -229,6 +306,10 @@ export default defineComponent({
             submit,
             busy,
             submitButton,
+            otp,
+            mfaRequired,
+            mfaMessage,
+            mfaHasCodeFactor,
             identityProviderQuery,
             identityProviderRef,
             buildIdentityProviderURL,
@@ -241,38 +322,77 @@ export default defineComponent({
     <div>
         <div class="text-center">
             <h1 class="font-bold">
-                {{ translationsDefault.login }}
+                {{ mfaRequired ? translationsDefault.mfaTitle : translationsDefault.login }}
             </h1>
         </div>
         <form @submit.prevent="submit">
-            <IFieldValidation
-                v-slot="{ value }"
-                :field="v.fields.name"
-            >
-                <VCFormGroup :validation="value">
-                    <template #label>
-                        {{ translationsDefault.name }}
-                    </template>
-                    <VCFormInput v-model="v.fields.name.$model.value" />
-                </VCFormGroup>
-            </IFieldValidation>
+            <template v-if="mfaRequired">
+                <VCAlert
+                    v-if="mfaMessage"
+                    :color="mfaHasCodeFactor ? 'error' : 'warning'"
+                    variant="soft"
+                    class="mb-3"
+                >
+                    {{ mfaMessage }}
+                </VCAlert>
 
-            <IFieldValidation
-                v-slot="{ value }"
-                :field="v.fields.password"
-            >
-                <VCFormGroup :validation="value">
-                    <template #label>
-                        {{ translationsDefault.password }}
-                    </template>
-                    <VCFormInput
-                        v-model="v.fields.password.$model.value"
-                        type="password"
+                <template v-if="mfaHasCodeFactor">
+                    <p class="text-center mb-3">
+                        {{ translationsDefault.mfaChallengeIntro }}
+                    </p>
+
+                    <VCFormGroup>
+                        <template #label>
+                            {{ translationsDefault.mfaCode }}
+                        </template>
+                        <VCFormInput
+                            v-model="otp"
+                            autocomplete="one-time-code"
+                            autofocus
+                        />
+                    </VCFormGroup>
+
+                    <VCButton
+                        type="submit"
+                        color="primary"
+                        :busy="busy"
+                        :disabled="busy || !otp.trim()"
+                        :label="translationsDefault.mfaVerify"
+                        class="w-full"
+                        @click="submit"
                     />
-                </VCFormGroup>
-            </IFieldValidation>
+                </template>
+            </template>
 
-            <!--
+            <template v-else>
+                <IFieldValidation
+                    v-slot="{ value }"
+                    :field="v.fields.name"
+                >
+                    <VCFormGroup :validation="value">
+                        <template #label>
+                            {{ translationsDefault.name }}
+                        </template>
+                        <VCFormInput v-model="v.fields.name.$model.value" />
+                    </VCFormGroup>
+                </IFieldValidation>
+
+                <IFieldValidation
+                    v-slot="{ value }"
+                    :field="v.fields.password"
+                >
+                    <VCFormGroup :validation="value">
+                        <template #label>
+                            {{ translationsDefault.password }}
+                        </template>
+                        <VCFormInput
+                            v-model="v.fields.password.$model.value"
+                            type="password"
+                        />
+                    </VCFormGroup>
+                </IFieldValidation>
+
+                <!--
                 <VCFormSubmit> from form-controls 2.x was dropped in
                 @vuecs/forms 4.x. The 4.x replacement is the
                 useSubmitButton() composable (see setup() above) which
@@ -283,86 +403,87 @@ export default defineComponent({
                 `label` to "Login" because the composable's default
                 (sourced from the vuecs defaults manager) is "Create".
             -->
-            <VCButton
-                v-bind="submitButton"
-                :label="translationsDefault.login"
-                class="w-full"
-            />
-
-            <div
-                v-if="registerLink || passwordForgotLink"
-                class="flex flex-row justify-between mt-2 text-sm"
-            >
-                <VCLink
-                    v-if="registerLink"
-                    v-bind="registerLink"
-                >
-                    {{ translationsDefault.createAccount }}
-                </VCLink>
-                <VCLink
-                    v-if="passwordForgotLink"
-                    v-bind="passwordForgotLink"
-                    class="ms-auto"
-                >
-                    {{ translationsDefault.forgotPassword }}
-                </VCLink>
-            </div>
-
-            <hr>
-
-            <template v-if="!codeRequest || !codeRequest.realm_id">
-                <ARealmPicker
-                    :value="form.realm_id"
-                    @change="updateRealmId"
+                <VCButton
+                    v-bind="submitButton"
+                    :label="translationsDefault.login"
+                    class="w-full"
                 />
-            </template>
 
-            <AIdentityProviders
-                ref="identityProviderRef"
-                :query="identityProviderQuery"
-                :footer="false"
-            >
-                <template #header>
-                    <ATitle :text="translationsDefault.identityProvider" />
-                </template>
-                <template #footer="props">
-                    <APagination
-                        :busy="props.busy"
-                        :meta="props.meta"
-                        :load="(data?: any) => props.load?.(data)"
-                        :total="props.total"
+                <div
+                    v-if="registerLink || passwordForgotLink"
+                    class="flex flex-row justify-between mt-2 text-sm"
+                >
+                    <VCLink
+                        v-if="registerLink"
+                        v-bind="registerLink"
+                    >
+                        {{ translationsDefault.createAccount }}
+                    </VCLink>
+                    <VCLink
+                        v-if="passwordForgotLink"
+                        v-bind="passwordForgotLink"
+                        class="ms-auto"
+                    >
+                        {{ translationsDefault.forgotPassword }}
+                    </VCLink>
+                </div>
+
+                <hr>
+
+                <template v-if="!codeRequest || !codeRequest.realm_id">
+                    <ARealmPicker
+                        :value="form.realm_id"
+                        @change="updateRealmId"
                     />
                 </template>
-                <template #body="props">
-                    <div class="flex flex-row flex-wrap gap-1">
-                        <div
-                            v-for="(item, key) in props.data"
-                            :key="key"
-                            class="a-login-provider-item"
-                        >
-                            <VCButton
-                                tag="a"
-                                :href="buildIdentityProviderURL(item.id)"
-                                size="sm"
-                                color="neutral"
-                                class="p-2 a-login-provider-box bg-fg"
+
+                <AIdentityProviders
+                    ref="identityProviderRef"
+                    :query="identityProviderQuery"
+                    :footer="false"
+                >
+                    <template #header>
+                        <ATitle :text="translationsDefault.identityProvider" />
+                    </template>
+                    <template #footer="props">
+                        <APagination
+                            :busy="props.busy"
+                            :meta="props.meta"
+                            :load="(data?: any) => props.load?.(data)"
+                            :total="props.total"
+                        />
+                    </template>
+                    <template #body="props">
+                        <div class="flex flex-row flex-wrap gap-1">
+                            <div
+                                v-for="(item, key) in props.data"
+                                :key="key"
+                                class="a-login-provider-item"
                             >
-                                <div class="flex flex-col">
-                                    <div class="text-center mb-1">
-                                        <AIdentityProviderIcon
-                                            class="text-2xl"
-                                            :entity="item"
-                                        />
+                                <VCButton
+                                    tag="a"
+                                    :href="buildIdentityProviderURL(item.id)"
+                                    size="sm"
+                                    color="neutral"
+                                    class="p-2 a-login-provider-box bg-fg"
+                                >
+                                    <div class="flex flex-col">
+                                        <div class="text-center mb-1">
+                                            <AIdentityProviderIcon
+                                                class="text-2xl"
+                                                :entity="item"
+                                            />
+                                        </div>
+                                        <div>
+                                            {{ item.name }}
+                                        </div>
                                     </div>
-                                    <div>
-                                        {{ item.name }}
-                                    </div>
-                                </div>
-                            </VCButton>
+                                </VCButton>
+                            </div>
                         </div>
-                    </div>
-                </template>
-            </AIdentityProviders>
+                    </template>
+                </AIdentityProviders>
+            </template>
         </form>
     </div>
 </template>

--- a/packages/client-web-kit/src/components/workflows/mfa/AMfaChallengeForm.vue
+++ b/packages/client-web-kit/src/components/workflows/mfa/AMfaChallengeForm.vue
@@ -17,6 +17,7 @@ import {
     TranslatorTranslationNamespace,
 } from '@authup/i18n';
 import { startAuthentication } from '@simplewebauthn/browser';
+import type { PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/browser';
 import { VCButton } from '@vuecs/button';
 import { VCAlert } from '@vuecs/elements';
 import { VCFormGroup, VCFormInput } from '@vuecs/forms';
@@ -147,7 +148,11 @@ export default defineComponent({
         };
 
         const authenticateWithPasskey = async () => {
-            const optionsJSON = (props.challenge?.webauthn ?? null) as Record<string, unknown> | null;
+            // The challenge payload is an opaque Record on the wire (the server
+            // keeps @simplewebauthn types out of the HTTP DTO); narrow it back to
+            // the browser API's option shape at this single boundary.
+            const optionsJSON = (props.challenge?.webauthn ?? null) as
+                unknown as PublicKeyCredentialRequestOptionsJSON | null;
             if (busy.value || !optionsJSON) {
                 return;
             }
@@ -155,7 +160,7 @@ export default defineComponent({
             busy.value = true;
             error.value = null;
             try {
-                const assertion = await startAuthentication({ optionsJSON: optionsJSON as never });
+                const assertion = await startAuthentication({ optionsJSON });
                 await apiClient.userAuthenticator.verifyChallenge({
                     kind: UserAuthenticatorKind.WEBAUTHN,
                     response: JSON.stringify(assertion),

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -627,6 +627,7 @@ export function createStore(context: StoreCreateContext) {
                 username: ctx.name,
                 password: ctx.password,
                 ...(ctx.realmId ? { realm_id: ctx.realmId } : {}),
+                ...(ctx.otp ? { otp: ctx.otp } : {}),
             });
 
             // Clear any previous identity's state (notably a retained id_token —

--- a/packages/client-web-kit/src/core/store/types.ts
+++ b/packages/client-web-kit/src/core/store/types.ts
@@ -42,7 +42,13 @@ export type StoreCreateContext = {
 export type StoreLoginContext = {
     name: string,
     password: string,
-    realmId?: string
+    realmId?: string,
+    /**
+     * A second-factor proof (TOTP or recovery code) submitted alongside the
+     * credentials when the user holds a confirmed authenticator — otherwise
+     * the password grant rejects the login with `mfa_required`.
+     */
+    otp?: string
 };
 
 export type StoreInstallOptions = {

--- a/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/login-form.spec.ts
@@ -7,6 +7,7 @@
 
 import { flushPromises } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
+import type { FakeClient } from '@authup/core-http-kit/testing';
 import { AIdentityProviders, ARealmPicker } from '../../../../src/components/entities';
 import { findTokenRequest, mountLoginForm } from '../../../utils';
 
@@ -19,6 +20,42 @@ async function submitWithCredentials(wrapper: LoginFormWrapper) {
 
     await wrapper.find('form').trigger('submit');
     await flushPromises();
+}
+
+function tokenRequests(httpClient: FakeClient) {
+    return httpClient.requests.filter(
+        (request) => request.method === 'POST' &&
+            new URL(request.url, 'http://localhost').pathname === '/token',
+    );
+}
+
+// A password-grant handler that rejects a credential-only login (as the server
+// does for an MFA-enrolled user) with `mfa_required`, and only succeeds once an
+// `otp` rides along.
+function mfaGatedTokenHandler(kinds: string[] = ['totp']) {
+    return (req: { body?: unknown }) => {
+        const body = (req.body ?? {}) as Record<string, any>;
+        if (!body.otp) {
+            const error = new Error('Complete a second-factor challenge to continue.');
+            (error as any).response = {
+                status: 400,
+                data: {
+                    code: 'mfa_required',
+                    error: 'mfa_required',
+                    kinds,
+                    message: 'Complete a second-factor challenge to continue.',
+                },
+            };
+            throw error;
+        }
+
+        return {
+            access_token: 'xyz',
+            token_type: 'Bearer',
+            expires_in: 3600,
+            refresh_token: 'abc',
+        };
+    };
 }
 
 describe('components/workflows/login', () => {
@@ -101,6 +138,86 @@ describe('components/workflows/login', () => {
         expect(body.username).toEqual('admin');
         expect(body.password).toEqual('start123');
         expect('realm_id' in body).toBe(false);
+    });
+
+    // Regression (plan 049 gap): an MFA-enrolled user logging in fresh gets
+    // `mfa_required` from the password grant. The form must NOT dead-end as a
+    // generic failure — it presents a second-factor step and resubmits the same
+    // credentials WITH the otp. Before the fix the credentials-only login threw
+    // and the challenge was never collected.
+    it('should present a second-factor step on mfa_required and complete with otp', async () => {
+        const { wrapper, httpClient } = mountLoginForm({}, { 'POST /token': mfaGatedTokenHandler(['totp']) });
+        await flushPromises();
+
+        // credential-only submit → transitions to the challenge step, no failure
+        await submitWithCredentials(wrapper);
+
+        expect((wrapper.vm as any).mfaRequired).toBe(true);
+        expect(wrapper.emitted('failed')).toBeUndefined();
+
+        // the realm picker / credential view is hidden in the challenge step
+        expect(wrapper.findComponent(ARealmPicker).exists()).toBe(false);
+
+        // the first token request carried NO otp
+        const first = findTokenRequest(httpClient);
+        expect(first!.body).toMatchObject({ grant_type: 'password', username: 'admin' });
+        expect('otp' in (first!.body as Record<string, unknown>)).toBe(false);
+
+        // enter the code and resubmit → the grant is retried WITH the otp
+        const otpInput = wrapper.find('input');
+        expect(otpInput.exists()).toBe(true);
+        await otpInput.setValue('123456');
+        await wrapper.find('form').trigger('submit');
+        await flushPromises();
+
+        const withOtp = tokenRequests(httpClient).find(
+            (request) => (request.body as Record<string, unknown>).otp,
+        );
+        expect(withOtp).toBeDefined();
+        expect(withOtp!.body).toMatchObject({
+            grant_type: 'password',
+            username: 'admin',
+            password: 'start123',
+            otp: '123456',
+        });
+
+        // the completed login never surfaced as a failure
+        expect(wrapper.emitted('failed')).toBeUndefined();
+    });
+
+    // Email / WebAuthn cannot ride a single password POST — the challenge step
+    // must not offer a useless code field to a user holding only those factors.
+    it('should not render an otp field when only interactive factors are enrolled', async () => {
+        const { wrapper } = mountLoginForm({}, { 'POST /token': mfaGatedTokenHandler(['webauthn']) });
+        await flushPromises();
+
+        await submitWithCredentials(wrapper);
+
+        expect((wrapper.vm as any).mfaRequired).toBe(true);
+        expect((wrapper.vm as any).mfaHasCodeFactor).toBe(false);
+        // no code input in the challenge step
+        expect(wrapper.find('input').exists()).toBe(false);
+        expect(wrapper.emitted('failed')).toBeUndefined();
+    });
+
+    // A non-mfa failure (bad credentials) must still surface as `failed`.
+    it('should emit failed for a non-mfa login error', async () => {
+        const { wrapper } = mountLoginForm({}, {
+            'POST /token': () => {
+                const error = new Error('invalid credentials');
+                (error as any).response = {
+                    status: 400,
+                    data: { code: 'entity_credentials_invalid', message: 'invalid credentials' },
+                };
+                throw error;
+            },
+        });
+        await flushPromises();
+
+        await submitWithCredentials(wrapper);
+
+        expect((wrapper.vm as any).mfaRequired).toBe(false);
+        expect(wrapper.emitted('failed')).toBeTruthy();
     });
 
     // Regression: the collection manager's setup-time load is

--- a/packages/client-web-kit/test/unit/core/store/login.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/login.spec.ts
@@ -88,4 +88,36 @@ describe('core/store/login', () => {
         expect(request).toBeDefined();
         expect('realm_id' in (request!.body as Record<string, string>)).toBe(false);
     });
+
+    it('should transmit otp (second factor) when provided', async () => {
+        const { store, httpClient } = buildStore();
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+            otp: '123456',
+        });
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect(request!.body).toMatchObject({
+            grant_type: 'password',
+            username: 'admin',
+            password: 'start123',
+            otp: '123456',
+        });
+    });
+
+    it('should omit otp when not provided', async () => {
+        const { store, httpClient } = buildStore();
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+        });
+
+        const request = findTokenRequest(httpClient);
+        expect(request).toBeDefined();
+        expect('otp' in (request!.body as Record<string, string>)).toBe(false);
+    });
 });

--- a/packages/core-http-kit/src/domains/workflows/oauth2/types.ts
+++ b/packages/core-http-kit/src/domains/workflows/oauth2/types.ts
@@ -37,7 +37,16 @@ export type OAuth2APIOptions = Options;
 export type OAuth2ClientAuthenticationParameters = ClientAuthenticationParameters;
 
 export type OAuth2TokenClientCredentialsGrantParameters = TokenClientCredentialsGrantParameters;
-export type OAuth2TokenPasswordGrantParameters = TokenPasswordGrantParameters;
+/**
+ * The `otp` field is an authup extension (not part of the RFC 6749 password
+ * grant): a user holding a confirmed second factor supplies a TOTP or
+ * recovery code alongside their credentials so the grant is not rejected
+ * with `mfa_required`. It rides as an extra form field — the token request
+ * transport serializes every string parameter.
+ */
+export type OAuth2TokenPasswordGrantParameters = TokenPasswordGrantParameters & {
+    otp?: string,
+};
 export type OAuth2TokenAuthorizationCodeGrantParameters = TokenAuthorizationCodeGrantParameters;
 export type OAuth2TokenRefreshTokenGrantParameters = TokenRefreshTokenGrantParameters;
 export type OAuth2TokenRobotCredentialsGrantParameters = TokenRobotCredentialsGrantParameters;

--- a/packages/server-kit/src/cache/adapters/memory.ts
+++ b/packages/server-kit/src/cache/adapters/memory.ts
@@ -35,12 +35,14 @@ export class MemoryCache implements ICache {
     }
 
     async get<T =unknown>(key: string): Promise<T | null> {
-        const output = await this.instance.get(key);
-        if (output) {
-            return output as T;
+        // Distinguish "absent/expired" (undefined) from a stored falsy value —
+        // a `0` counter or `false`/`''` must round-trip, not read back as null.
+        const output = this.instance.get(key);
+        if (typeof output === 'undefined') {
+            return null;
         }
 
-        return null;
+        return output as T;
     }
 
     async set(key: string, value: unknown, options: CacheSetOptions): Promise<void> {

--- a/packages/server-kit/src/cache/adapters/redis.ts
+++ b/packages/server-kit/src/cache/adapters/redis.ts
@@ -22,12 +22,15 @@ export class RedisCache implements ICache {
     }
 
     async get(key: string): Promise<any> {
+        // jsonAdapter.get returns undefined for an absent key — distinguish that
+        // from a stored falsy value (`0` counter, `false`, `''`) which must
+        // round-trip instead of reading back as null.
         const output = await this.jsonAdapter.get(key);
-        if (output) {
-            return output;
+        if (typeof output === 'undefined') {
+            return null;
         }
 
-        return null;
+        return output;
     }
 
     async pop<T = unknown>(key: string): Promise<T | null> {
@@ -44,9 +47,9 @@ export class RedisCache implements ICache {
     }
 
     async has(key: string) : Promise<boolean> {
-        const output = await this.get(key);
-
-        return !!output;
+        // EXISTS, not a truthiness check on the value — a stored falsy value
+        // (`0`/`false`/`''`) is still present.
+        return (await this.client.exists(key)) > 0;
     }
 
     async set(key: string, value: any, options: CacheSetOptions): Promise<void> {

--- a/packages/server-kit/test/unit/cache-memory.spec.ts
+++ b/packages/server-kit/test/unit/cache-memory.spec.ts
@@ -80,4 +80,24 @@ describe('src/cache/adapters/memory', () => {
             expect(await cache.increment('counter')).toBe(1);
         });
     });
+
+    describe('get (falsy round-trip)', () => {
+        it('returns null for an absent key', async () => {
+            const cache = new MemoryCache();
+
+            expect(await cache.get('missing')).toBeNull();
+        });
+
+        it('round-trips a stored falsy value instead of reading back null', async () => {
+            const cache = new MemoryCache();
+
+            await cache.set('zero', 0, {});
+            await cache.set('flag', false, {});
+            await cache.set('empty', '', {});
+
+            expect(await cache.get('zero')).toBe(0);
+            expect(await cache.get('flag')).toBe(false);
+            expect(await cache.get('empty')).toBe('');
+        });
+    });
 });

--- a/packages/server-kit/test/unit/cache-redis.spec.ts
+++ b/packages/server-kit/test/unit/cache-redis.spec.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    afterAll,
+    afterEach,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { RedisCache } from '../../src';
+
+// Bounded connection so this suite SKIPS (rather than hangs) when no redis is
+// reachable — CI without the compose stack, a laptop with docker down, etc.
+// With a compose redis up (`docker compose up -d redis`) it exercises the real
+// adapter.
+function createCache(): RedisCache {
+    const cache = new RedisCache({
+        host: process.env.REDIS_HOST ?? '127.0.0.1',
+        port: Number(process.env.REDIS_PORT ?? 6379),
+        lazyConnect: true,
+        connectTimeout: 1_500,
+        maxRetriesPerRequest: 1,
+        // fail fast instead of reconnecting forever when redis is down
+        retryStrategy: () => null,
+    } as never);
+
+    // swallow the async error events a down instance emits (unhandled 'error'
+    // would otherwise surface as a noisy rejection)
+    (cache as unknown as { client: { on(event: string, cb: () => void): void } })
+        .client.on('error', () => { /* ignored — availability is probed below */ });
+
+    return cache;
+}
+
+async function quit(cache: RedisCache): Promise<void> {
+    try {
+        await (cache as unknown as { client: { quit(): Promise<unknown> } }).client.quit();
+    } catch {
+        // already disconnected
+    }
+}
+
+const probe = createCache();
+let available: boolean;
+try {
+    await probe.set('__cache_probe__', 1, { ttl: 1_000 });
+    await probe.drop('__cache_probe__');
+    available = true;
+} catch {
+    available = false;
+}
+await quit(probe);
+
+const describeRedis = available ? describe : describe.skip;
+
+describeRedis('src/cache/adapters/redis', () => {
+    let cache: RedisCache;
+
+    beforeAll(() => {
+        cache = createCache();
+    });
+
+    afterEach(async () => {
+        await cache.clear();
+    });
+
+    afterAll(async () => {
+        await quit(cache);
+    });
+
+    describe('get (falsy round-trip)', () => {
+        it('returns null for an absent key', async () => {
+            expect(await cache.get('missing')).toBeNull();
+        });
+
+        it('round-trips a stored falsy value instead of reading back null', async () => {
+            await cache.set('zero', 0, { ttl: 5_000 });
+            await cache.set('flag', false, { ttl: 5_000 });
+            await cache.set('empty', '', { ttl: 5_000 });
+
+            expect(await cache.get('zero')).toBe(0);
+            expect(await cache.get('flag')).toBe(false);
+            expect(await cache.get('empty')).toBe('');
+        });
+    });
+
+    describe('has', () => {
+        it('is true for a stored falsy value and false when absent', async () => {
+            await cache.set('zero', 0, { ttl: 5_000 });
+
+            expect(await cache.has('zero')).toBe(true);
+            expect(await cache.has('missing')).toBe(false);
+        });
+    });
+
+    describe('add (set-if-absent)', () => {
+        it('stores when absent and refuses to overwrite when present', async () => {
+            expect(await cache.add('lock', 'first', { ttl: 5_000 })).toBe(true);
+            expect(await cache.add('lock', 'second', { ttl: 5_000 })).toBe(false);
+            expect(await cache.get('lock')).toBe('first');
+        });
+    });
+
+    describe('increment (atomic counter)', () => {
+        it('returns the post-increment value and never loses a concurrent update', async () => {
+            expect(await cache.increment('counter', 1, { ttl: 5_000 })).toBe(1);
+
+            const outputs = await Promise.all(
+                Array.from({ length: 10 }, () => cache.increment('counter', 1, { ttl: 5_000 })),
+            );
+
+            expect(await cache.get('counter')).toBe(11);
+            expect(new Set(outputs).size).toBe(10);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Audit + hardening of the Wave-3 MFA stack (plans 049/050). Two security-relevant fixes plus quality cleanups surfaced while reviewing `6d0422a..master`. The MFA enforcement itself was already fail-closed with no bypass — these fix a **broken login path** and an **admin-can-plant-a-factor** hole, and tidy the flagged cast/cache issues.

## 1. Interactive login was impossible for MFA-enrolled users 🔴

The hosted `LoginForm` password-granted with **no `otp`**, so an enrolled user hit `mfa_required` and dead-ended: Authorize.vue's post-login challenge ladder only fires on `loggedIn`, which the rejected grant never sets. The existing `grant-password-mfa` test masked this by reusing a *pre-enrollment* bearer session, so a genuinely fresh login by an enrolled user was untested and broken.

The password grant is the single credential-login MFA chokepoint (issuing a credential-only bearer would be a full-API bypass), so the fix is client-side:

- `OAuth2TokenPasswordGrantParameters` + `StoreLoginContext` gain an optional `otp`, forwarded on `createWithPassword`.
- `LoginForm` catches `mfa_required`, shows a second-factor step, and resubmits the same credentials **with** the code — fail-closed (no token before verify).
- The `mfa_required` error now carries `data.kinds`; the form shows a code field for TOTP/recovery and the server's message for email/webauthn-only.

**Known boundary (documented in architecture.md):** an email/webauthn-only user's *fresh* interactive login still needs a pre-MFA session (federated IdP or a pre-enrollment session) — that requires an MFA-ticket protocol, out of scope here.

## 2. Cross-user enrollment let an admin plant a factor it controls 🔴

Enrolling a **TOTP/recovery/webauthn** factor *for another user* handed the enroller a second factor it holds — TOTP seeds and recovery codes are returned in the enroll response, and a WebAuthn ceremony can be completed on the *enroller's own* authenticator. A malicious/compromised admin could plant a factor and pass the victim's MFA.

`UserAuthenticatorService.enroll` now rejects any non-self enrollment **except email** (whose code is mailed to the user's own verified mailbox, disclosing nothing). Admins reset a user's other factors by **deleting** them; the user re-enrolls — matching Keycloak/Okta/Authentik, which never hand a user's factor secret to an admin. The kit `AUserAuthenticatorEnroll` mirrors this (offers only the email option when `userId !== '@me'`).

## Quality / flagged items

- `challenge(userId, { issueMaterial })` — the authorize backstop and password grant read the requirement flags without minting/rotating the WebAuthn nonce on every request.
- `webauthn.ts`: dropped the `as never` transport casts (typed) and localized the one opaque-DTO bridge; `AMfaChallengeForm`: typed the `startAuthentication` cast.
- `MemoryCache.get` **and** `RedisCache.get`/`has`: fixed the falsy-zero bug so a stored `0`/`false`/`''` round-trips (`RedisCache.has` now uses `EXISTS`).
- `verify()` fail-open comment corrected re: concurrent double-consume under a cache outage.

## Tests

- `login-form.spec.ts` — challenge step + otp resubmit; no code field for interactive-only factors; non-mfa error still emits `failed`.
- `store/login.spec.ts` — otp forwarded / omitted.
- `cache-memory.spec.ts` + new `cache-redis.spec.ts` — falsy round-trip and the atomic `add`/`increment` primitives. The redis spec is **gated**: it runs against a compose redis (`docker compose up -d redis`) and skips cleanly (~400ms, no hang) when none is reachable.
- `user-authenticator/service.spec.ts` + HTTP `user-authenticator.spec.ts` — cross-user enrollment rejected for totp/recovery/webauthn, allowed for email; admin reset-by-delete.
- `grant-password-mfa.spec.ts` — asserts `kinds` on the `mfa_required` error.

All affected suites pass; `server-kit`, `client-web-kit`, and `server-core` build clean and lint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MFA step-up support to password-based login, including OTP entry and automatic credential resubmission.
  * Login responses now identify available second-factor options.
  * Enrollment for another account is limited to email authentication; the enrollment interface reflects this restriction.
* **Bug Fixes**
  * Improved handling of WebAuthn and non-code MFA flows during login.
  * Fixed caching of valid falsy values such as `0`, `false`, and empty strings.
  * Improved cache presence detection and reliability during concurrent updates.
* **Documentation**
  * Updated MFA enrollment, login, and enforcement guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->