### PR TITLE
fix(server-core): harden mfa verification locking

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2099,6 +2099,18 @@ mirrors this — when `userId !== '@me'` it offers only the email button
    the token endpoint. WebAuthn cannot ride a single POST — interactive kinds
    complete a fresh login through the MFA-pending ticket (below).
 
+**Intentional enforcement boundaries (#3251):** a federated IdP callback trusts
+the upstream provider and establishes its external-auth session without a local
+factor challenge (`mfaRequired` does not force local enrollment there); operators
+must enforce MFA upstream. Setting `mfaEnabled=false` is an explicit policy
+downgrade for every user, including already-enrolled users — device rows remain
+stored and reactivate when the feature is enabled again. Finally, the device-less
+direct password-grant pass-through above is the bootstrap the hosted UI needs to
+reach configure-inline enrollment; clients that require enrollment before an
+application token must use the authorization-code flow and exclude `password`
+from their `grant_types` allowlist. These boundaries are operator-facing in
+`docs/src/guide/deployment/configuration-server-core-mfa.md`.
+
 **The password grant is the single MFA chokepoint for credential login — the
 hosted `LoginForm` drives the `otp`, NOT a post-login challenge.** `store.login`
 (and `StoreLoginContext`) carry an optional `otp`, forwarded on the
@@ -2176,10 +2188,13 @@ adapter-kit `verifier.spec.ts` (non-access kind rejected).
 serializes its read-verify-save critical section per user via a cache lock
 (`mfaVerifyLock:<user_id>`, the atomic `ICache.add` set-if-absent — Redis
 `SET … NX`, single-tick memory adapter) so a factor is consumed exactly once
-under concurrency; a held lock bails `false` without penalty, and a cache
-outage fails open for factors with a persisted anti-replay backstop (TOTP
-step-counter, recovery `used_at`) but closed for EMAIL (cache-only
-single-use). Consumption is ordered **stamp-first**: the optional
+under concurrency. The lock stores a random owner token and its 10s lease is
+renewed every third of the TTL through `ICache.renewIfValue`; release uses
+`ICache.dropIfValue`, so an expired owner can neither extend nor delete a
+successor's lock. A held lock, unavailable cache, lost lease, or failed renewal
+bails `false` without penalty for every factor kind (fail closed); the persisted
+TOTP step-counter / recovery `used_at` remain defense in depth, not an outage
+fail-open path. Consumption is ordered **stamp-first**: the optional
 `UserAuthenticatorVerifyContext.onVerified` hook — the challenge controller
 stamps `session.mfa_at` (`ISessionManager.markMfaVerified`) inside it — runs
 after the factor matched but BEFORE the consumption persists (the device-row

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2212,7 +2212,12 @@ with the lockout deadline under `mfaThrottle:<user_id>` (TTL = the lock), so
 concurrent failures — verify or confirm — never under-count the
 `min(300, 1·2^(n−1))`s lock; reset on success, 429
 `MfaThrottledError` (`ErrorCode.MFA_ATTEMPT_THROTTLED`, `retryAfter` in the
-body). Config: `mfaEnabled` / `mfaRequired`
+body). The throttle READ on the throwing entry points (`confirm` /
+`confirmWebauthn` / `sendChallenge`) goes through `assertNotThrottledOrRetry`:
+a genuine lockout surfaces unchanged, but an unreadable throttle counter (cache
+outage) fails closed as a retry-able `MfaThrottledError` (429) rather than
+bubbling up as an internal 500 — matching `verify`'s fail-closed posture (which
+returns `false` per its boolean contract). Config: `mfaEnabled` / `mfaRequired`
 (`MFA_ENABLED` / `MFA_REQUIRED`; `mfaRequired` requires
 `mfaEnabled`, boot-validated — no key configuration; seed-encryption keys are
 auto-generated per realm, see *Realm Key Store*). Events: `mfaEnrolled` / `mfaRemoved` /

--- a/apps/server-core/src/core/entities/user-authenticator/constants.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/constants.ts
@@ -11,12 +11,14 @@
 export const USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX = 'mfaAttempt';
 export const USER_AUTHENTICATOR_THROTTLE_CACHE_PREFIX = 'mfaThrottle';
 
-// Per-user lock serializing concurrent verify critical sections so a factor
-// (recovery code / TOTP step) is consumed exactly once. The TTL only bounds a
-// crashed request holding the lock — generous relative to a verify (a bcrypt
-// compare / seed decrypt + one save).
+// Per-user renewable lock serializing concurrent verify critical sections so a
+// factor (recovery code / TOTP step) is consumed exactly once. The TTL bounds a
+// crashed request; the active owner renews its lease while verification runs.
 export const USER_AUTHENTICATOR_VERIFY_LOCK_CACHE_PREFIX = 'mfaVerifyLock';
 export const USER_AUTHENTICATOR_VERIFY_LOCK_TTL = 10_000;
+export const USER_AUTHENTICATOR_VERIFY_LOCK_RENEW_INTERVAL = Math.floor(
+    USER_AUTHENTICATOR_VERIFY_LOCK_TTL / 3,
+);
 
 /**
  * Per-account exponential backoff for failed challenge codes:

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -533,7 +533,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             throw new BadRequestError(`The authenticator kind ${entity.kind} can not be confirmed with a code.`);
         }
 
-        await this.assertNotThrottled(entity.user_id);
+        await this.assertNotThrottledOrRetry(entity.user_id);
 
         const withSecrets = await this.repository.findOneWithSecretsById(entity.id);
         if (!withSecrets) {
@@ -565,7 +565,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         // brute-force throttle, same lifecycle as the TOTP confirm branch — the
         // attestation verify is a real crypto call and must not be retryable
         // without backoff.
-        await this.assertNotThrottled(entity.user_id);
+        await this.assertNotThrottledOrRetry(entity.user_id);
 
         // challenge is keyed by the enrollment row id (see enrollWebauthn), so
         // overlapping ceremonies do not collide.
@@ -908,7 +908,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         }
 
         this.assertMail();
-        await this.assertNotThrottled(userId);
+        await this.assertNotThrottledOrRetry(userId);
 
         // require a CONFIRMED email factor — never mail a code to a user who
         // did not enroll email (no code-spray oracle).
@@ -1165,6 +1165,23 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         const lockedUntil = await this.cache.get<number>(this.buildThrottleCacheKey(userId));
         if (typeof lockedUntil === 'number' && lockedUntil > Date.now()) {
             throw new MfaThrottledError({ retryAfter: Math.ceil((lockedUntil - Date.now()) / 1_000) });
+        }
+    }
+
+    // Throttle gate for the throwing entry points (confirm / confirmWebauthn /
+    // sendChallenge). Mirrors verify()'s fail-closed posture: a genuine lockout
+    // surfaces unchanged, while an unreadable throttle counter (cache outage) is
+    // treated as a lockout — the caller is told to retry (429) rather than the
+    // outage bubbling up as an internal 500.
+    protected async assertNotThrottledOrRetry(userId: string): Promise<void> {
+        try {
+            await this.assertNotThrottled(userId);
+        } catch (e) {
+            if (isMfaThrottledError(e)) {
+                throw e;
+            }
+
+            throw new MfaThrottledError({ retryAfter: USER_AUTHENTICATOR_ATTEMPT_LOCK_FACTOR });
         }
     }
 

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup } from '@authup/kit';
 import {
@@ -25,6 +26,7 @@ import {
     ErrorCode,
     MfaThrottledError,
     UnauthorizedError,
+    isMfaThrottledError,
 } from '@authup/errors';
 import { 
     AbstractEntityService, 
@@ -68,6 +70,7 @@ import {
     USER_AUTHENTICATOR_TOTP_DIGITS,
     USER_AUTHENTICATOR_TOTP_PERIOD,
     USER_AUTHENTICATOR_VERIFY_LOCK_CACHE_PREFIX,
+    USER_AUTHENTICATOR_VERIFY_LOCK_RENEW_INTERVAL,
     USER_AUTHENTICATOR_VERIFY_LOCK_TTL,
     USER_AUTHENTICATOR_WEBAUTHN_AUTH_CACHE_PREFIX,
     USER_AUTHENTICATOR_WEBAUTHN_CHALLENGE_WINDOW,
@@ -98,6 +101,18 @@ type EmailCodeState = {
 type WebauthnChallengeState = {
     challenge: string,
     expiresAt: number,
+};
+
+type VerifyLock = {
+    status: 'acquired',
+    value: string,
+} | {
+    status: 'busy' | 'unavailable',
+};
+
+type VerifyLockLease = {
+    renew: () => Promise<boolean>,
+    stop: () => Promise<void>,
 };
 
 export class UserAuthenticatorService extends AbstractEntityService implements IUserAuthenticatorService {
@@ -621,7 +636,15 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         input: UserAuthenticatorVerifyInput,
         ctx: UserAuthenticatorVerifyContext = {},
     ): Promise<boolean> {
-        await this.assertNotThrottled(userId);
+        try {
+            await this.assertNotThrottled(userId);
+        } catch (e) {
+            if (isMfaThrottledError(e)) {
+                throw e;
+            }
+
+            return false;
+        }
 
         // Serialize the read-verify-save critical section per user so a single
         // factor (TOTP step / recovery / email code / webauthn counter) is
@@ -630,21 +653,11 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         // risk a double-consume; that request owns the outcome.
         const lockKey = this.buildVerifyLockCacheKey(userId);
         const lock = await this.acquireVerifyLock(lockKey);
-        if (lock === 'busy') {
+        if (lock.status !== 'acquired') {
             return false;
         }
-        // Lock acquisition fails open (cache down → 'unavailable') so a cache
-        // outage cannot brick MFA login. TOTP/recovery proceed because they carry
-        // a PERSISTED anti-replay backstop (TOTP step-counter / recovery used_at)
-        // — note this bounds SEQUENTIAL replay only; two verifies of the same
-        // still-valid code racing during an outage can both read-then-write and
-        // both pass (an accepted, narrow residual, since each still needs a valid
-        // code). EMAIL single-use rides entirely on the lock + cache drop with no
-        // persisted backstop, so without a real lock it MUST fail closed —
-        // otherwise concurrent verifies could both consume one code.
-        if (lock === 'unavailable' && input.kind === UserAuthenticatorKind.EMAIL) {
-            return false;
-        }
+
+        const lease = this.maintainVerifyLock(lockKey, lock.value);
 
         try {
             const devices = await this.repository.findAllWithSecretsByUser(userId, {
@@ -696,6 +709,10 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
                 return false;
             }
 
+            if (!await lease.renew()) {
+                return false;
+            }
+
             // Bind the proof to the caller's aggregate (the session mfa_at
             // stamp) BEFORE any consumption persists: a hook failure aborts
             // the verify with nothing consumed — never a burned single-use
@@ -704,6 +721,10 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             // bounded server-error window, not a lost factor.
             if (ctx.onVerified) {
                 await ctx.onVerified();
+            }
+
+            if (!await lease.renew()) {
+                return false;
             }
 
             matched.last_used_at = new Date().toISOString();
@@ -726,10 +747,8 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             await this.recordChallengeEvent(EventName.MFA_VERIFIED, userId, input.kind, ctx, matched);
             return true;
         } finally {
-            // only release a lock we actually hold (never a fail-open no-lock).
-            if (lock === 'acquired') {
-                await this.releaseVerifyLock(lockKey);
-            }
+            await lease.stop();
+            await this.releaseVerifyLock(lockKey, lock.value);
         }
     }
 
@@ -1084,24 +1103,61 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         });
     }
 
-    protected async acquireVerifyLock(key: string): Promise<'acquired' | 'busy' | 'unavailable'> {
+    protected async acquireVerifyLock(key: string): Promise<VerifyLock> {
+        const value = randomUUID();
+
         try {
-            return (await this.cache.add(key, 1, { ttl: USER_AUTHENTICATOR_VERIFY_LOCK_TTL })) ?
-                'acquired' :
-                'busy';
+            return (await this.cache.add(key, value, { ttl: USER_AUTHENTICATOR_VERIFY_LOCK_TTL })) ?
+                { status: 'acquired', value } :
+                { status: 'busy' };
         } catch {
-            // Cache down — no real lock. The caller decides: factors with a
-            // persisted anti-replay backstop (TOTP step-counter / recovery
-            // used_at) proceed; EMAIL (cache-only single-use) fails closed.
-            return 'unavailable';
+            return { status: 'unavailable' };
         }
     }
 
-    protected async releaseVerifyLock(key: string): Promise<void> {
+    protected maintainVerifyLock(key: string, value: string): VerifyLockLease {
+        let owned = true;
+        let pending : Promise<void> | undefined;
+
+        const queueRenewal = () => {
+            if (!owned || pending) {
+                return pending;
+            }
+
+            pending = this.cache
+                .renewIfValue(key, value, USER_AUTHENTICATOR_VERIFY_LOCK_TTL)
+                .then((renewed) => {
+                    owned = renewed;
+                })
+                .catch(() => {
+                    owned = false;
+                })
+                .finally(() => {
+                    pending = undefined;
+                });
+
+            return pending;
+        };
+
+        const timer = setInterval(queueRenewal, USER_AUTHENTICATOR_VERIFY_LOCK_RENEW_INTERVAL);
+
+        return {
+            renew: async () => {
+                await queueRenewal();
+                return owned;
+            },
+            stop: async () => {
+                clearInterval(timer);
+                await pending;
+            },
+        };
+    }
+
+    protected async releaseVerifyLock(key: string, value: string): Promise<void> {
         try {
-            await this.cache.drop(key);
+            await this.cache.dropIfValue(key, value);
         } catch {
-            // Best-effort release; the lock TTL bounds a stranded key.
+            // Best-effort release; the renewable lock TTL bounds a stranded key.
         }
     }
 

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -23,6 +23,7 @@ import {
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { FakePermissionEvaluator } from '@authup/server-test-kit';
 import { MailTemplateRenderer } from '../../../../../src/core/mail/index.ts';
@@ -31,6 +32,8 @@ import { UserAuthenticatorService } from '../../../../../src/core/entities/user-
 import {
     USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX,
     USER_AUTHENTICATOR_VERIFY_LOCK_CACHE_PREFIX,
+    USER_AUTHENTICATOR_VERIFY_LOCK_RENEW_INTERVAL,
+    USER_AUTHENTICATOR_VERIFY_LOCK_TTL,
     USER_AUTHENTICATOR_WEBAUTHN_AUTH_CACHE_PREFIX,
     USER_AUTHENTICATOR_WEBAUTHN_REG_CACHE_PREFIX,
 } from '../../../../../src/core/entities/user-authenticator/constants.ts';
@@ -344,6 +347,59 @@ describe('UserAuthenticatorService', () => {
             // the step was NOT consumed — the same code succeeds once the lock frees
             await cache.drop(lockKey);
             expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: code })).toBeTruthy();
+        });
+
+        it('keeps the verify lock beyond its base TTL while the success hook is in flight', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
+            const [code] = enrolled.codes!;
+
+            let markStarted! : () => void;
+            const started = new Promise<void>((resolve) => { markStarted = resolve; });
+            let releaseHook! : () => void;
+            const hookGate = new Promise<void>((resolve) => { releaseHook = resolve; });
+            const renew = vi.spyOn(cache, 'renewIfValue');
+
+            vi.useFakeTimers();
+            try {
+                const verification = service.verify(
+                    userId,
+                    { kind: UserAuthenticatorKind.RECOVERY, response: code },
+                    {
+                        onVerified: async () => {
+                            markStarted();
+                            await hookGate;
+                        },
+                    },
+                );
+
+                await started;
+                await vi.advanceTimersByTimeAsync(
+                    USER_AUTHENTICATOR_VERIFY_LOCK_TTL + USER_AUTHENTICATOR_VERIFY_LOCK_RENEW_INTERVAL,
+                );
+                expect(renew.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+                await expect(service.verify(userId, {
+                    kind: UserAuthenticatorKind.RECOVERY,
+                    response: code,
+                })).resolves.toBeFalsy();
+
+                releaseHook();
+                await expect(verification).resolves.toBeTruthy();
+            } finally {
+                vi.useRealTimers();
+            }
+        });
+
+        it('fails verification closed when the cache is unavailable', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+
+            cache.get = async () => { throw new Error('cache unavailable'); };
+
+            await expect(service.verify(userId, {
+                kind: UserAuthenticatorKind.TOTP,
+                response: totpCode(enrolled.secret!),
+            })).resolves.toBeFalsy();
         });
 
         it('ignores unconfirmed devices', async () => {

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -402,6 +402,21 @@ describe('UserAuthenticatorService', () => {
             })).resolves.toBeFalsy();
         });
 
+        it('fails enrollment confirmation closed (throttled, not a 500) when the cache is unavailable', async () => {
+            const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
+
+            // the throttle read blips — confirm must degrade to a retry-able 429,
+            // never surface the raw cache error as an internal 500.
+            cache.get = async () => { throw new Error('cache unavailable'); };
+
+            expect.assertions(1);
+            try {
+                await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            } catch (e) {
+                expect(isMfaThrottledError(e)).toBeTruthy();
+            }
+        });
+
         it('ignores unconfirmed devices', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
 

--- a/docs/src/.vitepress/config.mjs
+++ b/docs/src/.vitepress/config.mjs
@@ -182,6 +182,10 @@ export default defineConfig({
                                     link: '/guide/deployment/configuration-server-core-redis', 
                                 },
                                 {
+                                    text: 'MFA',
+                                    link: '/guide/deployment/configuration-server-core-mfa',
+                                },
+                                {
                                     text: 'SMTP',
                                     link: '/guide/deployment/configuration-server-core-smtp', 
                                 },

--- a/docs/src/guide/deployment/configuration-server-core-mfa.md
+++ b/docs/src/guide/deployment/configuration-server-core-mfa.md
@@ -1,0 +1,66 @@
+# Multi-factor authentication
+
+Authup supports TOTP, recovery codes, email codes, and WebAuthn credentials as
+second factors. Enable the feature with `mfaEnabled` (`MFA_ENABLED`) and require
+interactive enrollment for every local user with `mfaRequired`
+(`MFA_REQUIRED`). `mfaRequired` can only be enabled together with `mfaEnabled`.
+
+## Enforcement model
+
+With MFA enabled, a local user who has any confirmed authenticator must complete
+a second-factor challenge during password login and before authorization-code
+issuance. `mfaRequired` additionally routes a device-less user through inline
+enrollment on the hosted `/authorize` page.
+
+The following boundaries are intentional:
+
+- A federated identity-provider login trusts the upstream provider as the
+  authentication authority. The external callback establishes a session
+  without challenging the user's local Authup authenticators, and
+  `mfaRequired` does not force local enrollment on that callback. Configure and
+  enforce MFA at the upstream provider. The bootstrap tokens report the
+  external authentication method and no local OTP proof unless a later local
+  challenge stamps the session.
+- Setting `mfaEnabled` to `false` disables both local MFA configuration and
+  enforcement, including for users who already have confirmed authenticators.
+  Authenticator rows are retained and become active again when MFA is
+  re-enabled. Treat disabling this option as an authentication-policy
+  downgrade.
+- The direct resource-owner password grant permits a device-less user to obtain
+  the initial session even when `mfaRequired` is enabled. The hosted login uses
+  that same bootstrap session to reach inline enrollment, which cannot be
+  completed inside a single password-grant request. Restrict the `password`
+  grant with each client's `grant_types` allowlist and use the authorization
+  code flow when enrollment must be enforced before issuing an application
+  token.
+
+An external login that continues through the hosted authorization flow can
+still encounter the normal `/authorize` MFA backstop before a later client
+authorization code is issued. The bootstrap session created by the external
+callback itself is not locally MFA-gated.
+
+## Cache availability
+
+MFA verification uses a per-user cache lock to serialize factor consumption.
+The lock has an owner token and is renewed while verification is in progress;
+renewal and release are conditional on that token so an expired owner cannot
+extend or delete a successor's lock.
+
+Verification fails closed when the cache or lock is unavailable. This applies
+even to TOTP and recovery codes, whose counters and `used_at` stamps provide a
+persistent replay backstop, because allowing concurrent read-verify-save
+sections during an outage could accept the same factor twice. A configured
+Redis deployment should therefore include Redis availability in the login-path
+service-level objective.
+
+## Related settings
+
+- `mfaFreshnessMaxAge` (`MFA_FRESHNESS_MAX_AGE`) controls how long a session's
+  MFA proof satisfies an explicit `acr_values=urn:authup:mfa` step-up request.
+- `mfaTicketMaxAge` (`MFA_TICKET_MAX_AGE`) controls the short-lived pending
+  login ticket used by email and WebAuthn challenges.
+- Email authentication requires an SMTP transport. WebAuthn uses `publicUrl` as
+  its relying-party origin.
+
+See the [server configuration reference](./configuration-server-core.md) for
+all configuration formats and defaults.

--- a/docs/src/guide/deployment/configuration-server-core-mfa.md
+++ b/docs/src/guide/deployment/configuration-server-core-mfa.md
@@ -53,6 +53,11 @@ sections during an outage could accept the same factor twice. A configured
 Redis deployment should therefore include Redis availability in the login-path
 service-level objective.
 
+The same fail-closed posture applies to the per-account attempt throttle that
+guards enrollment confirmation and challenge-code delivery: when the throttle
+counter cannot be read, those endpoints degrade to a retry-able throttled
+response (HTTP 429) rather than surfacing the outage as an internal 500.
+
 ## Related settings
 
 - `mfaFreshnessMaxAge` (`MFA_FRESHNESS_MAX_AGE`) controls how long a session's

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -9,6 +9,9 @@ The environment variables in the .env file variant can also be provided via runt
 Always change the default admin password (`start123`) and robot secret before deploying to production.
 :::
 
+For MFA enforcement behavior and its federated-login, password-grant, feature-toggle,
+and cache-availability boundaries, see [Multi-factor authentication](./configuration-server-core-mfa.md).
+
 ::: code-group
 
 ```typescript [authup.server.core.ts]

--- a/packages/server-kit/src/cache/adapters/memory.ts
+++ b/packages/server-kit/src/cache/adapters/memory.ts
@@ -60,6 +60,23 @@ export class MemoryCache implements ICache {
         return true;
     }
 
+    async renewIfValue(key: string, value: string, ttl: number): Promise<boolean> {
+        if (this.instance.get(key) !== value) {
+            return false;
+        }
+
+        this.instance.set(key, value, { ttl });
+        return true;
+    }
+
+    async dropIfValue(key: string, value: string): Promise<boolean> {
+        if (this.instance.get(key) !== value) {
+            return false;
+        }
+
+        return this.instance.delete(key);
+    }
+
     async increment(key: string, value = 1, options: CacheSetOptions = {}): Promise<number> {
         // The read + write run in a single synchronous tick (no await
         // between), so this is atomic within the single-threaded process.

--- a/packages/server-kit/src/cache/adapters/redis.ts
+++ b/packages/server-kit/src/cache/adapters/redis.ts
@@ -11,6 +11,20 @@ import type { RedisClient, RedisClientOptions } from '../../redis';
 import { createRedisClient } from '../../redis';
 import type { CacheClearOptions, CacheSetOptions, ICache } from '../types';
 
+const RENEW_IF_VALUE_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('pexpire', KEYS[1], ARGV[2])
+end
+return 0
+`;
+
+const DROP_IF_VALUE_SCRIPT = `
+if redis.call('get', KEYS[1]) == ARGV[1] then
+    return redis.call('del', KEYS[1])
+end
+return 0
+`;
+
 export class RedisCache implements ICache {
     protected client : Client;
 
@@ -65,6 +79,29 @@ export class RedisCache implements ICache {
             await this.client.set(key, payload, 'NX');
 
         return result === 'OK';
+    }
+
+    async renewIfValue(key: string, value: string, ttl: number): Promise<boolean> {
+        const result = await this.client.eval(
+            RENEW_IF_VALUE_SCRIPT,
+            1,
+            key,
+            JSON.stringify(value),
+            ttl,
+        );
+
+        return result === 1;
+    }
+
+    async dropIfValue(key: string, value: string): Promise<boolean> {
+        const result = await this.client.eval(
+            DROP_IF_VALUE_SCRIPT,
+            1,
+            key,
+            JSON.stringify(value),
+        );
+
+        return result === 1;
     }
 
     async increment(key: string, value = 1, options: CacheSetOptions = {}): Promise<number> {

--- a/packages/server-kit/src/cache/types.ts
+++ b/packages/server-kit/src/cache/types.ts
@@ -35,6 +35,19 @@ export interface ICache {
     add(key: string, value: any, options?: CacheSetOptions) : Promise<boolean>;
 
     /**
+     * Atomically refresh the TTL only when the stored value still matches the
+     * supplied scalar owner token. Used to renew a distributed lock without
+     * extending a successor's lease after ownership changed.
+     */
+    renewIfValue(key: string, value: string, ttl: number): Promise<boolean>;
+
+    /**
+     * Atomically delete a key only when its value still matches the supplied
+     * scalar owner token. Used to release a distributed lock owner-safely.
+     */
+    dropIfValue(key: string, value: string): Promise<boolean>;
+
+    /**
      * Atomically increment the numeric value stored at the key by `value`
      * (default 1), treating an absent key as 0, and return the
      * post-increment value. A ttl (re)arms the key's expiry on every call —

--- a/packages/server-kit/test/unit/cache-memory.spec.ts
+++ b/packages/server-kit/test/unit/cache-memory.spec.ts
@@ -34,6 +34,20 @@ describe('src/cache/adapters/memory', () => {
             await cache.drop('lock');
             expect(await cache.add('lock', 1)).toBe(true);
         });
+
+        it('renews and releases only for the current owner', async () => {
+            const cache = new MemoryCache();
+
+            await cache.add('lock', 'first', { ttl: 5_000 });
+
+            expect(await cache.renewIfValue('lock', 'second', 10_000)).toBe(false);
+            expect(await cache.dropIfValue('lock', 'second')).toBe(false);
+            expect(await cache.get('lock')).toBe('first');
+
+            expect(await cache.renewIfValue('lock', 'first', 10_000)).toBe(true);
+            expect(await cache.dropIfValue('lock', 'first')).toBe(true);
+            expect(await cache.get('lock')).toBeNull();
+        });
     });
 
     describe('increment (atomic counter)', () => {

--- a/packages/server-kit/test/unit/cache-redis.spec.ts
+++ b/packages/server-kit/test/unit/cache-redis.spec.ts
@@ -105,6 +105,18 @@ describeRedis('src/cache/adapters/redis', () => {
             expect(await cache.add('lock', 'second', { ttl: 5_000 })).toBe(false);
             expect(await cache.get('lock')).toBe('first');
         });
+
+        it('renews and releases only for the current owner', async () => {
+            await cache.add('lock', 'first', { ttl: 5_000 });
+
+            expect(await cache.renewIfValue('lock', 'second', 10_000)).toBe(false);
+            expect(await cache.dropIfValue('lock', 'second')).toBe(false);
+            expect(await cache.get('lock')).toBe('first');
+
+            expect(await cache.renewIfValue('lock', 'first', 10_000)).toBe(true);
+            expect(await cache.dropIfValue('lock', 'first')).toBe(true);
+            expect(await cache.get('lock')).toBeNull();
+        });
     });
 
     describe('increment (atomic counter)', () => {


### PR DESCRIPTION
## Summary

- document the accepted MFA enforcement boundaries for federated login, feature disablement, and device-less password grants
- renew owner-tagged MFA verification locks during long-running checks and release them only while ownership still matches
- fail MFA verification closed when cache coordination is unavailable, with memory and Redis regression coverage

## Testing

- `npm run test --workspace=packages/server-kit -- test/unit/cache-memory.spec.ts test/unit/cache-redis.spec.ts`
- `npx vitest run test/unit/cache-redis.spec.ts --reporter=verbose` (against local Redis)
- `npm run build -w packages/server-kit`
- `npm run test --workspace=apps/server-core -- test/unit/core/entities/user-authenticator/service.spec.ts`
- `npm run test --workspace=apps/server-core -- test/unit/http/controllers/workflows/token/grant-password-mfa.spec.ts test/unit/http/controllers/workflows/token/mfa-login-ticket.spec.ts test/unit/http/controllers/entities/user-authenticator.spec.ts`
- `npm run check:types -w apps/server-core`
- `npm run build -w apps/server-core`
- `npm run build -w docs`
- ESLint on all changed TypeScript and JavaScript files

Closes #3251
Closes #3252

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved MFA verification reliability by preventing concurrent attempts from consuming the same one-time verification artifact.
  - Added safer handling when required cache services are unavailable.

- **Documentation**
  - Added a dedicated MFA deployment and configuration guide covering supported methods, enforcement rules, login flows, and operational requirements.
  - Updated configuration navigation and linked the new MFA guidance from the main server configuration documentation.

- **Bug Fixes**
  - Improved lock ownership handling so verification locks are renewed and released safely without interfering with other active requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->