### PR TITLE
feat(server-core): compile self-short-circuit getMany gates to row conditions

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1237,10 +1237,19 @@ plaintext-secret rows are hidden from unauthorized readers, and only when the
 `or(not(and(ne('secret', null), eq('secretHashed', false), eq('secretEncrypted',
 false))), compiled.condition)`, applied only when the decoded projection includes
 `secret` — the default projection is never gated (exactly today's loop semantics).
+The self-short-circuit / parent-permission gates (#3294) follow the same shape:
+`UserService` composes `or(eq('id', <actor user id>), compiled.condition)` (self term
+only for a user identity; `deny` → self term alone); `UserAttributeService` mirrors
+`canReadUserAttribute` — ownership `eq('userId', <actor id>)` OR the compiled
+**USER_UPDATE-only** condition (USER_SELF_MANAGE is deliberately not compiled: its
+ATTRIBUTE_NAMES denylist policy is non-lowerable and the self leg IS the ownership
+term); `UserAuthenticatorService` composes `eq('userId', <actor id>)` the same way
+(the owner-scoped nested self read skips compile outright — every row is own) and
+still sanitizes secret/codes on the compiled path; `RoleAttributeService` is a pure
+gate (key/trust-anchor shape, no ownership term).
 `FakePermissionEvaluator.compile` defaults to `post` so service tests keep their
-per-row expectations; override via `setCompileResult`. Still open on #3286: the
-user + attribute services (self short-circuit / parent-permission-per-record gates)
-and include gating via `relations.validate`.
+per-row expectations; override via `setCompileResult`. Still open on #3286:
+include gating via `relations.validate`.
 
 ### EA loading on tree roots
 

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -7,12 +7,13 @@
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { EntityNotFoundError, ValidationError } from '@authup/errors';
+import { inArray } from '@rapiq/core';
 import { PermissionName } from '@authup/core-kit';
 import type { RoleAttribute } from '@authup/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult  } from '@authup/server-kit';
 import { AbstractEntityService } from '@authup/server-kit';
 import type { IRoleAttributeRepository, IRoleAttributeService } from './types.ts';
-import { decodeQuery } from '../../query/index.ts';
+import { appendQueryConditions, decodeQuery } from '../../query/index.ts';
 import { roleAttributeSchema } from './schema.ts';
 
 export type RoleAttributeServiceContext = {
@@ -35,18 +36,35 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
         query: Record<string, any>,
         actor: ActorContext,
     ): Promise<EntityRepositoryFindManyResult<RoleAttribute>> {
-        await actor.permissionEvaluator.preEvaluateOneOf({
-            name: [
-                PermissionName.ROLE_READ,
-                PermissionName.ROLE_UPDATE,
-                PermissionName.ROLE_DELETE,
-            ],
-        });
+        const permissionNames = [
+            PermissionName.ROLE_READ,
+            PermissionName.ROLE_UPDATE,
+            PermissionName.ROLE_DELETE,
+        ];
+
+        await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
+
+        let parsed = decodeQuery(query, { schema: roleAttributeSchema });
+
+        // Compile the read permissions into a row condition (#3286 phase 3): the
+        // authorization runs as WHERE, so pagination and totals stay exact. A
+        // non-expressible policy falls back to the per-row loop below.
+        const compiled = await actor.permissionEvaluator.compile({ name: permissionNames });
+        if (compiled.verdict === 'deny') {
+            // no row can pass — a constant-false condition keeps the meta shape
+            parsed = appendQueryConditions(parsed, inArray('id', []));
+        } else if (compiled.verdict === 'conditional') {
+            parsed = appendQueryConditions(parsed, compiled.condition);
+        }
+
+        if (compiled.verdict !== 'post') {
+            return this.repository.findMany(parsed);
+        }
 
         const {
-            data: entities, 
-            meta, 
-        } = await this.repository.findMany(decodeQuery(query, { schema: roleAttributeSchema }));
+            data: entities,
+            meta,
+        } = await this.repository.findMany(parsed);
 
         const data: RoleAttribute[] = [];
         let { total } = meta;

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -7,13 +7,14 @@
 
 import { BuiltInPolicyType, PermissionError, definePolicyData } from '@authup/access';
 import { EntityNotFoundError, ValidationError } from '@authup/errors';
+import { eq, inArray, or } from '@rapiq/core';
 import { PermissionName } from '@authup/core-kit';
 import type { UserAttribute } from '@authup/core-kit';
 import { buildErrorMessageForAttribute } from 'validup';
 import type { ActorContext, EntityRepositoryFindManyResult  } from '@authup/server-kit';
 import { AbstractEntityService } from '@authup/server-kit';
 import type { IUserAttributeRepository, IUserAttributeService } from './types.ts';
-import { decodeQuery } from '../../query/index.ts';
+import { appendQueryConditions, decodeQuery } from '../../query/index.ts';
 import { userAttributeSchema } from './schema.ts';
 
 export type UserAttributeServiceContext = {
@@ -43,10 +44,37 @@ export class UserAttributeService extends AbstractEntityService implements IUser
             ],
         });
 
+        const parsed = decodeQuery(query, { schema: userAttributeSchema });
+
+        // Compile the foreign-row gate into a row condition (#3286 phase 3),
+        // mirroring canReadUserAttribute: own rows (the actor's userId) are
+        // always readable, foreign rows require USER_UPDATE. USER_SELF_MANAGE
+        // is deliberately not compiled — its ATTRIBUTE_NAMES denylist policy is
+        // non-lowerable, and the self leg is the ownership term anyway. A
+        // non-expressible USER_UPDATE policy falls back to the per-row loop.
+        const compiled = await actor.permissionEvaluator.compile({ name: PermissionName.USER_UPDATE });
+        if (compiled.verdict !== 'post') {
+            const self = actor.identity && actor.identity.type === 'user' ?
+                eq('userId', actor.identity.data.id) :
+                null;
+
+            let scoped = parsed;
+            if (compiled.verdict === 'deny') {
+                scoped = appendQueryConditions(parsed, self ?? inArray('id', []));
+            } else if (compiled.verdict === 'conditional') {
+                scoped = appendQueryConditions(
+                    parsed,
+                    self ? or(self, compiled.condition) : compiled.condition,
+                );
+            }
+
+            return this.repository.findMany(scoped);
+        }
+
         const {
             data: entities,
             meta,
-        } = await this.repository.findMany(decodeQuery(query, { schema: userAttributeSchema }));
+        } = await this.repository.findMany(parsed);
 
         const data: UserAttribute[] = [];
         let { total } = meta;

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from 'node:crypto';
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup } from '@authup/kit';
+import { eq, inArray, or } from '@rapiq/core';
 import {
     EventName, 
     EventRefType, 
@@ -91,7 +92,7 @@ import type {
     UserAuthenticatorWebauthnParameters,
 } from './types.ts';
 import type { WebauthnContext } from './webauthn.ts';
-import { decodeQuery } from '../../query/index.ts';
+import { appendQueryConditions, decodeQuery } from '../../query/index.ts';
 import { userAuthenticatorSchema } from './schema.ts';
 
 type EmailCodeState = {
@@ -183,9 +184,43 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             await actor.permissionEvaluator.preEvaluate({ name: PermissionName.USER_AUTHENTICATOR_READ });
         }
 
+        const parsed = decodeQuery(query, { schema: userAuthenticatorSchema });
+        const findManyOptions = options.userId ? { owner: { userId: options.userId } } : {};
+
+        // Own devices are ungated: the nested self read is already owner-scoped,
+        // and on the wider mounts ownership composes as an OR-alternative with
+        // the compiled USER_AUTHENTICATOR_READ condition (#3286 phase 3) — the
+        // whole gate runs as WHERE and pagination/totals stay exact. A
+        // non-expressible policy falls back to the per-row loop below.
+        const compiled = isSelf ?
+            { verdict: 'allow' as const } :
+            await actor.permissionEvaluator.compile({ name: PermissionName.USER_AUTHENTICATOR_READ });
+        if (compiled.verdict !== 'post') {
+            const ownership = actor.identity && actor.identity.type === IdentityType.USER ?
+                eq('userId', actor.identity.data.id) :
+                null;
+
+            let scoped = parsed;
+            if (compiled.verdict === 'deny') {
+                scoped = appendQueryConditions(parsed, ownership ?? inArray('id', []));
+            } else if (compiled.verdict === 'conditional') {
+                scoped = appendQueryConditions(
+                    parsed,
+                    ownership ? or(ownership, compiled.condition) : compiled.condition,
+                );
+            }
+
+            const { data, meta } = await this.repository.findMany(scoped, findManyOptions);
+
+            return {
+                data: data.map((entity) => this.sanitize(entity)),
+                meta,
+            };
+        }
+
         const { data: entities, meta } = await this.repository.findMany(
-            decodeQuery(query, { schema: userAuthenticatorSchema }),
-            options.userId ? { owner: { userId: options.userId } } : {},
+            parsed,
+            findManyOptions,
         );
 
         const data: UserAuthenticator[] = [];

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -8,6 +8,7 @@
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { EntityNotFoundError, ValidationError } from '@authup/errors';
+import { eq, inArray, or } from '@rapiq/core';
 import {
     PermissionName,
     UserValidator,
@@ -18,7 +19,7 @@ import type { IRealmRepository } from '../realm/types.ts';
 import { AbstractEntityService } from '@authup/server-kit';
 import { UserCredentialsService } from '../../authentication/credential/entities/user/module.ts';
 import type { IUserRepository, IUserService } from './types.ts';
-import { decodeQuery } from '../../query/index.ts';
+import { appendQueryConditions, decodeQuery } from '../../query/index.ts';
 import { userSchema } from './schema.ts';
 
 export type UserServiceContext = {
@@ -45,18 +46,44 @@ export class UserService extends AbstractEntityService implements IUserService {
         query: Record<string, any>,
         actor: ActorContext,
     ): Promise<EntityRepositoryFindManyResult<User>> {
-        await actor.permissionEvaluator.preEvaluateOneOf({
-            name: [
-                PermissionName.USER_READ,
-                PermissionName.USER_UPDATE,
-                PermissionName.USER_DELETE,
-            ],
-        });
+        const permissionNames = [
+            PermissionName.USER_READ,
+            PermissionName.USER_UPDATE,
+            PermissionName.USER_DELETE,
+        ];
+
+        await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
+
+        const parsed = decodeQuery(query, { schema: userSchema });
+
+        // Compile the read permissions into a row condition (#3286 phase 3). The
+        // own row is always readable, so the self short-circuit composes as an
+        // OR-alternative — the whole gate runs as WHERE and pagination/totals
+        // stay exact. A non-expressible policy falls back to the per-row loop
+        // below.
+        const compiled = await actor.permissionEvaluator.compile({ name: permissionNames });
+        if (compiled.verdict !== 'post') {
+            const self = actor.identity && actor.identity.type === 'user' ?
+                eq('id', actor.identity.data.id) :
+                null;
+
+            let scoped = parsed;
+            if (compiled.verdict === 'deny') {
+                scoped = appendQueryConditions(parsed, self ?? inArray('id', []));
+            } else if (compiled.verdict === 'conditional') {
+                scoped = appendQueryConditions(
+                    parsed,
+                    self ? or(self, compiled.condition) : compiled.condition,
+                );
+            }
+
+            return this.repository.findMany(scoped);
+        }
 
         const {
-            data: entities, 
-            meta, 
-        } = await this.repository.findMany(decodeQuery(query, { schema: userSchema }));
+            data: entities,
+            meta,
+        } = await this.repository.findMany(parsed);
 
         const data: User[] = [];
         let { total } = meta;

--- a/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/role-attribute/service.spec.ts
@@ -8,11 +8,14 @@
 import { randomUUID } from 'node:crypto';
 import { PermissionName } from '@authup/core-kit';
 import type { RoleAttribute } from '@authup/core-kit';
+import { eq } from '@rapiq/core';
+import { applyQuery } from '@rapiq/memory';
 import {
     beforeEach,
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
 import { BuiltInPolicyType, PermissionError } from '@authup/access';
@@ -68,6 +71,53 @@ describe('core/entities/role-attribute/service', () => {
 
         it('should throw when actor lacks permission', async () => {
             await expect(service.getMany({}, createDenyAllActor())).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('pushes a compiled conditional as WHERE and skips per-row evaluation', async () => {
+            const realmId = randomUUID();
+
+            const [inRealm, outOfRealm] = repository.seed([
+                createFakeRoleAttribute({
+                    name: 'in-realm',
+                    realmId,
+                }),
+                createFakeRoleAttribute({
+                    name: 'out-of-realm',
+                    realmId: randomUUID(),
+                }),
+            ]);
+
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', realmId),
+            });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            // the fake repository does not apply filters — replay the query the
+            // service built over the seeded rows instead
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [inRealm, outOfRealm]);
+            expect(applied.data.map((row) => row.id)).toEqual([inRealm.id]);
+
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
+        });
+
+        it('returns no rows on a compiled deny', async () => {
+            const seeded = repository.seed([createFakeRoleAttribute({ realmId: randomUUID() })]);
+
+            const actor = createAllowAllActor();
+            actor.permissionEvaluator.setCompileResult({ verdict: 'deny' });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, seeded);
+            expect(applied.data).toHaveLength(0);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-attribute/service.spec.ts
@@ -11,11 +11,14 @@ import {
     PermissionName,
 } from '@authup/core-kit';
 import type { Realm, User, UserAttribute } from '@authup/core-kit';
+import { eq } from '@rapiq/core';
+import { applyQuery } from '@rapiq/memory';
 import {
     beforeEach,
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
 import { BuiltInPolicyType, PermissionError } from '@authup/access';
@@ -95,6 +98,79 @@ describe('core/entities/user-attribute/service', () => {
 
         it('should throw when actor lacks permission', async () => {
             await expect(service.getMany({}, createDenyAllActor())).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('composes ownership with a compiled USER_UPDATE conditional as WHERE and skips per-row evaluation', async () => {
+            const userId = randomUUID();
+            const realmId = randomUUID();
+
+            // the own row lives OUTSIDE the compiled realm condition — only the
+            // ownership OR-term can include it
+            const [own, foreignSameRealm, foreignOtherRealm] = repository.seed([
+                createFakeUserAttribute({
+                    name: 'mine',
+                    userId,
+                    realmId: randomUUID(),
+                }),
+                createFakeUserAttribute({
+                    name: 'same-realm',
+                    userId: randomUUID(),
+                    realmId,
+                }),
+                createFakeUserAttribute({
+                    name: 'other-realm',
+                    userId: randomUUID(),
+                    realmId: randomUUID(),
+                }),
+            ]);
+
+            const actor = createUserActor(userId);
+            actor.permissionEvaluator.setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', realmId),
+            });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            // the foreign leg compiles USER_UPDATE only — USER_SELF_MANAGE's
+            // denylist policy is non-lowerable and the self leg is the ownership term
+            expect(actor.permissionEvaluator.compileCalls).toEqual([{ name: PermissionName.USER_UPDATE }]);
+
+            // the fake repository does not apply filters — replay the query the
+            // service built over the seeded rows instead
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [own, foreignSameRealm, foreignOtherRealm]);
+            expect(applied.data.map((row) => row.id).sort())
+                .toEqual([own.id, foreignSameRealm.id].sort());
+
+            expect(actor.permissionEvaluator.evaluateCalls).toHaveLength(0);
+        });
+
+        it('restricts to own rows on a compiled deny', async () => {
+            const userId = randomUUID();
+
+            const [own, foreign] = repository.seed([
+                createFakeUserAttribute({
+                    name: 'mine',
+                    userId,
+                }),
+                createFakeUserAttribute({
+                    name: 'other',
+                    userId: randomUUID(),
+                }),
+            ]);
+
+            const actor = createUserActor(userId);
+            actor.permissionEvaluator.setCompileResult({ verdict: 'deny' });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [own, foreign]);
+            expect(applied.data.map((row) => row.id)).toEqual([own.id]);
+            expect(actor.permissionEvaluator.evaluateCalls).toHaveLength(0);
         });
     });
 

--- a/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user-authenticator/service.spec.ts
@@ -15,6 +15,8 @@ import {
     isMfaThrottledError,
 } from '@authup/errors';
 import { JWKType, JWKUse } from '@authup/specs';
+import { eq } from '@rapiq/core';
+import { applyQuery } from '@rapiq/memory';
 import { MemoryCache, buildCacheKey } from '@authup/server-kit';
 import type { ActorContext } from '@authup/server-kit';
 import { Secret, TOTP } from 'otpauth';
@@ -941,6 +943,76 @@ describe('UserAuthenticatorService', () => {
             const deleted = await service.delete(enrolled.data.id, actor, { userId });
             expect(deleted.id).toEqual(enrolled.data.id);
             expect(await repository.findAllByUser(userId)).toHaveLength(0);
+        });
+
+        it('composes ownership with a compiled conditional as WHERE and skips per-row evaluation', async () => {
+            // the own device lives OUTSIDE the compiled realm condition — only
+            // the ownership OR-term can include it
+            const own = repository.seed({
+                kind: UserAuthenticatorKind.TOTP,
+                userId,
+                realmId: randomUUID(),
+                confirmed: true,
+                secret: 'seed-material',
+            });
+            const foreignSameRealm = repository.seed({
+                kind: UserAuthenticatorKind.TOTP,
+                userId: otherUserId,
+                realmId,
+                confirmed: true,
+            });
+            const foreignOtherRealm = repository.seed({
+                kind: UserAuthenticatorKind.TOTP,
+                userId: otherUserId,
+                realmId: randomUUID(),
+                confirmed: true,
+            });
+
+            const actor = makeActor();
+            (actor.permissionEvaluator as FakePermissionEvaluator).setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', realmId),
+            });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            const { data } = await service.getMany({}, actor);
+
+            // the fake repository does not apply filters — replay the query the
+            // service built over the seeded rows instead
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [own, foreignSameRealm, foreignOtherRealm]);
+            expect(applied.data.map((row) => row.id).sort())
+                .toEqual([own.id, foreignSameRealm.id].sort());
+
+            expect((actor.permissionEvaluator as FakePermissionEvaluator).evaluateCalls).toHaveLength(0);
+            // the compiled fast path still sanitizes secret material
+            expect(data.every((row) => row.secret === null && row.codes === null)).toBe(true);
+        });
+
+        it('restricts to own devices on a compiled deny', async () => {
+            const own = repository.seed({
+                kind: UserAuthenticatorKind.TOTP,
+                userId,
+                realmId,
+                confirmed: true,
+            });
+            const foreign = repository.seed({
+                kind: UserAuthenticatorKind.TOTP,
+                userId: otherUserId,
+                realmId,
+                confirmed: true,
+            });
+
+            const actor = makeActor();
+            (actor.permissionEvaluator as FakePermissionEvaluator).setCompileResult({ verdict: 'deny' });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [own, foreign]);
+            expect(applied.data.map((row) => row.id)).toEqual([own.id]);
+            expect((actor.permissionEvaluator as FakePermissionEvaluator).evaluateCalls).toHaveLength(0);
         });
 
         it('denies foreign device access without permission', async () => {

--- a/apps/server-core/test/unit/core/entities/user/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user/service.spec.ts
@@ -12,11 +12,14 @@ import {
 } from '@authup/core-kit';
 import type { Realm, User } from '@authup/core-kit';
 import { BuiltInPolicyType, PermissionError } from '@authup/access';
+import { eq } from '@rapiq/core';
+import { applyQuery } from '@rapiq/memory';
 import {
     beforeEach,
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
 import { UserService } from '../../../../../src/core/entities/user/service.ts';
@@ -110,6 +113,53 @@ describe('core/entities/user/service', () => {
             const result = await service.getMany({}, actor);
             expect(result.data).toHaveLength(0);
             expect(result.meta.total).toBe(0);
+        });
+
+        it('composes the self short-circuit with a compiled conditional as WHERE and skips per-row evaluation', async () => {
+            const realmId = randomUUID();
+            // the self row lives OUTSIDE the compiled realm condition — only the
+            // ownership OR-term can include it
+            const [selfUser, foreignSameRealm, foreignOtherRealm] = repository.seed([
+                createFakeUser({ name: 'self', realmId: randomUUID() }),
+                createFakeUser({ name: 'same-realm', realmId }),
+                createFakeUser({ name: 'other-realm', realmId: randomUUID() }),
+            ]);
+
+            const actor = createSelfActor(selfUser.id);
+            actor.permissionEvaluator.setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', realmId),
+            });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            // the fake repository does not apply filters — replay the query the
+            // service built over the seeded rows instead
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [selfUser, foreignSameRealm, foreignOtherRealm]);
+            expect(applied.data.map((row) => row.id).sort())
+                .toEqual([selfUser.id, foreignSameRealm.id].sort());
+
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
+        });
+
+        it('restricts to the own row on a compiled deny', async () => {
+            const [selfUser, foreign] = repository.seed([
+                createFakeUser({ name: 'self' }),
+                createFakeUser({ name: 'other' }),
+            ]);
+
+            const actor = createSelfActor(selfUser.id);
+            actor.permissionEvaluator.setCompileResult({ verdict: 'deny' });
+
+            const spy = vi.spyOn(repository, 'findMany');
+            await service.getMany({}, actor);
+
+            const query = spy.mock.calls[0]![0];
+            const applied = applyQuery(query, [selfUser, foreign]);
+            expect(applied.data.map((row) => row.id)).toEqual([selfUser.id]);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
     });
 


### PR DESCRIPTION
## What

Third slice of #3286 phase 3 — closes #3294. Converts the four remaining `getMany` gates with self-short-circuit / per-record-parent-permission shapes onto `IPermissionEvaluator.compile()`, so the authorization runs as WHERE and **pagination/totals stay exact** for scoped readers. The per-row `evaluate` + `total -= 1` drop loops survive only as the `post` fallback for non-expressible policies.

## Conversions

- **`UserService.getMany`** — `or(eq('id', <actor user id>), compiled.condition)` over the `USER_READ`/`USER_UPDATE`/`USER_DELETE` disjunction. The self term composes only for a user identity; a compiled `deny` restricts to the self term alone (constant-false without one).
- **`UserAttributeService.getMany`** — mirrors `canReadUserAttribute` exactly: ownership `eq('userId', <actor id>)` OR the compiled **`USER_UPDATE`-only** condition. `USER_SELF_MANAGE` is deliberately not compiled — its ATTRIBUTE_NAMES denylist policy is non-lowerable (compiling it would always degrade the disjunction to `post`), and the self leg *is* the ownership term. Pinned by a `compileCalls` assertion.
- **`UserAuthenticatorService.getMany`** — same `eq('userId', <actor id>)` ownership alternative on the wider mounts; the owner-scoped nested self read skips compile outright (every row is own). The compiled fast path still routes rows through `sanitize()` (secret/codes nulled).
- **`RoleAttributeService.getMany`** — no ownership leg; a pure gate over the `ROLE_READ`/`ROLE_UPDATE`/`ROLE_DELETE` disjunction (key/trust-anchor shape: `deny` → constant-false `inArray('id', [])`, keeps the meta shape).

The adapters already force-select every column the composed conditions read (`id`/`userId`/`realmId`, plan 039), so client `fields` projections cannot neutralize the WHERE terms.

## Tests

Each service spec gains the established compile-path cases (session/client pattern): capture the built query via `vi.spyOn(repository, 'findMany')`, replay it over seeded rows with `@rapiq/memory`'s `applyQuery`, assert the ownership term is what includes the own row (seeded *outside* the compiled realm condition), and assert **zero per-row evaluate calls**. `FakePermissionEvaluator.compile` still defaults to `post`, so all pre-existing per-row service tests keep their meaning.

Full server-core suite: 1695 passed (the 2 failing LDAP spec files are the pre-existing stale-container issue, unrelated).

With this, the only remaining #3286 item is include gating via `relations.validate` (noted in `.agents/architecture.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved authorization filtering for users, user attributes, authenticators, and role attributes by applying eligible access rules directly during queries.
  * Reduced unnecessary per-item permission checks when access conditions can be evaluated upfront.

* **Security**
  * Enforced ownership-based access alongside configured permission conditions.
  * Denied access now returns no unauthorized records while preserving permitted self-owned records.

* **Tests**
  * Added coverage for conditional and denied access scenarios, including ownership filtering and skipped per-item evaluations.

* **Documentation**
  * Updated architecture documentation for authorization gate behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->