### PR TITLE
fix(server-core): load yaml/json provisioning files

### DIFF
--- a/apps/server-core/src/app/modules/provisioning/sources/file/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/sources/file/module.ts
@@ -5,7 +5,7 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
-import { ValidatorGroup } from '@authup/kit';
+import { ValidatorGroup, isObject } from '@authup/kit';
 import { load, locateMany } from 'locter';
 import path from 'node:path';
 import type { RootProvisioningEntity } from '../../../../../core/provisioning/entities/index.ts';
@@ -37,7 +37,13 @@ export class FileProvisioningSource implements IProvisioningSource {
         const output : RootProvisioningEntity = {};
         for (const location of locations) {
             const raw = await load(location);
-            const data = await this.rootValidator.run(raw.default, { group: ValidatorGroup.PROVISIONING });
+            // locter yields a module namespace ({ default }) for js/ts/mjs files,
+            // but the parsed value directly for json/yaml/yml — unwrap the default
+            // export when present so every supported file type validates.
+            const entity = isObject(raw) && 'default' in raw ?
+                raw.default :
+                raw;
+            const data = await this.rootValidator.run(entity, { group: ValidatorGroup.PROVISIONING });
 
             compositeSource.merge(output, data);
         }

--- a/apps/server-core/test/data/sources-data/entities.json
+++ b/apps/server-core/test/data/sources-data/entities.json
@@ -1,0 +1,5 @@
+{
+  "scopes": [
+    { "attributes": { "name": "json_scope" } }
+  ]
+}

--- a/apps/server-core/test/data/sources-data/entities.yaml
+++ b/apps/server-core/test/data/sources-data/entities.yaml
@@ -1,0 +1,11 @@
+# Regression fixture: YAML provisioning file must load (locter returns the parsed
+# object directly, without a `.default` wrapper).
+permissions:
+  - attributes:
+      name: yaml_permission
+roles:
+  - attributes:
+      name: yaml_role
+    relations:
+      globalPermissions:
+        - yaml_permission

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -107,6 +107,24 @@ describe('app/modules/provisioning', () => {
         expect(realm.relations?.clients).toHaveLength(1);
     });
 
+    it('should load provisioning data from yaml and json files', async () => {
+        // locter returns json/yaml parsed content directly (no `.default` wrapper),
+        // unlike js/ts module files — the source must handle both, otherwise these
+        // files validate to nothing and are silently skipped.
+        const source = new FileProvisioningSource({ cwd: 'test/data/sources-data' });
+        const output = await source.load();
+
+        expect(output.permissions).toHaveLength(1);
+        expect(output.permissions![0].attributes.name).toBe('yaml_permission');
+
+        expect(output.roles).toHaveLength(1);
+        expect(output.roles![0].attributes.name).toBe('yaml_role');
+        expect(output.roles![0].relations?.globalPermissions).toEqual(['yaml_permission']);
+
+        expect(output.scopes).toHaveLength(1);
+        expect(output.scopes![0].attributes.name).toBe('json_scope');
+    });
+
     it('should synchronize provisioning data', async () => {
         const provisioning = new ProvisionerModule([
             new FileProvisioningSource({ cwd: 'test/data/sources' }),


### PR DESCRIPTION
## Problem

`FileProvisioningSource` reads the loaded module's `.default` export:

```ts
const raw = await load(location);
const data = await this.rootValidator.run(raw.default, { group: ValidatorGroup.PROVISIONING });
```

But `locter.load()` only exposes `.default` for **js/ts/mjs** files — **json/yaml/yml**
parse to the value *directly* (verified with locter 2.2.1). So for a YAML/JSON
provisioning file `raw.default` is `undefined`, the validator runs on `undefined`,
and the file **validates to an empty result and is silently skipped** — no error,
nothing provisioned. Only module files ever worked, even though the glob
(`*.{json,yaml,yml,ts,mts,mjs,js}`) advertises json/yaml/yml.

This surfaced deploying a `.yaml` provisioning file via Helm: the file was mounted
correctly and picked up, but no entities were created and nothing was logged.

## Fix

Unwrap the default export only when it's actually a module namespace, otherwise
use the parsed value:

```ts
const entity = isObject(raw) && 'default' in raw ? raw.default : raw;
const data = await this.rootValidator.run(entity, { group: ValidatorGroup.PROVISIONING });
```

This keeps module files (`.mts` fixture, real `export default`) working and makes
json/yaml/yml load as intended.

## Test

The only existing fixture was `test/data/sources/file.mts` — a module with a real
`default` export, which is why the gap went unnoticed. Added a `test/data/sources-data/`
fixture with a `.yaml` and a `.json` file and a test asserting both load (they
produce an empty result before the fix). Verified end-to-end against the real
`locter` + `RootProvisioningValidator` path.

## Note (follow-up, not in this PR)

The root cause is locter's dual return shape forcing every consumer to remember
`raw.default ?? raw`. A cleaner long-term fix is to normalize `load()` upstream to
always expose `.default` (plus top-level keys for data files); this server-core
change is defensive and stays correct either way, so it also acts as the compat
shim if/when locter is unified.
