### PR TITLE
refactor(server-core)!: wrap authenticator enroll response in data/meta envelope

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2050,8 +2050,11 @@ realtime), port `IUserAuthenticatorRepository` + `UserAuthenticatorService` in
   them ONLY via `findOneWithSecretsById` / `findAllWithSecretsByUser`
   (verification paths). Every read surface (`getMany`/`getOne`/enroll response
   entity) nulls both — the raw seed/URI/QR/codes appear exactly once, in the
-  enroll response (`{ entity, secret?, uri?, qr?, codes? }`; QR is a
-  server-rendered PNG data-URI via the `qrcode` dep, TOTP via `otpauth`).
+  enroll response (`{ data: <entity>, meta: { secret?, uri?, qr?, codes?,
+  webauthn? } }` — the entity under `data`, the shown-once provisioning
+  material under `meta`, the `EntityRecordWrappedResponse` envelope entity
+  record responses converge on; QR is a server-rendered PNG data-URI via the
+  `qrcode` dep, TOTP via `otpauth`).
 - The `findMany` adapter follows the plan-039 discipline
   (`applyRealmScopeSelect(qb, 'userAuthenticator', ['user_id'])`).
 

--- a/apps/server-core/src/adapters/http/controllers/entities/user-authenticator/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-authenticator/module.ts
@@ -89,10 +89,10 @@ export class UserAuthenticatorController {
         const userId = this.resolveUserId(id, event);
 
         // route wins silently over body
-        const { entity, meta } = await this.service.enroll({ ...data, user_id: userId }, actor);
+        const result = await this.service.enroll({ ...data, user_id: userId }, actor);
 
         event.response.status = 201;
-        return { data: entity, meta };
+        return result;
     }
 
     @DGet('/:deviceId', [ForceLoggedInMiddleware])

--- a/apps/server-core/src/adapters/http/controllers/entities/user-authenticator/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/user-authenticator/module.ts
@@ -89,10 +89,10 @@ export class UserAuthenticatorController {
         const userId = this.resolveUserId(id, event);
 
         // route wins silently over body
-        const result = await this.service.enroll({ ...data, user_id: userId }, actor);
+        const { entity, meta } = await this.service.enroll({ ...data, user_id: userId }, actor);
 
         event.response.status = 201;
-        return result;
+        return { data: entity, meta };
     }
 
     @DGet('/:deviceId', [ForceLoggedInMiddleware])

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -339,7 +339,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         return {
             entity: this.sanitize(entity),
-            webauthn: options,
+            meta: { webauthn: options },
         };
     }
 
@@ -385,7 +385,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         await this.recordEvent(EventName.MFA_ENROLLED, entity);
 
-        return { entity: this.sanitize(entity) };
+        return { entity: this.sanitize(entity), meta: {} };
     }
 
     protected async resolveTargetUser(
@@ -453,9 +453,11 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         return {
             entity: this.sanitize(entity),
-            secret: secret.base32,
-            uri,
-            qr: await QRCode.toDataURL(uri),
+            meta: {
+                secret: secret.base32,
+                uri,
+                qr: await QRCode.toDataURL(uri),
+            },
         };
     }
 
@@ -495,7 +497,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         return {
             entity: this.sanitize(entity),
-            codes,
+            meta: { codes },
         };
     }
 

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -338,7 +338,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         );
 
         return {
-            entity: this.sanitize(entity),
+            data: this.sanitize(entity),
             meta: { webauthn: options },
         };
     }
@@ -385,7 +385,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
 
         await this.recordEvent(EventName.MFA_ENROLLED, entity);
 
-        return { entity: this.sanitize(entity), meta: {} };
+        return { data: this.sanitize(entity), meta: {} };
     }
 
     protected async resolveTargetUser(
@@ -452,7 +452,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         entity = await this.repository.save(entity);
 
         return {
-            entity: this.sanitize(entity),
+            data: this.sanitize(entity),
             meta: {
                 secret: secret.base32,
                 uri,
@@ -496,7 +496,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
         await this.recordEvent(EventName.MFA_ENROLLED, entity);
 
         return {
-            entity: this.sanitize(entity),
+            data: this.sanitize(entity),
             meta: { codes },
         };
     }

--- a/apps/server-core/src/core/entities/user-authenticator/types.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/types.ts
@@ -104,8 +104,11 @@ export type UserAuthenticatorWebauthnParameters = {
     transports?: string[],
 };
 
-export type UserAuthenticatorEnrollResult = {
-    entity: UserAuthenticator,
+/**
+ * Kind-specific shown-once provisioning material — returned alongside the
+ * enrolled entity exactly once, never in a subsequent read.
+ */
+export type UserAuthenticatorEnrollResultMeta = {
     /**
      * TOTP: the raw base32 seed — present in the enroll response only,
      * never in a subsequent read.
@@ -128,6 +131,11 @@ export type UserAuthenticatorEnrollResult = {
      * `navigator.credentials.create()` (SimpleWebAuthn `startRegistration`).
      */
     webauthn?: Record<string, unknown>,
+};
+
+export type UserAuthenticatorEnrollResult = {
+    entity: UserAuthenticator,
+    meta: UserAuthenticatorEnrollResultMeta,
 };
 
 export type UserAuthenticatorChallengeStatus = {

--- a/apps/server-core/src/core/entities/user-authenticator/types.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/types.ts
@@ -134,7 +134,7 @@ export type UserAuthenticatorEnrollResultMeta = {
 };
 
 export type UserAuthenticatorEnrollResult = {
-    entity: UserAuthenticator,
+    data: UserAuthenticator,
     meta: UserAuthenticatorEnrollResultMeta,
 };
 

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -151,10 +151,10 @@ describe('UserAuthenticatorService', () => {
             expect(result.meta.secret).toBeDefined();
             expect(result.meta.uri).toContain('otpauth://totp/');
             expect(result.meta.qr).toContain('data:image/png');
-            expect(result.entity.confirmed).toBeFalsy();
-            expect(result.entity.secret).toBeNull();
-            expect(result.entity.user_id).toEqual(userId);
-            expect(result.entity.realm_id).toEqual(realmId);
+            expect(result.data.confirmed).toBeFalsy();
+            expect(result.data.secret).toBeNull();
+            expect(result.data.user_id).toEqual(userId);
+            expect(result.data.realm_id).toEqual(realmId);
 
             // at rest the seed is encrypted — never the raw base32
             const [stored] = await repository.findAllWithSecretsByUser(userId);
@@ -236,8 +236,8 @@ describe('UserAuthenticatorService', () => {
                 makeActor(),
             );
 
-            expect(result.entity.user_id).toEqual(otherUserId);
-            expect(result.entity.confirmed).toBeTruthy();
+            expect(result.data.user_id).toEqual(otherUserId);
+            expect(result.data.confirmed).toBeTruthy();
         });
     });
 
@@ -246,7 +246,7 @@ describe('UserAuthenticatorService', () => {
             const first = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
 
             const confirmed = await service.confirm(
-                first.entity.id,
+                first.data.id,
                 totpCode(first.meta.secret!),
                 makeActor(),
             );
@@ -257,7 +257,7 @@ describe('UserAuthenticatorService', () => {
 
             expect.assertions(3);
             try {
-                await service.confirm(second.entity.id, '000000', makeActor());
+                await service.confirm(second.data.id, '000000', makeActor());
             } catch (e) {
                 expect(isEntityCredentialsInvalidError(e)).toBeTruthy();
             }
@@ -268,8 +268,8 @@ describe('UserAuthenticatorService', () => {
         it('issues single-use codes, hashed at rest, with regenerate semantics', async () => {
             const first = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
             expect(first.meta.codes).toHaveLength(10);
-            expect(first.entity.confirmed).toBeTruthy();
-            expect(first.entity.codes).toBeNull();
+            expect(first.data.confirmed).toBeTruthy();
+            expect(first.data.codes).toBeNull();
 
             const [stored] = await repository.findAllWithSecretsByUser(userId);
             expect(stored.codes).not.toContain(first.meta.codes![0]);
@@ -306,7 +306,7 @@ describe('UserAuthenticatorService', () => {
     describe('verify (totp)', () => {
         it('verifies a valid code and stamps last_used_at', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             const verified = await service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
@@ -320,7 +320,7 @@ describe('UserAuthenticatorService', () => {
 
         it('rejects replay of an already-used login code within its window (#3237)', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             const code = totpCode(enrolled.meta.secret!);
             // the first LOGIN with this code is accepted (the confirmation does
@@ -335,7 +335,7 @@ describe('UserAuthenticatorService', () => {
 
         it('bails without consuming the factor when the verify lock is held', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // simulate a concurrent verify holding the per-user lock
             const lockKey = buildCacheKey({ prefix: USER_AUTHENTICATOR_VERIFY_LOCK_CACHE_PREFIX, key: userId });
@@ -392,7 +392,7 @@ describe('UserAuthenticatorService', () => {
 
         it('fails verification closed when the cache is unavailable', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             cache.get = async () => { throw new Error('cache unavailable'); };
 
@@ -411,7 +411,7 @@ describe('UserAuthenticatorService', () => {
 
             expect.assertions(1);
             try {
-                await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+                await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
             } catch (e) {
                 expect(isMfaThrottledError(e)).toBeTruthy();
             }
@@ -429,7 +429,7 @@ describe('UserAuthenticatorService', () => {
 
         it('fails closed (a plain verification failure) when the seed blob references an unknown key', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // same device rows, but a cipher whose key store no longer
             // resolves the blob's key id — verify must return false, not 500.
@@ -450,7 +450,7 @@ describe('UserAuthenticatorService', () => {
 
         it('lets infrastructure errors during seed decryption bubble (attempt not burned)', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // a cipher failing with a NON-blob-semantics error (database
             // outage, KEK misconfiguration) must surface as a thrown error —
@@ -486,7 +486,7 @@ describe('UserAuthenticatorService', () => {
     describe('per-account backoff', () => {
         it('locks after a failed attempt and releases after the window', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             const failed = await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: '000000' });
             expect(failed).toBeFalsy();
@@ -510,7 +510,7 @@ describe('UserAuthenticatorService', () => {
 
         it('counts concurrent failures atomically (#3237)', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: '000000' })).toBeFalsy();
 
@@ -522,7 +522,7 @@ describe('UserAuthenticatorService', () => {
 
         it('recovers from a legacy (non-numeric) attempt-counter value', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // a pre-upgrade deployment stored the state as a JSON object
             const key = buildCacheKey({ prefix: USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX, key: userId });
@@ -553,7 +553,7 @@ describe('UserAuthenticatorService', () => {
 
         it('does not consume the TOTP step when the onVerified hook fails', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
 
             const code = totpCode(enrolled.meta.secret!);
             await expect(service.verify(
@@ -630,7 +630,7 @@ describe('UserAuthenticatorService', () => {
             let status = await service.challenge(userId);
             expect(status.required).toBeFalsy();
 
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
+            await service.confirm(enrolled.data.id, totpCode(enrolled.meta.secret!), makeActor());
             status = await service.challenge(userId);
             expect(status.required).toBeTruthy();
             expect(status.kinds).toEqual([UserAuthenticatorKind.TOTP]);
@@ -658,8 +658,8 @@ describe('UserAuthenticatorService', () => {
             seedUserWithEmail();
 
             const result = await service.enroll({ kind: UserAuthenticatorKind.EMAIL }, makeActor());
-            expect(result.entity.kind).toEqual(UserAuthenticatorKind.EMAIL);
-            expect(result.entity.confirmed).toBeTruthy();
+            expect(result.data.kind).toEqual(UserAuthenticatorKind.EMAIL);
+            expect(result.data.confirmed).toBeTruthy();
 
             const status = await service.challenge(userId);
             expect(status.required).toBeTruthy();
@@ -748,7 +748,7 @@ describe('UserAuthenticatorService', () => {
                 .filter((device) => device.kind === UserAuthenticatorKind.EMAIL);
             expect(rows).toHaveLength(1);
             // updated in place — same row id, not remove-then-create
-            expect(second.entity.id).toEqual(first.entity.id);
+            expect(second.data.id).toEqual(first.data.id);
             expect(rows[0].confirmed).toBeTruthy();
         });
 
@@ -799,8 +799,8 @@ describe('UserAuthenticatorService', () => {
         it('enrolls with registration options and stores a challenge (unconfirmed)', async () => {
             const result = await service.enroll({ kind: UserAuthenticatorKind.WEBAUTHN }, makeActor());
 
-            expect(result.entity.kind).toEqual(UserAuthenticatorKind.WEBAUTHN);
-            expect(result.entity.confirmed).toBeFalsy();
+            expect(result.data.kind).toEqual(UserAuthenticatorKind.WEBAUTHN);
+            expect(result.data.confirmed).toBeFalsy();
             expect(result.meta.webauthn).toBeDefined();
             expect((result.meta.webauthn as any).challenge).toBeDefined();
             expect((result.meta.webauthn as any).rp.id).toEqual('localhost');
@@ -809,7 +809,7 @@ describe('UserAuthenticatorService', () => {
             // the new row id (not the user id) so ceremonies don't collide
             const cached = await cache.get(buildCacheKey({
                 prefix: USER_AUTHENTICATOR_WEBAUTHN_REG_CACHE_PREFIX,
-                key: result.entity.id,
+                key: result.data.id,
             }));
             expect(cached).not.toBeNull();
 
@@ -828,9 +828,9 @@ describe('UserAuthenticatorService', () => {
 
             // each ceremony cached its own challenge under its row id — the
             // second enroll did not overwrite the first's challenge
-            expect(first.entity.id).not.toEqual(second.entity.id);
-            expect(await cache.get(regKey(first.entity.id))).not.toBeNull();
-            expect(await cache.get(regKey(second.entity.id))).not.toBeNull();
+            expect(first.data.id).not.toEqual(second.data.id);
+            expect(await cache.get(regKey(first.data.id))).not.toBeNull();
+            expect(await cache.get(regKey(second.data.id))).not.toBeNull();
         });
 
         it('throttles repeated failed webauthn confirms (brute-force backoff)', async () => {
@@ -841,7 +841,7 @@ describe('UserAuthenticatorService', () => {
             await cache.set(
                 buildCacheKey({
                     prefix: USER_AUTHENTICATOR_WEBAUTHN_REG_CACHE_PREFIX,
-                    key: enrolled.entity.id,
+                    key: enrolled.data.id,
                 }),
                 { challenge: 'x', expiresAt: Date.now() - 1_000 },
                 { ttl: 10_000 },
@@ -850,7 +850,7 @@ describe('UserAuthenticatorService', () => {
             expect.assertions(2);
             let firstFailed = false;
             try {
-                await service.confirm(enrolled.entity.id, '{}', makeActor());
+                await service.confirm(enrolled.data.id, '{}', makeActor());
             } catch {
                 firstFailed = true;
             }
@@ -858,7 +858,7 @@ describe('UserAuthenticatorService', () => {
 
             // the next attempt is locked out (factor 1 → 1s after the first failure)
             try {
-                await service.confirm(enrolled.entity.id, '{}', makeActor());
+                await service.confirm(enrolled.data.id, '{}', makeActor());
             } catch (e) {
                 expect(isMfaThrottledError(e)).toBeTruthy();
             }
@@ -918,7 +918,7 @@ describe('UserAuthenticatorService', () => {
 
             expect.assertions(1);
             try {
-                await service.confirm(enrolled.entity.id, 'not-json', makeActor());
+                await service.confirm(enrolled.data.id, 'not-json', makeActor());
             } catch (e) {
                 expect(e).toBeDefined();
             }
@@ -935,11 +935,11 @@ describe('UserAuthenticatorService', () => {
             expect(data[0].secret).toBeNull();
             expect(data[0].codes).toBeNull();
 
-            const one = await service.getOne(enrolled.entity.id, actor, { userId });
+            const one = await service.getOne(enrolled.data.id, actor, { userId });
             expect(one.secret).toBeNull();
 
-            const deleted = await service.delete(enrolled.entity.id, actor, { userId });
-            expect(deleted.id).toEqual(enrolled.entity.id);
+            const deleted = await service.delete(enrolled.data.id, actor, { userId });
+            expect(deleted.id).toEqual(enrolled.data.id);
             expect(await repository.findAllByUser(userId)).toHaveLength(0);
         });
 

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -148,9 +148,9 @@ describe('UserAuthenticatorService', () => {
         it('enrolls an unconfirmed totp device with encrypted seed', async () => {
             const result = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
 
-            expect(result.secret).toBeDefined();
-            expect(result.uri).toContain('otpauth://totp/');
-            expect(result.qr).toContain('data:image/png');
+            expect(result.meta.secret).toBeDefined();
+            expect(result.meta.uri).toContain('otpauth://totp/');
+            expect(result.meta.qr).toContain('data:image/png');
             expect(result.entity.confirmed).toBeFalsy();
             expect(result.entity.secret).toBeNull();
             expect(result.entity.user_id).toEqual(userId);
@@ -159,7 +159,7 @@ describe('UserAuthenticatorService', () => {
             // at rest the seed is encrypted — never the raw base32
             const [stored] = await repository.findAllWithSecretsByUser(userId);
             expect(stored.secret).toBeDefined();
-            expect(stored.secret).not.toEqual(result.secret);
+            expect(stored.secret).not.toEqual(result.meta.secret);
         });
 
         it('fails closed when the feature is disabled', async () => {
@@ -247,7 +247,7 @@ describe('UserAuthenticatorService', () => {
 
             const confirmed = await service.confirm(
                 first.entity.id,
-                totpCode(first.secret!),
+                totpCode(first.meta.secret!),
                 makeActor(),
             );
             expect(confirmed.confirmed).toBeTruthy();
@@ -267,12 +267,12 @@ describe('UserAuthenticatorService', () => {
     describe('enroll (recovery)', () => {
         it('issues single-use codes, hashed at rest, with regenerate semantics', async () => {
             const first = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
-            expect(first.codes).toHaveLength(10);
+            expect(first.meta.codes).toHaveLength(10);
             expect(first.entity.confirmed).toBeTruthy();
             expect(first.entity.codes).toBeNull();
 
             const [stored] = await repository.findAllWithSecretsByUser(userId);
-            expect(stored.codes).not.toContain(first.codes![0]);
+            expect(stored.codes).not.toContain(first.meta.codes![0]);
 
             // regenerate replaces the previous set
             const second = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
@@ -281,7 +281,7 @@ describe('UserAuthenticatorService', () => {
 
             const verified = await service.verify(userId, {
                 kind: UserAuthenticatorKind.RECOVERY,
-                response: first.codes![0],
+                response: first.meta.codes![0],
             });
             expect(verified).toBeFalsy();
 
@@ -289,14 +289,14 @@ describe('UserAuthenticatorService', () => {
             service = buildService();
             const verifiedSecond = await service.verify(userId, {
                 kind: UserAuthenticatorKind.RECOVERY,
-                response: second.codes![0],
+                response: second.meta.codes![0],
             });
             expect(verifiedSecond).toBeTruthy();
         });
 
         it('accepts a recovery code exactly once', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
-            const [code] = enrolled.codes!;
+            const [code] = enrolled.meta.codes!;
 
             expect(await service.verify(userId, { kind: UserAuthenticatorKind.RECOVERY, response: code })).toBeTruthy();
             expect(await service.verify(userId, { kind: UserAuthenticatorKind.RECOVERY, response: code })).toBeFalsy();
@@ -306,11 +306,11 @@ describe('UserAuthenticatorService', () => {
     describe('verify (totp)', () => {
         it('verifies a valid code and stamps last_used_at', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             const verified = await service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
-                response: totpCode(enrolled.secret!),
+                response: totpCode(enrolled.meta.secret!),
             });
             expect(verified).toBeTruthy();
 
@@ -320,9 +320,9 @@ describe('UserAuthenticatorService', () => {
 
         it('rejects replay of an already-used login code within its window (#3237)', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
-            const code = totpCode(enrolled.secret!);
+            const code = totpCode(enrolled.meta.secret!);
             // the first LOGIN with this code is accepted (the confirmation does
             // not consume the step); a replay of the same code is rejected —
             // the consumed step is persisted and must strictly advance.
@@ -335,13 +335,13 @@ describe('UserAuthenticatorService', () => {
 
         it('bails without consuming the factor when the verify lock is held', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // simulate a concurrent verify holding the per-user lock
             const lockKey = buildCacheKey({ prefix: USER_AUTHENTICATOR_VERIFY_LOCK_CACHE_PREFIX, key: userId });
             expect(await cache.add(lockKey, 1)).toBeTruthy();
 
-            const code = totpCode(enrolled.secret!);
+            const code = totpCode(enrolled.meta.secret!);
             expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: code })).toBeFalsy();
 
             // the step was NOT consumed — the same code succeeds once the lock frees
@@ -351,7 +351,7 @@ describe('UserAuthenticatorService', () => {
 
         it('keeps the verify lock beyond its base TTL while the success hook is in flight', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
-            const [code] = enrolled.codes!;
+            const [code] = enrolled.meta.codes!;
 
             let markStarted! : () => void;
             const started = new Promise<void>((resolve) => { markStarted = resolve; });
@@ -392,13 +392,13 @@ describe('UserAuthenticatorService', () => {
 
         it('fails verification closed when the cache is unavailable', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             cache.get = async () => { throw new Error('cache unavailable'); };
 
             await expect(service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
-                response: totpCode(enrolled.secret!),
+                response: totpCode(enrolled.meta.secret!),
             })).resolves.toBeFalsy();
         });
 
@@ -411,7 +411,7 @@ describe('UserAuthenticatorService', () => {
 
             expect.assertions(1);
             try {
-                await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+                await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
             } catch (e) {
                 expect(isMfaThrottledError(e)).toBeTruthy();
             }
@@ -422,14 +422,14 @@ describe('UserAuthenticatorService', () => {
 
             const verified = await service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
-                response: totpCode(enrolled.secret!),
+                response: totpCode(enrolled.meta.secret!),
             });
             expect(verified).toBeFalsy();
         });
 
         it('fails closed (a plain verification failure) when the seed blob references an unknown key', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // same device rows, but a cipher whose key store no longer
             // resolves the blob's key id — verify must return false, not 500.
@@ -443,14 +443,14 @@ describe('UserAuthenticatorService', () => {
 
             const verified = await service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
-                response: totpCode(enrolled.secret!),
+                response: totpCode(enrolled.meta.secret!),
             });
             expect(verified).toBeFalsy();
         });
 
         it('lets infrastructure errors during seed decryption bubble (attempt not burned)', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // a cipher failing with a NON-blob-semantics error (database
             // outage, KEK misconfiguration) must surface as a thrown error —
@@ -472,7 +472,7 @@ describe('UserAuthenticatorService', () => {
 
             await expect(service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
-                response: totpCode(enrolled.secret!),
+                response: totpCode(enrolled.meta.secret!),
             })).rejects.toThrow('database gone');
 
             const attempts = await cache.get(buildCacheKey({
@@ -486,7 +486,7 @@ describe('UserAuthenticatorService', () => {
     describe('per-account backoff', () => {
         it('locks after a failed attempt and releases after the window', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             const failed = await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: '000000' });
             expect(failed).toBeFalsy();
@@ -503,14 +503,14 @@ describe('UserAuthenticatorService', () => {
 
             const verified = await service.verify(userId, {
                 kind: UserAuthenticatorKind.TOTP,
-                response: totpCode(enrolled.secret!),
+                response: totpCode(enrolled.meta.secret!),
             });
             expect(verified).toBeTruthy();
         });
 
         it('counts concurrent failures atomically (#3237)', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             expect(await service.verify(userId, { kind: UserAuthenticatorKind.TOTP, response: '000000' })).toBeFalsy();
 
@@ -522,7 +522,7 @@ describe('UserAuthenticatorService', () => {
 
         it('recovers from a legacy (non-numeric) attempt-counter value', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
             // a pre-upgrade deployment stored the state as a JSON object
             const key = buildCacheKey({ prefix: USER_AUTHENTICATOR_ATTEMPT_CACHE_PREFIX, key: userId });
@@ -538,7 +538,7 @@ describe('UserAuthenticatorService', () => {
     describe('verify unit of work (#3237)', () => {
         it('does not consume a recovery code when the onVerified hook fails', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
-            const [code] = enrolled.codes!;
+            const [code] = enrolled.meta.codes!;
 
             await expect(service.verify(
                 userId,
@@ -553,9 +553,9 @@ describe('UserAuthenticatorService', () => {
 
         it('does not consume the TOTP step when the onVerified hook fails', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.TOTP }, makeActor());
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
 
-            const code = totpCode(enrolled.secret!);
+            const code = totpCode(enrolled.meta.secret!);
             await expect(service.verify(
                 userId,
                 { kind: UserAuthenticatorKind.TOTP, response: code },
@@ -590,7 +590,7 @@ describe('UserAuthenticatorService', () => {
 
         it('runs the onVerified hook on success only, never on a failed code', async () => {
             const enrolled = await service.enroll({ kind: UserAuthenticatorKind.RECOVERY }, makeActor());
-            const [code] = enrolled.codes!;
+            const [code] = enrolled.meta.codes!;
 
             let calls = 0;
             const onVerified = async () => { calls += 1; };
@@ -630,7 +630,7 @@ describe('UserAuthenticatorService', () => {
             let status = await service.challenge(userId);
             expect(status.required).toBeFalsy();
 
-            await service.confirm(enrolled.entity.id, totpCode(enrolled.secret!), makeActor());
+            await service.confirm(enrolled.entity.id, totpCode(enrolled.meta.secret!), makeActor());
             status = await service.challenge(userId);
             expect(status.required).toBeTruthy();
             expect(status.kinds).toEqual([UserAuthenticatorKind.TOTP]);
@@ -801,9 +801,9 @@ describe('UserAuthenticatorService', () => {
 
             expect(result.entity.kind).toEqual(UserAuthenticatorKind.WEBAUTHN);
             expect(result.entity.confirmed).toBeFalsy();
-            expect(result.webauthn).toBeDefined();
-            expect((result.webauthn as any).challenge).toBeDefined();
-            expect((result.webauthn as any).rp.id).toEqual('localhost');
+            expect(result.meta.webauthn).toBeDefined();
+            expect((result.meta.webauthn as any).challenge).toBeDefined();
+            expect((result.meta.webauthn as any).rp.id).toEqual('localhost');
 
             // a challenge nonce was cached for the confirm ceremony, keyed by
             // the new row id (not the user id) so ceremonies don't collide

--- a/apps/server-core/test/unit/http/controllers/entities/user-authenticator-email.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user-authenticator-email.spec.ts
@@ -48,8 +48,8 @@ describe('src/http/controllers/user-authenticator (email otp)', () => {
         bearer.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
 
         const enrolled = await bearer.userAuthenticator.enroll('@me', { kind: UserAuthenticatorKind.EMAIL });
-        expect(enrolled.entity.kind).toEqual(UserAuthenticatorKind.EMAIL);
-        expect(enrolled.entity.confirmed).toBeTruthy();
+        expect(enrolled.data.kind).toEqual(UserAuthenticatorKind.EMAIL);
+        expect(enrolled.data.confirmed).toBeTruthy();
 
         const challenge = await bearer.userAuthenticator.challenge();
         expect(challenge.required).toBeTruthy();

--- a/apps/server-core/test/unit/http/controllers/entities/user-authenticator.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user-authenticator.spec.ts
@@ -48,8 +48,8 @@ describe('src/http/controllers/user-authenticator', () => {
         // secret-bearing factors are self-enrollment only — the user enrolls
         // their own recovery set (the admin never sees the codes).
         const enrolled = await userClient.userAuthenticator.enroll('@me', { kind: UserAuthenticatorKind.RECOVERY });
-        expect(enrolled.codes).toHaveLength(10);
-        expect(enrolled.entity.user_id).toEqual(userId);
+        expect(enrolled.meta.codes).toHaveLength(10);
+        expect(enrolled.data.user_id).toEqual(userId);
 
         // the admin can list it (secrets nulled) ...
         const list = await suite.client.userAuthenticator.getMany(userId);
@@ -57,8 +57,8 @@ describe('src/http/controllers/user-authenticator', () => {
         expect(list.data[0].codes ?? null).toBeNull();
 
         // ... and reset it by deleting (the sanctioned admin management path)
-        const deleted = await suite.client.userAuthenticator.delete(userId, enrolled.entity.id);
-        expect(deleted.id).toEqual(enrolled.entity.id);
+        const deleted = await suite.client.userAuthenticator.delete(userId, enrolled.data.id);
+        expect(deleted.id).toEqual(enrolled.data.id);
 
         const after = await suite.client.userAuthenticator.getMany(userId);
         expect(after.data).toHaveLength(0);
@@ -98,14 +98,14 @@ describe('src/http/controllers/user-authenticator', () => {
         );
 
         await expectClientError(
-            () => stranger.client.userAuthenticator.delete(owner.id, enrolled.entity.id),
+            () => stranger.client.userAuthenticator.delete(owner.id, enrolled.data.id),
             { status: 403 },
         );
 
         // a foreign device id under the OWN nested route is a 404, never
         // an existence oracle
         await expectClientError(
-            () => stranger.client.userAuthenticator.getOne('@me', enrolled.entity.id),
+            () => stranger.client.userAuthenticator.getOne('@me', enrolled.data.id),
             { status: 404 },
         );
     });

--- a/apps/server-core/test/unit/http/controllers/workflows/key-store.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/key-store.spec.ts
@@ -52,15 +52,15 @@ describe('src/http realm key store (zero-config MFA + jwks hygiene)', () => {
         bearer.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
 
         const enrolled = await bearer.userAuthenticator.enroll('@me', { kind: UserAuthenticatorKind.TOTP });
-        expect(enrolled.secret).toBeDefined();
+        expect(enrolled.meta.secret).toBeDefined();
 
         const totp = new TOTP({
             algorithm: 'SHA1',
             digits: 6,
             period: 30,
-            secret: Secret.fromBase32(enrolled.secret!),
+            secret: Secret.fromBase32(enrolled.meta.secret!),
         });
-        const confirmed = await bearer.userAuthenticator.confirm('@me', enrolled.entity.id, { code: totp.generate() });
+        const confirmed = await bearer.userAuthenticator.confirm('@me', enrolled.data.id, { code: totp.generate() });
         expect(confirmed.confirmed).toBeTruthy();
 
         // an enc key exists for the user's realm ...
@@ -74,13 +74,13 @@ describe('src/http realm key store (zero-config MFA + jwks hygiene)', () => {
         const device = await suite.dataSource.getRepository(UserAuthenticatorEntity)
             .createQueryBuilder('device')
             .addSelect('device.secret')
-            .where('device.id = :id', { id: enrolled.entity.id })
+            .where('device.id = :id', { id: enrolled.data.id })
             .getOne();
 
         const [version, keyId] = device!.secret!.split('.');
         expect(version).toEqual('v1');
         expect(encKeys.map((key) => key.id)).toContain(keyId);
-        expect(device!.secret).not.toContain(enrolled.secret!);
+        expect(device!.secret).not.toContain(enrolled.meta.secret!);
     });
 
     it('never surfaces enc keys via jwks', async () => {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-mfa.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-password-mfa.spec.ts
@@ -63,18 +63,18 @@ describe('src/http/controllers/token (password grant + authorize MFA)', () => {
 
         // 2) enroll + confirm a TOTP device on @me
         const enrolled = await bearer.userAuthenticator.enroll('@me', { kind: UserAuthenticatorKind.TOTP });
-        expect(enrolled.secret).toBeDefined();
-        expect(enrolled.uri).toContain('otpauth://totp/');
-        expect(enrolled.qr).toContain('data:image/png');
+        expect(enrolled.meta.secret).toBeDefined();
+        expect(enrolled.meta.uri).toContain('otpauth://totp/');
+        expect(enrolled.meta.qr).toContain('data:image/png');
 
         const totp = new TOTP({
             algorithm: 'SHA1',
             digits: 6,
             period: 30,
-            secret: Secret.fromBase32(enrolled.secret!),
+            secret: Secret.fromBase32(enrolled.meta.secret!),
         });
 
-        const confirmed = await bearer.userAuthenticator.confirm('@me', enrolled.entity.id, { code: totp.generate() });
+        const confirmed = await bearer.userAuthenticator.confirm('@me', enrolled.data.id, { code: totp.generate() });
         expect(confirmed.confirmed).toBeTruthy();
 
         // the read surface never carries secret material
@@ -177,9 +177,9 @@ describe('src/http/controllers/token (password grant + authorize MFA)', () => {
         bearer.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
 
         const enrolled = await bearer.userAuthenticator.enroll('@me', { kind: UserAuthenticatorKind.RECOVERY });
-        expect(enrolled.codes).toHaveLength(10);
+        expect(enrolled.meta.codes).toHaveLength(10);
 
-        const [code] = enrolled.codes!;
+        const [code] = enrolled.meta.codes!;
         const withRecovery = await httpRequest(suite, 'POST', '/token', {
             form: {
                 grant_type: 'password',

--- a/apps/server-core/test/unit/http/controllers/workflows/token/id-token-claims.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/id-token-claims.spec.ts
@@ -152,9 +152,9 @@ describe('src/http/controllers/token (id_token amr/acr claims)', () => {
             algorithm: 'SHA1',
             digits: 6,
             period: 30,
-            secret: Secret.fromBase32(enrolled.secret!),
+            secret: Secret.fromBase32(enrolled.meta.secret!),
         });
-        await enrollBearer.userAuthenticator.confirm('@me', enrolled.entity.id, { code: totp.generate() });
+        await enrollBearer.userAuthenticator.confirm('@me', enrolled.data.id, { code: totp.generate() });
 
         // fresh login WITH the second factor — the session carries mfa_at
         const withOtp = await httpRequest(suite, 'POST', '/token', {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/mfa-login-ticket.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/mfa-login-ticket.spec.ts
@@ -203,9 +203,9 @@ describe('src/http/controllers/token (mfa-pending login ticket)', () => {
             algorithm: 'SHA1',
             digits: 6,
             period: 30,
-            secret: Secret.fromBase32(enrolled.secret!),
+            secret: Secret.fromBase32(enrolled.meta.secret!),
         });
-        await bearer.userAuthenticator.confirm('@me', enrolled.entity.id, { code: totp.generate() });
+        await bearer.userAuthenticator.confirm('@me', enrolled.data.id, { code: totp.generate() });
 
         const rejected = await passwordGrant({ username: user.name, password });
         expect(rejected.status).toEqual(400);
@@ -234,11 +234,11 @@ describe('src/http/controllers/token (mfa-pending login ticket)', () => {
             algorithm: 'SHA1',
             digits: 6,
             period: 30,
-            secret: Secret.fromBase32(enrolled.secret!),
+            secret: Secret.fromBase32(enrolled.meta.secret!),
         });
         // confirm with the PREVIOUS step's code so the verify below can use
         // the current one (each TOTP use advances the persisted step).
-        await bearer.userAuthenticator.confirm('@me', enrolled.entity.id, { code: totp.generate({ timestamp: Date.now() - 30_000 }) });
+        await bearer.userAuthenticator.confirm('@me', enrolled.data.id, { code: totp.generate({ timestamp: Date.now() - 30_000 }) });
 
         const rejected = await passwordGrant({ username: user.name, password });
         const rejectedBody = await rejected.json();

--- a/packages/client-web-kit/src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue
+++ b/packages/client-web-kit/src/components/entities/user-authenticator/AUserAuthenticatorEnroll.vue
@@ -232,16 +232,16 @@ export default defineComponent({
                 // webauthn: run the registration ceremony immediately and
                 // confirm with the attestation (no display).
                 if (kind === UserAuthenticatorKind.WEBAUTHN) {
-                    if (!response.webauthn) {
+                    if (!response.meta.webauthn) {
                         throw new Error('The server did not return WebAuthn registration options.');
                     }
                     // the http-kit response type is intentionally framework-agnostic
                     // (Record<string, unknown>); assert the browser lib's shape here.
-                    const optionsJSON = response.webauthn as unknown as PublicKeyCredentialCreationOptionsJSON;
+                    const optionsJSON = response.meta.webauthn as unknown as PublicKeyCredentialCreationOptionsJSON;
                     const attestation = await startRegistration({ optionsJSON });
                     const entity = await apiClient.userAuthenticator.confirm(
                         props.userId,
-                        response.entity.id,
+                        response.data.id,
                         { code: JSON.stringify(attestation) },
                     );
                     await finishEnrollment(entity, kind);
@@ -251,7 +251,7 @@ export default defineComponent({
                 // email is confirmed on creation and has nothing to display —
                 // just signal completion (via the recovery nudge).
                 if (kind === UserAuthenticatorKind.EMAIL) {
-                    await finishEnrollment(response.entity, kind);
+                    await finishEnrollment(response.data, kind);
                     return;
                 }
 
@@ -260,7 +260,7 @@ export default defineComponent({
 
                 // recovery is confirmed on creation — the codes are shown once
                 if (kind === UserAuthenticatorKind.RECOVERY) {
-                    emit('done', response.entity);
+                    emit('done', response.data);
                 }
             } catch (e) {
                 error.value = extractErrorContext(e).message ?? null;
@@ -280,7 +280,7 @@ export default defineComponent({
             try {
                 const entity = await apiClient.userAuthenticator.confirm(
                     props.userId,
-                    enrollment.value.entity.id,
+                    enrollment.value.data.id,
                     { code: confirmCode.value.trim() },
                 );
                 emit('done', entity);
@@ -294,11 +294,11 @@ export default defineComponent({
         };
 
         const downloadRecoveryCodes = () => {
-            if (typeof window === 'undefined' || !enrollment.value?.codes) {
+            if (typeof window === 'undefined' || !enrollment.value?.meta.codes) {
                 return;
             }
 
-            const blob = new Blob([enrollment.value.codes.join('\n')], { type: 'text/plain' });
+            const blob = new Blob([enrollment.value.meta.codes.join('\n')], { type: 'text/plain' });
             const url = window.URL.createObjectURL(blob);
             const anchor = window.document.createElement('a');
             anchor.href = url;
@@ -403,11 +403,11 @@ export default defineComponent({
                 {{ translations.mfaScanQr }}
             </p>
             <div
-                v-if="enrollment.qr"
+                v-if="enrollment.meta.qr"
                 class="flex justify-center my-3"
             >
                 <img
-                    :src="enrollment.qr"
+                    :src="enrollment.meta.qr"
                     alt="QR"
                     class="max-w-[200px]"
                 >
@@ -416,7 +416,7 @@ export default defineComponent({
                 {{ translations.mfaManualKey }}
             </p>
             <p class="text-center font-mono break-all mb-3">
-                {{ enrollment.secret }}
+                {{ enrollment.meta.secret }}
             </p>
 
             <form @submit.prevent="confirm">
@@ -462,7 +462,7 @@ export default defineComponent({
             <p>{{ translations.mfaRecoveryIntro }}</p>
             <ul class="font-mono my-3 grid grid-cols-2 gap-1">
                 <li
-                    v-for="(code, index) in enrollment.codes"
+                    v-for="(code, index) in enrollment.meta.codes"
                     :key="index"
                 >
                     {{ code }}

--- a/packages/client-web-kit/test/unit/components/entities/user-authenticator-enroll.spec.ts
+++ b/packages/client-web-kit/test/unit/components/entities/user-authenticator-enroll.spec.ts
@@ -24,21 +24,22 @@ function buildHandlers(recoveryTotal: number) {
             const body = (req.body ?? {}) as Record<string, any>;
             if (body.kind === 'recovery') {
                 return {
-                    entity: {
-                        id: 'recovery-1', 
-                        kind: 'recovery', 
-                        confirmed: true, 
+                    data: {
+                        id: 'recovery-1',
+                        kind: 'recovery',
+                        confirmed: true,
                     },
-                    codes: ['aaaa-bbbb', 'cccc-dddd'],
+                    meta: { codes: ['aaaa-bbbb', 'cccc-dddd'] },
                 };
             }
 
             return {
-                entity: {
-                    id: 'email-1', 
-                    kind: 'email', 
-                    confirmed: true, 
-                }, 
+                data: {
+                    id: 'email-1',
+                    kind: 'email',
+                    confirmed: true,
+                },
+                meta: {},
             };
         },
         'GET /users/:id/authenticators': () => ({

--- a/packages/core-http-kit/src/domains/entities/user-authenticator/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user-authenticator/types.ts
@@ -9,7 +9,7 @@ import type { AuthorizationHeader } from 'hapic';
 import type { BuildInput } from 'rapiq';
 import type { User, UserAuthenticator, UserAuthenticatorKind } from '@authup/core-kit';
 import type { OAuth2TokenGrantResponse } from '@authup/specs';
-import type { EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
+import type { EntityCollectionResponse, EntityRecordResponse, EntityRecordWrappedResponse } from '../../types-base';
 
 export type UserAuthenticatorCreatePayload = {
     kind: `${UserAuthenticatorKind}`,
@@ -17,8 +17,11 @@ export type UserAuthenticatorCreatePayload = {
     user_id?: string,
 };
 
-export type UserAuthenticatorEnrollResponse = {
-    entity: UserAuthenticator,
+/**
+ * Shown-once provisioning material riding the enroll response `meta` —
+ * never part of the entity record, never in a subsequent read.
+ */
+export type UserAuthenticatorEnrollResponseMeta = {
     /**
      * TOTP: raw base32 seed — present in this response only.
      */
@@ -41,6 +44,11 @@ export type UserAuthenticatorEnrollResponse = {
      */
     webauthn?: Record<string, unknown>,
 };
+
+export type UserAuthenticatorEnrollResponse = EntityRecordWrappedResponse<
+    UserAuthenticator,
+    UserAuthenticatorEnrollResponseMeta
+>;
 
 export type UserAuthenticatorConfirmPayload = {
     code: string,

--- a/packages/core-http-kit/src/domains/types-base.ts
+++ b/packages/core-http-kit/src/domains/types-base.ts
@@ -10,6 +10,18 @@ import type { RequestBaseOptions, Response } from 'hapic';
 import type { BuildInput } from 'rapiq';
 
 export type EntityRecordResponse<R> = R;
+
+/**
+ * The target wire shape for entity-record responses: the record under
+ * `data`, response-scoped extras under `meta` (mirroring
+ * `EntityCollectionResponse`). Adopted per endpoint — bare-record
+ * responses (`EntityRecordResponse`) converge on this shape over time.
+ */
+export type EntityRecordWrappedResponse<R, M extends Record<string, any> = Record<string, any>> = {
+    data: R,
+    meta: M,
+};
+
 export type EntityCollectionResponse<R> = {
     data: R[],
     meta: {


### PR DESCRIPTION
## Summary

Reshapes the `POST /users/:id/authenticators` enroll response from entity-plus-extra-fields (`{ entity, secret?, uri?, qr?, codes?, webauthn? }`) to a `{ data, meta }` envelope: the enrolled device rides under `data`, the shown-once provisioning material under `meta` — the future response schema for entity record(s).

## Changes

- **@authup/core-http-kit**: new `EntityRecordWrappedResponse<R, M>` in `types-base.ts` (`{ data: R, meta: M }`, mirroring `EntityCollectionResponse`) — the target wire shape entity-record responses converge on, adopted per endpoint. `UserAuthenticatorEnrollResponse` is now `EntityRecordWrappedResponse<UserAuthenticator, UserAuthenticatorEnrollResponseMeta>` with the shown-once material (`secret`, `uri`, `qr`, `codes`, `webauthn`) moved into the meta type.
- **apps/server-core**: `UserAuthenticatorEnrollResult` stays domain-shaped as `{ entity, meta }`; the four `enroll*` return sites (totp, recovery, email, webauthn) nest their material under `meta` (email returns `meta: {}`). The controller stays thin and maps to the `{ data, meta }` wire shape.
- **@authup/client-web-kit**: `AUserAuthenticatorEnroll` reads `response.data` / `response.meta.*` in script and template.
- Tests updated across both layers (service spec asserts `result.meta.*`, HTTP specs assert `data`/`meta`, kit spec fakes return the envelope); `.agents/architecture.md` MFA section documents the new shape.

Breaking for the enroll wire shape / typed client, but the MFA surface has not shipped in a release yet.

## Verification

- Full monorepo build (22 projects incl. the embedded SSR UI bundle), `check:types` on server-core test files, ESLint clean.
- server-core suite: 1709 passed (the two LDAP suites fail in `beforeAll` with `InvalidCredentialsError` against a stale local LDAP container — pre-existing environmental drift, unrelated).
- client-web-kit: 141 passed; core-http-kit: 19 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Updated authenticator enrollment responses to place the enrolled device under `data`.
  * Moved one-time enrollment materials—including TOTP secrets, setup URIs, QR codes, recovery codes, and WebAuthn registration options—under `meta`.
  * Updated the enrollment experience to display TOTP and recovery information and complete WebAuthn setup using the revised response format.
* **Documentation**
  * Clarified the enrollment response structure and provisioning material formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->