### PR TITLE
fix(server-core): bound prometheus path-label cardinality via route templates

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2557,6 +2557,15 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   `authup_authorize_total{outcome}` (`denied` live since plan 052),
   `authup_refresh_replay_total`. Bounded label sets only — subject-level
   attribution belongs in the security event log, never in metric labels.
+  The `@routup/prometheus` `http_request_duration` `path` label follows the
+  same rule (issue #3253): `registerPrometheusMiddleware` supplies a
+  `normalizePath` (`createRouteTemplateNormalizePath`) that labels each
+  request by its registered route template (`/users/:id`,
+  `/realms/:realmId/users/:id`), read from the router's own route table
+  (routup flattens controller child-apps into the root with full patterns);
+  method-agnostic mounts label as `<mount>/**` (`/docs/**`, `/public/**`)
+  and anything unregistered collapses into a single `/{unmatched}` bucket —
+  raw ids/names never become label values, even on 401/404 probes.
 
 ## Provisioning Permissions With Policies
 

--- a/apps/server-core/src/adapters/http/middleware/built-in/prometheus.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/prometheus.ts
@@ -7,10 +7,144 @@
 
 import type { OptionsInput } from '@routup/prometheus';
 import { prometheus } from '@routup/prometheus';
-import type { App } from 'routup';
+import type { App, IAppEvent } from 'routup';
+
+const PATH_LABEL_UNMATCHED = '/{unmatched}';
+
+type RouteTemplate = {
+    method?: string,
+    segments: string[],
+    label: string,
+};
+
+type RouteTemplates = {
+    exact: RouteTemplate[],
+    prefix: RouteTemplate[],
+};
+
+function toPathSegments(path: string): string[] {
+    return path.split('/').filter((segment) => segment.length > 0);
+}
+
+function isParameterSegment(segment: string): boolean {
+    return segment.startsWith(':') || segment === '*';
+}
+
+function matchSegments(
+    templateSegments: string[],
+    segments: string[],
+    prefix: boolean,
+): boolean {
+    if (
+        prefix ?
+            segments.length < templateSegments.length :
+            segments.length !== templateSegments.length
+    ) {
+        return false;
+    }
+
+    for (const [i, templateSegment] of templateSegments.entries()) {
+        if (isParameterSegment(templateSegment)) {
+            continue;
+        }
+
+        if (templateSegment !== segments[i]) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function buildRouteTemplates(router: App): RouteTemplates {
+    const exact: RouteTemplate[] = [];
+    const prefix: RouteTemplate[] = [];
+    const seen = new Set<string>();
+
+    for (const route of router.routes) {
+        if (typeof route.path !== 'string') {
+            continue;
+        }
+
+        const segments = toPathSegments(route.path);
+        const label = `/${segments.join('/')}`;
+        const key = `${route.method || ''} ${label}`;
+        if (seen.has(key)) {
+            continue;
+        }
+        seen.add(key);
+
+        if (route.method) {
+            exact.push({
+                method: route.method, 
+                segments, 
+                label, 
+            });
+        } else if (segments.length > 0) {
+            prefix.push({ segments, label });
+        }
+    }
+
+    prefix.sort((a, b) => b.segments.length - a.segments.length);
+
+    return { exact, prefix };
+}
+
+/**
+ * The `path` label must stay bounded: labeling by the raw request path lets
+ * every probed id (`/users/<random-uuid>`, even on 401/404) mint a new
+ * prom-client time-series — unbounded registry growth. Requests are instead
+ * labeled by the registered route template (`/users/:id`), read from the
+ * router's own route table (child apps are flattened into the root with full
+ * patterns, and all routes are registered before `listen`, so a snapshot at
+ * first request is complete). Method-agnostic mounts (`/docs`, `/public`)
+ * label as `<mount>/**`; anything else collapses into one unmatched bucket.
+ */
+export function createRouteTemplateNormalizePath(
+    router: App,
+): (path: string, event: IAppEvent) => string {
+    let templates : RouteTemplates | undefined;
+
+    return (path, event) => {
+        if (!templates) {
+            templates = buildRouteTemplates(router);
+        }
+
+        const segments = toPathSegments(path);
+        const method = `${event.method}`.toUpperCase();
+
+        for (const template of templates.exact) {
+            if (
+                template.method !== method &&
+                !(method === 'HEAD' && template.method === 'GET')
+            ) {
+                continue;
+            }
+
+            if (matchSegments(template.segments, segments, false)) {
+                return template.label;
+            }
+        }
+
+        for (const template of templates.exact) {
+            if (matchSegments(template.segments, segments, false)) {
+                return template.label;
+            }
+        }
+
+        for (const template of templates.prefix) {
+            if (matchSegments(template.segments, segments, true)) {
+                return `${template.label}/**`;
+            }
+        }
+
+        return PATH_LABEL_UNMATCHED;
+    };
+}
 
 export function registerPrometheusMiddleware(router: App, input?: OptionsInput) {
     let options : OptionsInput = {
+        normalizePath: createRouteTemplateNormalizePath(router),
         skip(event) {
             let { path } = event;
             if (!path.startsWith('/')) {

--- a/apps/server-core/test/unit/http/middleware/prometheus-normalize-path.spec.ts
+++ b/apps/server-core/test/unit/http/middleware/prometheus-normalize-path.spec.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+import type { IAppEvent } from 'routup';
+import { App, defineCoreHandler } from 'routup';
+import { describe, expect, it } from 'vitest';
+import { createRouteTemplateNormalizePath } from '../../../../src/adapters/http/middleware/built-in/prometheus.ts';
+
+function createHandler() {
+    return defineCoreHandler(() => 'ok');
+}
+
+function createRouter(): App {
+    const router = new App();
+
+    const users = new App();
+    users.get('/', createHandler());
+    users.get('/:id', createHandler());
+    users.post('/', createHandler());
+    users.delete('/:id', createHandler());
+    users.post('/:id/authenticators/:deviceId/confirm', createHandler());
+
+    router.use('/users', users);
+    router.use('/realms/:realmId/users', users);
+
+    router.post('/token', createHandler());
+    router.get('/token/introspect', createHandler());
+
+    router.use('/docs', createHandler());
+    router.use(defineCoreHandler((event) => event.next()));
+
+    return router;
+}
+
+function createEvent(method: string): IAppEvent {
+    return { method } as IAppEvent;
+}
+
+describe('http/middleware/prometheus/normalize-path', () => {
+    const normalize = createRouteTemplateNormalizePath(createRouter());
+
+    it('should label a parameterized route by its template', () => {
+        expect(normalize('/users/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', createEvent('GET')))
+            .toEqual('/users/:id');
+        expect(normalize('/users/@me', createEvent('GET')))
+            .toEqual('/users/:id');
+        expect(normalize('/users/foo/authenticators/bar/confirm', createEvent('POST')))
+            .toEqual('/users/:id/authenticators/:deviceId/confirm');
+    });
+
+    it('should label nested realm mounts by their template', () => {
+        expect(normalize('/realms/master/users/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', createEvent('GET')))
+            .toEqual('/realms/:realmId/users/:id');
+        expect(normalize('/realms/master/users', createEvent('POST')))
+            .toEqual('/realms/:realmId/users');
+    });
+
+    it('should keep static routes as-is', () => {
+        expect(normalize('/users', createEvent('GET'))).toEqual('/users');
+        expect(normalize('/token', createEvent('POST'))).toEqual('/token');
+        expect(normalize('/token/introspect', createEvent('GET'))).toEqual('/token/introspect');
+    });
+
+    it('should ignore trailing slashes', () => {
+        expect(normalize('/users/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d/', createEvent('GET')))
+            .toEqual('/users/:id');
+    });
+
+    it('should match HEAD requests against GET routes', () => {
+        expect(normalize('/users/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', createEvent('HEAD')))
+            .toEqual('/users/:id');
+    });
+
+    it('should label a method mismatch by the route shape of the url', () => {
+        expect(normalize('/users/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', createEvent('PATCH')))
+            .toEqual('/users/:id');
+        expect(normalize('/users/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', createEvent('OPTIONS')))
+            .toEqual('/users/:id');
+    });
+
+    it('should label method-agnostic mounts with a wildcard suffix', () => {
+        expect(normalize('/docs/swagger.json', createEvent('GET'))).toEqual('/docs/**');
+        expect(normalize('/docs', createEvent('GET'))).toEqual('/docs/**');
+    });
+
+    it('should collapse unregistered paths into a single bucket', () => {
+        expect(normalize('/no-such-route/9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d', createEvent('GET')))
+            .toEqual('/{unmatched}');
+        expect(normalize('/users/foo/bar', createEvent('GET')))
+            .toEqual('/{unmatched}');
+    });
+});

--- a/apps/server-core/test/unit/http/middleware/prometheus.spec.ts
+++ b/apps/server-core/test/unit/http/middleware/prometheus.spec.ts
@@ -47,6 +47,33 @@ describe('http/middleware/prometheus', () => {
         expect(body).toContain('path="/authorize"');
     });
 
+    it('should label parameterized routes by their route template', async () => {
+        const idOne = '9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d';
+        const idTwo = '1c9e5c8e-0f2a-4b8e-9d3e-5a1b2c3d4e5f';
+
+        await httpRequest(suite, 'GET', `/users/${idOne}`);
+        await httpRequest(suite, 'GET', `/users/${idTwo}`);
+        await httpRequest(suite, 'GET', `/realms/master/users/${idOne}`);
+
+        const response = await httpRequest(suite, 'GET', '/metrics');
+        expect(response.status).toEqual(200);
+
+        const body = await response.text();
+        expect(body).toContain('path="/users/:id"');
+        expect(body).toContain('path="/realms/:realmId/users/:id"');
+        expect(body).not.toContain(idOne);
+        expect(body).not.toContain(idTwo);
+    });
+
+    it('should collapse unregistered paths into a single unmatched bucket', async () => {
+        await httpRequest(suite, 'GET', '/no-such-route/e5f6a7b8-c9d0-1234-5678-90abcdef1234');
+
+        const response = await httpRequest(suite, 'GET', '/metrics');
+        const body = await response.text();
+        expect(body).toContain('path="/{unmatched}"');
+        expect(body).not.toContain('no-such-route');
+    });
+
     it('should not meter the metrics self-scrape or the root status endpoint', async () => {
         await httpRequest(suite, 'GET', '/');
         await httpRequest(suite, 'GET', '/metrics');


### PR DESCRIPTION
## Summary

Fixes #3253.

The `http_request_duration` histogram labeled requests by the **raw** request path, so every probed id (`/users/<random-uuid>`, even on 401/404) minted a new prom-client time-series — unbounded label cardinality and a memory-exhaustion vector.

`registerPrometheusMiddleware` now supplies a `normalizePath` (`createRouteTemplateNormalizePath`) that labels each request by its **registered route template**, read from the router's own route table: routup flattens controller child-apps into the root `App` with full concatenated patterns (`/users/:id`, `/realms/:realmId/users/:id`), and all routes register before `listen`, so a lazy snapshot at first request is complete and can never drift from the real routing (no hand-maintained pattern table, and unlike an id-regex approach it also bounds name-based lookups like `/roles/<name>`).

Label resolution order, all bounded:

1. Method-bound templates in registration order (dispatch-faithful; HEAD falls back to GET) → `/users/:id`
2. Shape match ignoring method — OPTIONS pre-flights and method-not-allowed probes still label by route shape
3. Method-agnostic mounts → `/docs/**`, `/public/**`
4. Everything else → a single `/{unmatched}` bucket, so 404 probes of arbitrary paths collapse into one time-series

An operator-supplied `normalizePath` via `middlewarePrometheus` config still wins (input spreads over the defaults, same as `skip`).

## Tests

- New unit spec `prometheus-normalize-path.spec.ts`: templates, nested realm mounts, statics, trailing slashes, HEAD→GET, method mismatch, wildcard mounts, unmatched bucket
- Integration spec now asserts `/metrics` contains `path="/users/:id"` / `path="/realms/:realmId/users/:id"` and that probed UUIDs never appear in the exposition body
- Full server-core suite passes (159 files / 1710 tests); `check:types` and eslint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prometheus HTTP metrics now label requests using registered route templates instead of concrete IDs or names.
  * Unregistered routes are grouped under a single `/{unmatched}` label.
  * Wildcard mounts and `HEAD` requests are labeled consistently with their route definitions.

* **Bug Fixes**
  * Reduced metric label variation and prevented sensitive or highly variable path values from appearing in metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->