### PR TITLE
fix(server-adapter)!: enforce certificate binding inside TokenVerifier.verify()

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1732,7 +1732,15 @@ realm trust is only an authentication concern. Refresh must present the same
 thumbprint, and rotation preserves the claim. Authup's authorization
 middleware and `server-adapter-*` consumers fail closed on a bound token unless
 the resource request supplies that thumbprint; resource servers compare only
-the signed thumbprint and do not repeat chain validation.
+the signed thumbprint and do not repeat chain validation. On the adapter side
+the enforcement lives inside `@authup/server-adapter-kit`'s
+`TokenVerifier.verify(token, options?)` itself (issue #3268):
+`options.certificateThumbprint` takes the presented thumbprint as a value or a
+lazy provider (invoked only when the payload carries `cnf`), and the check runs
+on every verify — cached results included, since the binding is per-request
+evidence. The `verifyRequest`/`verifySocket` wrappers merely forward a lazy
+per-request provider; a direct `verify(token)` call on a bound token without a
+thumbprint fails closed (`JWTError`), never open.
 
 ### PKCE for public clients
 

--- a/docs/src/sdks/javascript/server-adapter/node-middleware.md
+++ b/docs/src/sdks/javascript/server-adapter/node-middleware.md
@@ -43,6 +43,11 @@ Behind a proxy, derive the value from the proxy's authenticated certificate
 contract instead. Never hash an unchecked public header; the proxy must remove
 and overwrite it, and the backend listener must be private.
 
+Enforcement lives inside `TokenVerifier.verify()` itself — the middleware only
+forwards a lazy thumbprint provider. Calling `verify(token)` directly on a
+bound token therefore also fails closed; pass the presented thumbprint via
+`verify(token, { certificateThumbprint })`.
+
 ```typescript
 import { Router } from 'routup';
 import { createMiddleware } from '@authup/server-adapter-node';

--- a/docs/src/sdks/javascript/server-adapter/socket-middleware.md
+++ b/docs/src/sdks/javascript/server-adapter/socket-middleware.md
@@ -85,3 +85,8 @@ const data = await verifySocket(socket, {
 Bound tokens fail closed when the callback or certificate is absent. Treat the
 callback as a TLS/proxy trust boundary; do not accept an unchecked thumbprint
 sent in `handshake.auth` by the public caller.
+
+Enforcement lives inside `TokenVerifier.verify()` itself — the helper only
+forwards a lazy thumbprint provider. Calling `verify(token)` directly on a
+bound token therefore also fails closed; pass the presented thumbprint via
+`verify(token, { certificateThumbprint })`.

--- a/docs/src/sdks/javascript/server-adapter/web-middleware.md
+++ b/docs/src/sdks/javascript/server-adapter/web-middleware.md
@@ -62,6 +62,12 @@ removes and overwrites; do not return an unchecked public request header. The
 adapter compares the thumbprint only and deliberately does not repeat the
 authorization server's certificate-chain validation.
 
+Enforcement lives inside `TokenVerifier.verify()` itself — the helper only
+forwards a lazy thumbprint provider. Calling `verify(token)` directly on a
+bound token therefore also fails closed; pass the presented thumbprint via
+`verify(token, { certificateThumbprint })` (a value or a provider, invoked
+only when the token carries a `cnf` binding).
+
 ## Routup v5
 
 ```typescript

--- a/packages/server-adapter-kit/src/verifier/module.ts
+++ b/packages/server-adapter-kit/src/verifier/module.ts
@@ -27,12 +27,14 @@ import {
     verifyToken,
 } from '@authup/server-kit';
 import { importJWK } from 'jose';
+import { assertTokenCertificateBinding } from '../certificate-binding';
 import type { ITokenVerifierCache } from './cache';
 import type {
-    ITokenVerifier, 
-    TokenVerificationData, 
-    TokenVerificationDataInput, 
+    ITokenVerifier,
+    TokenVerificationData,
+    TokenVerificationDataInput,
     TokenVerifierContext,
+    TokenVerifyOptions,
 } from './types';
 
 export class TokenVerifier implements ITokenVerifier {
@@ -62,15 +64,27 @@ export class TokenVerifier implements ITokenVerifier {
         }
     }
 
-    async verify(token: string) : Promise<TokenVerificationData> {
+    async verify(token: string, options: TokenVerifyOptions = {}) : Promise<TokenVerificationData> {
         if (this.interceptorMounted) {
-            return this.verifyRemote(token);
+            return this.verifyRemote(token, options);
         }
 
-        return this.verifyLocal(token);
+        return this.verifyLocal(token, options);
     }
 
-    async verifyLocal(token: string) : Promise<TokenVerificationData> {
+    async verifyLocal(token: string, options: TokenVerifyOptions = {}) : Promise<TokenVerificationData> {
+        const output = await this.resolveLocal(token);
+        await this.assertCertificateBinding(output, options);
+        return output;
+    }
+
+    async verifyRemote(token: string, options: TokenVerifyOptions = {}) : Promise<TokenVerificationData> {
+        const output = await this.resolveRemote(token);
+        await this.assertCertificateBinding(output, options);
+        return output;
+    }
+
+    protected async resolveLocal(token: string) : Promise<TokenVerificationData> {
         let output: TokenVerificationData | undefined;
         if (this.cache) {
             output = await this.cache.get(token);
@@ -136,7 +150,7 @@ export class TokenVerifier implements ITokenVerifier {
         return output;
     }
 
-    async verifyRemote(token: string) : Promise<TokenVerificationData> {
+    protected async resolveRemote(token: string) : Promise<TokenVerificationData> {
         let output: TokenVerificationData | undefined;
         if (this.cache) {
             output = await this.cache.get(token);
@@ -218,6 +232,29 @@ export class TokenVerifier implements ITokenVerifier {
         }
 
         return secondsDiff;
+    }
+
+    /**
+     * RFC 8705: a certificate-bound token (`cnf.x5t#S256`) fails closed
+     * unless the caller supplies the presented certificate's thumbprint.
+     * Runs on every verify — cached results included, since the binding is
+     * per-request evidence, not a property of the token alone.
+     *
+     * @protected
+     */
+    protected async assertCertificateBinding(
+        data: TokenVerificationData,
+        options: TokenVerifyOptions,
+    ) : Promise<void> {
+        if (!data.cnf) {
+            return;
+        }
+
+        const thumbprint = typeof options.certificateThumbprint === 'function' ?
+            await options.certificateThumbprint() :
+            options.certificateThumbprint;
+
+        assertTokenCertificateBinding(data, thumbprint);
     }
 
     protected transform(input: TokenVerificationDataInput) : TokenVerificationData {

--- a/packages/server-adapter-kit/src/verifier/module.ts
+++ b/packages/server-adapter-kit/src/verifier/module.ts
@@ -75,13 +75,15 @@ export class TokenVerifier implements ITokenVerifier {
     async verifyLocal(token: string, options: TokenVerifyOptions = {}) : Promise<TokenVerificationData> {
         const output = await this.resolveLocal(token);
         await this.assertCertificateBinding(output, options);
-        return output;
+        // never expose the cache-owned object: a caller mutating its result
+        // (e.g. stripping cnf) must not poison later cache hits.
+        return structuredClone(output);
     }
 
     async verifyRemote(token: string, options: TokenVerifyOptions = {}) : Promise<TokenVerificationData> {
         const output = await this.resolveRemote(token);
         await this.assertCertificateBinding(output, options);
-        return output;
+        return structuredClone(output);
     }
 
     protected async resolveLocal(token: string) : Promise<TokenVerificationData> {

--- a/packages/server-adapter-kit/src/verifier/types.ts
+++ b/packages/server-adapter-kit/src/verifier/types.ts
@@ -13,8 +13,18 @@ import type { TokenCreator } from '@authup/core-http-kit';
 import type { ITokenVerifierCache } from './cache';
 
 export interface ITokenVerifier {
-    verify(token: string) : Promise<TokenVerificationData>
+    verify(token: string, options?: TokenVerifyOptions) : Promise<TokenVerificationData>
 }
+
+export type TokenVerifyOptions = {
+    /**
+     * RFC 8705: SHA-256 DER thumbprint of the client certificate presented
+     * alongside the token, or a lazy provider for it (only invoked when the
+     * token carries a `cnf` binding). A certificate-bound token fails
+     * verification unless the resolved thumbprint matches `cnf.x5t#S256`.
+     */
+    certificateThumbprint?: string | (() => string | undefined | Promise<string | undefined>),
+};
 
 export type TokenVerifierContext = {
     baseURL: string,

--- a/packages/server-adapter-kit/test/data/token.ts
+++ b/packages/server-adapter-kit/test/data/token.ts
@@ -33,6 +33,15 @@ export const TokenPayload : OAuth2TokenIntrospectionResponse = {
     iat: Math.floor(Date.now() / 1000),
 };
 
+export const TokenCertificateThumbprint = 'expected-thumbprint';
+
+export const BoundTokenPayload : OAuth2TokenIntrospectionResponse = {
+    ...TokenPayload,
+    cnf: { 'x5t#S256': TokenCertificateThumbprint },
+};
+
+export const BoundTokenID = 'bound-token';
+
 export async function introspectToken(data: TokenIntrospectParameters = {}) : Promise<OAuth2TokenIntrospectionResponse> {
     switch (data.token) {
         case ErrorCode.JWT_INVALID: {
@@ -40,6 +49,9 @@ export async function introspectToken(data: TokenIntrospectParameters = {}) : Pr
         }
         case ErrorCode.JWT_EXPIRED: {
             throw createResponseError(JWTError.expired());
+        }
+        case BoundTokenID: {
+            return BoundTokenPayload;
         }
         default: {
             return TokenPayload;

--- a/packages/server-adapter-kit/test/unit/verifier.spec.ts
+++ b/packages/server-adapter-kit/test/unit/verifier.spec.ts
@@ -17,12 +17,19 @@ import {
 import { Client } from '@authup/core-http-kit';
 import { TokenAPI } from '@hapic/oauth2';
 import { MemoryTokenVerifierCache, TokenVerifier } from '../../src';
-import { TokenPayload, introspectToken } from '../data/token';
+import {
+    BoundTokenID,
+    BoundTokenPayload,
+    TokenCertificateThumbprint,
+    TokenPayload,
+    introspectToken,
+} from '../data/token';
 import { Faker } from '../utils';
 
 describe('verifier', () => {
     let token : string;
     let mfaToken : string;
+    let boundToken : string;
     beforeAll(async () => {
         const faker = new Faker();
 
@@ -31,6 +38,7 @@ describe('verifier', () => {
             ...TokenPayload,
             kind: OAuth2TokenKind.MFA,
         });
+        boundToken = await faker.sign(BoundTokenPayload);
 
         vitest.spyOn(TokenAPI.prototype, 'introspect').mockImplementation((options) => introspectToken(options));
         vitest.spyOn(Client.prototype, 'getJwk').mockReturnValue(faker.useJwk());
@@ -110,5 +118,84 @@ describe('verifier', () => {
         } catch (e) {
             expect(e).toBeInstanceOf(JWTError);
         }
+    });
+
+    // RFC 8705: certificate binding is enforced inside verify() itself —
+    // a direct caller bypassing the request/socket wrappers must never
+    // accept a bound token without the presented certificate's thumbprint.
+    describe('certificate binding', () => {
+        it('should not verify a certificate-bound token without a thumbprint', async () => {
+            const tokenVerifier = new TokenVerifier({ baseURL: 'http://localhost:3001' });
+
+            await expect(tokenVerifier.verify(boundToken))
+                .rejects.toBeInstanceOf(JWTError);
+        });
+
+        it('should not verify a certificate-bound token with a mismatched thumbprint', async () => {
+            const tokenVerifier = new TokenVerifier({ baseURL: 'http://localhost:3001' });
+
+            await expect(tokenVerifier.verify(boundToken, { certificateThumbprint: 'other-thumbprint' }))
+                .rejects.toBeInstanceOf(JWTError);
+        });
+
+        it('should verify a certificate-bound token with a matching thumbprint value', async () => {
+            const tokenVerifier = new TokenVerifier({ baseURL: 'http://localhost:3001' });
+
+            const output = await tokenVerifier.verify(boundToken, { certificateThumbprint: TokenCertificateThumbprint });
+            expect(output.cnf).toEqual({ 'x5t#S256': TokenCertificateThumbprint });
+        });
+
+        it('should resolve the thumbprint via an async provider', async () => {
+            const tokenVerifier = new TokenVerifier({ baseURL: 'http://localhost:3001' });
+
+            const certificateThumbprint = vitest.fn(async () => TokenCertificateThumbprint);
+            const output = await tokenVerifier.verify(boundToken, { certificateThumbprint });
+
+            expect(output).toBeDefined();
+            expect(certificateThumbprint).toHaveBeenCalledOnce();
+        });
+
+        it('should not invoke the thumbprint provider for an unbound token', async () => {
+            const tokenVerifier = new TokenVerifier({ baseURL: 'http://localhost:3001' });
+
+            const certificateThumbprint = vitest.fn(() => TokenCertificateThumbprint);
+            const output = await tokenVerifier.verify(token, { certificateThumbprint });
+
+            expect(output).toBeDefined();
+            expect(certificateThumbprint).not.toHaveBeenCalled();
+        });
+
+        // The binding is per-request evidence, not a property of the token
+        // alone — a cached verification result must not bypass it.
+        it('should enforce the binding on cache hits', async () => {
+            const cache = new MemoryTokenVerifierCache();
+            const tokenVerifier = new TokenVerifier({
+                baseURL: 'http://localhost:3001',
+                cache,
+            });
+
+            const output = await tokenVerifier.verify(boundToken, { certificateThumbprint: TokenCertificateThumbprint });
+            expect(output).toEqual(await cache.get(boundToken));
+
+            await expect(tokenVerifier.verify(boundToken))
+                .rejects.toBeInstanceOf(JWTError);
+        });
+
+        it('should enforce the binding on remote introspection', async () => {
+            const tokenVerifier = new TokenVerifier({
+                baseURL: 'http://localhost:3001',
+                creator: () => Promise.resolve({
+                    access_token: 'foo',
+                    expires_in: 3600,
+                    token_type: 'Bearer',
+                }),
+            });
+
+            await expect(tokenVerifier.verify(BoundTokenID))
+                .rejects.toBeInstanceOf(JWTError);
+
+            const output = await tokenVerifier.verify(BoundTokenID, { certificateThumbprint: TokenCertificateThumbprint });
+            expect(output.cnf).toEqual({ 'x5t#S256': TokenCertificateThumbprint });
+        });
     });
 });

--- a/packages/server-adapter-kit/test/unit/verifier.spec.ts
+++ b/packages/server-adapter-kit/test/unit/verifier.spec.ts
@@ -165,6 +165,26 @@ describe('verifier', () => {
             expect(certificateThumbprint).not.toHaveBeenCalled();
         });
 
+        // MemoryTokenVerifierCache retains object references — a caller
+        // mutating its result (e.g. stripping cnf) must not poison the
+        // cached entry and bypass the binding on later verifications.
+        it('should not let a caller mutation of the result poison the cached entry', async () => {
+            const cache = new MemoryTokenVerifierCache();
+            const tokenVerifier = new TokenVerifier({
+                baseURL: 'http://localhost:3001',
+                cache,
+            });
+
+            const output = await tokenVerifier.verify(boundToken, { certificateThumbprint: TokenCertificateThumbprint });
+            delete output.cnf;
+
+            const cached = await cache.get(boundToken);
+            expect(cached?.cnf).toEqual({ 'x5t#S256': TokenCertificateThumbprint });
+
+            await expect(tokenVerifier.verify(boundToken))
+                .rejects.toBeInstanceOf(JWTError);
+        });
+
         // The binding is per-request evidence, not a property of the token
         // alone — a cached verification result must not bypass it.
         it('should enforce the binding on cache hits', async () => {

--- a/packages/server-adapter-node/src/verify-request.ts
+++ b/packages/server-adapter-node/src/verify-request.ts
@@ -6,7 +6,7 @@
  */
 
 import type { IncomingMessage } from 'node:http';
-import { assertTokenCertificateBinding, extractBearerToken } from '@authup/server-adapter-kit';
+import { extractBearerToken } from '@authup/server-adapter-kit';
 import type { TokenVerificationData } from '@authup/server-adapter-kit';
 import type { VerifyRequestOptions } from './types';
 
@@ -30,11 +30,5 @@ export async function verifyRequest(
         return undefined;
     }
 
-    const data = await options.tokenVerifier.verify(token);
-    const certificateThumbprint = data.cnf ?
-        await options.certificateThumbprintByRequest?.(req) :
-        undefined;
-    assertTokenCertificateBinding(data, certificateThumbprint);
-
-    return data;
+    return options.tokenVerifier.verify(token, { certificateThumbprint: () => options.certificateThumbprintByRequest?.(req) });
 }

--- a/packages/server-adapter-node/test/unit/verify-request.spec.ts
+++ b/packages/server-adapter-node/test/unit/verify-request.spec.ts
@@ -29,6 +29,8 @@ const sampleData: TokenVerificationData = {
     permissions: [],
 };
 
+const verifyOptions = { certificateThumbprint: expect.any(Function) };
+
 describe('verifyRequest (node)', () => {
     it('resolves with undefined when no Authorization header and no fallback token', async () => {
         const verifier = createVerifier(vi.fn());
@@ -46,7 +48,31 @@ describe('verifyRequest (node)', () => {
         );
 
         expect(result).toBe(sampleData);
-        expect(verify).toHaveBeenCalledWith('abc.def.ghi');
+        expect(verify).toHaveBeenCalledWith('abc.def.ghi', verifyOptions);
+    });
+
+    // Binding enforcement lives inside TokenVerifier.verify() (see
+    // @authup/server-adapter-kit's verifier.spec) — the wrapper only
+    // forwards a lazy per-request thumbprint provider.
+    it('forwards a lazy certificate thumbprint provider into verify', async () => {
+        const verify = vi.fn<ITokenVerifier['verify']>(async () => sampleData);
+        const certificateThumbprintByRequest = vi.fn(async () => 'expected-thumbprint');
+
+        const req = createRequest({ authorization: 'Bearer abc' });
+        await verifyRequest(req, {
+            tokenVerifier: createVerifier(verify),
+            certificateThumbprintByRequest,
+        });
+
+        expect(certificateThumbprintByRequest).not.toHaveBeenCalled();
+
+        const [, options] = verify.mock.calls[0];
+        const provider = options?.certificateThumbprint;
+        expect(provider).toBeTypeOf('function');
+        if (typeof provider === 'function') {
+            await expect(provider()).resolves.toBe('expected-thumbprint');
+            expect(certificateThumbprintByRequest).toHaveBeenCalledWith(req);
+        }
     });
 
     it('rejects with BearerTokenMalformedError for a malformed Authorization header', async () => {
@@ -96,7 +122,7 @@ describe('verifyRequest (node)', () => {
 
         expect(result).toBe(sampleData);
         expect(tokenByRequest).toHaveBeenCalledWith(req);
-        expect(verify).toHaveBeenCalledWith('cookie-token');
+        expect(verify).toHaveBeenCalledWith('cookie-token', verifyOptions);
     });
 
     it('does not invoke tokenByRequest when the Authorization header is present', async () => {
@@ -112,7 +138,7 @@ describe('verifyRequest (node)', () => {
         );
 
         expect(tokenByRequest).not.toHaveBeenCalled();
-        expect(verify).toHaveBeenCalledWith('abc');
+        expect(verify).toHaveBeenCalledWith('abc', verifyOptions);
     });
 
     it('accepts a tokenByRequest value that already starts with Bearer', async () => {
@@ -124,7 +150,7 @@ describe('verifyRequest (node)', () => {
             tokenByRequest,
         });
 
-        expect(verify).toHaveBeenCalledWith('cookie-token');
+        expect(verify).toHaveBeenCalledWith('cookie-token', verifyOptions);
     });
 
     it('treats opaque tokens that share the "Bearer" prefix-letters as bare tokens', async () => {
@@ -136,6 +162,6 @@ describe('verifyRequest (node)', () => {
             tokenByRequest,
         });
 
-        expect(verify).toHaveBeenCalledWith('BearerLooksFakeButOpaque');
+        expect(verify).toHaveBeenCalledWith('BearerLooksFakeButOpaque', verifyOptions);
     });
 });

--- a/packages/server-adapter-socket-io/src/verify-socket.ts
+++ b/packages/server-adapter-socket-io/src/verify-socket.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { assertTokenCertificateBinding, extractBearerToken } from '@authup/server-adapter-kit';
+import { extractBearerToken } from '@authup/server-adapter-kit';
 import type { TokenVerificationData } from '@authup/server-adapter-kit';
 import type { Socket, VerifySocketOptions } from './types';
 
@@ -27,11 +27,5 @@ export async function verifySocket(
         token = extractBearerToken(token)!;
     }
 
-    const data = await options.tokenVerifier.verify(token as string);
-    const certificateThumbprint = data.cnf ?
-        await options.certificateThumbprintBySocket?.(socket) :
-        undefined;
-    assertTokenCertificateBinding(data, certificateThumbprint);
-
-    return data;
+    return options.tokenVerifier.verify(token as string, { certificateThumbprint: () => options.certificateThumbprintBySocket?.(socket) });
 }

--- a/packages/server-adapter-socket-io/test/unit/verify-socket.spec.ts
+++ b/packages/server-adapter-socket-io/test/unit/verify-socket.spec.ts
@@ -29,6 +29,8 @@ const sampleData: TokenVerificationData = {
     permissions: [],
 };
 
+const verifyOptions = { certificateThumbprint: expect.any(Function) };
+
 describe('verifySocket', () => {
     it('resolves with undefined when no token is present', async () => {
         const verify = vi.fn();
@@ -43,14 +45,38 @@ describe('verifySocket', () => {
         const result = await verifySocket(createSocket({ token: 'abc.def.ghi' }), { tokenVerifier: createVerifier(verify) });
 
         expect(result).toBe(sampleData);
-        expect(verify).toHaveBeenCalledWith('abc.def.ghi');
+        expect(verify).toHaveBeenCalledWith('abc.def.ghi', verifyOptions);
     });
 
     it('strips a Bearer prefix from the handshake token', async () => {
         const verify = vi.fn(async () => sampleData);
         await verifySocket(createSocket({ token: 'Bearer abc.def.ghi' }), { tokenVerifier: createVerifier(verify) });
 
-        expect(verify).toHaveBeenCalledWith('abc.def.ghi');
+        expect(verify).toHaveBeenCalledWith('abc.def.ghi', verifyOptions);
+    });
+
+    // Binding enforcement lives inside TokenVerifier.verify() (see
+    // @authup/server-adapter-kit's verifier.spec) — the wrapper only
+    // forwards a lazy per-socket thumbprint provider.
+    it('forwards a lazy certificate thumbprint provider into verify', async () => {
+        const verify = vi.fn<ITokenVerifier['verify']>(async () => sampleData);
+        const certificateThumbprintBySocket = vi.fn(async () => 'expected-thumbprint');
+
+        const socket = createSocket({ token: 'abc' });
+        await verifySocket(socket, {
+            tokenVerifier: createVerifier(verify),
+            certificateThumbprintBySocket,
+        });
+
+        expect(certificateThumbprintBySocket).not.toHaveBeenCalled();
+
+        const [, options] = verify.mock.calls[0];
+        const provider = options?.certificateThumbprint;
+        expect(provider).toBeTypeOf('function');
+        if (typeof provider === 'function') {
+            await expect(provider()).resolves.toBe('expected-thumbprint');
+            expect(certificateThumbprintBySocket).toHaveBeenCalledWith(socket);
+        }
     });
 
     it('rejects with BearerTokenMalformedError on a malformed Bearer-prefixed token', async () => {
@@ -94,7 +120,7 @@ describe('verifySocket', () => {
 
         expect(result).toBe(sampleData);
         expect(tokenBySocket).toHaveBeenCalledWith(socket);
-        expect(verify).toHaveBeenCalledWith('header-token');
+        expect(verify).toHaveBeenCalledWith('header-token', verifyOptions);
     });
 
     it('does not invoke tokenBySocket when handshake.auth.token is present', async () => {
@@ -107,6 +133,6 @@ describe('verifySocket', () => {
         });
 
         expect(tokenBySocket).not.toHaveBeenCalled();
-        expect(verify).toHaveBeenCalledWith('abc');
+        expect(verify).toHaveBeenCalledWith('abc', verifyOptions);
     });
 });

--- a/packages/server-adapter-web/src/verify-request.ts
+++ b/packages/server-adapter-web/src/verify-request.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { assertTokenCertificateBinding, extractBearerToken } from '@authup/server-adapter-kit';
+import { extractBearerToken } from '@authup/server-adapter-kit';
 import type { TokenVerificationData } from '@authup/server-adapter-kit';
 import type { VerifyRequestOptions } from './types';
 
@@ -29,11 +29,5 @@ export async function verifyRequest(
         return undefined;
     }
 
-    const data = await options.tokenVerifier.verify(token);
-    const certificateThumbprint = data.cnf ?
-        await options.certificateThumbprintByRequest?.(request) :
-        undefined;
-    assertTokenCertificateBinding(data, certificateThumbprint);
-
-    return data;
+    return options.tokenVerifier.verify(token, { certificateThumbprint: () => options.certificateThumbprintByRequest?.(request) });
 }

--- a/packages/server-adapter-web/test/unit/verify-request.spec.ts
+++ b/packages/server-adapter-web/test/unit/verify-request.spec.ts
@@ -24,6 +24,8 @@ const sampleData: TokenVerificationData = {
     permissions: [],
 };
 
+const verifyOptions = { certificateThumbprint: expect.any(Function) };
+
 describe('verifyRequest', () => {
     it('resolves with undefined when no Authorization header and no fallback token', async () => {
         const verifier = createVerifier(vi.fn());
@@ -41,36 +43,31 @@ describe('verifyRequest', () => {
         );
 
         expect(result).toBe(sampleData);
-        expect(verify).toHaveBeenCalledWith('abc.def.ghi');
+        expect(verify).toHaveBeenCalledWith('abc.def.ghi', verifyOptions);
     });
 
-    it('fails closed for a certificate-bound token when no certificate is resolved', async () => {
-        const verify = vi.fn(async () => ({
-            ...sampleData,
-            cnf: { 'x5t#S256': 'expected-thumbprint' },
-        }));
-
-        await expect(verifyRequest(
-            new Request('http://localhost/', { headers: { authorization: 'Bearer bound-token' } }),
-            { tokenVerifier: createVerifier(verify) },
-        )).rejects.toThrow();
-    });
-
-    it('accepts a certificate-bound token only when the resolved thumbprint matches', async () => {
-        const data: TokenVerificationData = {
-            ...sampleData,
-            cnf: { 'x5t#S256': 'expected-thumbprint' },
-        };
+    // Binding enforcement lives inside TokenVerifier.verify() (see
+    // @authup/server-adapter-kit's verifier.spec) — the wrapper only
+    // forwards a lazy per-request thumbprint provider.
+    it('forwards a lazy certificate thumbprint provider into verify', async () => {
+        const verify = vi.fn<ITokenVerifier['verify']>(async () => sampleData);
         const certificateThumbprintByRequest = vi.fn(async () => 'expected-thumbprint');
 
-        const request = new Request('http://localhost/', { headers: { authorization: 'Bearer bound-token' } });
-        const result = await verifyRequest(request, {
-            tokenVerifier: createVerifier(vi.fn(async () => data)),
+        const request = new Request('http://localhost/', { headers: { authorization: 'Bearer abc' } });
+        await verifyRequest(request, {
+            tokenVerifier: createVerifier(verify),
             certificateThumbprintByRequest,
         });
 
-        expect(result).toBe(data);
-        expect(certificateThumbprintByRequest).toHaveBeenCalledWith(request);
+        expect(certificateThumbprintByRequest).not.toHaveBeenCalled();
+
+        const [, options] = verify.mock.calls[0];
+        const provider = options?.certificateThumbprint;
+        expect(provider).toBeTypeOf('function');
+        if (typeof provider === 'function') {
+            await expect(provider()).resolves.toBe('expected-thumbprint');
+            expect(certificateThumbprintByRequest).toHaveBeenCalledWith(request);
+        }
     });
 
     it('rejects with BearerTokenMalformedError for a malformed Authorization header', async () => {
@@ -120,7 +117,7 @@ describe('verifyRequest', () => {
 
         expect(result).toBe(sampleData);
         expect(tokenByRequest).toHaveBeenCalledWith(request);
-        expect(verify).toHaveBeenCalledWith('cookie-token');
+        expect(verify).toHaveBeenCalledWith('cookie-token', verifyOptions);
     });
 
     it('does not invoke tokenByRequest when the Authorization header is present', async () => {
@@ -136,7 +133,7 @@ describe('verifyRequest', () => {
         );
 
         expect(tokenByRequest).not.toHaveBeenCalled();
-        expect(verify).toHaveBeenCalledWith('abc');
+        expect(verify).toHaveBeenCalledWith('abc', verifyOptions);
     });
 
     it('accepts a tokenByRequest value that already starts with Bearer', async () => {
@@ -148,7 +145,7 @@ describe('verifyRequest', () => {
             tokenByRequest,
         });
 
-        expect(verify).toHaveBeenCalledWith('cookie-token');
+        expect(verify).toHaveBeenCalledWith('cookie-token', verifyOptions);
     });
 
     it('treats opaque tokens that share the "Bearer" prefix-letters as bare tokens', async () => {
@@ -160,6 +157,6 @@ describe('verifyRequest', () => {
             tokenByRequest,
         });
 
-        expect(verify).toHaveBeenCalledWith('BearerLooksFakeButOpaque');
+        expect(verify).toHaveBeenCalledWith('BearerLooksFakeButOpaque', verifyOptions);
     });
 });


### PR DESCRIPTION
## Problem

RFC 8705 `cnf`/`x5t#S256` enforcement lived only in the `verifyRequest` / `verifySocket` wrappers (`@authup/server-adapter-node` / `-web` / `-socket-io`). The primitive `TokenVerifier.verify()` failed **open** on a bound token: a resource server calling `verify()` directly accepted a bound, stolen token with no certificate — silently losing the proof-of-possession the binding exists to provide.

## Changes

- `@authup/server-adapter-kit`: `ITokenVerifier.verify(token, options?)` gains `options.certificateThumbprint` — the presented certificate's SHA-256 DER thumbprint as a value or a lazy provider (invoked only when the payload carries `cnf`). `verify()`, `verifyLocal()`, and `verifyRemote()` all assert the binding via `assertTokenCertificateBinding` on every verification — **cached results included**, since the binding is per-request evidence, not a property of the token alone. The former public bodies moved to protected `resolveLocal`/`resolveRemote`.
- The three wrappers forward a lazy per-request/per-socket thumbprint provider into `verify()` and drop their own post-verify assert. Wrapper-level behavior is unchanged.
- Binding-enforcement tests moved onto the real `TokenVerifier` in `server-adapter-kit`'s `verifier.spec.ts` (no-thumbprint, mismatch, value match, async provider, provider laziness for unbound tokens, cache-hit enforcement, remote introspection); the wrapper specs now assert only that the lazy provider is forwarded.
- Docs: the three middleware pages and `.agents/architecture.md` note that enforcement lives in the primitive.

## Breaking change (deliberate)

`TokenVerifier.verify(token)` without a thumbprint now fails closed (`JWTError`) on a certificate-bound token instead of returning it. That is exactly the vulnerable behavior this fixes; direct callers must pass `verify(token, { certificateThumbprint })`. Unbound tokens are unaffected.

closes #3268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added certificate-bound token verification using certificate thumbprints.
  * Token verification now supports direct or lazy, asynchronous thumbprint providers.
  * Added enforcement across HTTP request and socket authentication flows.
  * Bound tokens fail closed when the required thumbprint is missing or incorrect.

* **Documentation**
  * Clarified certificate-binding behavior and direct verification requirements across middleware guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->