### PR TITLE
fix(server-core): consent findMany mysql duplicate-column (fields.default)

### DIFF
--- a/apps/server-core/src/app/modules/oauth2/repositories/consent/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/consent/repository.ts
@@ -37,10 +37,17 @@ export class ConsentRepositoryAdapter implements IConsentRepository {
         const { pagination } = applyQuery(qb, query, {
             defaultAlias: 'consent',
             fields: {
-                allowed: [
+                // `default` (not just `allowed`) so applyQuery adds an explicit
+                // per-column SELECT: it populates expressionMap.selects, which
+                // applyRealmScopeSelect dedupes against. Without it the default
+                // "select all" is implicit (empty selects) and the force-select
+                // re-adds consent.sub — a duplicate `consent_sub` alias that
+                // mysql rejects under the client join (see helpers.ts).
+                default: [
                     'id',
                     'client_id',
                     'realm_id',
+                    'user_id',
                     'sub',
                     'sub_kind',
                     'scope',


### PR DESCRIPTION
Fixes the `Test Server Core (mysql)` failure introduced with the Wave 4 consent feature (#3246). All 11 `consent.spec.ts` HTTP tests were failing on **mysql only** with `QueryFailedError: Duplicate column name 'consent_sub'` (postgres and sqlite tolerate the duplicate alias, which is why it slipped through).

## Root cause
`ConsentRepositoryAdapter.findMany` joins a client **summary** (`leftJoin('consent.client', …)`) and force-selects the realm-gate columns via `applyRealmScopeSelect(qb, 'consent', ['sub','sub_kind'])`. That helper dedupes the force-select against `qb.expressionMap.selects` — but the consent `fields` config declared only `allowed` (no `default`), so the default "select all" stayed **implicit** (empty selects map). The dedupe therefore couldn't see that `consent.sub` was already selected and re-added it, producing two `consent.sub AS consent_sub` columns. Under the client join + pagination (the DISTINCT id-subquery), mysql rejects the duplicate alias.

Sibling realm-scoped adapters (e.g. `client`) don't hit this because they declare `fields.default`, which makes `applyQuery` emit an explicit per-column select that the dedupe can match.

## Fix
Declare `fields.default` (all columns) on the consent adapter. `applyQuery` now emits an explicit select, `applyRealmScopeSelect` dedupes `realm_id`/`sub`/`sub_kind`, and no duplicate alias is produced. The plan-039 protection is preserved: a narrower `?fields=` projection still triggers the force-select (those columns aren't in the projection, so they're added exactly once).

## Verification
`consent` HTTP + service specs pass on **mysql, postgres, and sqlite** (11/11 mysql, 11/11 postgres, 37/37 sqlite locally).
