### PR TITLE
feat: compile permissions to row conditions for getMany authorization

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1206,10 +1206,30 @@ mode (field = single-string `attributeName`, default `realmId`; under `withCondi
 an absent `realmMatch` resource key PENDS with the condition instead of neutral-passing
 — the resource realm IS the unknown row column for a query builder) and strict
 single-key attribute mode. Anything non-lowerable stays a per-row post-check (fail-safe:
-`toCondition` returning null/throwing just yields a condition-less pending). Phase 3
-(service integration: `compilePermissionPolicy`, replacing manual realm scoping and the
-per-row `evaluate` + `total -= 1` drop loops, include gating via `relations.validate`)
-is still open on #3286.
+`toCondition` returning null/throwing just yields a condition-less pending).
+
+**Permission compile (#3286 phase 3):** `IPermissionEvaluator.compile(ctx)` →
+`allow | deny | { verdict: 'conditional', condition } | post` is the query-build
+counterpart of `evaluate()` — the same walk with `withConditions`, classified. Multiple
+names compile as a disjunction (`evaluateOneOf` semantics): any `allow` short-circuits,
+any non-expressible name degrades the whole result to `post` (partial OR pushdown would
+wrongly exclude rows). The server-core `PermissionBindingPolicyEvaluator` composes the
+grant disjunction under `withConditions`: with no resource realm present the scope-mode
+reach PENDS with its condition over the row's realm column (default field `realmId`)
+instead of neutral-passing — `any` stays unrestricted (policy-free `any` grants settle
+TRUE → compile `allow`, the admin fast path), `none` reaches nothing — and each grant
+term is `and(reachCondition, junctionPolicyCondition)`, OR-composed all-or-nothing.
+`getMany` consumers (`KeyService`, `TrustAnchorService`) run
+`compile({ name: PERMISSION_NAMES })` and: `deny` → append a constant-false condition
+(`inArray('id', [])`, keeps meta shape); `conditional` → `appendQueryConditions` — the
+authorization runs as WHERE, so **pagination and totals stay exact**; `post` → the old
+per-row `evaluate` + `total -= 1` drop loop remains as the sound fallback (and the
+plan-039 force-select discipline still serves exactly that path).
+`FakePermissionEvaluator.compile` defaults to `post` so service tests keep their
+per-row expectations; override via `setCompileResult`. Still open on #3286: migrating
+the remaining drop-loop services (session/event/client/consent/user + attribute
+services — these need the ownership-alternative OR-composition) and include gating via
+`relations.validate`.
 
 ### EA loading on tree roots
 

--- a/apps/server-core/package.json
+++ b/apps/server-core/package.json
@@ -137,6 +137,7 @@
         "@ilingo/validup": "^1.0.1",
         "@ilingo/validup-vue": "^1.0.1",
         "@ilingo/vue": "^6.0.0",
+        "@rapiq/memory": "^2.0.0-beta.6",
         "@tailwindcss/vite": "^4.3.2",
         "@trapi/cli": "^2.0.1",
         "@types/ldapjs": "^3.0.6",

--- a/apps/server-core/src/adapters/http/request/permission/module.ts
+++ b/apps/server-core/src/adapters/http/request/permission/module.ts
@@ -8,6 +8,8 @@
 import { ScopeName } from '@authup/core-kit';
 import type {
     IPermissionEvaluator,
+    PermissionCompileContext,
+    PermissionCompileResult,
     PermissionEvaluationContext,
 } from '@authup/access';
 import { BuiltInPolicyType, PolicyData } from '@authup/access';
@@ -46,7 +48,13 @@ export class RequestPermissionEvaluator implements IPermissionEvaluator {
 
     // --------------------------------------------------------------
 
-    protected extendContext(ctx: PermissionEvaluationContext) {
+    async compile(ctx: PermissionCompileContext) : Promise<PermissionCompileResult> {
+        return this.evaluator.compile(this.extendContext(ctx));
+    }
+
+    // --------------------------------------------------------------
+
+    protected extendContext<T extends PermissionEvaluationContext | PermissionCompileContext>(ctx: T) : T {
         const scopes = useRequestScopes(this.event);
         const identity = useRequestIdentity(this.event);
 

--- a/apps/server-core/src/core/entities/key/service.ts
+++ b/apps/server-core/src/core/entities/key/service.ts
@@ -6,7 +6,7 @@
  */
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
-import { eq } from '@rapiq/core';
+import { eq, inArray } from '@rapiq/core';
 import {
     EntityConflictError,
     EntityNotFoundError,
@@ -85,7 +85,30 @@ export class KeyService extends AbstractEntityService implements IKeyService {
             parsed = appendQueryConditions(parsed, eq('realmId', options.realmId));
         }
 
+        // Compile the read permissions against the knowns (actor identity) into a
+        // row condition (issue #3286 phase 3): the authorization runs as WHERE, so
+        // pagination and totals stay exact. Non-expressible policies fall back to
+        // the per-row post-evaluation below.
+        const compiled = await actor.permissionEvaluator.compile({ name: PERMISSION_NAMES });
+        if (compiled.verdict === 'deny') {
+            // no row can pass — a constant-false condition keeps the meta shape
+            parsed = appendQueryConditions(parsed, inArray('id', []));
+        } else if (compiled.verdict === 'conditional') {
+            parsed = appendQueryConditions(parsed, compiled.condition);
+        }
+
         const { data: entities, meta } = await this.repository.findMany(parsed);
+
+        if (compiled.verdict !== 'post') {
+            for (const entity of entities) {
+                // Belt-and-braces: the read projection never selects private
+                // material, but null it explicitly so no future adapter change
+                // can leak it onto a read surface (cf. authentik CVE-2024-42490).
+                entity.decryptionKey = null;
+            }
+
+            return { data: entities, meta };
+        }
 
         const data: Key[] = [];
         let { total } = meta;
@@ -99,9 +122,6 @@ export class KeyService extends AbstractEntityService implements IKeyService {
                         ...this.resourceRealmMatch(entity),
                     }),
                 });
-                // Belt-and-braces: the read projection never selects private
-                // material, but null it explicitly so no future adapter change
-                // can leak it onto a read surface (cf. authentik CVE-2024-42490).
                 entity.decryptionKey = null;
                 data.push(entity);
             } catch {

--- a/apps/server-core/src/core/entities/trust-anchor/service.ts
+++ b/apps/server-core/src/core/entities/trust-anchor/service.ts
@@ -6,7 +6,7 @@
  */
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
-import { eq } from '@rapiq/core';
+import { eq, inArray } from '@rapiq/core';
 import type { TrustAnchor } from '@authup/core-kit';
 import {
     EntityType,
@@ -71,7 +71,23 @@ export class TrustAnchorService extends AbstractEntityService implements ITrustA
             parsed = appendQueryConditions(parsed, eq('realmId', options.realmId));
         }
 
+        // Compile the read permissions against the knowns (actor identity) into a
+        // row condition (issue #3286 phase 3): the authorization runs as WHERE, so
+        // pagination and totals stay exact. Non-expressible policies fall back to
+        // the per-row post-evaluation below.
+        const compiled = await actor.permissionEvaluator.compile({ name: PERMISSION_NAMES });
+        if (compiled.verdict === 'deny') {
+            // no row can pass — a constant-false condition keeps the meta shape
+            parsed = appendQueryConditions(parsed, inArray('id', []));
+        } else if (compiled.verdict === 'conditional') {
+            parsed = appendQueryConditions(parsed, compiled.condition);
+        }
+
         const { data: entities, meta } = await this.repository.findMany(parsed);
+
+        if (compiled.verdict !== 'post') {
+            return { data: entities, meta };
+        }
 
         const data: TrustAnchor[] = [];
         let { total } = meta;

--- a/apps/server-core/src/core/security/policy/evaluator.ts
+++ b/apps/server-core/src/core/security/policy/evaluator.ts
@@ -5,6 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { ICondition } from '@rapiq/core';
+import { and, or } from '@rapiq/core';
 import type { Issue } from 'validup';
 import type {
     IPolicyEvaluator,
@@ -19,9 +21,11 @@ import {
     PolicyEngine,
     PolicyIssueCode,
     RealmMatchPolicyEvaluator,
+    RealmScope,
     aggregatePermissionPolicyBindings,
     definePolicyIssueItem,
     maybeInvertPolicyOutcome,
+    normalizeRealmScope,
 } from '@authup/access';
 import type { IIdentityPermissionProvider } from '../../identity/permission/types.ts';
 
@@ -125,7 +129,9 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
         // grant's passing policy must not ride an `any` grant's wider reach).
         const issues : Issue[] = [];
         const pendingIssues : Issue[] = [];
+        const conditions : ICondition[] = [];
         let pending = false;
+        let lowerable = true;
         for (const grant of aggr.grants) {
             // Realm reach (coarse, actor-relative) — a SEPARATE factor from the grant's
             // policy, ANDed with it. The realm-match evaluator runs in SCOPE MODE: it reads the
@@ -134,17 +140,45 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
             // key-PRESENCE is the discriminator. Invoked DIRECTLY (not via PolicyEngine) so
             // the reach factor can never be skipped by a caller's include/exclude filters or
             // deferred by the engine's data-availability gate.
+            //
+            // Under `withConditions` (query-build) with no resource realm present, the
+            // reach PENDS with its condition form over the row's realm column instead of
+            // neutral-passing — `any` stays unrestricted and `none` reaches nothing, so
+            // neither pollutes the composed WHERE with constant terms.
+            let reachCondition : ICondition | null = null;
             const realmOutcome = await this.realmMatchEvaluator.evaluate(
                 { scope: grant.realmScope },
                 ctx,
             );
-            if (!realmOutcome.success) {
+            if (realmOutcome.pending) {
+                const scope = normalizeRealmScope(grant.realmScope);
+                if (scope === RealmScope.NONE) {
+                    continue;
+                }
+
+                if (scope !== RealmScope.ANY) {
+                    if (!realmOutcome.condition) {
+                        pending = true;
+                        lowerable = false;
+                        continue;
+                    }
+
+                    reachCondition = realmOutcome.condition;
+                }
+            } else if (!realmOutcome.success) {
                 continue;
             }
 
             if (!grant.policy) {
-                // Reach matches and this grant carries no further restriction.
-                return { success: maybeInvertPolicyOutcome(true, policy.invert) };
+                if (!reachCondition) {
+                    // Reach matches and this grant carries no further restriction.
+                    return { success: maybeInvertPolicyOutcome(true, policy.invert) };
+                }
+
+                // Reach is the grant's only restriction — a pure condition term.
+                conditions.push(reachCondition);
+                pending = true;
+                continue;
             }
 
             // Missing evaluators is a misconfiguration: let the engine fail CLOSED with a
@@ -160,7 +194,13 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
             });
 
             if (outcome.success) {
-                return { success: maybeInvertPolicyOutcome(true, policy.invert) };
+                if (!reachCondition) {
+                    return { success: maybeInvertPolicyOutcome(true, policy.invert) };
+                }
+
+                conditions.push(reachCondition);
+                pending = true;
+                continue;
             }
 
             // A PENDING junction policy (required data key absent — e.g. an ATTRIBUTES
@@ -169,6 +209,16 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
             // disjunction to false.
             if (outcome.pending) {
                 pending = true;
+
+                if (ctx.withConditions && outcome.condition) {
+                    conditions.push(
+                        reachCondition ?
+                            and(reachCondition, outcome.condition) :
+                            outcome.condition,
+                    );
+                } else {
+                    lowerable = false;
+                }
 
                 if (outcome.issues) {
                     pendingIssues.push(...outcome.issues);
@@ -183,13 +233,24 @@ export class PermissionBindingPolicyEvaluator implements IPolicyEvaluator {
         }
 
         // No grant term settled true. If some term is still pending, the disjunction is
-        // pending — deliberately uninverted (unknown stays unknown under negation).
+        // pending — deliberately uninverted (unknown stays unknown under negation). The
+        // condition form composes the grant terms as a disjunction, all-or-nothing: a
+        // single non-expressible grant term makes the whole binding non-expressible
+        // (pushing a partial OR would wrongly exclude rows).
         if (pending) {
-            return {
+            const result : PolicyEvaluationResult = {
                 success: false,
                 pending: true,
                 issues: pendingIssues,
             };
+
+            if (ctx.withConditions && lowerable && conditions.length > 0) {
+                result.condition = conditions.length === 1 ?
+                    conditions[0]! :
+                    or(...conditions);
+            }
+
+            return result;
         }
 
         // No grant term satisfied (reach ∧ policies). Apply `invert` ONCE to the aggregated

--- a/apps/server-core/test/unit/core/entities/key/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/key/service.spec.ts
@@ -19,11 +19,14 @@ import {
 import { ErrorCode, isAuthupError } from '@authup/errors';
 import { AsymmetricKey, createAsymmetricKeyPair } from '@authup/server-kit';
 import { JWKType, JWKUse, JWTAlgorithm } from '@authup/specs';
+import { eq } from '@rapiq/core';
+import { applyQuery } from '@rapiq/memory';
 import {
     beforeEach,
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import {
     createAllowAllActor,
@@ -99,6 +102,61 @@ describe('core/entities/key/service', () => {
             const result = await service.getMany({}, actor);
             expect(result.data).toHaveLength(1);
             expect(result.meta.total).toEqual(1);
+        });
+
+        it('pushes a compiled conditional into the row query and skips per-row evaluation', async () => {
+            const realmA = randomUUID();
+            const rows = [buildKey({ realmId: realmA }), buildKey()];
+            repository.seed(rows);
+
+            const spy = vi.spyOn(repository, 'findMany');
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', realmA),
+            });
+
+            await service.getMany({}, actor);
+
+            // the fake repository does not apply filters — assert the QUERY carries
+            // the compiled condition by replaying it over the seeded rows
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, rows);
+            expect(applied.data).toHaveLength(1);
+            expect(applied.data[0]!.realmId).toEqual(realmA);
+
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
+        });
+
+        it('keeps rows and totals untouched on a compiled allow', async () => {
+            repository.seed([buildKey(), buildKey()]);
+
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setCompileResult({ verdict: 'allow' });
+
+            const result = await service.getMany({}, actor);
+            expect(result.data).toHaveLength(2);
+            expect(result.meta.total).toEqual(2);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
+            for (const entity of result.data) {
+                expect(entity.decryptionKey).toBeNull();
+            }
+        });
+
+        it('matches no row on a compiled deny', async () => {
+            const rows = [buildKey(), buildKey()];
+            repository.seed(rows);
+
+            const spy = vi.spyOn(repository, 'findMany');
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setCompileResult({ verdict: 'deny' });
+
+            await service.getMany({}, actor);
+
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, rows);
+            expect(applied.data).toHaveLength(0);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
     });
 

--- a/apps/server-core/test/unit/core/security/permission-binding-evaluator.spec.ts
+++ b/apps/server-core/test/unit/core/security/permission-binding-evaluator.spec.ts
@@ -13,6 +13,8 @@ import {
     RealmScope,
     definePolicyEvaluationContext,
 } from '@authup/access';
+import type { IFilter, IFilters } from '@rapiq/core';
+import { compileFilters } from '@rapiq/memory';
 import { describe, expect, it } from 'vitest';
 import { PermissionBindingPolicyEvaluator } from '../../../../src/core/security/policy/evaluator.ts';
 import { FakeIdentityPermissionProvider } from '../helpers/index.ts';
@@ -50,12 +52,14 @@ describe('core/security/policy — PermissionBindingPolicyEvaluator disjunction 
         bindings: PermissionPolicyBinding[],
         resourceRealm?: string | null,
         withResourceRealm?: boolean,
+        withConditions?: boolean,
     };
 
     const run = ({
-        bindings, 
-        resourceRealm, 
-        withResourceRealm = true, 
+        bindings,
+        resourceRealm,
+        withResourceRealm = true,
+        withConditions = false,
     }: RunOptions) => {
         const provider = new FakeIdentityPermissionProvider();
         provider.setBindings(bindings);
@@ -74,6 +78,7 @@ describe('core/security/policy — PermissionBindingPolicyEvaluator disjunction 
             definePolicyEvaluationContext({
                 data: new PolicyData(data),
                 evaluators: PolicyDefaultEvaluators,
+                withConditions,
             }),
         );
     };
@@ -169,6 +174,144 @@ describe('core/security/policy — PermissionBindingPolicyEvaluator disjunction 
         it('denies when the actor holds no matching grant', async () => {
             const outcome = await run({ bindings: [], resourceRealm: REALM_A });
             expect(outcome.success).toBe(false);
+        });
+    });
+
+    // Query-build lowering (#3286 phase 3): with `withConditions` and no resource
+    // realm, the grant disjunction composes into a rapiq condition over the row's
+    // realm column instead of neutral-passing. Semantic parity is asserted by
+    // compiling the condition with @rapiq/memory and testing rows.
+    describe('withConditions (compile lowering)', () => {
+        const rows = [
+            { realmId: REALM_A },
+            { realmId: REALM_B },
+            { realmId: null },
+        ];
+
+        const predicateOf = (outcome: Awaited<ReturnType<typeof run>>) => {
+            expect(outcome.pending).toBe(true);
+            expect(outcome.condition).toBeDefined();
+            return compileFilters(outcome.condition as IFilter | IFilters, { caseSensitive: true });
+        };
+
+        it('lowers a policy-free own grant to the realm condition', async () => {
+            const outcome = await run({
+                bindings: [grant(RealmScope.OWN)],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            const predicate = predicateOf(outcome);
+            expect(rows.map(predicate)).toEqual([true, false, false]);
+        });
+
+        it('lowers a policy-free ownOrNull grant including null resources', async () => {
+            const outcome = await run({
+                bindings: [grant(RealmScope.OWN_OR_NULL)],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            const predicate = predicateOf(outcome);
+            expect(rows.map(predicate)).toEqual([true, false, true]);
+        });
+
+        it('settles TRUE for a policy-free any grant (no pointless condition)', async () => {
+            const outcome = await run({
+                bindings: [grant(RealmScope.ANY)],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            expect(outcome.success).toBe(true);
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        it('settles FALSE for a none grant', async () => {
+            const outcome = await run({
+                bindings: [grant(RealmScope.NONE)],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            expect(outcome.success).toBe(false);
+            expect(outcome.pending).toBeFalsy();
+        });
+
+        it('ANDs the reach with a lowerable junction policy', async () => {
+            const attributesPolicy = {
+                type: BuiltInPolicyType.ATTRIBUTES,
+                query: { name: { $eq: 'admin' } },
+            };
+            const outcome = await run({
+                bindings: [grant(RealmScope.OWN, [attributesPolicy])],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            const predicate = predicateOf(outcome);
+            expect(predicate({ realmId: REALM_A, name: 'admin' })).toBe(true);
+            expect(predicate({ realmId: REALM_A, name: 'guest' })).toBe(false);
+            expect(predicate({ realmId: REALM_B, name: 'admin' })).toBe(false);
+        });
+
+        it('ORs grant terms and keeps each policy paired with its own reach', async () => {
+            const attributesPolicy = {
+                type: BuiltInPolicyType.ATTRIBUTES,
+                query: { name: { $eq: 'admin' } },
+            };
+            const outcome = await run({
+                bindings: [
+                    grant(RealmScope.OWN),
+                    grant(RealmScope.ANY, [attributesPolicy]),
+                ],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            const predicate = predicateOf(outcome);
+            // own realm: reachable policy-free
+            expect(predicate({ realmId: REALM_A, name: 'guest' })).toBe(true);
+            // foreign realm: only via the any grant, whose policy must match
+            expect(predicate({ realmId: REALM_B, name: 'admin' })).toBe(true);
+            expect(predicate({ realmId: REALM_B, name: 'guest' })).toBe(false);
+        });
+
+        it('stays pending without a condition for a non-expressible junction policy', async () => {
+            const attributeNamesPolicy = {
+                type: BuiltInPolicyType.ATTRIBUTE_NAMES,
+                names: ['name'],
+            };
+            const outcome = await run({
+                bindings: [grant(RealmScope.OWN, [attributeNamesPolicy])],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            expect(outcome.success).toBe(false);
+            expect(outcome.pending).toBe(true);
+            expect(outcome.condition).toBeUndefined();
+        });
+
+        it('settles TRUE when a settled-true policy rides an any reach', async () => {
+            const outcome = await run({
+                bindings: [grant(RealmScope.ANY, [passingPolicy])],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            expect(outcome.success).toBe(true);
+        });
+
+        it('lowers a settled-true policy on an own reach to the reach condition', async () => {
+            const outcome = await run({
+                bindings: [grant(RealmScope.OWN, [passingPolicy])],
+                withResourceRealm: false,
+                withConditions: true,
+            });
+
+            const predicate = predicateOf(outcome);
+            expect(rows.map(predicate)).toEqual([true, false, false]);
         });
     });
 });

--- a/docs/src/sdks/javascript/access/permission-checker.md
+++ b/docs/src/sdks/javascript/access/permission-checker.md
@@ -106,3 +106,33 @@ at the gate.
 
 `evaluateOneOf` / `preEvaluateOneOf` are variants that pass when **any** of the given
 permission names passes (affirmative decision strategy).
+
+## Compile
+
+`compile` is the **query-build** counterpart of `evaluate`: instead of deciding a
+single access request, it expresses the permission's restrictions as a condition over
+row attributes (a rapiq `ICondition`), so list endpoints can enforce authorization in
+the database query itself — keeping pagination and totals exact.
+
+```typescript
+const result = await evaluator.compile({ name: 'user_update' });
+
+switch (result.verdict) {
+    case 'allow':        // no restriction — every row passes
+        break;
+    case 'deny':         // no row can pass
+        break;
+    case 'conditional':  // push result.condition into the row query (WHERE)
+        break;
+    case 'post':         // not expressible — load rows and evaluate() per row
+        break;
+}
+```
+
+Multiple names compile as a disjunction (`evaluateOneOf` semantics): any unrestricted
+name yields `allow`, and a single non-expressible name degrades the whole result to
+`post` — pushing only part of a disjunction would wrongly exclude rows.
+
+A `conditional` result is **exact**: a row satisfies the condition if and only if a
+full `evaluate()` with that row's attributes would pass. When it cannot be guaranteed,
+`compile` returns `post` instead — falling back to per-row evaluation is always sound.

--- a/package-lock.json
+++ b/package-lock.json
@@ -392,6 +392,7 @@
                 "@ilingo/validup": "^1.0.1",
                 "@ilingo/validup-vue": "^1.0.1",
                 "@ilingo/vue": "^6.0.0",
+                "@rapiq/memory": "^2.0.0-beta.6",
                 "@tailwindcss/vite": "^4.3.2",
                 "@trapi/cli": "^2.0.1",
                 "@types/ldapjs": "^3.0.6",

--- a/packages/access/src/permission/evaluator/module.ts
+++ b/packages/access/src/permission/evaluator/module.ts
@@ -5,6 +5,8 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import type { ICondition } from '@rapiq/core';
+import { or } from '@rapiq/core';
 import { ErrorCode } from '@authup/errors';
 import type { Issue } from 'validup';
 import { defineIssueItem } from 'validup';
@@ -22,7 +24,13 @@ import { PermissionError } from '../error';
 import type { IPermissionProvider } from '../provider';
 
 import type { PermissionPolicyBindingAggregated } from '../types.ts';
-import type { IPermissionEvaluator, PermissionEvaluationContext, PermissionEvaluatorOptions } from './types.ts';
+import type {
+    IPermissionEvaluator,
+    PermissionCompileContext,
+    PermissionCompileResult,
+    PermissionEvaluationContext,
+    PermissionEvaluatorOptions,
+} from './types.ts';
 
 export class PermissionEvaluator implements IPermissionEvaluator {
     protected provider : IPermissionProvider;
@@ -224,5 +232,91 @@ export class PermissionEvaluator implements IPermissionEvaluator {
                 decisionStrategy: DecisionStrategy.AFFIRMATIVE,
             },
         });
+    }
+
+    // ----------------------------------------------
+
+    /**
+     * Compile the permission's policy trees against the knowns bag into a
+     * {@link PermissionCompileResult} — the query-build counterpart of
+     * {@link evaluate} (issue #3286 phase 3). Runs the SAME evaluation walk with
+     * `withConditions` enabled: policies that settle with the knowns settle here,
+     * pending subtrees contribute their exact condition form. Multiple names are
+     * a disjunction (any-of), so a single non-expressible name degrades the whole
+     * compilation to `post` — pushing only some disjuncts would wrongly exclude
+     * rows another name would admit.
+     */
+    async compile(ctx: PermissionCompileContext) : Promise<PermissionCompileResult> {
+        const names = Array.isArray(ctx.name) ? ctx.name : [ctx.name];
+
+        const dataBase = ctx.data || new PolicyData();
+
+        const conditions : ICondition[] = [];
+        let post = false;
+
+        for (const name of names) {
+            const binding = await this.findOne(name, {
+                realmId: ctx.realmId,
+                clientId: ctx.clientId,
+            });
+            if (!binding) {
+                // unresolvable permission — a settled-false disjunct, drops out
+                continue;
+            }
+
+            const grantPolicies = binding.grants
+                .map((grant) => grant.policy)
+                .filter((grantPolicy): grantPolicy is BasePolicy => !!grantPolicy);
+
+            if (grantPolicies.length < binding.grants.length) {
+                // some grant is policy-free => unrestricted
+                return { verdict: 'allow' };
+            }
+
+            const data = dataBase.clone();
+            data.set(BuiltInPolicyType.PERMISSION_BINDING, binding);
+
+            const compositePolicy : CompositePolicy = {
+                type: BuiltInPolicyType.COMPOSITE,
+                decisionStrategy: DecisionStrategy.AFFIRMATIVE,
+                children: grantPolicies,
+            };
+
+            const evaluationResult = await this.policyEngine.evaluate(
+                compositePolicy,
+                definePolicyEvaluationContext({
+                    data,
+                    withConditions: true,
+                }),
+            );
+
+            if (evaluationResult.success) {
+                return { verdict: 'allow' };
+            }
+
+            if (evaluationResult.pending) {
+                if (evaluationResult.condition) {
+                    conditions.push(evaluationResult.condition);
+                } else {
+                    post = true;
+                }
+            }
+            // settled false — the disjunct drops out
+        }
+
+        if (post) {
+            return { verdict: 'post' };
+        }
+
+        if (conditions.length === 0) {
+            return { verdict: 'deny' };
+        }
+
+        if (conditions.length === 1) {
+            const [condition] = conditions;
+            return { verdict: 'conditional', condition: condition! };
+        }
+
+        return { verdict: 'conditional', condition: or(...conditions) };
     }
 }

--- a/packages/access/src/permission/evaluator/types.ts
+++ b/packages/access/src/permission/evaluator/types.ts
@@ -5,6 +5,7 @@
  *  view the LICENSE file that was distributed with this source code.
  */
 
+import type { ICondition } from '@rapiq/core';
 import type { DecisionStrategy } from '@authup/kit';
 import type { IPolicyEngine, PolicyData } from '../../policy';
 import type { IPermissionProvider } from '../provider';
@@ -17,6 +18,8 @@ export interface IPermissionEvaluator {
     preEvaluate(ctx: PermissionEvaluationContext): Promise<void>;
 
     preEvaluateOneOf(ctx: PermissionEvaluationContext): Promise<void>;
+
+    compile(ctx: PermissionCompileContext): Promise<PermissionCompileResult>;
 }
 
 export type PermissionEvaluatorOptions = {
@@ -49,3 +52,35 @@ export type PermissionEvaluationContext = {
     data?: PolicyData,
     options?: PermissionEvaluationOptions
 };
+
+export type PermissionCompileContext = {
+    /**
+     * Permission name(s). Several names compile as a disjunction — the row is
+     * readable when ANY of them passes (`evaluateOneOf` semantics).
+     */
+    name: string | string[],
+    realmId?: string | null,
+    clientId?: string | null,
+    /**
+     * The knowns bag (typically the actor identity). Row-dependent keys
+     * (`attributes`, `realmMatch`) are deliberately absent — they are what the
+     * compiled condition ranges over.
+     */
+    data?: PolicyData,
+};
+
+/**
+ * Outcome of compiling a permission's policy trees against the knowns bag
+ * (issue #3286 phase 3) — the query-build counterpart of `evaluate()`:
+ *
+ * - `allow` — settled true for every row; no restriction needed.
+ * - `deny` — settled false for every row; no row can pass.
+ * - `conditional` — the EXACT residual as a rapiq condition over row attributes:
+ *   push it into the row query (WHERE) and skip per-row post-evaluation.
+ * - `post` — some pending policy is not expressible as a condition; fall back to
+ *   loading rows and evaluating per row (always sound).
+ */
+export type PermissionCompileResult = { verdict: 'allow' } |
+    { verdict: 'deny' } |
+    { verdict: 'conditional', condition: ICondition } |
+    { verdict: 'post' };

--- a/packages/access/test/unit/permission/compile.spec.ts
+++ b/packages/access/test/unit/permission/compile.spec.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { ICondition, IFilter, IFilters } from '@rapiq/core';
+import { compileFilters } from '@rapiq/memory';
+import type { PermissionPolicyBinding } from '../../../src';
+import {
+    BuiltInPolicyType,
+    PermissionEvaluator,
+    PermissionMemoryProvider,
+    PolicyDefaultEvaluators,
+    PolicyEngine,
+    definePolicyData,
+    definePolicyWithType,
+} from '../../../src';
+
+const identityData = {
+    type: 'user',
+    id: '245e3c5d-5747-4fbd-8554-c33d34780c58',
+    realmId: 'c641912c-21e5-4cb4-84b6-169e2b2bb023',
+};
+
+const abilities : PermissionPolicyBinding[] = [
+    { permission: { name: 'user_create' } },
+    {
+        permission: { name: 'user_edit' },
+        policies: [
+            definePolicyWithType(BuiltInPolicyType.ATTRIBUTES, { query: { name: { $eq: 'admin' } } }),
+        ],
+    },
+    {
+        permission: { name: 'user_update' },
+        policies: [
+            definePolicyWithType(BuiltInPolicyType.ATTRIBUTE_NAMES, { names: ['name'] }),
+        ],
+    },
+    {
+        permission: { name: 'user_view' },
+        policies: [
+            definePolicyWithType(BuiltInPolicyType.IDENTITY, { types: ['client'] }),
+        ],
+    },
+];
+
+const evaluator = new PermissionEvaluator({
+    provider: new PermissionMemoryProvider(abilities),
+    policyEngine: new PolicyEngine(PolicyDefaultEvaluators),
+});
+
+const test = (condition: ICondition) => compileFilters(condition as IFilter | IFilters, { caseSensitive: true });
+
+describe('src/permission/evaluator (compile)', () => {
+    it('should compile an unrestricted permission to allow', async () => {
+        const result = await evaluator.compile({ name: 'user_create' });
+        expect(result.verdict).toEqual('allow');
+    });
+
+    it('should compile a lowerable policy to a conditional', async () => {
+        const result = await evaluator.compile({ name: 'user_edit' });
+        expect(result.verdict).toEqual('conditional');
+
+        if (result.verdict === 'conditional') {
+            const predicate = test(result.condition);
+            expect(predicate({ name: 'admin' })).toBeTruthy();
+            expect(predicate({ name: 'guest' })).toBeFalsy();
+        }
+    });
+
+    it('should short-circuit to allow when any name is unrestricted', async () => {
+        const result = await evaluator.compile({ name: ['user_edit', 'user_create'] });
+        expect(result.verdict).toEqual('allow');
+    });
+
+    it('should degrade to post when any name is not expressible', async () => {
+        const result = await evaluator.compile({ name: ['user_edit', 'user_update'] });
+        expect(result.verdict).toEqual('post');
+    });
+
+    it('should compile an unresolvable permission to deny', async () => {
+        const result = await evaluator.compile({ name: 'unknown' });
+        expect(result.verdict).toEqual('deny');
+    });
+
+    it('should compile a settled-false policy to deny', async () => {
+        const result = await evaluator.compile({
+            name: 'user_view',
+            data: definePolicyData({ [BuiltInPolicyType.IDENTITY]: identityData }),
+        });
+        expect(result.verdict).toEqual('deny');
+    });
+
+    it('should drop settled-false names from the disjunction', async () => {
+        const result = await evaluator.compile({
+            name: ['user_edit', 'user_view'],
+            data: definePolicyData({ [BuiltInPolicyType.IDENTITY]: identityData }),
+        });
+        expect(result.verdict).toEqual('conditional');
+    });
+
+    it('should degrade to post when a pending policy carries no condition', async () => {
+        // identity policy without identity data: pending, not expressible
+        const result = await evaluator.compile({ name: 'user_view' });
+        expect(result.verdict).toEqual('post');
+    });
+});

--- a/packages/server-test-kit/src/fake-permission-evaluator.ts
+++ b/packages/server-test-kit/src/fake-permission-evaluator.ts
@@ -5,7 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { IPermissionEvaluator, PermissionEvaluationContext } from '@authup/access';
+import type {
+    IPermissionEvaluator,
+    PermissionCompileContext,
+    PermissionCompileResult,
+    PermissionEvaluationContext,
+} from '@authup/access';
 import { PermissionError } from '@authup/access';
 
 export type EvaluatorMethodName = 'evaluate' | 'evaluateOneOf' | 'preEvaluate' | 'preEvaluateOneOf';
@@ -25,6 +30,10 @@ export class FakePermissionEvaluator implements IPermissionEvaluator {
     public preEvaluateCalls: PermissionEvaluationContext[] = [];
 
     public preEvaluateOneOfCalls: PermissionEvaluationContext[] = [];
+
+    public compileCalls: PermissionCompileContext[] = [];
+
+    private compileResult: PermissionCompileResult = { verdict: 'post' };
 
     private behavior: EvaluatorBehavior;
 
@@ -50,6 +59,20 @@ export class FakePermissionEvaluator implements IPermissionEvaluator {
     async preEvaluateOneOf(ctx: PermissionEvaluationContext): Promise<void> {
         this.preEvaluateOneOfCalls.push(ctx);
         await this.behavior({ method: 'preEvaluateOneOf', ctx });
+    }
+
+    /**
+     * Defaults to `post` — services then take their per-row evaluation path, so
+     * existing service tests keep asserting the `evaluate` calls they set up.
+     * Override per test via {@link setCompileResult}.
+     */
+    async compile(ctx: PermissionCompileContext): Promise<PermissionCompileResult> {
+        this.compileCalls.push(ctx);
+        return this.compileResult;
+    }
+
+    setCompileResult(result: PermissionCompileResult) {
+        this.compileResult = result;
     }
 
     setBehavior(behavior: EvaluatorBehavior) {


### PR DESCRIPTION
## What

First slice of #3286 phase 3 — permission authorization compiled into the row query. Builds on the tri-state engine (#3290) and condition lowering (#3291).

### `@authup/access`

- `IPermissionEvaluator.compile(ctx) => PermissionCompileResult` — the query-build counterpart of `evaluate()`. Runs the SAME evaluation walk with `withConditions` and classifies the outcome:
  - `allow` — settled true for every row (no restriction),
  - `deny` — settled false for every row,
  - `conditional` — the EXACT residual as a rapiq `ICondition` over row attributes,
  - `post` — not expressible; per-row evaluation remains the sound fallback.
- Multiple names compile as a disjunction (`evaluateOneOf` semantics): any `allow` short-circuits; any non-expressible name degrades the whole result to `post` — pushing part of a disjunction would wrongly exclude rows another name would admit.

### `apps/server-core`

- `PermissionBindingPolicyEvaluator` composes the grant disjunction under `withConditions`: with no resource realm in the bag, the scope-mode reach **pends with its condition** over the row's realm column (default field `realmId`) instead of neutral-passing. `any` stays unrestricted — a policy-free `any` grant settles TRUE, so an admin compiles to `allow` with zero WHERE overhead; `none` reaches nothing. Each grant term is `and(reachCondition, junctionPolicyCondition)`, OR-composed **all-or-nothing** (one non-expressible grant makes the binding non-expressible). The non-`withConditions` paths are byte-identical in behavior.
- `KeyService.getMany` / `TrustAnchorService.getMany` consume the verdict: `conditional` → `appendQueryConditions` (authorization runs as WHERE — **pagination and totals are now exact** for realm-scoped readers); `deny` → constant-false condition (keeps the meta shape); `post` → the existing per-row `evaluate` + `total -= 1` loop stays as fallback (and the plan-039 force-select discipline keeps serving exactly that path).
- `RequestPermissionEvaluator.compile` forwards with the request-scoped identity enrichment. A non-global-scope bearer has no identity in the bag → `system.identity` pends without a condition → `post` → the per-row path denies as today (fail-safe).

### `@authup/server-test-kit`

- `FakePermissionEvaluator.compile` records calls and defaults to `post`, so existing service tests keep asserting their per-row `evaluate` expectations; override per test via `setCompileResult`.

## The bug class this retires (for the converted services)

The per-row drop loops silently corrupted pagination: a page of 20 with 15 forbidden rows returned 5 items and a wrong total, with page boundaries drifting per reader. For key/trust-anchor reads the realm reach + junction policies now filter in SQL, so a `realm_admin` gets correctly paged, correctly counted results.

## Tests

- `packages/access/test/unit/permission/compile.spec.ts` — verdict matrix (allow/deny/conditional/post), disjunction semantics (allow short-circuit, post degradation, settled-false drop), semantic predicate parity via `@rapiq/memory`.
- `test/unit/core/security/permission-binding-evaluator.spec.ts` — new `withConditions` block: own/ownOrNull reach lowering (row-semantics via `compileFilters`), `any` fast-path TRUE, `none` FALSE, reach ∧ junction-policy AND-composition, per-grant OR pairing (reach stays with its own policy), non-expressible junction policy → pending without condition, settled-true policy on own reach → reach condition.
- `test/unit/core/entities/key/service.spec.ts` — conditional pushes the condition into the repository query (replayed via `@rapiq/memory` `applyQuery`) and skips per-row evaluation; allow keeps rows/totals untouched (and still nulls `decryptionKey`); deny matches no row.
- Existing key/trust-anchor HTTP realm-isolation tests now exercise the real compile path end-to-end and pass unchanged.

Verified: access 140/140, server-test-kit 11/11, client-web-kit 150/150, server-core `check:types` clean + full suite 1683/1683 (2 failed suite files = the documented pre-existing LDAP stale-container binds), docs build green, ESLint clean.

## Remaining on #3286

- The ownership-composed drop-loop services (session / event / client / consent / user / attribute services) — these OR an ownership alternative (`sub`/`subKind`, `actorId`) into the gate, so their conversion composes `or(ownershipCondition, compiled.condition)` service-side.
- Include gating via the schema `relations.validate` hooks (rapiq ≥ beta.5).

Part of #3286.