### PR TITLE
fix: dedupe realm-scope gate selects - postgres list queries with include failed

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1662,9 +1662,15 @@ secret_encrypted` — the plaintext-secret gate precondition), `role-attribute`,
 no `fields`, so the call is pinning defense in depth there). `role` / `scope` /
 `permission` / `policy` list paths carry no per-row realm gate (their
 `resourceRealmMatch` usages are write paths on server-loaded data), so they are
-deliberately not force-selected. Regression specs:
+deliberately not force-selected. The helper **dedupes against the already-applied
+projection** (`qb.expressionMap.selects`) — TypeORM's `addSelect` is NOT a no-op
+for an already-selected column: it emits a second identically-aliased select, and
+under a join + take (TypeORM's DISTINCT id-subquery wrapper) postgres rejects the
+wrapper's `ORDER BY "<alias>_id"` as ambiguous (mysql: duplicate column name), so
+every `include=` list query on these adapters 500'd. Regression specs:
 `session-realm-isolation.spec.ts` and
-`realm-isolation-field-projection.spec.ts`. When adding a per-row gate to a new
+`realm-isolation-field-projection.spec.ts`, plus the `include=realm` collection
+cases in `user.spec.ts` / `robot.spec.ts`. When adding a per-row gate to a new
 `getMany`, wire `applyRealmScopeSelect` into its adapter with every column the
 gate reads.
 

--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,78 @@
+# design-sync notes — authup/authup
+
+## The one thing to know first
+
+**This repo is outside the design-sync converter's envelope.** The component
+kit (`@authup/client-web-kit` + `@vuecs/*`) is **Vue 3**; Claude Design renders
+React only ("a non-React DS has nothing for the design agent to build with").
+There is no Storybook and no React surface anywhere in the monorepo. A faithful
+component sync is impossible without a reimplementation, which the skill
+forbids. **Do not run the converter scripts here.**
+
+The agreed fallback (user-approved 2026-07-12): a hand-authored
+**tokens-and-styles-only** sync — canonical design tokens + the plain-CSS layer
+of the kit's logged-out auth chrome, no component bundle, no `_ds_sync.json`
+anchor (honest omission for a hand-authored shape; every re-sync re-verifies,
+which is cheap at this size).
+
+## Target project — additive contract (IMPORTANT)
+
+`projectId` (pinned in config.json) is the user's **pre-existing, hand-built**
+"Authup Design System" project — re-adopted on explicit user choice, NOT
+created by this skill. It contains hand-authored content that must never be
+overwritten or deleted by a sync:
+
+- root `styles.css`, `colors_and_type.css`, `README.md`, `SKILL.md`
+- `preview/_base.css` and all pre-existing `preview/*.html` cards
+- `ui_kits/**`, `assets/**` (logo kit), `scraps/**`, design-canvas files
+
+Files **owned by this sync** (safe to rewrite on re-sync):
+
+- `tokens/authup-tokens.css` — canonical token sheet
+- `tokens/authup-auth-components.css` — verbatim kit auth-chrome CSS
+- `guidelines/repo-token-sync.md` — vocabulary + drift report
+- `preview/tokens-canonical-surfaces.html`, `preview/tokens-primary-ramp.html`,
+  `preview/components-auth-shell.html` — cards, group "Repo sync"
+- `_ds_needs_recompile` — refresh marker (write first as fence, re-arm last)
+
+## Re-sync procedure (custom shape)
+
+1. Re-derive the token sheet from:
+   `packages/client-web-theme/assets/css/index.css` (brand, surfaces, chrome,
+   vc bridge, primary ramp), `packages/client-web-kit-theme/assets/css/styles/
+   tokens.css` (kit component tokens), `.../styles/{auth,realm,picker,login}.css`
+   (verbatim component CSS), `client-web-theme/assets/css/styles/root.css`
+   (typography). Kit defaults overridden by app-level rebinds → emit the
+   winning value, note the kit default in a comment.
+2. Stage into `ds-bundle/` (gitignored). `ds-bundle/preview/_base.css` is a
+   LOCAL VERIFY COPY of the project's card base stylesheet — never upload it.
+3. Verify cards visually: serve ds-bundle with `python3 -m http.server`, then
+   screenshot with the playwright-cache headless shell
+   (`~/Library/Caches/ms-playwright/chromium_headless_shell-*/chrome-headless-shell-mac-arm64/chrome-headless-shell
+   --headless --screenshot=… --window-size=WxH URL`). The Chrome extension MCP
+   was not connected on this machine.
+4. Cross-check every class/token named in the guidelines against the shipped
+   CSS (grep) before upload.
+5. `finalize_plan` with the exact owned paths above, `deletes: []`, then
+   sentinel → files → sentinel re-arm.
+
+## Gotchas learned
+
+- The kit component CSS assumes **Tailwind preflight**: standalone consumers
+  (and preview cards) need `* { box-sizing: border-box }` and
+  `a { text-decoration: none }` or the realm-search input overflows the auth
+  card and links render underlined.
+- The project's existing cards put the `@dsCard` marker on line 2 (after
+  `<!doctype html>`), use Google-Fonts links + relative `_base.css`; cross-dir
+  relative links (`../tokens/…`) are the converter norm and work.
+- The auth card is 460px max-width: three realm tiles wrap to two rows and
+  overflow a 520px-high card viewport — keep the demo grid to two tiles.
+- The project's hand-authored `colors_and_type.css` predates the Tailwind-v4
+  theme rework and has drifted (Bootstrap-blue `--authup-primary: #337ab7`,
+  chrome-never-flips model, `[data-theme]` toggle, missing chrome/kit tokens).
+  The drift report lives in `guidelines/repo-token-sync.md` (uploaded) and
+  `.design-sync/conventions.md` (committed master copy). Deliberately NOT
+  auto-fixed — their previews/ui_kits may depend on the old values; adopting
+  the canonical sheet is the user's / their design agent's call.
+- Dark mode: repo-canonical selector is the `.dark` class; the synced token
+  sheet also matches `[data-theme="dark"]` for the project's older previews.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,5 +1,8 @@
 {
     "projectId": "9f2a0d2f-fbf9-4f54-84c0-d1712aa73c6d",
+    "pkg": "@authup/client-web-theme",
     "shape": "custom",
-    "note": "Vue 3 design system — outside the design-sync converter's React-only envelope. Hand-authored tokens-and-styles enrichment of an existing, actively-used project; additive layout, never overwrite hand-authored root styles.css / README.md. See NOTES.md."
+    "note": "Vue 3 design system — outside the design-sync converter's React-only envelope; never run the converter here. Hand-authored tokens-and-styles enrichment of the user's pre-existing, hand-built project. Additive contract + re-sync procedure in NOTES.md.",
+    "lastSync": "2026-07-12",
+    "lastSyncCommit": "a6dca3c9a"
 }

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,99 @@
+# Repo token sync — canonical authup tokens
+
+Machine-derived from the `authup/authup` monorepo (commit `a6dca3c9a`, synced
+2026-07-12). When these files and a hand-authored file in this project
+disagree, **these files carry the shipped product's current values.**
+
+## What was synced
+
+| File | Contents | Source of truth in the repo |
+|---|---|---|
+| `tokens/authup-tokens.css` | All design tokens: brand accents, slate ramp, light+dark surfaces, flipping chrome model, vuecs semantic bridge, periwinkle primary ramp, auth/realm/picker/login component tokens, typography | `packages/client-web-theme/assets/css/index.css`, `packages/client-web-kit-theme/assets/css/styles/tokens.css`, `packages/client-web-theme/assets/css/styles/root.css` |
+| `tokens/authup-auth-components.css` | Verbatim component CSS for the logged-out chrome: `.a-auth-shell` (aurora + card), `.a-auth-gadget`, `.a-auth-back-link`, `.a-realm-grid` (tiles, search, skeleton, empty state), `.a-picker-item`, `.a-login-provider-box` | `packages/client-web-kit-theme/assets/css/styles/{auth,realm,picker,login}.css` |
+
+## How to build with it
+
+Load order: tokens first, then components (the components file `@import`s the
+tokens itself, so importing only it also works):
+
+```html
+<link rel="stylesheet" href="tokens/authup-auth-components.css">
+```
+
+- **Setup**: the kit CSS assumes Tailwind preflight — at minimum set
+  `* { box-sizing: border-box }` and `a { text-decoration: none }` globally,
+  or inputs/links inside the auth card render slightly off.
+- **Style via CSS custom properties** — `var(--authup-*)` for authup identity,
+  `var(--vc-color-*)` for the semantic layer (bg / fg / border / primary
+  ramp). Never hard-code a hex that has a token.
+- **Login-ish screens**: use the real classes — wrap in
+  `.a-auth-shell` → `.a-auth-shell-aurora` + `.a-auth-shell-card`; realm
+  pickers are `.a-realm-grid` > `.a-realm-grid-item` (with
+  `.a-realm-grid-item-name` / `-slug`).
+- **Dark mode**: add class `dark` (repo-canonical) or
+  `data-theme="dark"` (this project's older previews) on a root element.
+  Chrome tokens re-pin to the slate ramp; surfaces flip to the dark ramp
+  (`#16171a < #1f2024 < #26272c < #2d2f35 < #34373d`).
+- **Primary actions** paint `--vc-color-primary-600` (pure periwinkle) with
+  `--vc-color-on-primary` (#fff) text.
+
+Minimal idiomatic snippet:
+
+```html
+<div class="a-auth-shell">
+  <div class="a-auth-shell-aurora"></div>
+  <div class="a-auth-shell-card">
+    <h2 style="font-family: var(--authup-font-display); margin: 0;">Sign in</h2>
+    <div class="a-realm-grid">
+      <div class="a-realm-grid-item">
+        <span class="a-realm-grid-item-name">master</span>
+        <span class="a-realm-grid-item-slug">the admin realm</span>
+      </div>
+    </div>
+  </div>
+</div>
+```
+
+## Drift found vs this project's hand-authored `colors_and_type.css`
+
+The hand-authored extraction predates the repo's Tailwind-v4 theme rework.
+Where they disagree, the repo has moved on:
+
+1. **Primary is periwinkle, not Bootstrap blue.** `--authup-primary: #337ab7`
+   (+ hover/dark/info/success/warning/danger Bootstrap variants) no longer
+   exists in the repo. Primary = `#6d7fcc` with a `color-mix` ramp
+   (`--vc-color-primary-50…950`); status colors come from `@vuecs/design`'s
+   OKLCH semantic palettes, not authup-owned tokens.
+2. **The chrome now flips with the mode.** "Chrome stays slate in BOTH
+   themes" is outdated: light mode renders the header/sidebar/footer as a
+   light raised surface (`--authup-chrome-*` aliasing the semantic tokens);
+   only dark mode pins the slate ramp. New tokens: `--authup-chrome-bg`,
+   `-bg-elevated`, `-fg`, `-fg-muted`, `-border`,
+   `--authup-chrome-edge-shadow-{bottom,top,right}` (drop shadow in light,
+   recessed inset band in dark).
+3. **The signature title bar is periwinkle, not slate.** The 4px
+   `.title::before` bar paints `var(--authup-periwinkle)` in the repo
+   (`generics.css`), not `--authup-slate-800`.
+4. **Dark-mode selector is a `.dark` class**, toggled by the in-app switch
+   (Tailwind `@custom-variant`), not `[data-theme="dark"]` /
+   `prefers-color-scheme`. The synced token sheet supports both selectors.
+5. **New component token groups** absent from the old extraction:
+   `--authup-auth-*` (auth card, aurora, logo), `--authup-realm-grid-*`,
+   `--authup-picker-item-*`, `--authup-login-provider-*`.
+6. **Salmon narrowed.** `#ff5b5b` is now dropdown-hover text only, no longer
+   footer links.
+7. **Legacy `--authup-bg-*` aliases** (`--authup-bg-app`, `-content`, `-card`,
+   `-list`, `-list-active`, `-page`) don't exist in the repo — the
+   `--authup-surface-*` group is the only surface vocabulary.
+
+## What is deliberately NOT here
+
+- **Live components.** The kit (`@authup/client-web-kit`) is Vue 3; Claude
+  Design renders React, so no component bundle is synced. The CSS above is
+  the faithful, framework-neutral layer of the same components.
+- **The Tailwind utility layer and vuecs `<VC*>` class maps** — they require
+  a Tailwind JIT build against the app's sources and are not extractable as
+  static CSS.
+- **Fonts** — Asap + Nunito load from Google Fonts (this project's root
+  `styles.css` already does that; the repo's client-web uses
+  `@nuxtjs/google-fonts`).

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ authup.**.conf
 .nx
 coverage
 .agents/plans
+ds-bundle/

--- a/apps/server-core/src/app/modules/database/repositories/helpers.ts
+++ b/apps/server-core/src/app/modules/database/repositories/helpers.ts
@@ -14,18 +14,24 @@ import { In, IsNull } from 'typeorm';
  * projection omitting `realm_id` would otherwise leave the per-row
  * `resourceRealmMatch` with no realm to match — neutralizing the realm_scope
  * reach factor and leaking cross-realm rows to an own/ownOrNull-scoped reader.
- * `addSelect` appends to the projected SELECT and is a no-op when the column
- * is already selected. Call it AFTER `applyQuery`.
+ * Call it AFTER `applyQuery`. Columns already in the projection must be
+ * skipped: `addSelect` emits a second identically-aliased column, and under a
+ * join + take (the DISTINCT id-subquery) postgres then rejects the wrapper's
+ * `ORDER BY "<alias>_id"` as ambiguous (mysql: duplicate column name).
  */
 export function applyRealmScopeSelect<T extends ObjectLiteral>(
     qb: SelectQueryBuilder<T>,
     alias: string,
     extraColumns: string[] = [],
 ): void {
-    qb.addSelect([
-        `${alias}.realm_id`,
-        ...extraColumns.map((column) => `${alias}.${column}`),
-    ]);
+    const existing = new Set(qb.expressionMap.selects.map((select) => select.selection));
+    const selections = ['realm_id', ...extraColumns]
+        .map((column) => `${alias}.${column}`)
+        .filter((selection) => !existing.has(selection));
+
+    if (selections.length > 0) {
+        qb.addSelect(selections);
+    }
 }
 
 export function translateWhereConditions(where: Record<string, any>): Record<string, any> {

--- a/apps/server-core/test/unit/http/controllers/entities/robot.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/robot.spec.ts
@@ -63,6 +63,15 @@ describe('src/http/controllers/robot', () => {
         expect(response.data.length).toBeGreaterThanOrEqual(3);
     });
 
+    it('should read collection with realm include', async () => {
+        const response = await suite.client
+            .robot
+            .getMany({ include: ['realm'] });
+
+        expect(response.data.length).toBeGreaterThanOrEqual(3);
+        expect(response.data[0].realm).toBeDefined();
+    });
+
     it('should read resource', async () => {
         const response = await suite.client
             .robot

--- a/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
@@ -51,6 +51,27 @@ describe('src/http/controllers/user', () => {
         expect(response.data.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('should read collection with realm include', async () => {
+        const response = await suite.client
+            .user
+            .getMany({ include: ['realm'] });
+
+        expect(response.data.length).toBeGreaterThanOrEqual(2);
+        expect(response.data[0].realm).toBeDefined();
+    });
+
+    it('should read collection with fields projection and realm include', async () => {
+        const response = await suite.client
+            .user
+            .getMany({
+                fields: ['id', 'name'],
+                include: ['realm'],
+            });
+
+        expect(response.data.length).toBeGreaterThanOrEqual(2);
+        expect(response.data[0].realm).toBeDefined();
+    });
+
     it('should read resource', async () => {
         const response = await suite.client
             .user


### PR DESCRIPTION
## Problem

Reported against a production deployment (`authup/authup` + `postgres:18`): `GET /users?include=realm` — and every other realm-gated list combining `include=` with an overlapping `fields` projection, e.g. `/robots?include=realm` or `/users?include=realm&fields=id,name` — returns 500 with `column reference "user_id" is ambiguous`.

## Root cause

`applyRealmScopeSelect` (plan 039) re-added `realm_id` / extra gate columns even when the rapiq `fields` projection had already selected them. TypeORM's `addSelect` is **not** a no-op for an already-selected column — it emits a second identically-aliased select — and under a join + take (TypeORM's DISTINCT id-subquery wrapper) postgres rejects the wrapper's `ORDER BY "user_id"` as ambiguous (mysql: duplicate column name in the derived table). Not reachable in CI before: no spec exercised `include=` on a `getMany`.

## Changes

- `applyRealmScopeSelect` now dedupes against the already-applied projection (`qb.expressionMap.selects`); its doc comment previously (wrongly) claimed `addSelect` deduped.
- Regression tests: `include=realm` collection cases in `user.spec.ts` / `robot.spec.ts`, including a `fields` + `include` combination.
- `.agents/architecture.md` plan-039 paragraph updated accordingly.

## Verification

- Reproduced the 500s by booting the built server against a scratch postgres DB created by the migration CLI; fixed endpoints return 200 with correct joined data.
- Full server-core suite passes on sqlite; the affected specs also pass against postgres and mysql; `check:types` clean.

## Out of scope

The same report also surfaced `GET /robot-roles?include=robot` failing on postgres (`operator does not exist: uuid = character varying`): migration-created schemas carry `auth_robot_roles.robot_id` as `character varying` without FK (plus the legacy orphaned `client_id` join column) from the initial migration, while the entity joins robot via `robot_id`. A schema-alignment migration was deliberately dropped from this PR — the robot entity is slated for removal, at which point the table goes away entirely.