### PR TITLE
feat: nudge recovery-code enrollment after email/webauthn factors

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1929,7 +1929,12 @@ backstop), `enrollmentRequired` → inline `AUserAuthenticatorEnroll`. Silent
 (`prompt=none`) flows skip the form and let the auto-consent hit the server
 backstop → `interaction_required` redirect. Enrollment components
 (`entities/user-authenticator/`): `AUserAuthenticatorEnroll` (kind picker → TOTP
-QR data-URI + confirm-a-code / recovery one-time codes with download) and
+QR data-URI + confirm-a-code / recovery one-time codes with download; after a
+successful self email/webauthn enrollment with no existing recovery codes it
+shows a SOFT recovery-code nudge — generate or skip, with the `done` emit
+deferred until the nudge resolves so the authorize ladder's re-render can't
+unmount the shown-once codes; fail-open on the lookup, never for an admin
+managing another user) and
 `AUserAuthenticators` (list + delete + embedded enroll), hosted on the settings
 Security tab (`@me`) and an admin Authenticators tab
 (`users/[id]/authenticators.vue`, gated on `USER_AUTHENTICATOR_READ`). i18n:

--- a/packages/client-web-kit/src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue
+++ b/packages/client-web-kit/src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue
@@ -6,6 +6,7 @@
   -->
 <script lang="ts">
 /* global window */
+import type { UserAuthenticator } from '@authup/core-kit';
 import { UserAuthenticatorKind } from '@authup/core-kit';
 import type { UserAuthenticatorEnrollResponse } from '@authup/core-http-kit';
 import {
@@ -64,6 +65,9 @@ export default defineComponent({
             { namespace: TranslatorTranslationNamespace.CLIENT, key: TranslatorTranslationClientKey.MFA_RECOVERY_SAVE },
             { namespace: TranslatorTranslationNamespace.CLIENT, key: TranslatorTranslationClientKey.MFA_DOWNLOAD },
             { namespace: TranslatorTranslationNamespace.CLIENT, key: TranslatorTranslationClientKey.MFA_SETUP_REQUIRED },
+            { namespace: TranslatorTranslationNamespace.CLIENT, key: TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE },
+            { namespace: TranslatorTranslationNamespace.CLIENT, key: TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_GENERATE },
+            { namespace: TranslatorTranslationNamespace.CLIENT, key: TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_SKIP },
             { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.ABORT },
             { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.CLOSE },
         ]);
@@ -102,6 +106,88 @@ export default defineComponent({
             error.value = null;
         };
 
+        // Soft recovery-code nudge (issue #3242 follow-up): a just-enrolled
+        // email/webauthn factor without backup recovery codes leaves the
+        // account one lost mailbox / authenticator away from a locked-out
+        // login — offer (never force) generating codes before finishing.
+        // While set, it holds the enrolled entity whose `done` emit is
+        // DEFERRED until the nudge resolves (skip, or codes acknowledged) —
+        // the authorize ladder re-renders on `done`, which would otherwise
+        // unmount the nudge (and the displayed codes) immediately.
+        const recoveryNudge = ref<UserAuthenticator | null>(null);
+
+        const finishEnrollment = async (entity: UserAuthenticator, kind: `${UserAuthenticatorKind}`) => {
+            if (
+                managingOther.value ||
+                (
+                    kind !== UserAuthenticatorKind.EMAIL &&
+                    kind !== UserAuthenticatorKind.WEBAUTHN
+                )
+            ) {
+                emit('done', entity);
+                return;
+            }
+
+            try {
+                const { meta } = await apiClient.userAuthenticator.getMany(props.userId, {
+                    filter: { kind: UserAuthenticatorKind.RECOVERY },
+                    pagination: { limit: 1 },
+                });
+                if (meta.total > 0) {
+                    emit('done', entity);
+                    return;
+                }
+            } catch {
+                // fail open — never block a completed enrollment on the nudge
+                emit('done', entity);
+                return;
+            }
+
+            recoveryNudge.value = entity;
+        };
+
+        const skipRecoveryNudge = () => {
+            if (!recoveryNudge.value) {
+                return;
+            }
+
+            const entity = recoveryNudge.value;
+            recoveryNudge.value = null;
+            emit('done', entity);
+        };
+
+        const generateRecoveryCodes = async () => {
+            if (busy.value) {
+                return;
+            }
+
+            busy.value = true;
+            error.value = null;
+            try {
+                // deliberately NOT enroll(): the nudge defers every `done`
+                // until the codes were acknowledged (close), so the parent
+                // cannot re-render the shown-once codes away.
+                const response = await apiClient.userAuthenticator.enroll(props.userId, { kind: UserAuthenticatorKind.RECOVERY });
+
+                enrollment.value = response;
+                enrollmentKind.value = UserAuthenticatorKind.RECOVERY;
+            } catch (e) {
+                error.value = extractErrorContext(e).message ?? null;
+            } finally {
+                busy.value = false;
+            }
+        };
+
+        const closeRecoveryCodes = () => {
+            reset();
+
+            if (recoveryNudge.value) {
+                const entity = recoveryNudge.value;
+                recoveryNudge.value = null;
+                emit('done', entity);
+            }
+        };
+
         const enroll = async (kind: `${UserAuthenticatorKind}`) => {
             if (busy.value) {
                 return;
@@ -127,14 +213,14 @@ export default defineComponent({
                         response.entity.id,
                         { code: JSON.stringify(attestation) },
                     );
-                    emit('done', entity);
+                    await finishEnrollment(entity, kind);
                     return;
                 }
 
                 // email is confirmed on creation and has nothing to display —
-                // just signal completion.
+                // just signal completion (via the recovery nudge).
                 if (kind === UserAuthenticatorKind.EMAIL) {
-                    emit('done', response.entity);
+                    await finishEnrollment(response.entity, kind);
                     return;
                 }
 
@@ -204,6 +290,10 @@ export default defineComponent({
             confirm,
             reset,
             downloadRecoveryCodes,
+            recoveryNudge,
+            skipRecoveryNudge,
+            generateRecoveryCodes,
+            closeRecoveryCodes,
         };
     },
 });
@@ -219,8 +309,34 @@ export default defineComponent({
             {{ error }}
         </VCAlert>
 
+        <!-- recovery-code nudge after an email/webauthn enrollment -->
+        <template v-if="recoveryNudge && !enrollment">
+            <VCAlert
+                color="warning"
+                variant="soft"
+                class="mb-3"
+            >
+                {{ translations.mfaRecoveryNudge }}
+            </VCAlert>
+            <div class="flex gap-2">
+                <VCButton
+                    :disabled="busy"
+                    :busy="busy"
+                    color="primary"
+                    :label="translations.mfaRecoveryNudgeGenerate"
+                    @click="generateRecoveryCodes"
+                />
+                <VCButton
+                    :disabled="busy"
+                    color="neutral"
+                    :label="translations.mfaRecoveryNudgeSkip"
+                    @click="skipRecoveryNudge"
+                />
+            </div>
+        </template>
+
         <!-- kind picker (unless an enrollment is in progress or a kind is forced) -->
-        <template v-if="!enrollment">
+        <template v-else-if="!enrollment">
             <p
                 v-if="forcedKind"
                 class="text-center mb-3"
@@ -340,7 +456,7 @@ export default defineComponent({
                 <VCButton
                     color="neutral"
                     :label="translations.close"
-                    @click="reset"
+                    @click="closeRecoveryCodes"
                 />
             </div>
         </template>

--- a/packages/client-web-kit/test/unit/components/entities/user-authenticator-enroll.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/user-authenticator-enroll.spec.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { flushPromises } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import AUserAuthenticatorEnroll from '../../../../src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue';
+import { mountKitComponent } from '../../../utils';
+
+type MountResult = ReturnType<typeof mountKitComponent>;
+
+function findButton(wrapper: MountResult['wrapper'], label: string) {
+    return wrapper.findAll('button').find(
+        (button) => button.text().includes(label),
+    );
+}
+
+function buildHandlers(recoveryTotal: number) {
+    return {
+        'POST /users/:id/authenticators': (req: { body?: unknown }) => {
+            const body = (req.body ?? {}) as Record<string, any>;
+            if (body.kind === 'recovery') {
+                return {
+                    entity: {
+                        id: 'recovery-1', 
+                        kind: 'recovery', 
+                        confirmed: true, 
+                    },
+                    codes: ['aaaa-bbbb', 'cccc-dddd'],
+                };
+            }
+
+            return {
+                entity: {
+                    id: 'email-1', 
+                    kind: 'email', 
+                    confirmed: true, 
+                }, 
+            };
+        },
+        'GET /users/:id/authenticators': () => ({
+            data: [],
+            meta: { total: recoveryTotal },
+        }),
+    };
+}
+
+describe('components/entities/user-authenticator/AUserAuthenticatorEnroll', () => {
+    // Soft recovery-code nudge (issue #3242 follow-up): after enrolling a
+    // factor that cannot ride the single-POST otp path (email / webauthn),
+    // a user without backup recovery codes is offered — never forced — to
+    // generate them before the enrollment completes.
+    it('should nudge for recovery codes after an email enrollment and defer done until skip', async () => {
+        const { wrapper } = mountKitComponent(AUserAuthenticatorEnroll, {}, buildHandlers(0));
+        await flushPromises();
+
+        await findButton(wrapper, 'Email code')!.trigger('click');
+        await flushPromises();
+
+        // enrollment succeeded, but done is DEFERRED behind the nudge
+        expect(wrapper.emitted('done')).toBeUndefined();
+        expect(wrapper.text()).toContain('recovery codes');
+        expect(findButton(wrapper, 'Generate recovery codes')).toBeDefined();
+
+        await findButton(wrapper, 'Skip for now')!.trigger('click');
+        await flushPromises();
+
+        const done = wrapper.emitted('done');
+        expect(done).toBeTruthy();
+        expect(done![0][0]).toMatchObject({ id: 'email-1', kind: 'email' });
+    });
+
+    it('should generate codes from the nudge and emit done once acknowledged', async () => {
+        const { wrapper, httpClient } = mountKitComponent(AUserAuthenticatorEnroll, {}, buildHandlers(0));
+        await flushPromises();
+
+        await findButton(wrapper, 'Email code')!.trigger('click');
+        await flushPromises();
+
+        await findButton(wrapper, 'Generate recovery codes')!.trigger('click');
+        await flushPromises();
+
+        // the shown-once codes must stay mounted — done not emitted yet
+        expect(wrapper.emitted('done')).toBeUndefined();
+        expect(wrapper.text()).toContain('aaaa-bbbb');
+
+        const recoveryEnroll = httpClient.requests.find(
+            (request) => request.method === 'POST' &&
+                request.url.includes('authenticators') &&
+                (request.body as Record<string, any>)?.kind === 'recovery',
+        );
+        expect(recoveryEnroll).toBeDefined();
+
+        await findButton(wrapper, 'Close')!.trigger('click');
+        await flushPromises();
+
+        const done = wrapper.emitted('done');
+        expect(done).toBeTruthy();
+        expect(done![0][0]).toMatchObject({ id: 'email-1', kind: 'email' });
+    });
+
+    it('should not nudge when recovery codes already exist', async () => {
+        const { wrapper } = mountKitComponent(AUserAuthenticatorEnroll, {}, buildHandlers(1));
+        await flushPromises();
+
+        await findButton(wrapper, 'Email code')!.trigger('click');
+        await flushPromises();
+
+        expect(findButton(wrapper, 'Generate recovery codes')).toBeUndefined();
+        expect(wrapper.emitted('done')).toBeTruthy();
+    });
+
+    it('should not nudge when managing another user', async () => {
+        const { wrapper } = mountKitComponent(
+            AUserAuthenticatorEnroll,
+            { userId: 'user-2' },
+            buildHandlers(0),
+        );
+        await flushPromises();
+
+        await findButton(wrapper, 'Email code')!.trigger('click');
+        await flushPromises();
+
+        expect(findButton(wrapper, 'Generate recovery codes')).toBeUndefined();
+        expect(wrapper.emitted('done')).toBeTruthy();
+    });
+});

--- a/packages/i18n/src/catalogs/de/client.ts
+++ b/packages/i18n/src/catalogs/de/client.ts
@@ -117,6 +117,9 @@ export const TranslatorTranslationClientGerman : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.MFA_DEVICE_NAME]: 'Gerätename',
     [TranslatorTranslationClientKey.MFA_NO_DEVICES]: 'Es wurden noch keine Authenticator-Geräte hinzugefügt.',
     [TranslatorTranslationClientKey.MFA_DEVICE_UNCONFIRMED]: 'nicht bestätigt',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE]: 'Hinterlege zusätzlich Wiederherstellungscodes, damit du dich weiterhin anmelden kannst, falls du den Zugriff auf diesen zweiten Faktor verlierst.',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_GENERATE]: 'Wiederherstellungscodes erstellen',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_SKIP]: 'Vorerst überspringen',
 
     [TranslatorTranslationClientKey.MFA_USE_EMAIL]: 'E-Mail-Code verwenden',
     [TranslatorTranslationClientKey.MFA_SEND_CODE]: 'Code senden',

--- a/packages/i18n/src/catalogs/en/client.ts
+++ b/packages/i18n/src/catalogs/en/client.ts
@@ -117,6 +117,9 @@ export const TranslatorTranslationClientEnglish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.MFA_DEVICE_NAME]: 'Device name',
     [TranslatorTranslationClientKey.MFA_NO_DEVICES]: 'No authenticator devices have been added yet.',
     [TranslatorTranslationClientKey.MFA_DEVICE_UNCONFIRMED]: 'not confirmed',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE]: 'Add backup recovery codes so you can still sign in if you lose access to this second factor.',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_GENERATE]: 'Generate recovery codes',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_SKIP]: 'Skip for now',
 
     [TranslatorTranslationClientKey.MFA_USE_EMAIL]: 'Use an email code',
     [TranslatorTranslationClientKey.MFA_SEND_CODE]: 'Send code',

--- a/packages/i18n/src/catalogs/es/client.ts
+++ b/packages/i18n/src/catalogs/es/client.ts
@@ -117,6 +117,9 @@ export const TranslatorTranslationClientSpanish : NamespaceTranslations<`${Trans
     [TranslatorTranslationClientKey.MFA_DEVICE_NAME]: 'Nombre del dispositivo',
     [TranslatorTranslationClientKey.MFA_NO_DEVICES]: 'Aún no se han añadido dispositivos de autenticación.',
     [TranslatorTranslationClientKey.MFA_DEVICE_UNCONFIRMED]: 'no confirmado',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE]: 'Añade códigos de recuperación de respaldo para poder iniciar sesión aunque pierdas el acceso a este segundo factor.',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_GENERATE]: 'Generar códigos de recuperación',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_SKIP]: 'Omitir por ahora',
 
     [TranslatorTranslationClientKey.MFA_USE_EMAIL]: 'Usar un código por correo',
     [TranslatorTranslationClientKey.MFA_SEND_CODE]: 'Enviar código',

--- a/packages/i18n/src/catalogs/fr/client.ts
+++ b/packages/i18n/src/catalogs/fr/client.ts
@@ -117,6 +117,9 @@ export const TranslatorTranslationClientFrench : NamespaceTranslations<`${Transl
     [TranslatorTranslationClientKey.MFA_DEVICE_NAME]: 'Nom de l\'appareil',
     [TranslatorTranslationClientKey.MFA_NO_DEVICES]: 'Aucun appareil d\'authentification n\'a encore été ajouté.',
     [TranslatorTranslationClientKey.MFA_DEVICE_UNCONFIRMED]: 'non confirmé',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE]: 'Ajoutez des codes de récupération de secours afin de pouvoir vous connecter même si vous perdez l\'accès à ce deuxième facteur.',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_GENERATE]: 'Générer des codes de récupération',
+    [TranslatorTranslationClientKey.MFA_RECOVERY_NUDGE_SKIP]: 'Ignorer pour l\'instant',
 
     [TranslatorTranslationClientKey.MFA_USE_EMAIL]: 'Utiliser un code par e-mail',
     [TranslatorTranslationClientKey.MFA_SEND_CODE]: 'Envoyer le code',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -158,6 +158,9 @@ export enum TranslatorTranslationClientKey {
     MFA_DEVICE_NAME = 'mfaDeviceName',
     MFA_NO_DEVICES = 'mfaNoDevices',
     MFA_DEVICE_UNCONFIRMED = 'mfaDeviceUnconfirmed',
+    MFA_RECOVERY_NUDGE = 'mfaRecoveryNudge',
+    MFA_RECOVERY_NUDGE_GENERATE = 'mfaRecoveryNudgeGenerate',
+    MFA_RECOVERY_NUDGE_SKIP = 'mfaRecoveryNudgeSkip',
 }
 
 /**


### PR DESCRIPTION
The soft-nudge interim mitigation proposed in #3242 (kept separate from the MFA-pending ticket in #3244 — the two are independent and merge in any order).

## What

After a successful **self** enrollment of an **email** or **WebAuthn** factor, `AUserAuthenticatorEnroll` checks whether the account holds any recovery codes. If not, it shows a dismissible nudge — *"Add backup recovery codes so you can still sign in if you lose access to this second factor."* — with **Generate recovery codes** / **Skip for now**. Generating reuses the existing shown-once codes view (download + close).

Rationale: an account whose only factor is a mailbox or a passkey is one lost device away from a locked-out interactive login. Recovery codes already complete a fresh login via the `otp` fast-path (#3241), so having a backup turns a support case into a self-service recovery. Soft, not forced — matching Keycloak/Okta, which don't force backup-code enrollment either.

## Behavior details

- **`done` is deferred until the nudge resolves** (skip, or the codes were acknowledged via Close). The hosted authorize ladder re-renders on `done` (`enrollmentRequired` flow) and would otherwise unmount the nudge — and worse, the shown-once recovery codes — immediately. The nudge-initiated recovery enrollment therefore deliberately does not reuse the picker's `enroll()` path (which emits `done` at enroll time).
- **Fail-open**: if the recovery-codes lookup errors, the enrollment completes as before — the nudge can never block it.
- **No nudge for admins managing another user** (`userId !== '@me'`): the enroller would be generating the *user's* codes for themselves — exactly the admin-held-factor problem #3241 closed; the server only permits email enrollment for others anyway.
- TOTP enrollments are not nudged (a TOTP code already rides the single-POST login path — the issue scoped the nudge to the interactive-only kinds).

## i18n

New `authupClient` keys `MFA_RECOVERY_NUDGE` / `MFA_RECOVERY_NUDGE_GENERATE` / `MFA_RECOVERY_NUDGE_SKIP`, authored in all four locales (en/de/fr/es); locale-parity test green.

## Tests

`packages/client-web-kit` `user-authenticator-enroll.spec.ts`: nudge shown + `done` deferred until skip; generate → codes stay mounted until Close, then `done` (once, with the original entity); no nudge when recovery codes exist; no nudge when managing another user. Full kit suite (19 files / 120 tests), i18n suite (77), lint all green.
