### PR TITLE
fix(server-core): policy-check denial + typed descendant-tree loading

### DIFF
--- a/apps/server-core/src/adapters/database/domains/policy/repository.ts
+++ b/apps/server-core/src/adapters/database/domains/policy/repository.ts
@@ -32,8 +32,14 @@ export class PolicyRepository extends EATreeRepository<Policy, PolicyAttribute> 
     }
 
     async findDescendantsTreeById(id: string): Promise<BasePolicy | null> {
-        const entity = this.create();
-        entity.id = id;
+        // The root must be a fully-loaded row: findDescendantsTree() mutates
+        // the passed entity (children + EA) but never populates its base
+        // columns — an id-only stub would yield a `type`-less tree that every
+        // engine consumer fails closed on (policy_evaluator_not_found).
+        const entity = await this.findOneBy({ id });
+        if (!entity) {
+            return null;
+        }
 
         try {
             return await this.findDescendantsTree(entity);

--- a/apps/server-core/src/core/identity/policy/checker/service.ts
+++ b/apps/server-core/src/core/identity/policy/checker/service.ts
@@ -59,7 +59,7 @@ export class PolicyCheckerService implements IPolicyCheckerService {
         }
 
         const engine = new PolicyEngine(this.ctx.identityPermissionProvider);
-        await engine.evaluate(
+        await engine.evaluateOrFail(
             entity,
             definePolicyEvaluationContext({ data: new PolicyData(input) }),
         );

--- a/apps/server-core/test/unit/core/identity/policy/checker.spec.ts
+++ b/apps/server-core/test/unit/core/identity/policy/checker.spec.ts
@@ -12,7 +12,7 @@ import {
     expect,
     it,
 } from 'vitest';
-import { BuiltInPolicyType } from '@authup/access';
+import { BuiltInPolicyType, PolicyError } from '@authup/access';
 import { IdentityType } from '@authup/core-kit';
 import { EntityNotFoundError } from '@authup/errors';
 import { createNanoID } from '@authup/kit';
@@ -85,6 +85,21 @@ describe('core/identity/policy/checker', () => {
                 identity: { type: IdentityType.USER, data: adminUser as any },
             },
         )).resolves.toBeUndefined();
+    });
+
+    it('rejects when the policy evaluation does not succeed', async () => {
+        const policyRepository = new PolicyRepository(suite.dataSource);
+        const policy = await policyRepository.save(policyRepository.create({
+            type: BuiltInPolicyType.IDENTITY,
+            name: `${BuiltInPolicyType.IDENTITY}-denial`,
+            built_in: true,
+        }));
+
+        await expect(service.check(
+            policy.id,
+            {},
+            createAllowAllActor(),
+        )).rejects.toBeInstanceOf(PolicyError);
     });
 
     it('safeCheck wraps failures into Result<null>', async () => {


### PR DESCRIPTION
Two independent fixes to the policy-evaluation path, found while working on the authorize flow. Both are pre-existing on `master` and unrelated to any feature.

## 1. `PolicyCheckerService.check` reported success on a denial

`check()` ran `engine.evaluate(...)` and **discarded the result**, so a policy that evaluated to `{ success: false }` still resolved as success — `POST /policies/:id/check` reported a *failing* policy as passing, contradicting the method's `@throws` contract. Switched to `engine.evaluateOrFail(...)`, which throws a `PolicyError` carrying the evaluation issues. Added a denial regression test to the checker spec (the existing suite only covered the pass and not-found cases).

## 2. `findDescendantsTreeById` built type-less policy trees

The method rooted the descendants tree on an **id-only stub** (`this.create(); entity.id = id`). `EATreeRepository.findDescendantsTree()` attaches children + extra-attributes but never populates base columns, so the returned root carried **no `type`** — every `PolicyEngine` consumer then failed closed with `policy_evaluator_not_found`. Now loads the row first (`findOneBy({ id })`, `null` on miss) and builds the tree on it.

**Behavioral change worth calling out:** this path is also used for Layer-2 junction-policy loading (`bindings.ts`). A grant restricted via `role_permission.policy_id` (etc.) previously **always evaluated fail-closed deny** because its tree was type-less — such policies now genuinely evaluate. No existing test pinned the broken behavior (full suite stays green), but any deployment relying on a junction `policy_id` restriction will see it start taking effect.

## Verification
- Full dependency-ordered build green (22 projects).
- Full `apps/server-core` suite green.
- New checker-denial regression test added.
