### PR TITLE
feat(server-core): emit audit events for key & trust-anchor lifecycle operations

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2306,8 +2306,15 @@ every read and the create response null `decryption_key` (authentik
 CVE-2024-42490 is the cautionary tale). Typed client: `client.key.*`
 (`KeyCreatePayload`/`KeyUpdatePayload`; `delete(id, { force })`). Keys have
 **no entity subscriber** (deliberate — `afterInsert` content would carry raw
-private material onto the realtime bus), so no entity-CRUD audit rows;
-explicit `EventService` emits are a follow-up.
+private material onto the realtime bus); the audit trail comes from
+explicit, metadata-only `EventService.record()` emits inside `KeyService`
+(issue #3269): ENTITY-scope `created`/`updated`/`deleted` rows with
+`ref_type: key`, actor from the `ActorContext`, request attribution via the
+injected `useRequestEventContext` getter, `data` limited to
+`name`/`use`/`status` plus a scalar `diff` on update and `force: true` on a
+forced crypto-shred — never `decryption_key`/`encryption_key`/`certificate`.
+The emits ride the default (long) event retention, not the short
+entity-churn TTL, and are not gated by `eventLogEntityEnabled`.
 
 **Imported certificates (plan 071 Stage B):** create may attach an immutable
 PEM certificate chain only to an **imported signature key** (never generated
@@ -2338,7 +2345,11 @@ as keys. The web UI presents the collection as **Trusted CAs** inside `/keys`.
 Stage C intentionally provides only schema, CRUD API, typed client, and UI:
 the `enabled` anchors are consumed later by plan 072 when proxy-forwarded
 client certificates are authenticated for RFC 8705. Like keys, trust anchors
-have no entity subscriber. The table was folded into migration
+have no entity subscriber; `TrustAnchorService` records the same explicit
+ENTITY-scope lifecycle events as `KeyService` (`ref_type: trustAnchor`,
+`data`: `name`/`enabled` + update diff — never certificate bytes; creating
+an enabled CA anchor is what turns on mTLS client auth for a realm, so it
+must be visible in `auth_events`). The table was folded into migration
 `1783856507391` while its release window remained open.
 
 - **`use` hygiene is load-bearing:** the signer supports oct (HMAC) keys, so
@@ -2510,7 +2521,14 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   key), `REFRESH_REPLAY_DETECTED` (`revokeFamily`), `AUTHORIZE`
   (`OAuth2Authorization.authorize()`, `data.reason: autoConsent|consent` from
   `client.built_in`), `LOGOUT` (end-session hint revoke), `REGISTER` /
-  `ACCOUNT_ACTIVATED`, `PASSWORD_RESET_REQUESTED/COMPLETED`. Token issuance
+  `ACCOUNT_ACTIVATED`, `PASSWORD_RESET_REQUESTED/COMPLETED`, and the
+  **key / trust-anchor lifecycle** (issue #3269): `KeyService` /
+  `TrustAnchorService` record ENTITY-scope `created`/`updated`/`deleted`
+  rows themselves (both entities are deliberately subscriber-less, so the
+  CRUD bridge never sees them) — metadata-only `data`
+  (`name`/`use`/`status`/`enabled`, update `diff`, `force` on crypto-shred),
+  actor from the `ActorContext`, request attribution via the injected
+  `useRequestEventContext` getter, default (long) retention. Token issuance
   emits **no rows** (plan 016's `auth_session_tokens` already inventories every
   token; volume control).
 - **Entity-CRUD bridge (plan 057 Stage 2, hub's EntityEventHandler):**

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -109,6 +109,7 @@ import {
     UserController,
     UserPermissionController,
     UserRoleController,
+    useRequestEventContext,
 } from '../../../../adapters/http/index.ts';
 import {
     ActivateController,
@@ -776,7 +777,11 @@ export class HTTPControllerModule {
     createKeyController(container: IContainer) {
         // the DI singleton carries the optional KEK cipher — never construct
         // a fresh adapter here.
-        const service = new KeyService({ repository: container.resolve(OAuth2InjectionToken.KeyStore) });
+        const service = new KeyService({
+            repository: container.resolve(OAuth2InjectionToken.KeyStore),
+            eventService: container.resolve(DatabaseInjectionKey.EventService),
+            requestContext: useRequestEventContext,
+        });
         return new KeyController({ service });
     }
 
@@ -784,7 +789,11 @@ export class HTTPControllerModule {
         const repository = new TrustAnchorRepositoryAdapter(
             container.resolve(DatabaseInjectionKey.DataSource),
         );
-        const service = new TrustAnchorService({ repository });
+        const service = new TrustAnchorService({
+            repository,
+            eventService: container.resolve(DatabaseInjectionKey.EventService),
+            requestContext: useRequestEventContext,
+        });
         return new TrustAnchorController({ service });
     }
 

--- a/apps/server-core/src/core/entities/event/sanitize.ts
+++ b/apps/server-core/src/core/entities/event/sanitize.ts
@@ -16,6 +16,9 @@ import { EVENT_DIFF_SECRET_KEY_REGEX } from './diff.ts';
  * smuggle a secret past the boundary (this subsumes a denylist: password,
  * client_secret, code, code_verifier, *token* etc. are simply never listed).
  * session_id / jti / revoked_session_id are opaque correlation ids, not PII.
+ * name / use / status / enabled / force describe key & trust-anchor lifecycle
+ * operations (issue #3269) — canonical identifiers and enum/flag metadata,
+ * never material. kind is the MFA authenticator kind (totp/email/...).
  *
  * The single structured exception is `diff` (entity-CRUD bridge): it survives
  * only as a one-level object of `{ next, previous }` scalar pairs, keys
@@ -35,6 +38,12 @@ const DATA_KEY_ALLOW_LIST = [
     'session_id',
     'jti',
     'revoked_session_id',
+    'name',
+    'use',
+    'status',
+    'enabled',
+    'force',
+    'kind',
 ] as const;
 
 const DATA_VALUE_MAX_LENGTH = 512;

--- a/apps/server-core/src/core/entities/key/service.ts
+++ b/apps/server-core/src/core/entities/key/service.ts
@@ -310,7 +310,10 @@ export class KeyService extends AbstractEntityService implements IKeyService {
         entity.id = entityId;
         entity.decryption_key = null;
 
-        await this.recordEvent(EventName.DELETED, entity, actor, { ...(options.force ? { force: true } : {}) });
+        // force only carries crypto-shred semantics for encryption keys — a
+        // sig-key delete with a stray force flag must not read as a shred.
+        const forcedCryptoShred = entity.use === JWKUse.ENCRYPTION && !!options.force;
+        await this.recordEvent(EventName.DELETED, entity, actor, { ...(forcedCryptoShred ? { force: true } : {}) });
 
         return entity;
     }

--- a/apps/server-core/src/core/entities/key/service.ts
+++ b/apps/server-core/src/core/entities/key/service.ts
@@ -13,22 +13,33 @@ import {
     isError as isRawError,
 } from '@authup/errors';
 import type { Key } from '@authup/core-kit';
-import { KeyStatus, KeyValidator, PermissionName } from '@authup/core-kit';
 import {
-    ValidatorGroup, 
-    arrayBufferToBase64, 
-    base64ToArrayBuffer, 
+    EntityType,
+    EventName,
+    EventScope,
+    KeyStatus,
+    KeyValidator,
+    PermissionName,
+} from '@authup/core-kit';
+import {
+    ValidatorGroup,
+    arrayBufferToBase64,
+    base64ToArrayBuffer,
     createNanoID,
 } from '@authup/kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
 import { AbstractEntityService, AsymmetricKey, createAsymmetricKeyPair } from '@authup/server-kit';
 import { JWKType, JWKUse, JWTAlgorithm } from '@authup/specs';
 import { getRandomValues } from 'uncrypto';
+import { buildEntityDiff } from '../event/index.ts';
+import type { EventRequestContext, IEventService } from '../event/index.ts';
 import { assertCertificateMatchesKey, isWrappedKeyMaterial, parseCertificateChain } from '../../key/index.ts';
 import type { IKeyRepository, IKeyService, KeyDeleteOptions } from './types.ts';
 
 export type KeyServiceContext = {
     repository: IKeyRepository;
+    eventService?: IEventService;
+    requestContext?: () => EventRequestContext | undefined;
 };
 
 const PERMISSION_NAMES = [
@@ -42,10 +53,16 @@ export class KeyService extends AbstractEntityService implements IKeyService {
 
     protected validator: KeyValidator;
 
+    protected eventService?: IEventService;
+
+    protected requestContext?: () => EventRequestContext | undefined;
+
     constructor(ctx: KeyServiceContext) {
         super();
         this.repository = ctx.repository;
         this.validator = new KeyValidator();
+        this.eventService = ctx.eventService;
+        this.requestContext = ctx.requestContext;
     }
 
     async getMany(
@@ -204,6 +221,8 @@ export class KeyService extends AbstractEntityService implements IKeyService {
         // metadata + public part only (authentik CVE-2024-42490).
         entity.decryption_key = null;
 
+        await this.recordEvent(EventName.CREATED, entity, actor);
+
         return entity;
     }
 
@@ -242,10 +261,15 @@ export class KeyService extends AbstractEntityService implements IKeyService {
             }, entity);
         }
 
+        const previous = this.pickAuditFields(entity);
+
         entity = this.repository.merge(entity, validated);
         await this.repository.save(entity);
 
         entity.decryption_key = null;
+
+        const diff = buildEntityDiff(this.pickAuditFields(entity), previous);
+        await this.recordEvent(EventName.UPDATED, entity, actor, { ...(Object.keys(diff).length > 0 ? { diff } : {}) });
 
         return entity;
     }
@@ -286,10 +310,58 @@ export class KeyService extends AbstractEntityService implements IKeyService {
         entity.id = entityId;
         entity.decryption_key = null;
 
+        await this.recordEvent(EventName.DELETED, entity, actor, { ...(options.force ? { force: true } : {}) });
+
         return entity;
     }
 
     // ------------------------------------------------------------------
+
+    /**
+     * Metadata-only audit trail for key lifecycle operations (issue #3269) —
+     * keys deliberately have no entity subscriber (private material must stay
+     * off the realtime/audit bus), so the security-relevant mutations are
+     * recorded explicitly. The payload never carries key material.
+     */
+    protected async recordEvent(
+        name: `${EventName}`,
+        entity: Key,
+        actor: ActorContext,
+        data: Record<string, any> = {},
+    ): Promise<void> {
+        const requestContext = this.requestContext ?
+            this.requestContext() :
+            undefined;
+
+        await this.eventService?.record({
+            scope: EventScope.ENTITY,
+            name,
+            refType: EntityType.KEY,
+            refId: entity.id,
+            realmId: entity.realm_id ?? null,
+            actorType: actor.identity?.type ?? null,
+            actorId: actor.identity?.data.id ?? null,
+            actorName: actor.identity?.data.name ?? null,
+            requestPath: requestContext?.requestPath ?? null,
+            requestMethod: requestContext?.requestMethod ?? null,
+            requestIpAddress: requestContext?.requestIpAddress ?? null,
+            requestUserAgent: requestContext?.requestUserAgent ?? null,
+            data: {
+                name: entity.name,
+                use: entity.use,
+                status: entity.status,
+                ...data,
+            },
+        });
+    }
+
+    protected pickAuditFields(entity: Key): Record<string, any> {
+        return {
+            name: entity.name,
+            priority: entity.priority,
+            status: entity.status,
+        };
+    }
 
     protected async generateMaterial(
         validated: Partial<Key>,

--- a/apps/server-core/src/core/entities/trust-anchor/service.ts
+++ b/apps/server-core/src/core/entities/trust-anchor/service.ts
@@ -7,16 +7,26 @@
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import type { TrustAnchor } from '@authup/core-kit';
-import { PermissionName, TrustAnchorValidator } from '@authup/core-kit';
+import {
+    EntityType,
+    EventName,
+    EventScope,
+    PermissionName,
+    TrustAnchorValidator,
+} from '@authup/core-kit';
 import { EntityNotFoundError, ValidationError } from '@authup/errors';
 import { ValidatorGroup } from '@authup/kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
 import { AbstractEntityService } from '@authup/server-kit';
+import { buildEntityDiff } from '../event/index.ts';
+import type { EventRequestContext, IEventService } from '../event/index.ts';
 import { parseCertificateChain } from '../../key/index.ts';
 import type { ITrustAnchorRepository, ITrustAnchorService } from './types.ts';
 
 export type TrustAnchorServiceContext = {
     repository: ITrustAnchorRepository,
+    eventService?: IEventService,
+    requestContext?: () => EventRequestContext | undefined,
 };
 
 const PERMISSION_NAMES = [
@@ -30,10 +40,16 @@ export class TrustAnchorService extends AbstractEntityService implements ITrustA
 
     protected validator: TrustAnchorValidator;
 
+    protected eventService?: IEventService;
+
+    protected requestContext?: () => EventRequestContext | undefined;
+
     constructor(ctx: TrustAnchorServiceContext) {
         super();
         this.repository = ctx.repository;
         this.validator = new TrustAnchorValidator();
+        this.eventService = ctx.eventService;
+        this.requestContext = ctx.requestContext;
     }
 
     async getMany(
@@ -134,8 +150,12 @@ export class TrustAnchorService extends AbstractEntityService implements ITrustA
             validated.enabled = true;
         }
 
-        const entity = this.repository.create(validated);
-        return this.repository.save(entity);
+        let entity = this.repository.create(validated);
+        entity = await this.repository.save(entity);
+
+        await this.recordEvent(EventName.CREATED, entity, actor);
+
+        return entity;
     }
 
     async update(
@@ -171,8 +191,15 @@ export class TrustAnchorService extends AbstractEntityService implements ITrustA
             }, entity);
         }
 
+        const previous = this.pickAuditFields(entity);
+
         entity = this.repository.merge(entity, validated);
-        return this.repository.save(entity);
+        entity = await this.repository.save(entity);
+
+        const diff = buildEntityDiff(this.pickAuditFields(entity), previous);
+        await this.recordEvent(EventName.UPDATED, entity, actor, { ...(Object.keys(diff).length > 0 ? { diff } : {}) });
+
+        return entity;
     }
 
     async delete(
@@ -198,6 +225,55 @@ export class TrustAnchorService extends AbstractEntityService implements ITrustA
         await this.repository.remove(entity);
         entity.id = entityId;
 
+        await this.recordEvent(EventName.DELETED, entity, actor);
+
         return entity;
+    }
+
+    // ------------------------------------------------------------------
+
+    /**
+     * Metadata-only audit trail for trust-anchor lifecycle operations
+     * (issue #3269) — trust anchors have no entity subscriber, so the
+     * security-relevant mutations (an enabled CA anchor turns on mTLS client
+     * auth for a realm) are recorded explicitly. The payload never carries
+     * certificate bytes.
+     */
+    protected async recordEvent(
+        name: `${EventName}`,
+        entity: TrustAnchor,
+        actor: ActorContext,
+        data: Record<string, any> = {},
+    ): Promise<void> {
+        const requestContext = this.requestContext ?
+            this.requestContext() :
+            undefined;
+
+        await this.eventService?.record({
+            scope: EventScope.ENTITY,
+            name,
+            refType: EntityType.TRUST_ANCHOR,
+            refId: entity.id,
+            realmId: entity.realm_id ?? null,
+            actorType: actor.identity?.type ?? null,
+            actorId: actor.identity?.data.id ?? null,
+            actorName: actor.identity?.data.name ?? null,
+            requestPath: requestContext?.requestPath ?? null,
+            requestMethod: requestContext?.requestMethod ?? null,
+            requestIpAddress: requestContext?.requestIpAddress ?? null,
+            requestUserAgent: requestContext?.requestUserAgent ?? null,
+            data: {
+                name: entity.name,
+                enabled: entity.enabled,
+                ...data,
+            },
+        });
+    }
+
+    protected pickAuditFields(entity: TrustAnchor): Record<string, any> {
+        return {
+            name: entity.name,
+            enabled: entity.enabled,
+        };
     }
 }

--- a/apps/server-core/test/unit/core/entities/event/sanitize.spec.ts
+++ b/apps/server-core/test/unit/core/entities/event/sanitize.spec.ts
@@ -22,6 +22,12 @@ describe('sanitizeEventData', () => {
         ['session_id', 'b0e8b3d2-0000-0000-0000-000000000000'],
         ['jti', 'b0e8b3d2-1111-1111-1111-111111111111'],
         ['revoked_session_id', 'b0e8b3d2-2222-2222-2222-222222222222'],
+        ['name', 'sig-primary'],
+        ['use', 'enc'],
+        ['status', 'disabled'],
+        ['enabled', 'true'],
+        ['force', 'true'],
+        ['kind', 'totp'],
     ])('keeps the allowlisted scalar key %s', (key, value) => {
         expect(sanitizeEventData({ [key]: value })).toEqual({ [key]: value });
     });

--- a/apps/server-core/test/unit/core/entities/key/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/key/service.spec.ts
@@ -7,8 +7,15 @@
 
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import type { Key } from '@authup/core-kit';
-import { KeyStatus, PermissionName } from '@authup/core-kit';
+import type { Key, User } from '@authup/core-kit';
+import {
+    EntityType,
+    EventName,
+    EventScope,
+    IdentityType,
+    KeyStatus,
+    PermissionName,
+} from '@authup/core-kit';
 import { ErrorCode, isAuthupError } from '@authup/errors';
 import { AsymmetricKey, createAsymmetricKeyPair } from '@authup/server-kit';
 import { JWKType, JWKUse, JWTAlgorithm } from '@authup/specs';
@@ -24,6 +31,7 @@ import {
     createMasterRealmActor,
 } from '@authup/server-test-kit';
 import { KeyService } from '../../../../../src/core/entities/key/service.ts';
+import { FakeEventService } from '../../helpers/index.ts';
 import { FakeKeyRepository } from './fake-repository.ts';
 
 const CERTIFICATE = readFileSync(
@@ -374,6 +382,125 @@ describe('core/entities/key/service', () => {
 
             await service.delete(seeded.id, createAllowAllActor());
             expect(repository.getAll()).toHaveLength(0);
+        });
+    });
+
+    describe('audit events', () => {
+        let eventService: FakeEventService;
+
+        const buildActor = (actorId: string) => {
+            const actor = createAllowAllActor();
+            actor.identity = {
+                type: IdentityType.USER,
+                data: { id: actorId, name: 'admin' } as User,
+            };
+            return actor;
+        };
+
+        beforeEach(() => {
+            eventService = new FakeEventService();
+            service = new KeyService({
+                repository,
+                eventService,
+                requestContext: () => ({
+                    actorType: null,
+                    actorId: null,
+                    actorName: null,
+                    requestPath: '/keys',
+                    requestMethod: 'POST',
+                    requestIpAddress: '203.0.113.7',
+                    requestUserAgent: 'vitest',
+                }),
+            });
+        });
+
+        it('records a metadata-only created event (never key material)', async () => {
+            const actorId = randomUUID();
+            const realmId = randomUUID();
+            const entity = await service.create({ use: JWKUse.SIGNATURE, realm_id: realmId }, buildActor(actorId));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            const [call] = eventService.recordCalls;
+            expect(call).toMatchObject({
+                scope: EventScope.ENTITY,
+                name: EventName.CREATED,
+                refType: EntityType.KEY,
+                refId: entity.id,
+                realmId,
+                actorType: IdentityType.USER,
+                actorId,
+                actorName: 'admin',
+                requestPath: '/keys',
+                requestIpAddress: '203.0.113.7',
+            });
+            // exact payload — id/name/use/status metadata only
+            expect(call.data).toEqual({
+                name: entity.name,
+                use: JWKUse.SIGNATURE,
+                status: KeyStatus.ACTIVE,
+            });
+            const serialized = JSON.stringify(call);
+            expect(serialized).not.toContain('decryption_key');
+            expect(serialized).not.toContain('encryption_key');
+            expect(serialized).not.toContain('certificate');
+        });
+
+        it('records an updated event carrying the scalar diff (status change)', async () => {
+            const [seeded] = repository.seed([buildKey({ name: 'primary', status: KeyStatus.ACTIVE })]);
+
+            await service.update(seeded.id, { status: KeyStatus.DISABLED }, buildActor(randomUUID()));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            const [call] = eventService.recordCalls;
+            expect(call.name).toEqual(EventName.UPDATED);
+            expect(call.data).toEqual({
+                name: 'primary',
+                use: JWKUse.SIGNATURE,
+                status: KeyStatus.DISABLED,
+                diff: { status: { next: KeyStatus.DISABLED, previous: KeyStatus.ACTIVE } },
+            });
+        });
+
+        it('records an updated event without a diff when nothing changed', async () => {
+            const [seeded] = repository.seed([buildKey()]);
+
+            await service.update(seeded.id, {}, buildActor(randomUUID()));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            expect(eventService.recordCalls[0].data!.diff).toBeUndefined();
+        });
+
+        it('records a deleted event and flags a forced crypto-shred', async () => {
+            const [seeded] = repository.seed([buildKey({ use: JWKUse.ENCRYPTION, type: JWKType.OCT })]);
+            repository.blobReferences = 3;
+
+            await service.delete(seeded.id, buildActor(randomUUID()), { force: true });
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            const [call] = eventService.recordCalls;
+            expect(call.name).toEqual(EventName.DELETED);
+            expect(call.refId).toEqual(seeded.id);
+            expect(call.data).toMatchObject({ use: JWKUse.ENCRYPTION, force: true });
+        });
+
+        it('records a plain deleted event without the force flag', async () => {
+            const [seeded] = repository.seed([buildKey()]);
+
+            await service.delete(seeded.id, buildActor(randomUUID()));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            expect(eventService.recordCalls[0].data!.force).toBeUndefined();
+        });
+
+        it('records nothing when the mutation fails', async () => {
+            await expect(service.update(randomUUID(), { name: 'renamed' }, buildActor(randomUUID())))
+                .rejects.toThrow();
+            const [seeded] = repository.seed([buildKey({ use: JWKUse.ENCRYPTION, type: JWKType.OCT })]);
+            repository.blobReferences = 1;
+            await expect(service.delete(seeded.id, buildActor(randomUUID())))
+                .rejects.toThrow();
+
+            expect(eventService.recordCalls).toHaveLength(0);
         });
     });
 });

--- a/apps/server-core/test/unit/core/entities/key/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/key/service.spec.ts
@@ -492,6 +492,15 @@ describe('core/entities/key/service', () => {
             expect(eventService.recordCalls[0].data!.force).toBeUndefined();
         });
 
+        it('never flags a signature-key delete as a crypto-shred (force is enc-only)', async () => {
+            const [seeded] = repository.seed([buildKey()]);
+
+            await service.delete(seeded.id, buildActor(randomUUID()), { force: true });
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            expect(eventService.recordCalls[0].data!.force).toBeUndefined();
+        });
+
         it('records nothing when the mutation fails', async () => {
             await expect(service.update(randomUUID(), { name: 'renamed' }, buildActor(randomUUID())))
                 .rejects.toThrow();

--- a/apps/server-core/test/unit/core/entities/trust-anchor/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/trust-anchor/service.spec.ts
@@ -7,8 +7,14 @@
 
 import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
-import type { TrustAnchor } from '@authup/core-kit';
-import { PermissionName } from '@authup/core-kit';
+import type { TrustAnchor, User } from '@authup/core-kit';
+import {
+    EntityType,
+    EventName,
+    EventScope,
+    IdentityType,
+    PermissionName,
+} from '@authup/core-kit';
 import { ErrorCode } from '@authup/errors';
 import {
     createAllowAllActor,
@@ -22,6 +28,7 @@ import {
     it,
 } from 'vitest';
 import { TrustAnchorService } from '../../../../../src/core/entities/trust-anchor/service.ts';
+import { FakeEventService } from '../../helpers/index.ts';
 import { FakeTrustAnchorRepository } from './fake-repository.ts';
 
 const CA_CERTIFICATE = readFileSync(
@@ -181,6 +188,100 @@ describe('core/entities/trust-anchor/service', () => {
             const deleted = await service.delete(seeded.id, createAllowAllActor());
             expect(deleted.id).toEqual(seeded.id);
             expect(repository.getAll()).toHaveLength(0);
+        });
+    });
+
+    describe('audit events', () => {
+        let eventService: FakeEventService;
+
+        const buildActor = (actorId: string) => {
+            const actor = createAllowAllActor();
+            actor.identity = {
+                type: IdentityType.USER,
+                data: { id: actorId, name: 'admin' } as User,
+            };
+            return actor;
+        };
+
+        beforeEach(() => {
+            eventService = new FakeEventService();
+            service = new TrustAnchorService({
+                repository,
+                eventService,
+                requestContext: () => ({
+                    actorType: null,
+                    actorId: null,
+                    actorName: null,
+                    requestPath: '/trust-anchors',
+                    requestMethod: 'POST',
+                    requestIpAddress: '203.0.113.7',
+                    requestUserAgent: 'vitest',
+                }),
+            });
+        });
+
+        it('records a metadata-only created event (never certificate bytes)', async () => {
+            const actorId = randomUUID();
+            const realmId = randomUUID();
+            const entity = await service.create({
+                name: 'audited-ca',
+                certificate: CA_CERTIFICATE,
+                realm_id: realmId,
+            }, buildActor(actorId));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            const [call] = eventService.recordCalls;
+            expect(call).toMatchObject({
+                scope: EventScope.ENTITY,
+                name: EventName.CREATED,
+                refType: EntityType.TRUST_ANCHOR,
+                refId: entity.id,
+                realmId,
+                actorType: IdentityType.USER,
+                actorId,
+                actorName: 'admin',
+                requestPath: '/trust-anchors',
+                requestIpAddress: '203.0.113.7',
+            });
+            expect(call.data).toEqual({ name: 'audited-ca', enabled: true });
+            expect(JSON.stringify(call)).not.toContain('BEGIN CERTIFICATE');
+        });
+
+        it('records an updated event carrying the scalar diff (enabled flip)', async () => {
+            const [seeded] = repository.seed([buildTrustAnchor({ name: 'primary-ca', enabled: true })]);
+
+            await service.update(seeded.id, { enabled: false }, buildActor(randomUUID()));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            const [call] = eventService.recordCalls;
+            expect(call.name).toEqual(EventName.UPDATED);
+            expect(call.data).toEqual({
+                name: 'primary-ca',
+                enabled: false,
+                diff: { enabled: { next: false, previous: true } },
+            });
+        });
+
+        it('records a deleted event', async () => {
+            const [seeded] = repository.seed([buildTrustAnchor()]);
+
+            await service.delete(seeded.id, buildActor(randomUUID()));
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            const [call] = eventService.recordCalls;
+            expect(call.name).toEqual(EventName.DELETED);
+            expect(call.refType).toEqual(EntityType.TRUST_ANCHOR);
+            expect(call.refId).toEqual(seeded.id);
+        });
+
+        it('records nothing when the mutation fails', async () => {
+            await expect(service.create({
+                name: 'leaf-only',
+                certificate: NON_CA_CERTIFICATE,
+                realm_id: randomUUID(),
+            }, buildActor(randomUUID()))).rejects.toThrow();
+
+            expect(eventService.recordCalls).toHaveLength(0);
         });
     });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/key.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/key.spec.ts
@@ -236,4 +236,32 @@ describe('src/http/controllers/key', () => {
 
         expect(response.data.realm_id).toEqual(realm.id);
     });
+
+    it('should record attributed, metadata-only lifecycle audit events', async () => {
+        const created = await suite.client.key.create({
+            use: JWKUse.SIGNATURE,
+            name: 'audited-key',
+            realm_id: realm.id,
+        });
+        await suite.client.key.update(created.id, { status: KeyStatus.PASSIVE });
+        await suite.client.key.delete(created.id);
+
+        const { data } = await suite.client.event.getMany({ filter: { ref_type: 'key', ref_id: created.id } });
+
+        expect(data).toHaveLength(3);
+        expect(new Set(data.map((row) => row.name)))
+            .toEqual(new Set(['created', 'updated', 'deleted']));
+        for (const row of data) {
+            expect(row.realm_id).toEqual(realm.id);
+            expect(row.actor_type).toEqual('user');
+            expect(row.actor_name).toEqual('admin');
+            expect(row.request_method).toBeTruthy();
+            expect(row.data).toMatchObject({ name: 'audited-key', use: JWKUse.SIGNATURE });
+            // metadata only — never key material
+            expect(JSON.stringify(row.data)).not.toMatch(/decryption|encryption|certificate/);
+        }
+
+        const updatedRow = data.find((row) => row.name === 'updated');
+        expect(updatedRow!.data!.diff).toEqual({ status: { next: KeyStatus.PASSIVE, previous: KeyStatus.ACTIVE } });
+    });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/trust-anchor.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/trust-anchor.spec.ts
@@ -136,4 +136,31 @@ describe('src/http/controllers/trust-anchor', () => {
             { status: 404 },
         );
     });
+
+    it('should record attributed, metadata-only lifecycle audit events', async () => {
+        const created = await suite.client.trustAnchor.create({
+            name: 'audited-client-ca',
+            certificate: CA_CERTIFICATE,
+            realm_id: realm.id,
+        });
+        await suite.client.trustAnchor.update(created.id, { enabled: false });
+        await suite.client.trustAnchor.delete(created.id);
+
+        const { data } = await suite.client.event.getMany({ filter: { ref_type: 'trustAnchor', ref_id: created.id } });
+
+        expect(data).toHaveLength(3);
+        expect(new Set(data.map((row) => row.name)))
+            .toEqual(new Set(['created', 'updated', 'deleted']));
+        for (const row of data) {
+            expect(row.realm_id).toEqual(realm.id);
+            expect(row.actor_type).toEqual('user');
+            expect(row.actor_name).toEqual('admin');
+            expect(row.data).toMatchObject({ name: 'audited-client-ca' });
+            // metadata only — never certificate bytes
+            expect(JSON.stringify(row.data)).not.toContain('BEGIN CERTIFICATE');
+        }
+
+        const updatedRow = data.find((row) => row.name === 'updated');
+        expect(updatedRow!.data!.diff).toEqual({ enabled: { next: false, previous: true } });
+    });
 });


### PR DESCRIPTION
## Summary

Closes #3269.

Keys and trust anchors are deliberately subscriber-less (private material must stay off the realtime/audit bus), which left their security-sensitive mutations — enabling a CA trust anchor (turns on mTLS client auth for a realm), disabling/deleting a signing key, force crypto-shredding an encryption key — invisible in `auth_events` while routine entity edits are logged.

`KeyService` / `TrustAnchorService` now record explicit, **metadata-only** `EventService.record()` emits on create / update / delete:

- Generic `created`/`updated`/`deleted` under `EventScope.ENTITY` with `ref_type: key` / `trustAnchor` (the entity-event handler's realm-key map already carried both entries).
- **Actor** attribution from the `ActorContext`, **realm** from the entity, **request** attribution (path / method / IP / user-agent) via the same injected `useRequestEventContext` AsyncLocalStorage getter the entity-CRUD bridge uses; both wired from the controller factories (`DatabaseInjectionKey.EventService`).
- **Payload**: keys carry `name`/`use`/`status` + a scalar `diff` (name/priority/status) on update + `force: true` on a forced crypto-shred; trust anchors carry `name`/`enabled` + diff. Never `decryption_key` / `encryption_key` / `certificate` bytes — enforced centrally by the sanitizer's allowlist-first write boundary.
- Emits ride the **default (long) event retention** and are not gated by `eventLogEntityEnabled` — these are security events, not entity churn.

### Drive-by fix

The MFA lifecycle events (`mfaEnrolled`/`mfaRemoved`/…) pass `data: { kind }`, but `kind` was never in the sanitizer allowlist, so their data was silently stripped to `null` at the write boundary. `kind` is now allowlisted, with spec coverage.

## Tests

- Service-level `audit events` blocks in the key + trust-anchor specs: attribution, exact payloads, status/enabled diffs, force flag, no-emit-on-failure, no-material assertions.
- One end-to-end HTTP test per entity pinning the factory wiring (create → update → delete yields three attributed rows via `client.event.getMany`).
- Sanitizer spec extended for the new allowlist keys.
- Full server-core suite green (1725 passed; the 2 failing LDAP spec files fail identically on an untouched checkout — local LDAP container state, unrelated).

## Docs

`.agents/architecture.md`: key-store + Stage C sections no longer defer the emits as a follow-up; the Security Event Log emit-sites list now includes the key / trust-anchor lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added security event logging for key and trust-anchor creation, updates, and deletion.
  * Events include actor and request details plus relevant metadata and change differences.
  * Sensitive key and certificate material is excluded from event records.
  * Forced key deletion is clearly marked in the audit event.

* **Documentation**
  * Updated architecture documentation to describe lifecycle event logging and security event coverage.

* **Tests**
  * Added coverage for lifecycle events, metadata sanitization, attribution, diffs, and failure handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->