### PR TITLE
feat(access): derive preEvaluate from data availability (tri-state policy engine)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -876,8 +876,9 @@ factor, ANDed with the junction's `policyId` policies) by invoking the
 `RealmMatchPolicyEvaluator` in **SCOPE MODE**: a grant's `realmScope` is matched
 against the resource realm supplied under the **`realmMatch` PolicyData key** (a single id,
 `null`, or an array of ids — `realmScopeMatches` requires the scope to reach every listed
-realm). The realm-match call is made **directly** (not via the policy engine — `realmMatch`
-is in `policiesExcluded`) and stays **outside** the `policies[]` merge, so the policy-free
+realm). The realm-match call is made **directly** (not via the policy engine — so it can
+never be skipped by a caller's include/exclude filters or deferred by the engine's
+data-availability gate) and stays **outside** the `policies[]` merge, so the policy-free
 fail-open drop can never touch realm reach. A **realm-less / anonymous** actor can never
 satisfy `own`/`ownOrNull` (only `any`), and the factor neutral-passes when no `realmMatch`
 key is present (`preEvaluate` / gate checks / realm-less resources).
@@ -1156,9 +1157,34 @@ Two-layer rejection:
 1. **Validator** silently strips fields it doesn't mount (e.g. `builtIn`, `realmId` on UPDATE) — these never reach the policy.
 2. **ATTRIBUTE_NAMES policy** rejects validated fields not in the allowlist (e.g. `active` on a client) — produces a `value_invalid` issue and the request fails.
 
-### preEvaluate auto-exclusion
+### preEvaluate is derived from data availability (tri-state, issue #3286)
 
-`preEvaluate` (no input data) automatically skips evaluators that require attributes — `ATTRIBUTES`, `ATTRIBUTE_NAMES`, `REALM_MATCH`. This means binding ATTRIBUTE_NAMES policies to a permission does **not** break gate checks in pre-flight scenarios. The full check happens in the second `evaluate()` call where `validated` data is supplied.
+The policy engine is tri-state: a policy whose declared data requirements
+(`IPolicyEvaluator.requires?(value)` — PolicyData keys, checked by the engine before
+invoking the evaluator) are not satisfied by the current bag returns
+`{ success: false, pending: true }` instead of evaluating against missing data. Built-in
+`requires`: identity → `[IDENTITY]`; attributes / attributeNames → `[ATTRIBUTES]`;
+permissionBinding → `[PERMISSION_BINDING]` (IDENTITY deliberately not declared — a missing
+identity must stay a settled deny so a scope-restricted bearer fails the pre-gate through
+`system.default`); realmMatch → `[IDENTITY]` in scope mode (the `realmMatch` resource key
+stays a neutral-pass discriminator), `[IDENTITY, ATTRIBUTES]` in attribute mode; date/time/
+composite → none. The composite algebra treats pending children as UNKNOWN (never counted,
+never masked to a settled value) and settles despite them only when no resolution could
+change the outcome; `invert` is **never applied to a pending result** — mask-then-negate ≠
+negate-then-mask was the pre-gate inversion bug this replaced. Server-core's
+`PermissionBindingPolicyEvaluator` propagates a pending junction policy as a pending grant
+term (the disjunction settles false only when every term settled).
+
+`preEvaluate` passes `pendingPolicies: 'permit'` (a `PermissionEvaluationOptions` flag,
+default `'deny'`): a grant whose policy tree is pending passes the gate; only a tree that
+settles false with the current bag denies. This replaced the hand-maintained
+`policiesExcluded: [ATTRIBUTES, ATTRIBUTE_NAMES, REALM_MATCH]` list — new policy types
+place themselves via `requires` with zero engine edits. Binding ATTRIBUTE_NAMES policies to
+a permission still does **not** break gate checks (pending → permitted); the full check
+happens in the second `evaluate()` call where `validated` data is supplied (pending ⇒
+`success: false` ⇒ deny, preserving the historical missing-data deny).
+`policiesIncluded`/`policiesExcluded` remain functional for explicit callers (e.g. the
+event service's reach derivation).
 
 ### EA loading on tree roots
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -77,6 +77,29 @@ Do **not** use `peerDependencies` as a blanket "dedup enforcer" on leaves — de
 - Environment variable names use `SCREAMING_SNAKE_CASE` with `_ENABLED` suffix: `REGISTRATION_ENABLED`, `PASSWORD_RECOVERY_ENABLED`, `EMAIL_VERIFICATION_ENABLED`
 - Config file keys (`.conf`) use `camelCase` matching the TypeScript property name
 
+## Upstream (Own) Libraries
+
+Most non-framework dependencies are maintained by the same author (tada5hi) and can be
+changed easily: `rapiq` (`@rapiq/*`), `vuecs` (`@vuecs/*`), `validup` (`@validup/*`),
+`ilingo` (`@ilingo/*`), `routup` (`@routup/*`), `hapic` (`@hapic/*`), `ebec` (`@ebec/*`),
+`typeorm-extension`, `smob`, `locter` — each lives at `github.com/tada5hi/<name>`.
+
+- **When authup work reveals a gap, bug, or awkward API in one of these, open an issue in
+  the upstream repo** (`gh issue create --repo tada5hi/<name>`) describing the authup use
+  case — do NOT silently build an authup-side workaround. Workarounds calcify; upstream
+  changes are cheap here. Precedents: tada5hi/rapiq#790 (TS2590), #800
+  (`assertSchemaMatchesEntity`), #806 (context RFC), #811 (public-IR negation);
+  tada5hi/vuecs#1591 (theme-manager merge), #1601 (generic `VCTable`), #1689 (Reka
+  trigger-label snapshot).
+- **rapiq is experimental** — big breaking changes are still expected and welcome; authup
+  is the driving consumer, so gaps found during authup work should shape rapiq's design
+  now while breakage is cheap.
+- A deliberate authup-side fallback while an upstream issue is open is fine (e.g. keeping
+  `invert: true` policies as post-checks until rapiq#811) — but the issue must exist so
+  the fallback has a removal trigger.
+- When upstream code is consulted, also update the corresponding mapping file under
+  `.agents/references/` (see below).
+
 ## References
 
 External project references live in `.agents/references/` — one Markdown file per external project

--- a/apps/server-core/src/core/security/policy/evaluator.ts
+++ b/apps/server-core/src/core/security/policy/evaluator.ts
@@ -41,6 +41,14 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
         this.identityPermissionProvider = identityPermissionProvider;
     }
 
+    requires() : string[] {
+        // IDENTITY is deliberately NOT declared: a missing identity must stay a
+        // settled DATA_MISSING deny (fail-closed) so a scope-restricted or anonymous
+        // bearer still fails the pre-gate through system.default — pending would be
+        // permitted there.
+        return [BuiltInPolicyType.PERMISSION_BINDING];
+    }
+
     async accessData(ctx: PolicyEvaluationContext) : Promise<PermissionPolicyBindingAggregated | null> {
         if (!ctx.data.has(BuiltInPolicyType.PERMISSION_BINDING)) {
             return null;
@@ -116,13 +124,16 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
         // policy-bound `any` grant's wider reach) and the symmetric OVER-grant (an `own`
         // grant's passing policy must not ride an `any` grant's wider reach).
         const issues : Issue[] = [];
+        const pendingIssues : Issue[] = [];
+        let pending = false;
         for (const grant of aggr.grants) {
             // Realm reach (coarse, actor-relative) — a SEPARATE factor from the grant's
             // policy, ANDed with it. The realm-match evaluator runs in SCOPE MODE: it reads the
             // resource realm from ctx.data[REALM_MATCH] (fallback ATTRIBUTES.realmId) and
             // neutral-passes when absent (preEvaluate / gate checks / realm-less resources) —
-            // key-PRESENCE is the discriminator. Invoked DIRECTLY (not via PolicyEngine —
-            // REALM_MATCH is in policiesExcluded, so the engine would skip it).
+            // key-PRESENCE is the discriminator. Invoked DIRECTLY (not via PolicyEngine) so
+            // the reach factor can never be skipped by a caller's include/exclude filters or
+            // deferred by the engine's data-availability gate.
             const realmOutcome = await this.realmMatchEvaluator.evaluate(
                 { scope: grant.realmScope },
                 ctx,
@@ -152,9 +163,33 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
                 return { success: maybeInvertPolicyOutcome(true, policy.invert) };
             }
 
+            // A PENDING junction policy (required data key absent — e.g. an ATTRIBUTES
+            // policy at the pre-gate) leaves this grant term UNKNOWN, not failed: the
+            // grant could still pass once the data arrives, so it must not settle the
+            // disjunction to false.
+            if (outcome.pending) {
+                pending = true;
+
+                if (outcome.issues) {
+                    pendingIssues.push(...outcome.issues);
+                }
+
+                continue;
+            }
+
             if (outcome.issues) {
                 issues.push(...outcome.issues);
             }
+        }
+
+        // No grant term settled true. If some term is still pending, the disjunction is
+        // pending — deliberately uninverted (unknown stays unknown under negation).
+        if (pending) {
+            return {
+                success: false,
+                pending: true,
+                issues: pendingIssues,
+            };
         }
 
         // No grant term satisfied (reach ∧ policies). Apply `invert` ONCE to the aggregated

--- a/packages/access/src/permission/evaluator/module.ts
+++ b/packages/access/src/permission/evaluator/module.ts
@@ -144,7 +144,15 @@ export class PermissionEvaluator implements IPermissionEvaluator {
                 }),
             );
 
-            if (evaluationResult.success) {
+            // A pending evaluation (missing data keys) is settled by the caller's
+            // phase: the full evaluate denies (fail-closed default), the pre-gate
+            // permits — the enriched-bag evaluate is the backstop.
+            const passed = evaluationResult.success || (
+                options.pendingPolicies === 'permit' &&
+                !!evaluationResult.pending
+            );
+
+            if (passed) {
                 if (decisionStrategy === DecisionStrategy.AFFIRMATIVE) {
                     return;
                 }
@@ -194,15 +202,16 @@ export class PermissionEvaluator implements IPermissionEvaluator {
     // ----------------------------------------------
 
     async preEvaluate(ctx: PermissionEvaluationContext) : Promise<void> {
+        // The pre-gate is DERIVED from data availability (issue #3286): policies whose
+        // required data keys are absent from the bag stay pending and are permitted —
+        // only a tree that settles false with the current bag denies. This replaces the
+        // former hand-maintained type exclusion list (ATTRIBUTES / ATTRIBUTE_NAMES /
+        // REALM_MATCH), whose mask-to-true encoding broke under `invert`.
         return this.evaluate({
             ...ctx,
             options: {
                 ...(ctx.options || {}),
-                policiesExcluded: [
-                    BuiltInPolicyType.ATTRIBUTES,
-                    BuiltInPolicyType.ATTRIBUTE_NAMES,
-                    BuiltInPolicyType.REALM_MATCH,
-                ],
+                pendingPolicies: 'permit',
             },
         });
     }

--- a/packages/access/src/permission/evaluator/types.ts
+++ b/packages/access/src/permission/evaluator/types.ts
@@ -30,6 +30,16 @@ export type PermissionEvaluationOptions = {
     decisionStrategy?: `${DecisionStrategy}`,
     policiesIncluded?: string[],
     policiesExcluded?: string[],
+    /**
+     * How a grant whose policy evaluation is PENDING (a required data key is absent —
+     * see `PolicyEvaluationResult.pending`) is treated:
+     *
+     * - `deny` (default): pending counts as failure — full `evaluate()` semantics,
+     *   matching the historical missing-data deny.
+     * - `permit`: pending counts as pass — the data-availability-derived pre-gate
+     *   (`preEvaluate()`): only a tree that settles false with the current bag denies.
+     */
+    pendingPolicies?: 'deny' | 'permit',
 };
 
 export type PermissionEvaluationContext = {

--- a/packages/access/src/policy/built-in/attribute-names/evaluator.ts
+++ b/packages/access/src/policy/built-in/attribute-names/evaluator.ts
@@ -11,6 +11,7 @@ import type { PolicyIssue } from '../../issue';
 import { PolicyIssueCode, definePolicyIssueItem } from '../../issue';
 import { AttributeNamesPolicyValidator } from './validator';
 import { AttributesPolicyEvaluator } from '../attributes';
+import { BuiltInPolicyType } from '../constants';
 
 export class AttributeNamesPolicyEvaluator implements IPolicyEvaluator {
     protected validator : AttributeNamesPolicyValidator;
@@ -20,6 +21,10 @@ export class AttributeNamesPolicyEvaluator implements IPolicyEvaluator {
     constructor() {
         this.validator = new AttributeNamesPolicyValidator();
         this.attributesEvaluator = new AttributesPolicyEvaluator();
+    }
+
+    requires() : string[] {
+        return [BuiltInPolicyType.ATTRIBUTES];
     }
 
     async evaluate(value: Record<string, any>, ctx: PolicyEvaluationContext): Promise<PolicyEvaluationResult> {

--- a/packages/access/src/policy/built-in/attributes/evaluator.ts
+++ b/packages/access/src/policy/built-in/attributes/evaluator.ts
@@ -27,6 +27,10 @@ export class AttributesPolicyEvaluator<
         this.parser = new MongoFiltersParser();
     }
 
+    requires() : string[] {
+        return [BuiltInPolicyType.ATTRIBUTES];
+    }
+
     async accessData(ctx: PolicyEvaluationContext) : Promise<T | null> {
         if (!ctx.data.has(BuiltInPolicyType.ATTRIBUTES)) {
             return null;

--- a/packages/access/src/policy/built-in/composite/evaluator.ts
+++ b/packages/access/src/policy/built-in/composite/evaluator.ts
@@ -25,12 +25,14 @@ export class CompositePolicyEvaluator implements IPolicyEvaluator {
         const policy = await this.validator.run(value);
 
         let count = 0;
+        let pending = 0;
 
         const decisionStrategy = policy.decisionStrategy ??
             DecisionStrategy.UNANIMOUS;
 
         const engine = new PolicyEngine(ctx.evaluators);
         const issues : PolicyIssue[] = [];
+        const pendingIssues : PolicyIssue[] = [];
 
         for (const childPolicy of policy.children) {
             const path = [
@@ -42,6 +44,23 @@ export class CompositePolicyEvaluator implements IPolicyEvaluator {
                 ...ctx,
                 path,
             });
+
+            // A pending child is UNKNOWN, not a failure: it neither counts nor
+            // early-returns. Masking it to a settled value breaks under negation
+            // (mask-then-negate ≠ negate-then-mask — issue #3286).
+            if (outcome.pending) {
+                pending++;
+
+                if (outcome.issues && outcome.issues.length > 0) {
+                    pendingIssues.push(defineIssueGroup({
+                        message: `The evaluation of child policy ${childPolicy.type} is pending`,
+                        issues: outcome.issues,
+                        path,
+                    }));
+                }
+
+                continue;
+            }
 
             if (outcome.success) {
                 if (decisionStrategy === DecisionStrategy.AFFIRMATIVE) {
@@ -82,7 +101,42 @@ export class CompositePolicyEvaluator implements IPolicyEvaluator {
             }
         }
 
-        if (count > 0) {
+        // Settle the remainder: the composite settles despite pending children only
+        // when no resolution of those children could change the outcome.
+        let settled : boolean | null;
+        switch (decisionStrategy) {
+            case DecisionStrategy.AFFIRMATIVE: {
+                // every settled child failed; any pending child could still succeed
+                settled = pending > 0 ? null : false;
+                break;
+            }
+            case DecisionStrategy.UNANIMOUS: {
+                // every settled child succeeded; any pending child could still fail
+                settled = pending > 0 ? null : count > 0;
+                break;
+            }
+            default: {
+                // CONSENSUS: final outcome is `count > 0`, each pending worth ±1
+                if (count - pending > 0) {
+                    settled = true;
+                } else if (count + pending <= 0) {
+                    settled = false;
+                } else {
+                    settled = null;
+                }
+            }
+        }
+
+        if (settled === null) {
+            // Unknown stays unknown — `invert` is deliberately NOT applied.
+            return {
+                success: false,
+                pending: true,
+                issues: pendingIssues,
+            };
+        }
+
+        if (settled) {
             return { success: maybeInvertPolicyOutcome(true, policy.invert) };
         }
 
@@ -91,7 +145,7 @@ export class CompositePolicyEvaluator implements IPolicyEvaluator {
             success,
             issues: success ? [] : [
                 defineIssueGroup({
-                    message: `The evaluation of composite policy failed (${DecisionStrategy.CONSENSUS})`,
+                    message: `The evaluation of composite policy failed (${decisionStrategy})`,
                     issues: issues || [],
                     path: ctx.path,
                 }),

--- a/packages/access/src/policy/built-in/identity/evaluator.ts
+++ b/packages/access/src/policy/built-in/identity/evaluator.ts
@@ -8,6 +8,7 @@
 import type { IPolicyEvaluator, PolicyEvaluationContext, PolicyEvaluationResult } from '../../evaluation';
 import { PolicyIssueCode, definePolicyIssueItem } from '../../issue';
 import { maybeInvertPolicyOutcome } from '../../helpers';
+import { BuiltInPolicyType } from '../constants';
 import { PolicyIdentityDataValidator } from './data';
 import type { IdentityPolicyData } from './types';
 import { IdentityPolicyValidator } from './validator';
@@ -20,6 +21,10 @@ export class IdentityPolicyEvaluator implements IPolicyEvaluator {
     constructor() {
         this.validator = new IdentityPolicyValidator();
         this.dataValidator = new PolicyIdentityDataValidator();
+    }
+
+    requires() : string[] {
+        return [BuiltInPolicyType.IDENTITY];
     }
 
     async accessData(ctx: PolicyEvaluationContext) : Promise<IdentityPolicyData | null> {

--- a/packages/access/src/policy/built-in/permission-binding/module.ts
+++ b/packages/access/src/policy/built-in/permission-binding/module.ts
@@ -7,6 +7,7 @@
 
 import type { IPolicyEvaluator, PolicyEvaluationResult } from '../../evaluation';
 import { maybeInvertPolicyOutcome } from '../../helpers';
+import { BuiltInPolicyType } from '../constants';
 import { PermissionBindingPolicyValidator } from './validator';
 
 export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
@@ -14,6 +15,12 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
 
     constructor() {
         this.validator = new PermissionBindingPolicyValidator();
+    }
+
+    requires() : string[] {
+        // IDENTITY is deliberately NOT declared: a missing identity must stay a
+        // settled deny (fail-closed), never a pending the pre-gate would permit.
+        return [BuiltInPolicyType.PERMISSION_BINDING];
     }
 
     async evaluate(value: Record<string, any>): Promise<PolicyEvaluationResult> {

--- a/packages/access/src/policy/built-in/realm-match/evaluator.ts
+++ b/packages/access/src/policy/built-in/realm-match/evaluator.ts
@@ -28,6 +28,17 @@ export class RealmMatchPolicyEvaluator implements IPolicyEvaluator {
         this.attributesEvaluator = new AttributesPolicyEvaluator();
     }
 
+    requires(value: Record<string, any>) : string[] {
+        // SCOPE MODE: the resource realm key (REALM_MATCH) is deliberately NOT
+        // required — an absent key is the documented neutral-pass (gate checks /
+        // realm-less resources), so requiring it would wrongly pend those runs.
+        if (value.scope) {
+            return [BuiltInPolicyType.IDENTITY];
+        }
+
+        return [BuiltInPolicyType.IDENTITY, BuiltInPolicyType.ATTRIBUTES];
+    }
+
     async evaluate(value: Record<string, any>, ctx: PolicyEvaluationContext): Promise<PolicyEvaluationResult> {
         // todo: catch errors + transform to issue(s)
         const policy = await this.validator.run(value);

--- a/packages/access/src/policy/engine/module.ts
+++ b/packages/access/src/policy/engine/module.ts
@@ -116,30 +116,30 @@ export class PolicyEngine implements IPolicyEngine {
             };
         }
 
-        // Data-availability gate: a policy whose declared data requirements are not
-        // satisfied yet is PENDING — not true, not false. Like the include/exclude
-        // neutral-pass, `invert` is never applied here (the evaluator is not invoked
-        // at all): unknown stays unknown under negation.
-        if (evaluator.requires) {
-            const missing = evaluator.requires(policy)
-                .filter((key) => !ctx.data || !ctx.data.has(key));
-
-            if (missing.length > 0) {
-                return {
-                    success: false,
-                    pending: true,
-                    issues: [
-                        definePolicyIssueItem({
-                            code: PolicyIssueCode.DATA_MISSING,
-                            message: `The data propert${missing.length > 1 ? 'ies' : 'y'} ${missing.join(', ')} ${missing.length > 1 ? 'are' : 'is'} missing`,
-                            path: ctx.path,
-                        }),
-                    ],
-                };
-            }
-        }
-
         try {
+            // Data-availability gate: a policy whose declared data requirements are not
+            // satisfied yet is PENDING — not true, not false. Like the include/exclude
+            // neutral-pass, `invert` is never applied here (the evaluator is not invoked
+            // at all): unknown stays unknown under negation.
+            if (evaluator.requires) {
+                const missing = evaluator.requires(policy)
+                    .filter((key) => !ctx.data || !ctx.data.has(key));
+
+                if (missing.length > 0) {
+                    return {
+                        success: false,
+                        pending: true,
+                        issues: [
+                            definePolicyIssueItem({
+                                code: PolicyIssueCode.DATA_MISSING,
+                                message: `The data propert${missing.length > 1 ? 'ies' : 'y'} ${missing.join(', ')} ${missing.length > 1 ? 'are' : 'is'} missing`,
+                                path: ctx.path,
+                            }),
+                        ],
+                    };
+                }
+            }
+
             return await evaluator.evaluate(policy, {
                 ...ctx,
                 evaluators: {

--- a/packages/access/src/policy/engine/module.ts
+++ b/packages/access/src/policy/engine/module.ts
@@ -14,6 +14,7 @@ import type {
     PolicyEvaluators,
 } from '../evaluation';
 import type { PolicyIssue } from '../issue';
+import { PolicyIssueCode, definePolicyIssueItem } from '../issue';
 import type { IPolicyEngine } from './types.ts';
 import { PolicyError, isPolicyError } from '../error';
 import type { BasePolicy } from '../types.ts';
@@ -113,6 +114,29 @@ export class PolicyEngine implements IPolicyEngine {
                 success: false,
                 issues,
             };
+        }
+
+        // Data-availability gate: a policy whose declared data requirements are not
+        // satisfied yet is PENDING — not true, not false. Like the include/exclude
+        // neutral-pass, `invert` is never applied here (the evaluator is not invoked
+        // at all): unknown stays unknown under negation.
+        if (evaluator.requires) {
+            const missing = evaluator.requires(policy)
+                .filter((key) => !ctx.data || !ctx.data.has(key));
+
+            if (missing.length > 0) {
+                return {
+                    success: false,
+                    pending: true,
+                    issues: [
+                        definePolicyIssueItem({
+                            code: PolicyIssueCode.DATA_MISSING,
+                            message: `The data propert${missing.length > 1 ? 'ies' : 'y'} ${missing.join(', ')} ${missing.length > 1 ? 'are' : 'is'} missing`,
+                            path: ctx.path,
+                        }),
+                    ],
+                };
+            }
         }
 
         try {

--- a/packages/access/src/policy/evaluation/types.ts
+++ b/packages/access/src/policy/evaluation/types.ts
@@ -12,10 +12,30 @@ export type PolicyEvaluators = Record<string, IPolicyEvaluator>;
 
 export type PolicyEvaluationResult = {
     success: boolean,
+    /**
+     * The policy could not be settled yet — a data key it requires is absent from the
+     * evaluation bag (see {@link IPolicyEvaluator.requires}). Pending always rides on
+     * `success: false` (fail-closed: a consumer that ignores the flag behaves like a
+     * deny); only pre-gate style consumers treat pending as a pass.
+     *
+     * Unknown stays unknown: `invert` is never applied to a pending result.
+     */
+    pending?: boolean,
     issues?: Issue[]
 };
 
 export interface IPolicyEvaluator {
+    /**
+     * PolicyData keys this policy needs before it can settle (e.g. `identity`,
+     * `attributes`). When any returned key is absent from the evaluation bag, the
+     * engine returns a pending result instead of invoking {@link evaluate}.
+     *
+     * Receives the raw (unvalidated) policy configuration, since data needs may be
+     * config-dependent (e.g. realm-match scope vs. attribute mode). Omit the method
+     * (or return an empty array) for policies evaluable with ambient data only.
+     */
+    requires?(value: Record<string, any>): string[];
+
     /**
      * Execute the policy with specific data and a given context.
      */

--- a/packages/access/test/unit/permission/pre-evaluate.spec.ts
+++ b/packages/access/test/unit/permission/pre-evaluate.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DecisionStrategy } from '@authup/kit';
+import type { PermissionPolicyBinding } from '../../../src';
+import {
+    BuiltInPolicyType,
+    PermissionError,
+    PermissionEvaluator,
+    PermissionMemoryProvider,
+    PolicyDefaultEvaluators,
+    PolicyEngine,
+    definePolicyData,
+    definePolicyWithType,
+} from '../../../src';
+
+const identityData = {
+    type: 'user',
+    id: '245e3c5d-5747-4fbd-8554-c33d34780c58',
+    realmId: 'c641912c-21e5-4cb4-84b6-169e2b2bb023',
+};
+
+const attributesPolicy = definePolicyWithType(BuiltInPolicyType.ATTRIBUTES, { query: { name: { $eq: 'admin' } } });
+
+const abilities : PermissionPolicyBinding[] = [
+    {
+        permission: { name: 'user_edit' },
+        policies: [attributesPolicy],
+    },
+    {
+        permission: { name: 'user_view' },
+        policies: [
+            definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['client'] }),
+        ],
+    },
+    {
+        // NOT(attributes AND identity) — the issue #3286 inversion regression.
+        permission: { name: 'user_remove' },
+        policies: [
+            definePolicyWithType(BuiltInPolicyType.COMPOSITE, {
+                invert: true,
+                decisionStrategy: DecisionStrategy.UNANIMOUS,
+                children: [
+                    attributesPolicy,
+                    definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['user'] }),
+                ],
+            }),
+        ],
+    },
+];
+
+const evaluator = new PermissionEvaluator({
+    provider: new PermissionMemoryProvider(abilities),
+    policyEngine: new PolicyEngine(PolicyDefaultEvaluators),
+});
+
+describe('src/permission/evaluator (derived pre-gate)', () => {
+    it('should permit a pending attributes policy at the pre-gate', async () => {
+        await expect(evaluator.preEvaluate({ name: 'user_edit' }))
+            .resolves.toBeUndefined();
+    });
+
+    it('should deny a pending attributes policy on full evaluation', async () => {
+        await expect(evaluator.evaluate({ name: 'user_edit' }))
+            .rejects.toBeInstanceOf(PermissionError);
+    });
+
+    it('should settle an attributes policy once the data is present', async () => {
+        await expect(evaluator.evaluate({
+            name: 'user_edit',
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' } }),
+        })).resolves.toBeUndefined();
+
+        await expect(evaluator.evaluate({
+            name: 'user_edit',
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: { name: 'guest' } }),
+        })).rejects.toBeInstanceOf(PermissionError);
+    });
+
+    it('should deny a settled-false identity policy at the pre-gate', async () => {
+        await expect(evaluator.preEvaluate({
+            name: 'user_view',
+            data: definePolicyData({ [BuiltInPolicyType.IDENTITY]: identityData }),
+        })).rejects.toBeInstanceOf(PermissionError);
+    });
+
+    it('should permit a pending identity policy at the pre-gate', async () => {
+        await expect(evaluator.preEvaluate({ name: 'user_view' }))
+            .resolves.toBeUndefined();
+    });
+
+    // Regression (issue #3286): the former exclusion-list pre-gate masked the
+    // attributes child to `true` and evaluated NOT(identity) — a spurious settled
+    // deny for a satisfying identity. Tri-state keeps the tree pending instead.
+    it('should not spuriously deny an inverted composite at the pre-gate', async () => {
+        await expect(evaluator.preEvaluate({
+            name: 'user_remove',
+            data: definePolicyData({ [BuiltInPolicyType.IDENTITY]: identityData }),
+        })).resolves.toBeUndefined();
+    });
+
+    it('should keep full semantics for the inverted composite', async () => {
+        // NOT(false AND true) => allow
+        await expect(evaluator.evaluate({
+            name: 'user_remove',
+            data: definePolicyData({
+                [BuiltInPolicyType.IDENTITY]: identityData,
+                [BuiltInPolicyType.ATTRIBUTES]: { name: 'guest' },
+            }),
+        })).resolves.toBeUndefined();
+
+        // NOT(true AND true) => deny
+        await expect(evaluator.evaluate({
+            name: 'user_remove',
+            data: definePolicyData({
+                [BuiltInPolicyType.IDENTITY]: identityData,
+                [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' },
+            }),
+        })).rejects.toBeInstanceOf(PermissionError);
+    });
+
+    it('should keep explicit policy exclusion functional', async () => {
+        await expect(evaluator.evaluate({
+            name: 'user_edit',
+            options: { policiesExcluded: [BuiltInPolicyType.ATTRIBUTES] },
+        })).resolves.toBeUndefined();
+    });
+});

--- a/packages/access/test/unit/policy/composite.spec.ts
+++ b/packages/access/test/unit/policy/composite.spec.ts
@@ -1,0 +1,160 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { DecisionStrategy } from '@authup/kit';
+import type { BasePolicy } from '../../../src';
+import {
+    BuiltInPolicyType,
+    PolicyEngine,
+    definePolicyData,
+    definePolicyEvaluationContext,
+    definePolicyWithType,
+} from '../../../src';
+import { PolicyDefaultEvaluators } from '../../../src/policy/constants.ts';
+
+const engine = new PolicyEngine(PolicyDefaultEvaluators);
+
+// settles true: the identity data below is of type `user`.
+const truthy = definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['user'] });
+
+// settles false: the identity data below is not of type `client`.
+const falsy = definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['client'] });
+
+// stays pending: no ATTRIBUTES key in the data bag.
+const pending = definePolicyWithType(BuiltInPolicyType.ATTRIBUTES, { query: { name: { $eq: 'admin' } } });
+
+const context = () => definePolicyEvaluationContext({
+    data: definePolicyData({
+        [BuiltInPolicyType.IDENTITY]: {
+            type: 'user',
+            id: '245e3c5d-5747-4fbd-8554-c33d34780c58',
+            realmId: 'c641912c-21e5-4cb4-84b6-169e2b2bb023',
+        },
+    }),
+});
+
+function composite(
+    decisionStrategy: `${DecisionStrategy}`,
+    children: BasePolicy[],
+    invert?: boolean,
+) {
+    return definePolicyWithType(BuiltInPolicyType.COMPOSITE, {
+        decisionStrategy,
+        children,
+        ...(invert ? { invert } : {}),
+    });
+}
+
+describe('src/policy/composite (tri-state algebra)', () => {
+    describe(DecisionStrategy.AFFIRMATIVE, () => {
+        it('should settle true on a settled-true child despite pendings', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.AFFIRMATIVE, [pending, truthy]),
+                context(),
+            );
+            expect(outcome.success).toBeTruthy();
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        it('should stay pending when no child settled true and one is pending', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.AFFIRMATIVE, [pending, falsy]),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+        });
+
+        it('should settle false when every child settled false', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.AFFIRMATIVE, [falsy, falsy]),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeFalsy();
+        });
+    });
+
+    describe(DecisionStrategy.UNANIMOUS, () => {
+        it('should settle false on a settled-false child despite pendings', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.UNANIMOUS, [pending, falsy]),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        it('should stay pending when every settled child succeeded and one is pending', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.UNANIMOUS, [pending, truthy]),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+        });
+
+        it('should settle true when every child settled true', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.UNANIMOUS, [truthy, truthy]),
+                context(),
+            );
+            expect(outcome.success).toBeTruthy();
+            expect(outcome.pending).toBeFalsy();
+        });
+    });
+
+    describe(DecisionStrategy.CONSENSUS, () => {
+        it('should settle true when pendings cannot flip the balance', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.CONSENSUS, [truthy, truthy, pending]),
+                context(),
+            );
+            expect(outcome.success).toBeTruthy();
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        it('should settle false when pendings cannot flip the balance', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.CONSENSUS, [falsy, falsy, pending]),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        it('should stay pending when the balance straddles zero', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.CONSENSUS, [truthy, falsy, pending]),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+        });
+    });
+
+    describe('invert', () => {
+        it('should never apply invert to a pending composite', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.AFFIRMATIVE, [pending], true),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+        });
+
+        it('should apply invert to a settled composite', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.UNANIMOUS, [truthy], true),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeFalsy();
+        });
+    });
+});

--- a/packages/access/test/unit/policy/engine.spec.ts
+++ b/packages/access/test/unit/policy/engine.spec.ts
@@ -115,6 +115,31 @@ describe('src/policy', () => {
             expect(outcome.pending).toBeFalsy();
         });
 
+        // Infrastructure fail-closed contract: a registered evaluator whose
+        // `requires()` throws must degrade to a structured settled deny —
+        // never an escaped rejection, never a pending result.
+        it('should fail closed when an evaluator requires() throws', async () => {
+            const engine = new PolicyEngine({
+                broken: {
+                    requires() : string[] {
+                        throw new Error('bad requires');
+                    },
+                    async evaluate() {
+                        return { success: true };
+                    },
+                },
+            });
+
+            const outcome = await engine.evaluate(
+                definePolicyWithType('broken', {}),
+                definePolicyEvaluationContext(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeFalsy();
+            expect(outcome.issues).toHaveLength(1);
+            expect(outcome.issues![0].message).toMatch(/bad requires/);
+        });
+
         // The issue #3286 regression: NOT(attributes AND identity) with a satisfying
         // identity and no attributes yet. Masking attributes to true would evaluate
         // NOT(identity) and produce a spurious settled deny — the tree must stay pending.

--- a/packages/access/test/unit/policy/engine.spec.ts
+++ b/packages/access/test/unit/policy/engine.spec.ts
@@ -78,4 +78,84 @@ describe('src/policy', () => {
         outcome = await enforcer.evaluate(compositePolicy, definePolicyEvaluationContext({ data: new PolicyData({ attributes: { name: 'foo' } }) }));
         expect(outcome.success).toBeFalsy();
     });
+
+    describe('data-availability gate (tri-state)', () => {
+        const identityData = {
+            type: 'user',
+            id: '245e3c5d-5747-4fbd-8554-c33d34780c58',
+            realmId: 'c641912c-21e5-4cb4-84b6-169e2b2bb023',
+        };
+
+        it('should return pending when a required data key is absent', async () => {
+            const policy = definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['user'] });
+
+            const outcome = await enforcer.evaluate(policy, definePolicyEvaluationContext());
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+            expect(outcome.issues).toHaveLength(1);
+        });
+
+        it('should not apply invert to a pending result', async () => {
+            const policy = definePolicyWithType(BuiltInPolicyType.IDENTITY, {
+                types: ['user'],
+                invert: true,
+            });
+
+            const outcome = await enforcer.evaluate(policy, definePolicyEvaluationContext());
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+        });
+
+        it('should settle when the required data key is present', async () => {
+            const policy = definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['user'] });
+            const data = new PolicyData({ [BuiltInPolicyType.IDENTITY]: identityData });
+
+            const outcome = await enforcer.evaluate(policy, definePolicyEvaluationContext({ data }));
+            expect(outcome.success).toBeTruthy();
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        // The issue #3286 regression: NOT(attributes AND identity) with a satisfying
+        // identity and no attributes yet. Masking attributes to true would evaluate
+        // NOT(identity) and produce a spurious settled deny — the tree must stay pending.
+        it('should stay pending under inversion instead of settling a masked deny', async () => {
+            const policy = definePolicyWithType(BuiltInPolicyType.COMPOSITE, {
+                invert: true,
+                decisionStrategy: DecisionStrategy.UNANIMOUS,
+                children: [
+                    definePolicyWithType(
+                        BuiltInPolicyType.ATTRIBUTES,
+                        defineAttributesPolicy<User>({ query: { name: { $eq: 'admin' } } }),
+                    ),
+                    definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['user'] }),
+                ],
+            });
+
+            const data = new PolicyData({ [BuiltInPolicyType.IDENTITY]: identityData });
+
+            const outcome = await enforcer.evaluate(policy, definePolicyEvaluationContext({ data }));
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeTruthy();
+
+            // full bag, attributes fail: NOT(false AND true) => allow
+            const allowed = await enforcer.evaluate(policy, definePolicyEvaluationContext({
+                data: new PolicyData({
+                    [BuiltInPolicyType.IDENTITY]: identityData,
+                    [BuiltInPolicyType.ATTRIBUTES]: { name: 'guest' },
+                }),
+            }));
+            expect(allowed.success).toBeTruthy();
+            expect(allowed.pending).toBeFalsy();
+
+            // full bag, attributes match: NOT(true AND true) => deny (settled)
+            const denied = await enforcer.evaluate(policy, definePolicyEvaluationContext({
+                data: new PolicyData({
+                    [BuiltInPolicyType.IDENTITY]: identityData,
+                    [BuiltInPolicyType.ATTRIBUTES]: { name: 'admin' },
+                }),
+            }));
+            expect(denied.success).toBeFalsy();
+            expect(denied.pending).toBeFalsy();
+        });
+    });
 });


### PR DESCRIPTION
## What

Phase 1 of #3286 — the policy engine becomes **tri-state** (`settled(true) | settled(false) | pending`), and `preEvaluate` is derived from data availability instead of a hand-maintained type exclusion list. Public API shapes are unchanged.

### `@authup/access`

- `PolicyEvaluationResult` gains `pending?: boolean`. Pending rides on `success: false` (fail-closed: any consumer that ignores the flag behaves like a deny), so full `evaluate()` needs no change — the historical missing-data deny is preserved with a pending-flavored `DATA_MISSING` issue.
- `IPolicyEvaluator` gains optional `requires?(value)`: the PolicyData keys the policy needs before it can settle. The engine checks it after the include/exclude neutral-pass, before invoking the evaluator; any missing key → pending. Like the neutral-pass, `invert` is never applied to a pending result — unknown stays unknown under negation.
- Built-in `requires`: identity → `IDENTITY`; attributes / attributeNames → `ATTRIBUTES`; permissionBinding → `PERMISSION_BINDING`; realmMatch → `IDENTITY` in scope mode (the `realmMatch` resource key stays the neutral-pass discriminator), `IDENTITY, ATTRIBUTES` in attribute mode; date / time / composite → none.
- Composite algebra: pending children are UNKNOWN — never counted, never masked to a settled value. Sound early returns stand (AFFIRMATIVE settles true on a settled-true child, UNANIMOUS settles false on a settled-false child); the tail settles despite pendings only when no resolution could change the outcome (CONSENSUS: `count − p > 0` / `count + p ≤ 0`); otherwise the composite returns pending, uninverted.
- `PermissionEvaluationOptions` gains `pendingPolicies?: 'deny' | 'permit'` (default `deny`). `preEvaluate` passes `permit` instead of `policiesExcluded: [ATTRIBUTES, ATTRIBUTE_NAMES, REALM_MATCH]` — the gate is now derived: a pending grant tree passes, only a tree that settles false with the current bag denies. `policiesIncluded`/`policiesExcluded` remain functional for explicit callers (e.g. the event service's reach derivation).

### `apps/server-core`

- `PermissionBindingPolicyEvaluator` declares `requires: [PERMISSION_BINDING]` — IDENTITY deliberately NOT declared, so a missing identity stays a settled `DATA_MISSING` deny and a scope-restricted / anonymous bearer still fails the pre-gate through `system.default`.
- Its grant loop propagates a **pending junction (Layer-2) policy as a pending grant term** (the disjunction settles false only when every term settled). Without this, an attributes-bound junction grant would settle to deny at the pre-gate — the Layer-2 counterpart of the behavior-preservation invariant, which the issue's notes only covered for Layer-1. The direct scope-mode realm-match call stays engine-bypassing, so realm reach can never pend or be filtered away.

## The bug this fixes

The old pre-gate masked excluded policy types to `{ success: true }`. Under an odd number of inversions the over-approximation flips to under-approximation: `composite { invert, children: [attributes, identity] }` with a satisfying identity was **spuriously denied** at the pre-gate (`NOT(masked-true AND true)`), even though the full policy `NOT(attributes AND identity)` allows whenever the row's attributes fail. With tri-state, the attributes child stays pending, the composite stays pending, `invert` is skipped, and the gate permits — the enriched-bag `evaluate()` remains the authority.

## Behavior preservation (verified)

- attributes-only grant at pre-gate: old neutral-pass ≡ new pending+permit — same outcome, both layers (Layer-1 binding policies and Layer-2 junction policies).
- `AND(identity, attributes)` at pre-gate: identity-false still denies early; identity-true → pending → permit.
- Full `evaluate` with missing data: denied before (evaluator `DATA_MISSING`), denied now (engine pending, `success: false`).
- Third-party evaluators without `requires`: behave exactly as today.
- Scope-restricted bearer (no identity in bag): still denied at the pre-gate via `system.permission-binding`'s settled identity-missing deny.

## Tests

- `test/unit/policy/engine.spec.ts`: requires-gate (pending on missing key, invert not applied to pending, settles when present) + the #3286 inversion regression at engine level, incl. full-bag assertions that the inverted semantics still settle correctly.
- `test/unit/policy/composite.spec.ts` (new): tri-state algebra matrix across AFFIRMATIVE / UNANIMOUS / CONSENSUS + invert-never-applies-to-pending.
- `test/unit/permission/pre-evaluate.spec.ts` (new): derived pre-gate (pending permits, settled-false denies at the gate, full-evaluate semantics intact, explicit `policiesExcluded` backcompat) + the regression (`preEvaluate` no longer spuriously throws).

Verified: `@authup/access` 114/114; server-core `check:types` clean + full suite 1671/1671 (the 2 failed LDAP suite files are the documented pre-existing stale-container bind failures); client-web-kit 150/150; ESLint clean.

Part of #3286 (phases 2–3 — `lower()` pushdown and service integration — follow separately).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Policy evaluations now distinguish between settled and pending results when required data is unavailable.
  * Added configurable handling for pending policies during pre-evaluation.
  * Composite policies now preserve pending states across decision strategies and inversion.
  * Added structured issues identifying missing evaluation data.

* **Bug Fixes**
  * Prevented incomplete data from producing premature denials or permits.
  * Improved inverted composite policy behavior while required data remains pending.

* **Documentation**
  * Clarified realm matching, pending evaluation, and data availability behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->