### PR TITLE
fix(server-core): prevent cross-realm audit event disclosure

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2519,9 +2519,10 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   repository force-selects the gate columns (`applyRealmScopeSelect`, plan-039
   discipline). Nested `/realms/:realmId/events` reads add a mandatory
   repository realm predicate (and single-record reads fail as not found on a
-  mismatch). Because collections still apply asynchronous per-row policies
-  after the database query, their response total is the visible page count
-  rather than the unauthorized backing-table total. `EVENT_READ`
+  mismatch). Flat collection reads derive the actor's coarse realm reach from
+  `EVENT_READ` and apply it (plus an own-row alternative) before database
+  pagination, keeping cross-realm rows out of both pages and totals. Residual
+  per-row policy denials decrement the repository total. `EVENT_READ`
   auto-provisions via `Object.values(PermissionName)`:
   `admin` = `any`, `realm_admin` = `ownOrNull` (deliberately NOT in the OWN
   override list). Typed client: `client.event.getMany/getOne`.

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -872,7 +872,7 @@ Realm-scoped controllers are dual-mounted via `@routup/decorators` array paths:
 export class UserController { ... }
 ```
 
-This applies to the six controllers that read realm context: `client`, `robot`, `user`, `permission`, `policy`, `identity-provider`. Junction controllers (e.g. `client-role`, `user-permission`) are mounted flat — their realm is implicit via the parent entity's joins.
+This applies to the controllers that read realm context: `client`, `robot`, `user`, `permission`, `policy`, `identity-provider`, and `event`. Junction controllers (e.g. `client-role`, `user-permission`) are mounted flat — their realm is implicit via the parent entity's joins.
 
 **Request flow**:
 
@@ -2508,15 +2508,21 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   `data: null` (no column dumps). Rows self-prune on a short per-row TTL via
   `EventRecordInput.retentionDays` (config `eventLogEntityEnabled` default
   `true` / `eventLogEntityRetentionDays` default `7` days, env
-  `EVENT_LOG_ENTITY_*`). v1 semantics: `realm_id` is read from the entity's
-  own column — junction rows (rolePermission, userRole, ...) carry none and
-  stay realm-less (null).
+  `EVENT_LOG_ENTITY_*`). Realm attribution uses the resource's canonical
+  owner realm: direct entities use `realm_id`, junctions use the owner-side
+  key (`role_realm_id`, `user_realm_id`, `client_realm_id`, ...), identity
+  provider accounts use `user_realm_id`, and a realm uses its own `id`.
 - **Read API:** `GET /events` (+ `/realms/:realmId/events`),
   read-only, gated by `EVENT_READ` with the session-service shape: a reader
   without the permission is force-scoped to its own rows (`actor_id` +
   `actor_type`), a scoped reader gets per-row realm_scope drops, and the
   repository force-selects the gate columns (`applyRealmScopeSelect`, plan-039
-  discipline). `EVENT_READ` auto-provisions via `Object.values(PermissionName)`:
+  discipline). Nested `/realms/:realmId/events` reads add a mandatory
+  repository realm predicate (and single-record reads fail as not found on a
+  mismatch). Because collections still apply asynchronous per-row policies
+  after the database query, their response total is the visible page count
+  rather than the unauthorized backing-table total. `EVENT_READ`
+  auto-provisions via `Object.values(PermissionName)`:
   `admin` = `any`, `realm_admin` = `ownOrNull` (deliberately NOT in the OWN
   override list). Typed client: `client.event.getMany/getOne`.
 - **Admin UI:** `apps/client-web/pages/events/` — a read-only list page

--- a/apps/server-core/src/adapters/http/controllers/entities/event/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/event/module.ts
@@ -18,7 +18,7 @@ import { useRequestQuery } from '@routup/basic/query';
 import type { EntityCollectionResponse } from '@authup/core-http-kit';
 import type { IEventService } from '../../../../../core/index.ts';
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
-import { buildActorContext } from '../../../request/index.ts';
+import { buildActorContext, getRequestRealmID } from '../../../request/index.ts';
 
 export type EventControllerContext = {
     service: IEventService,
@@ -43,7 +43,11 @@ export class EventController {
         const {
             data,
             meta,
-        } = await this.service.getMany(useRequestQuery(event), actor);
+        } = await this.service.getMany(
+            useRequestQuery(event),
+            actor,
+            { realmId: getRequestRealmID(event) },
+        );
 
         return {
             data,
@@ -58,6 +62,6 @@ export class EventController {
     ): Promise<Event> {
         const actor = buildActorContext(event);
 
-        return this.service.getOne(id, actor);
+        return this.service.getOne(id, actor, { realmId: getRequestRealmID(event) });
     }
 }

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -97,6 +97,10 @@ export class EventRepositoryAdapter implements IEventRepository {
             });
         }
 
+        if (options.realmId) {
+            qb.andWhere('event.realm_id = :routeRealmId', { routeRealmId: options.realmId });
+        }
+
         const [entities, total] = await qb.getManyAndCount();
 
         return {

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -101,6 +101,28 @@ export class EventRepositoryAdapter implements IEventRepository {
             qb.andWhere('event.realm_id = :routeRealmId', { routeRealmId: options.realmId });
         }
 
+        if (options.visibility) {
+            const constraints: string[] = [];
+            const parameters: Record<string, unknown> = {};
+            const realmIds = options.visibility.realmIds
+                .filter((realmId): realmId is string => realmId !== null);
+
+            if (realmIds.length > 0) {
+                constraints.push('event.realm_id IN (:...visibleRealmIds)');
+                parameters.visibleRealmIds = realmIds;
+            }
+            if (options.visibility.realmIds.includes(null)) {
+                constraints.push('event.realm_id IS NULL');
+            }
+            if (options.visibility.owner) {
+                constraints.push('(event.actor_id = :visibleActorId AND event.actor_type = :visibleActorType)');
+                parameters.visibleActorId = options.visibility.owner.actorId;
+                parameters.visibleActorType = options.visibility.owner.actorType;
+            }
+
+            qb.andWhere(`(${constraints.length > 0 ? constraints.join(' OR ') : '1 = 0'})`, parameters);
+        }
+
         const [entities, total] = await qb.getManyAndCount();
 
         return {

--- a/apps/server-core/src/core/entities/event/entity-event-handler.ts
+++ b/apps/server-core/src/core/entities/event/entity-event-handler.ts
@@ -5,8 +5,13 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { EntityDefaultEventName, EventName, EventScope } from '@authup/core-kit';
-import { isObject } from '@authup/kit';
+import {
+    EntityDefaultEventName,
+    EntityType,
+    EventName,
+    EventScope,
+} from '@authup/core-kit';
+import { hasOwnProperty, isObject } from '@authup/kit';
 import type { DomainEventPublishContext, IDomainEventHandler } from '@authup/server-kit';
 import { buildEntityDiff } from './diff.ts';
 import type {
@@ -25,6 +30,40 @@ const ENTITY_EVENT_NAME_MAP : Record<string, `${EventName}`> = {
     [EntityDefaultEventName.CREATED]: EventName.CREATED,
     [EntityDefaultEventName.UPDATED]: EventName.UPDATED,
     [EntityDefaultEventName.DELETED]: EventName.DELETED,
+};
+
+const ENTITY_REALM_KEY_MAP : Record<`${EntityType}`, string> = {
+    [EntityType.CLIENT]: 'realm_id',
+    [EntityType.CLIENT_PERMISSION]: 'client_realm_id',
+    [EntityType.CLIENT_ROLE]: 'client_realm_id',
+    [EntityType.CLIENT_SCOPE]: 'client_realm_id',
+    [EntityType.CONSENT]: 'realm_id',
+    [EntityType.EVENT]: 'realm_id',
+    [EntityType.IDENTITY_PROVIDER]: 'realm_id',
+    [EntityType.IDENTITY_PROVIDER_ACCOUNT]: 'user_realm_id',
+    [EntityType.IDENTITY_PROVIDER_ATTRIBUTE]: 'realm_id',
+    [EntityType.IDENTITY_PROVIDER_ATTRIBUTE_MAPPING]: 'provider_realm_id',
+    [EntityType.IDENTITY_PROVIDER_PERMISSION_MAPPING]: 'provider_realm_id',
+    [EntityType.IDENTITY_PROVIDER_ROLE_MAPPING]: 'provider_realm_id',
+    [EntityType.KEY]: 'realm_id',
+    [EntityType.POLICY]: 'realm_id',
+    [EntityType.POLICY_ATTRIBUTE]: 'realm_id',
+    [EntityType.PERMISSION]: 'realm_id',
+    [EntityType.PERMISSION_POLICY]: 'permission_realm_id',
+    [EntityType.REALM]: 'id',
+    [EntityType.ROBOT]: 'realm_id',
+    [EntityType.ROBOT_PERMISSION]: 'robot_realm_id',
+    [EntityType.ROBOT_ROLE]: 'robot_realm_id',
+    [EntityType.ROLE]: 'realm_id',
+    [EntityType.ROLE_ATTRIBUTE]: 'realm_id',
+    [EntityType.ROLE_PERMISSION]: 'role_realm_id',
+    [EntityType.SCOPE]: 'realm_id',
+    [EntityType.SESSION]: 'realm_id',
+    [EntityType.TRUST_ANCHOR]: 'realm_id',
+    [EntityType.USER]: 'realm_id',
+    [EntityType.USER_ATTRIBUTE]: 'realm_id',
+    [EntityType.USER_PERMISSION]: 'user_realm_id',
+    [EntityType.USER_ROLE]: 'user_realm_id',
 };
 
 /**
@@ -58,11 +97,11 @@ export class EntityEventHandler implements IDomainEventHandler {
                 return;
             }
 
-            // v1 semantics: realm attribution reads the entity's own realm_id
-            // column — junction rows (rolePermission, userRole, ...) carry no
-            // realm_id column and stay realm-less (null).
             const refId = ctx.content.data?.id ?? null;
-            const realmId = ctx.content.data?.realm_id ?? null;
+            const realmIdCurrent = resolveEntityRealmId(ctx.content.type, ctx.content.data);
+            const realmId = typeof realmIdCurrent === 'undefined' ?
+                (resolveEntityRealmId(ctx.content.type, ctx.dataPrevious) ?? null) :
+                realmIdCurrent;
 
             const requestContext = this.requestContext ?
                 this.requestContext() :
@@ -97,4 +136,20 @@ export class EntityEventHandler implements IDomainEventHandler {
             // fail the originating publish.
         }
     }
+}
+
+function resolveEntityRealmId(
+    type: string,
+    data: unknown,
+): string | null | undefined {
+    if (!isObject(data)) {
+        return undefined;
+    }
+
+    const key = ENTITY_REALM_KEY_MAP[type as `${EntityType}`] ?? 'realm_id';
+    if (!hasOwnProperty(data, key)) {
+        return undefined;
+    }
+
+    return typeof data[key] === 'string' ? data[key] : null;
 }

--- a/apps/server-core/src/core/entities/event/service.ts
+++ b/apps/server-core/src/core/entities/event/service.ts
@@ -16,6 +16,7 @@ import { sanitizeEventData } from './sanitize.ts';
 import type {
     EventRecordInput,
     EventServiceOptions,
+    EventServiceReadOptions,
     IEventRepository,
     IEventService,
 } from './types.ts';
@@ -106,6 +107,7 @@ export class EventService extends AbstractEntityService implements IEventService
     async getMany(
         query: Record<string, any>,
         actor: ActorContext,
+        options: EventServiceReadOptions = {},
     ): Promise<EntityRepositoryFindManyResult<Event>> {
         let canReadAll = true;
         try {
@@ -124,13 +126,16 @@ export class EventService extends AbstractEntityService implements IEventService
                     actorId: actor.identity!.data.id,
                     actorType: actor.identity!.type,
                 },
+                ...(options.realmId ? { realmId: options.realmId } : {}),
             });
         }
 
-        const { data: entities, meta } = await this.repository.findMany(query);
+        const { data: entities, meta } = await this.repository.findMany(
+            query,
+            options.realmId ? { realmId: options.realmId } : undefined,
+        );
 
         const data: Event[] = [];
-        let { total } = meta;
 
         for (const entity of entities) {
             if (this.isOwnedBy(entity, actor)) {
@@ -148,7 +153,7 @@ export class EventService extends AbstractEntityService implements IEventService
                 });
                 data.push(entity);
             } catch {
-                total -= 1;
+                continue;
             }
         }
 
@@ -156,14 +161,14 @@ export class EventService extends AbstractEntityService implements IEventService
             data,
             meta: {
                 ...meta,
-                total,
+                total: data.length,
             },
         };
     }
 
-    async getOne(id: string, actor: ActorContext): Promise<Event> {
+    async getOne(id: string, actor: ActorContext, options: EventServiceReadOptions = {}): Promise<Event> {
         const entity = await this.repository.findOneById(id);
-        if (!entity) {
+        if (!entity || (options.realmId && entity.realm_id !== options.realmId)) {
             throw new EntityNotFoundError();
         }
 

--- a/apps/server-core/src/core/entities/event/service.ts
+++ b/apps/server-core/src/core/entities/event/service.ts
@@ -14,6 +14,7 @@ import { AbstractEntityService } from '@authup/server-kit';
 import type { ActorContext, EntityRepositoryFindManyResult, Logger } from '@authup/server-kit';
 import { sanitizeEventData } from './sanitize.ts';
 import type {
+    EventReadVisibility,
     EventRecordInput,
     EventServiceOptions,
     EventServiceReadOptions,
@@ -49,6 +50,55 @@ export class EventService extends AbstractEntityService implements IEventService
             !!entity.actor_id &&
             entity.actor_id === actor.identity.data.id &&
             entity.actor_type === actor.identity.type;
+    }
+
+    protected async canReadRealm(actor: ActorContext, realmId: string | null): Promise<boolean> {
+        try {
+            await actor.permissionEvaluator.evaluate({
+                name: PermissionName.EVENT_READ,
+                data: definePolicyData({ [BuiltInPolicyType.REALM_MATCH]: realmId }),
+                options: {
+                    policiesIncluded: [
+                        BuiltInPolicyType.COMPOSITE,
+                        BuiltInPolicyType.PERMISSION_BINDING,
+                        BuiltInPolicyType.REALM_MATCH,
+                    ],
+                },
+            });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    protected async resolveReadVisibility(actor: ActorContext): Promise<EventReadVisibility | undefined> {
+        const actorRealmId = this.getActorRealmId(actor);
+        let foreignRealmId = randomUUID();
+        while (foreignRealmId === actorRealmId) {
+            foreignRealmId = randomUUID();
+        }
+
+        if (await this.canReadRealm(actor, foreignRealmId)) {
+            return undefined;
+        }
+
+        const realmIds: Array<string | null> = [];
+        if (actorRealmId && await this.canReadRealm(actor, actorRealmId)) {
+            realmIds.push(actorRealmId);
+        }
+        if (await this.canReadRealm(actor, null)) {
+            realmIds.push(null);
+        }
+
+        return {
+            realmIds,
+            ...(actor.identity ? {
+                owner: {
+                    actorId: actor.identity.data.id,
+                    actorType: actor.identity.type,
+                },
+            } : {}),
+        };
     }
 
     async record(input: EventRecordInput): Promise<void> {
@@ -130,10 +180,11 @@ export class EventService extends AbstractEntityService implements IEventService
             });
         }
 
-        const { data: entities, meta } = await this.repository.findMany(
-            query,
-            options.realmId ? { realmId: options.realmId } : undefined,
-        );
+        const visibility = await this.resolveReadVisibility(actor);
+        const { data: entities, meta } = await this.repository.findMany(query, {
+            ...(options.realmId ? { realmId: options.realmId } : {}),
+            ...(visibility ? { visibility } : {}),
+        });
 
         const data: Event[] = [];
 
@@ -161,7 +212,7 @@ export class EventService extends AbstractEntityService implements IEventService
             data,
             meta: {
                 ...meta,
-                total: data.length,
+                total: meta.total - (entities.length - data.length),
             },
         };
     }

--- a/apps/server-core/src/core/entities/event/types.ts
+++ b/apps/server-core/src/core/entities/event/types.ts
@@ -24,6 +24,7 @@ export type EventFindManyOptions = {
      * rapiq filter.
      */
     owner?: EventOwner,
+    realmId?: string,
 };
 
 export type EventCountRecentFilter = {
@@ -95,6 +96,10 @@ export type EventServiceOptions = {
     retentionDays?: number,
 };
 
+export type EventServiceReadOptions = {
+    realmId?: string,
+};
+
 /**
  * Actor + request attribution for entity-CRUD audit rows. The shape is
  * defined here (core) so core never imports from adapters/http — the wiring
@@ -131,10 +136,14 @@ export interface IEventService {
      * rows ("my sign-in history"); an actor with EVENT_READ sees every row
      * its realm reach permits.
      */
-    getMany(query: Record<string, any>, actor: ActorContext): Promise<EntityRepositoryFindManyResult<Event>>;
+    getMany(
+        query: Record<string, any>,
+        actor: ActorContext,
+        options?: EventServiceReadOptions,
+    ): Promise<EntityRepositoryFindManyResult<Event>>;
 
     /**
      * Read a single audit event. Own rows need no permission.
      */
-    getOne(id: string, actor: ActorContext): Promise<Event>;
+    getOne(id: string, actor: ActorContext, options?: EventServiceReadOptions): Promise<Event>;
 }

--- a/apps/server-core/src/core/entities/event/types.ts
+++ b/apps/server-core/src/core/entities/event/types.ts
@@ -18,6 +18,11 @@ export type EventOwner = {
     actorType: string,
 };
 
+export type EventReadVisibility = {
+    owner?: EventOwner,
+    realmIds: Array<string | null>,
+};
+
 export type EventFindManyOptions = {
     /**
      * Mandatory owner constraint (self-service scope) — not overridable by a
@@ -25,6 +30,12 @@ export type EventFindManyOptions = {
      */
     owner?: EventOwner,
     realmId?: string,
+    /**
+     * Rows reachable through the actor's realm-scoped permission, plus the
+     * actor's own rows. Applied before pagination so meta.total cannot include
+     * events outside that reach.
+     */
+    visibility?: EventReadVisibility,
 };
 
 export type EventCountRecentFilter = {

--- a/apps/server-core/test/unit/core/entities/event/entity-event-handler.spec.ts
+++ b/apps/server-core/test/unit/core/entities/event/entity-event-handler.spec.ts
@@ -6,7 +6,12 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { EventName, EventScope, IdentityType } from '@authup/core-kit';
+import {
+    EntityType,
+    EventName,
+    EventScope,
+    IdentityType,
+} from '@authup/core-kit';
 import type { DomainEventPublishContext } from '@authup/server-kit';
 import { 
     beforeEach, 
@@ -93,12 +98,74 @@ describe('EntityEventHandler', () => {
         expect(call.realmId).toEqual(realmId);
     });
 
-    it('leaves the realm null for entities without a realm_id column (junction v1 semantics)', async () => {
-        await buildHandler().handle(buildPublishContext({ content: { type: 'rolePermission', data: { id: entityId } } }));
+    it.each([
+        [EntityType.CLIENT_PERMISSION, 'client_realm_id'],
+        [EntityType.CLIENT_ROLE, 'client_realm_id'],
+        [EntityType.CLIENT_SCOPE, 'client_realm_id'],
+        [EntityType.IDENTITY_PROVIDER_ACCOUNT, 'user_realm_id'],
+        [EntityType.IDENTITY_PROVIDER_ATTRIBUTE_MAPPING, 'provider_realm_id'],
+        [EntityType.IDENTITY_PROVIDER_PERMISSION_MAPPING, 'provider_realm_id'],
+        [EntityType.IDENTITY_PROVIDER_ROLE_MAPPING, 'provider_realm_id'],
+        [EntityType.PERMISSION_POLICY, 'permission_realm_id'],
+        [EntityType.ROBOT_PERMISSION, 'robot_realm_id'],
+        [EntityType.ROBOT_ROLE, 'robot_realm_id'],
+        [EntityType.ROLE_PERMISSION, 'role_realm_id'],
+        [EntityType.USER_PERMISSION, 'user_realm_id'],
+        [EntityType.USER_ROLE, 'user_realm_id'],
+    ])('attributes %s events to the canonical owner realm', async (type, key) => {
+        await buildHandler().handle(buildPublishContext({
+            content: {
+                type,
+                data: {
+                    id: entityId,
+                    [key]: realmId,
+                },
+            },
+        }));
 
-        const [call] = eventService.recordCalls;
-        expect(call.refType).toEqual('rolePermission');
-        expect(call.realmId).toBeNull();
+        expect(eventService.recordCalls[0].realmId).toEqual(realmId);
+    });
+
+    it('attributes realm events to the realm itself', async () => {
+        await buildHandler().handle(buildPublishContext({
+            content: {
+                type: EntityType.REALM,
+                data: { id: realmId },
+            },
+        }));
+
+        expect(eventService.recordCalls[0].realmId).toEqual(realmId);
+    });
+
+    it('preserves a null owner realm instead of using the member realm', async () => {
+        await buildHandler().handle(buildPublishContext({
+            content: {
+                type: EntityType.ROLE_PERMISSION,
+                data: {
+                    id: entityId,
+                    role_realm_id: null,
+                    permission_realm_id: realmId,
+                },
+            },
+        }));
+
+        expect(eventService.recordCalls[0].realmId).toBeNull();
+    });
+
+    it('falls back to the previous owner realm for a partial update payload', async () => {
+        await buildHandler().handle(buildPublishContext({
+            content: {
+                type: EntityType.USER_ROLE,
+                event: 'updated',
+                data: { id: entityId },
+            },
+            dataPrevious: {
+                id: entityId,
+                user_realm_id: realmId,
+            },
+        }));
+
+        expect(eventService.recordCalls[0].realmId).toEqual(realmId);
     });
 
     it('stamps actor/request fields from the injected request context', async () => {

--- a/apps/server-core/test/unit/core/entities/event/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/event/fake-repository.ts
@@ -84,6 +84,11 @@ export class FakeEventRepository implements IEventRepository {
         if (options.realmId) {
             data = data.filter((row) => row.realm_id === options.realmId);
         }
+        if (options.visibility) {
+            const { owner, realmIds } = options.visibility;
+            data = data.filter((row) => realmIds.includes(row.realm_id) ||
+                (!!owner && row.actor_id === owner.actorId && row.actor_type === owner.actorType));
+        }
 
         return {
             data,

--- a/apps/server-core/test/unit/core/entities/event/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/event/fake-repository.ts
@@ -81,6 +81,9 @@ export class FakeEventRepository implements IEventRepository {
             data = data.filter((row) => row.actor_id === owner.actorId &&
                 row.actor_type === owner.actorType);
         }
+        if (options.realmId) {
+            data = data.filter((row) => row.realm_id === options.realmId);
+        }
 
         return {
             data,

--- a/apps/server-core/test/unit/core/entities/event/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/event/service.spec.ts
@@ -6,6 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { BuiltInPolicyType } from '@authup/access';
 import type { Event, User } from '@authup/core-kit';
 import { EventName, EventScope, IdentityType } from '@authup/core-kit';
 import type { ActorContext } from '@authup/server-kit';
@@ -264,7 +265,30 @@ describe('EventService', () => {
             expect(meta.total).toEqual(1);
         });
 
-        it('does not expose a backing-table total after per-row authorization', async () => {
+        it('applies actor realm reach before pagination', async () => {
+            const ownRealm = seedForeign();
+            const global = seedForeign({ realm_id: null });
+            seedForeign({ realm_id: otherRealmId });
+
+            const actor = makeActor({ allow: true });
+            (actor.permissionEvaluator as FakePermissionEvaluator).setBehavior(({ method, ctx }) => {
+                if (method !== 'evaluate') {
+                    return;
+                }
+
+                const resourceRealm = ctx.data?.get<string | null>(BuiltInPolicyType.REALM_MATCH);
+                if (resourceRealm !== realmId && resourceRealm !== null) {
+                    throw new Error('Realm denied');
+                }
+            });
+
+            const { data, meta } = await service.getMany({}, actor);
+
+            expect(data.map((row) => row.id)).toEqual([ownRealm.id, global.id]);
+            expect(meta.total).toEqual(2);
+        });
+
+        it('preserves the backing total when all page rows are authorized', async () => {
             const visible = seedForeign();
             repository.findMany = async () => ({
                 data: [visible],
@@ -279,7 +303,36 @@ describe('EventService', () => {
             const { data, meta } = await service.getMany({}, actor);
 
             expect(data).toHaveLength(1);
-            expect(meta.total).toEqual(1);
+            expect(meta.total).toEqual(125);
+        });
+
+        it('subtracts rows denied during per-row authorization from the backing total', async () => {
+            const visible = seedForeign();
+            const denied = seedForeign();
+            repository.findMany = async () => ({
+                data: [visible, denied],
+                meta: {
+                    total: 125,
+                    limit: 50,
+                    offset: 0,
+                },
+            });
+
+            const actor = makeActor({ allow: true });
+            (actor.permissionEvaluator as FakePermissionEvaluator).setBehavior(({ method, ctx }) => {
+                if (method !== 'evaluate' || ctx.options?.policiesIncluded) {
+                    return;
+                }
+
+                const attributes = ctx.data?.get<Event>(BuiltInPolicyType.ATTRIBUTES);
+                if (attributes?.id === denied.id) {
+                    throw new Error('Event denied');
+                }
+            });
+            const { data, meta } = await service.getMany({}, actor);
+
+            expect(data.map((row) => row.id)).toEqual([visible.id]);
+            expect(meta.total).toEqual(124);
         });
 
         it('drops rows a privileged actor is not authorized for (realm reach)', async () => {

--- a/apps/server-core/test/unit/core/entities/event/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/event/service.spec.ts
@@ -23,6 +23,7 @@ import { FakeEventRepository } from './fake-repository.ts';
 const DAY_IN_MS = 86_400_000;
 
 const realmId = randomUUID();
+const otherRealmId = randomUUID();
 const userId = randomUUID();
 const otherUserId = randomUUID();
 
@@ -241,6 +242,46 @@ describe('EventService', () => {
             expect(meta.total).toEqual(2);
         });
 
+        it('applies the route realm as a mandatory repository constraint', async () => {
+            const ownRealm = seedForeign();
+            seedForeign({ realm_id: otherRealmId });
+
+            const actor = makeActor({ allow: true });
+            const { data, meta } = await service.getMany({}, actor, { realmId });
+
+            expect(data.map((row) => row.id)).toEqual([ownRealm.id]);
+            expect(meta.total).toEqual(1);
+        });
+
+        it('combines the route realm with the self-service owner constraint', async () => {
+            const ownRealm = seedOwn();
+            seedOwn({ realm_id: otherRealmId });
+
+            const actor = makeActor({ allow: false });
+            const { data, meta } = await service.getMany({}, actor, { realmId });
+
+            expect(data.map((row) => row.id)).toEqual([ownRealm.id]);
+            expect(meta.total).toEqual(1);
+        });
+
+        it('does not expose a backing-table total after per-row authorization', async () => {
+            const visible = seedForeign();
+            repository.findMany = async () => ({
+                data: [visible],
+                meta: {
+                    total: 125,
+                    limit: 50,
+                    offset: 0,
+                },
+            });
+
+            const actor = makeActor({ allow: true });
+            const { data, meta } = await service.getMany({}, actor);
+
+            expect(data).toHaveLength(1);
+            expect(meta.total).toEqual(1);
+        });
+
         it('drops rows a privileged actor is not authorized for (realm reach)', async () => {
             seedOwn();
             seedForeign();
@@ -286,6 +327,14 @@ describe('EventService', () => {
 
             const result = await service.getOne(row.id, actor);
             expect(result.id).toEqual(row.id);
+        });
+
+        it('hides a row outside the route realm before checking ownership', async () => {
+            const row = seedOwn({ realm_id: otherRealmId });
+            const actor = makeActor({ allow: false });
+
+            await expect(service.getOne(row.id, actor, { realmId })).rejects.toBeDefined();
+            expect((actor.permissionEvaluator as FakePermissionEvaluator).preEvaluateCalls).toHaveLength(0);
         });
 
         it('throws when the row does not exist', async () => {

--- a/apps/server-core/test/unit/http/controllers/entities/event-entity-bridge.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/event-entity-bridge.spec.ts
@@ -285,5 +285,12 @@ describe('event (entity-CRUD bridge)', () => {
         const foreign = await actor.event.getMany({ filter: { id: recorded.data[0].id } });
         expect(foreign.data).toHaveLength(0);
         expect(foreign.meta.total).toEqual(0);
+
+        const foreignBeyondPage = await actor.event.getMany({
+            filter: { id: recorded.data[0].id },
+            pagination: { limit: 1, offset: 1 },
+        });
+        expect(foreignBeyondPage.data).toHaveLength(0);
+        expect(foreignBeyondPage.meta.total).toEqual(0);
     });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/event-entity-bridge.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/event-entity-bridge.spec.ts
@@ -5,8 +5,15 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { EventName, EventScope, PermissionName } from '@authup/core-kit';
+import {
+    type Event,
+    EventName,
+    EventScope,
+    PermissionName,
+} from '@authup/core-kit';
 import { Client as HTTPClient } from '@authup/core-http-kit';
+import { RealmScope } from '@authup/access';
+import { buildQuery } from 'rapiq';
 import {
     afterAll,
     beforeAll,
@@ -15,9 +22,15 @@ import {
     it,
 } from 'vitest';
 import { createTestApplication } from '../../../../app';
-import { createFakeClient, createFakeRealm, createFakeRole } from '../../../../utils';
+import {
+    createFakeClient,
+    createFakeRealm,
+    createFakeRole,
+    httpRequest,
+} from '../../../../utils';
 
 const SECRET_KEY_REGEX = /(password|secret|hash|token|credential)/i;
+const ADMIN_AUTHORIZATION = `Basic ${Buffer.from('admin:start123').toString('base64')}`;
 
 /**
  * End-to-end coverage for the entity-CRUD audit bridge (plan 057 Stage 2):
@@ -193,5 +206,84 @@ describe('event (entity-CRUD bridge)', () => {
             },
         });
         expect(foreign.data.some((row) => row.ref_id === foreignRole.id)).toBe(false);
+    });
+
+    it('attributes a junction event to its owner realm and hides it from an ownOrNull reader', async () => {
+        const realmB = await suite.client.realm.create(createFakeRealm());
+        const foreignRole = await suite.client.role.create(
+            createFakeRole({ realm_id: realmB.id }),
+        );
+        const userRead = await suite.client.permission.getOne(PermissionName.USER_READ);
+        const binding = await suite.client.rolePermission.create({
+            role_id: foreignRole.id,
+            permission_id: userRead.id,
+        });
+
+        const recorded = await suite.client.event.getMany({
+            filter: {
+                scope: EventScope.ENTITY,
+                name: EventName.CREATED,
+                ref_id: binding.id,
+            },
+        });
+        expect(recorded.data).toHaveLength(1);
+        expect(recorded.data[0].ref_type).toEqual('rolePermission');
+        expect(recorded.data[0].realm_id).toEqual(realmB.id);
+
+        const query = buildQuery({ filter: { id: recorded.data[0].id } });
+        const ownRouteResponse = await httpRequest(
+            suite,
+            'GET',
+            `/realms/master/events${query}`,
+            { headers: { Authorization: ADMIN_AUTHORIZATION } },
+        );
+        expect(ownRouteResponse.status).toEqual(200);
+        const ownRouteBody = await ownRouteResponse.json() as { data: Event[] };
+        expect(ownRouteBody.data).toHaveLength(0);
+
+        const foreignRouteResponse = await httpRequest(
+            suite,
+            'GET',
+            `/realms/${realmB.id}/events${query}`,
+            { headers: { Authorization: ADMIN_AUTHORIZATION } },
+        );
+        expect(foreignRouteResponse.status).toEqual(200);
+        const foreignRouteBody = await foreignRouteResponse.json() as { data: Event[] };
+        expect(foreignRouteBody.data.map((row) => row.id)).toEqual([recorded.data[0].id]);
+
+        const wrongRouteRecord = await httpRequest(
+            suite,
+            'GET',
+            `/realms/master/events/${recorded.data[0].id}`,
+            { headers: { Authorization: ADMIN_AUTHORIZATION } },
+        );
+        expect(wrongRouteRecord.status).toEqual(404);
+
+        const actorSecret = 'bridge-own-or-null-actor-secret';
+        const actorClient = await suite.client.client.create({
+            ...createFakeClient(),
+            auth_method: 'secret',
+            token_binding_method: 'none',
+            secret: actorSecret,
+            secret_hashed: false,
+            secret_encrypted: false,
+        });
+        const eventRead = await suite.client.permission.getOne(PermissionName.EVENT_READ);
+        await suite.client.clientPermission.create({
+            client_id: actorClient.id,
+            permission_id: eventRead.id,
+            realm_scope: RealmScope.OWN_OR_NULL,
+        });
+
+        const token = await suite.client.token.createWithClientCredentials({
+            client_id: actorClient.id,
+            client_secret: actorSecret,
+        });
+        const actor = new HTTPClient({ baseURL: suite.baseURL });
+        actor.setAuthorizationHeader({ type: 'Bearer', token: token.access_token });
+
+        const foreign = await actor.event.getMany({ filter: { id: recorded.data[0].id } });
+        expect(foreign.data).toHaveLength(0);
+        expect(foreign.meta.total).toEqual(0);
     });
 });


### PR DESCRIPTION
## Summary

- attribute entity audit events to their canonical owner realm, including junction records and identity-provider accounts
- enforce `/realms/:realmId/events` as a mandatory read constraint through explicit `{ realmId }` service options
- expose only the visible page count after per-row authorization

## Testing

- `npx eslint --fix` on all changed TypeScript files
- `npm run test --workspace=apps/server-core -- test/unit/core/entities/event/entity-event-handler.spec.ts test/unit/core/entities/event/service.spec.ts test/unit/http/controllers/entities/event-entity-bridge.spec.ts`
- `npm run build -w apps/server-core`

Closes #3250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Event logs are now correctly restricted to the selected realm.
  - Individual events from other realms are hidden from unauthorized readers.
  - Event records now use the owning resource’s realm for attribution, including junction records.
  - Partial updates retain the correct previous realm attribution.
  - Event totals now reflect only visible, authorized records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->