### PR TITLE
feat(server-core): gate include authorization at decode via relations.validate

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -142,17 +142,52 @@ usable at the service level and nothing in core depends on TypeORM:
   entity metadata.
 - **Registry + codec + decode** — `core/query/` owns the `SchemaRegistry`
   (all entity schemas), the URL codec bound to it (decodes both the v2
-  expression dialect and legacy v1 bracket payloads), and
-  `decodeQuery(input, { schema, parameters? })` → `Query` (IR). `schema`
-  accepts the colocated schema object or a registered name; `parameters`
-  restricts which parameters are parsed/defaulted (e.g. `['filters']` for the
-  session bulk revoke, `['fields', 'relations']` for single reads).
+  expression dialect and legacy v1 bracket payloads), and the **async**
+  `decodeQuery(input, { schema, parameters?, actor? })` → `Promise<Query>`
+  (IR; async because the schema validate hooks await the actor's permission
+  pre-gate). `schema` accepts the colocated schema object or a registered
+  name; `parameters` restricts which parameters are parsed/defaulted (e.g.
+  `['filters']` for the session bulk revoke, `['fields', 'relations']` for
+  single reads); `actor` rides the decode context into the schema validate
+  hooks (see *Include authorization* below).
 - **Services decode once** — `getMany` calls
-  `this.repository.findMany(decodeQuery(query, { schema: roleSchema }))`;
+  `this.repository.findMany(await decodeQuery(query, { schema: roleSchema, actor }))`;
   multi-branch services (session/consent/event) decode into a local and pass
   the IR to every branch. Allow-lists, defaults and pagination bounds are all
   applied at decode time, so services can also inspect or compose the IR
   before handing it down.
+- **Include authorization — the relations read gate (#3295)** — every
+  schema's `relations.validate` hook is `createRelationsReadGate(schemaMapping)`
+  (`core/query/relations.ts`; schemas import that FILE directly, never the
+  `core/query` barrel — the barrel reaches `module.ts`, which imports every
+  schema, and the cycle would TDZ-crash). Per include segment the hook maps
+  the relation to its target entity type (the schema's own `schemaMapping`)
+  and runs the derived pre-gate (`preEvaluateOneOf`, #3290) for that type's
+  read-permission disjunction (`RELATION_TARGET_READ_GATES`, mirroring each
+  target service's own `getMany` gate; POLICY sits under the PERMISSION
+  family; REALM and IDENTITY_PROVIDER are deliberately ungated — both lists
+  are anonymous surfaces). Nested paths gate hop by hop. **Deny = silent
+  strip** (fail-soft, matching the allow-lists): the include — and every
+  dotted filter/sort/field key riding the denied relation path — is pruned,
+  the request still succeeds with the un-joined row shape. Caller classes:
+  a SYSTEM decode (no `actor` option) runs unrestricted; every REQUEST
+  decode passes the actor (`buildActorContext` supplies one for anonymous
+  requests too — an anonymous actor holds no grants, so its gated includes
+  strip). Every schema now declares `relations` explicitly (an omitted
+  allow-list falls back to rapiq's syntactic name check — that hole is
+  closed; `event`/`realm` pin `allowed: []`). **Known residual:** a dotted
+  filter/sort/field key whose relation is NOT explicitly included bypasses
+  the hook (the SQL adapters auto-join such paths) — upstream
+  tada5hi/rapiq#815 is the removal trigger.
+- **Junction/attribute schemas pin `fields.default`** — with no root fields
+  declared, an `include=` decodes the relation's default fields ONLY, and
+  the typeorm adapter's `select()` replace then drops every root column
+  (including the id TypeORM's DISTINCT-id pagination wrapper needs — every
+  junction `include=` 500'd before #3295 surfaced it). The explicit
+  `default` list keeps the root projection riding alongside relation
+  fields; it must enumerate EVERY scalar column (boot validation checks
+  key existence, not completeness — a column missing from `default`
+  silently vanishes from the API response).
 - **Server-derived scopes ride `appendQueryConditions(query, ...conds)`**
   (core/query) — an immutable AND-wrap of the filter tree
   (`IFilters.and`, the wrap-and-inject primitive; parameter nodes carry
@@ -1248,8 +1283,9 @@ term); `UserAuthenticatorService` composes `eq('userId', <actor id>)` the same w
 still sanitizes secret/codes on the compiled path; `RoleAttributeService` is a pure
 gate (key/trust-anchor shape, no ownership term).
 `FakePermissionEvaluator.compile` defaults to `post` so service tests keep their
-per-row expectations; override via `setCompileResult`. Still open on #3286:
-include gating via `relations.validate`.
+per-row expectations; override via `setCompileResult`. The final #3286 piece —
+include gating via `relations.validate` — shipped as #3295: see *Query IR flow →
+Include authorization*.
 
 ### EA loading on tree roots
 
@@ -1730,10 +1766,13 @@ Domain type `Consent` (core-kit) + `EntityType.CONSENT`, TypeORM entity +
   DELETEs behind an error-tone `useAlertDialog`). The self-service list
   endpoint joins only a **client summary** (id / name / displayName /
   builtIn) — never the full `ClientEntity` (`client` is deliberately absent
-  from the adapter's `relations.allowed`, so a raw `?include=client` cannot
+  from the schema's `relations.allowed`, so a raw `?include=client` cannot
   force the full-column join and leak redirectUri patterns / grantTypes /
   secret-storage flags / `accessPolicyId` to a self-service user without
-  `CLIENT_READ`). Revoking consent stops the next silent/auto issue;
+  `CLIENT_READ`; kept even after the #3295 include gate — the summary DTO
+  is the deliberate self-service shape regardless of the reader's
+  permissions, and the adapter's manual summary join would collide with a
+  rapiq `client` join anyway). Revoking consent stops the next silent/auto issue;
   already-issued tokens are unaffected (revoke those via the sessions API —
   stated limitation).
 - **Subject deletion:** the subject is polymorphic (`sub`/`subKind`), but a
@@ -2074,8 +2113,8 @@ extraColumns?)` (`app/modules/database/repositories/helpers.ts`) is called AFTER
 `applyQuery` in: `session` (`+ sub, subKind` — ownership check), `user`
 (`+ id` — self short-circuit), `client` (`+ secretHashed,
 secretEncrypted` — the plaintext-secret gate precondition), `role-attribute`,
-`user-attribute` (`+ userId` — isMe check; the two attribute adapters configure
-no `fields`, so the call is pinning defense in depth there). `role` / `scope` /
+`user-attribute` (`+ userId` — isMe check; since #3295 the two attribute schemas
+declare `fields.default`, so the call dedupes against that projection). `role` / `scope` /
 `permission` / `policy` list paths carry no per-row realm gate (their
 `resourceRealmMatch` usages are write paths on server-loaded data), so they are
 deliberately not force-selected. The helper **dedupes against the already-applied

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -68,6 +68,7 @@ import {
 } from '../../../../../core/index.ts';
 import {
     applyRouteRealmIDToBody,
+    buildActorContext,
     getBodyRealmID,
     getRequestParamID,
     getRequestRealmID,
@@ -126,7 +127,10 @@ export class IdentityProviderController {
             data,
             meta,
         } = await this.repository.findMany(
-            decodeQuery(useRequestQuery(event), { schema: identityProviderSchema }),
+            await decodeQuery(useRequestQuery(event), {
+                schema: identityProviderSchema,
+                actor: buildActorContext(event),
+            }),
         );
 
         try {

--- a/apps/server-core/src/core/entities/client-permission/schema.ts
+++ b/apps/server-core/src/core/entities/client-permission/schema.ts
@@ -8,12 +8,29 @@
 import { defineSchema } from '@rapiq/core';
 import type { ClientPermission } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { client: EntityType.CLIENT, permission: EntityType.PERMISSION };
 
 export const clientPermissionSchema = defineSchema<ClientPermission>({
     name: EntityType.CLIENT_PERMISSION,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'policyId',
+            'realmScope',
+            'permissionId',
+            'permissionRealmId',
+            'clientId',
+            'clientRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['clientId', 'permissionId'] },
-    relations: { allowed: ['client', 'permission'] },
+    relations: { allowed: ['client', 'permission'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { client: EntityType.CLIENT, permission: EntityType.PERMISSION },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/client-permission/service.ts
+++ b/apps/server-core/src/core/entities/client-permission/service.ts
@@ -58,7 +58,7 @@ export class ClientPermissionService extends JunctionEntityService implements IC
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: clientPermissionSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: clientPermissionSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/client-role/schema.ts
+++ b/apps/server-core/src/core/entities/client-role/schema.ts
@@ -8,12 +8,27 @@
 import { defineSchema } from '@rapiq/core';
 import type { ClientRole } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { client: EntityType.CLIENT, role: EntityType.ROLE };
 
 export const clientRoleSchema = defineSchema<ClientRole>({
     name: EntityType.CLIENT_ROLE,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'clientId',
+            'clientRealmId',
+            'roleId',
+            'roleRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['clientId', 'roleId'] },
-    relations: { allowed: ['client', 'role'] },
+    relations: { allowed: ['client', 'role'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { client: EntityType.CLIENT, role: EntityType.ROLE },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/client-role/service.ts
+++ b/apps/server-core/src/core/entities/client-role/service.ts
@@ -50,7 +50,7 @@ export class ClientRoleService extends JunctionEntityService implements IClientR
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: clientRoleSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: clientRoleSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/client-scope/schema.ts
+++ b/apps/server-core/src/core/entities/client-scope/schema.ts
@@ -8,11 +8,25 @@
 import { defineSchema } from '@rapiq/core';
 import type { ClientScope } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { client: EntityType.CLIENT, scope: EntityType.SCOPE };
 
 export const clientScopeSchema = defineSchema<ClientScope>({
     name: EntityType.CLIENT_SCOPE,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'default',
+            'clientId',
+            'clientRealmId',
+            'scopeId',
+            'scopeRealmId',
+        ],
+    },
     filters: { allowed: ['clientId', 'scopeId', 'default'] },
-    relations: { allowed: ['client', 'scope'] },
+    relations: { allowed: ['client', 'scope'], validate: createRelationsReadGate(schemaMapping) },
     pagination: { maxLimit: 50 },
-    schemaMapping: { client: EntityType.CLIENT, scope: EntityType.SCOPE },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/client-scope/service.ts
+++ b/apps/server-core/src/core/entities/client-scope/service.ts
@@ -46,7 +46,7 @@ export class ClientScopeService extends JunctionEntityService implements IClient
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: clientScopeSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: clientScopeSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/client/schema.ts
+++ b/apps/server-core/src/core/entities/client/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { Client } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM, accessPolicy: EntityType.POLICY };
 
 export const clientSchema = defineSchema<Client>({
     name: EntityType.CLIENT,
@@ -37,8 +40,8 @@ export const clientSchema = defineSchema<Client>({
         allowed: ['secret'],
     },
     filters: { allowed: ['id', 'name', 'realmId'] },
-    relations: { allowed: ['realm', 'accessPolicy'] },
+    relations: { allowed: ['realm', 'accessPolicy'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { realm: EntityType.REALM, accessPolicy: EntityType.POLICY },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -61,7 +61,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
 
-        const parsed = decodeQuery(query, { schema: clientSchema });
+        const parsed = await decodeQuery(query, { schema: clientSchema, actor });
 
         // The per-row gate below only fires for rows exposing a PLAINTEXT secret,
         // and only when the projection actually selects the (non-default) `secret`
@@ -160,7 +160,11 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         const entity = await this.repository.findOne(
             idOrName,
-            decodeQuery(query, { schema: clientSchema, parameters: ['fields', 'relations'] }),
+            await decodeQuery(query, {
+                schema: clientSchema, 
+                parameters: ['fields', 'relations'], 
+                actor, 
+            }),
             realmId,
         );
         if (!entity) {

--- a/apps/server-core/src/core/entities/consent/schema.ts
+++ b/apps/server-core/src/core/entities/consent/schema.ts
@@ -9,6 +9,9 @@ import { defineSchema } from '@rapiq/core';
 import type { Consent } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
 import { CONSENT_FILTER_KEYS } from './types.ts';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const consentSchema = defineSchema<Consent>({
     name: EntityType.CONSENT,
@@ -33,8 +36,8 @@ export const consentSchema = defineSchema<Consent>({
         ],
     },
     filters: { allowed: [...CONSENT_FILTER_KEYS] },
-    relations: { allowed: ['realm'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['createdAt', 'updatedAt', 'scope'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { realm: EntityType.REALM },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/consent/service.ts
+++ b/apps/server-core/src/core/entities/consent/service.ts
@@ -66,7 +66,7 @@ export class ConsentService extends AbstractEntityService implements IConsentSer
         actor: ActorContext,
         options: ConsentServiceReadOptions = {},
     ): Promise<EntityRepositoryFindManyResult<Consent>> {
-        const parsed = decodeQuery(query, { schema: consentSchema });
+        const parsed = await decodeQuery(query, { schema: consentSchema, actor });
 
         let canReadAll = true;
         try {

--- a/apps/server-core/src/core/entities/event/schema.ts
+++ b/apps/server-core/src/core/entities/event/schema.ts
@@ -50,6 +50,7 @@ export const eventSchema = defineSchema<Event>({
             'createdAt',
         ], 
     },
+    relations: { allowed: [] },
     sort: { allowed: ['createdAt'] },
     pagination: { maxLimit: 50 },
 });

--- a/apps/server-core/src/core/entities/event/service.ts
+++ b/apps/server-core/src/core/entities/event/service.ts
@@ -168,7 +168,7 @@ export class EventService extends AbstractEntityService implements IEventService
         actor: ActorContext,
         options: EventServiceReadOptions = {},
     ): Promise<EntityRepositoryFindManyResult<Event>> {
-        const parsed = decodeQuery(query, { schema: eventSchema });
+        const parsed = await decodeQuery(query, { schema: eventSchema, actor });
 
         let canReadAll = true;
         try {

--- a/apps/server-core/src/core/entities/identity-provider-role-mapping/schema.ts
+++ b/apps/server-core/src/core/entities/identity-provider-role-mapping/schema.ts
@@ -8,12 +8,31 @@
 import { defineSchema } from '@rapiq/core';
 import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { role: EntityType.ROLE, provider: EntityType.IDENTITY_PROVIDER };
 
 export const identityProviderRoleMappingSchema = defineSchema<IdentityProviderRoleMapping>({
     name: EntityType.IDENTITY_PROVIDER_ROLE_MAPPING,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'name',
+            'value',
+            'valueIsRegex',
+            'synchronizationMode',
+            'providerId',
+            'providerRealmId',
+            'roleId',
+            'roleRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['roleId', 'providerId'] },
-    relations: { allowed: ['role', 'provider'] },
+    relations: { allowed: ['role', 'provider'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { role: EntityType.ROLE, provider: EntityType.IDENTITY_PROVIDER },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
+++ b/apps/server-core/src/core/entities/identity-provider-role-mapping/service.ts
@@ -55,7 +55,7 @@ export class IdentityProviderRoleMappingService extends JunctionEntityService im
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: identityProviderRoleMappingSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: identityProviderRoleMappingSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/identity-provider/schema.ts
+++ b/apps/server-core/src/core/entities/identity-provider/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { IdentityProvider } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const identityProviderSchema = defineSchema<IdentityProvider>({
     name: EntityType.IDENTITY_PROVIDER,
@@ -25,8 +28,8 @@ export const identityProviderSchema = defineSchema<IdentityProvider>({
         ],
     },
     filters: { allowed: ['name', 'protocol', 'enabled', 'realmId'] },
-    relations: { allowed: ['realm'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { realm: EntityType.REALM },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/key/schema.ts
+++ b/apps/server-core/src/core/entities/key/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { Key } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const keySchema = defineSchema<Key>({
     name: EntityType.KEY,
@@ -36,6 +39,7 @@ export const keySchema = defineSchema<Key>({
             'realmId',
         ], 
     },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: {
         allowed: [
             'id',
@@ -45,7 +49,8 @@ export const keySchema = defineSchema<Key>({
             'status',
             'createdAt',
             'updatedAt',
-        ], 
+        ],
     },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/key/service.ts
+++ b/apps/server-core/src/core/entities/key/service.ts
@@ -80,7 +80,7 @@ export class KeyService extends AbstractEntityService implements IKeyService {
     ): Promise<EntityRepositoryFindManyResult<Key>> {
         await actor.permissionEvaluator.preEvaluateOneOf({ name: PERMISSION_NAMES });
 
-        let parsed = decodeQuery(query, { schema: keySchema });
+        let parsed = await decodeQuery(query, { schema: keySchema, actor });
         if (options.realmId) {
             parsed = appendQueryConditions(parsed, eq('realmId', options.realmId));
         }

--- a/apps/server-core/src/core/entities/permission-policy/schema.ts
+++ b/apps/server-core/src/core/entities/permission-policy/schema.ts
@@ -8,12 +8,27 @@
 import { defineSchema } from '@rapiq/core';
 import type { PermissionPolicy } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { permission: EntityType.PERMISSION, policy: EntityType.POLICY };
 
 export const permissionPolicySchema = defineSchema<PermissionPolicy>({
     name: EntityType.PERMISSION_POLICY,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'permissionId',
+            'permissionRealmId',
+            'policyId',
+            'policyRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['permissionId', 'policyId'] },
-    relations: { allowed: ['permission', 'policy'] },
+    relations: { allowed: ['permission', 'policy'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { permission: EntityType.PERMISSION, policy: EntityType.POLICY },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/permission-policy/service.ts
+++ b/apps/server-core/src/core/entities/permission-policy/service.ts
@@ -44,7 +44,7 @@ export class PermissionPolicyService extends JunctionEntityService implements IP
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: permissionPolicySchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: permissionPolicySchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -115,7 +115,7 @@ export class PermissionService extends AbstractEntityService implements IPermiss
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: permissionSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: permissionSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/policy/schema.ts
+++ b/apps/server-core/src/core/entities/policy/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { Policy } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { children: EntityType.POLICY, realm: EntityType.REALM };
 
 export const policySchema = defineSchema<Policy>({
     name: EntityType.POLICY,
@@ -27,8 +30,8 @@ export const policySchema = defineSchema<Policy>({
         ],
     },
     filters: { allowed: ['id', 'name', 'type', 'parentId', 'realmId'] },
-    relations: { allowed: ['children', 'realm'] },
+    relations: { allowed: ['children', 'realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { children: EntityType.POLICY, realm: EntityType.REALM },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/policy/service.ts
+++ b/apps/server-core/src/core/entities/policy/service.ts
@@ -61,7 +61,7 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: policySchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: policySchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/realm/schema.ts
+++ b/apps/server-core/src/core/entities/realm/schema.ts
@@ -23,6 +23,7 @@ export const realmSchema = defineSchema<Realm>({
         ],
     },
     filters: { allowed: ['id', 'builtIn', 'displayName', 'name'] },
+    relations: { allowed: [] },
     sort: { allowed: ['id', 'name', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
 });

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -52,7 +52,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
     async getMany(
         query: Record<string, any>,
     ): Promise<EntityRepositoryFindManyResult<Realm>> {
-        return this.repository.findMany(decodeQuery(query, { schema: realmSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: realmSchema }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/role-attribute/schema.ts
+++ b/apps/server-core/src/core/entities/role-attribute/schema.ts
@@ -8,10 +8,26 @@
 import { defineSchema } from '@rapiq/core';
 import type { RoleAttribute } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { role: EntityType.ROLE, realm: EntityType.REALM };
 
 export const roleAttributeSchema = defineSchema<RoleAttribute>({
     name: EntityType.ROLE_ATTRIBUTE,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'name',
+            'value',
+            'roleId',
+            'realmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['id', 'name', 'roleId', 'realmId'] },
+    relations: { allowed: ['role', 'realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: {
         allowed: [
             'id',
@@ -20,7 +36,8 @@ export const roleAttributeSchema = defineSchema<RoleAttribute>({
             'realmId',
             'createdAt',
             'updatedAt',
-        ], 
+        ],
     },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/role-attribute/service.ts
+++ b/apps/server-core/src/core/entities/role-attribute/service.ts
@@ -44,7 +44,7 @@ export class RoleAttributeService extends AbstractEntityService implements IRole
 
         await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
 
-        let parsed = decodeQuery(query, { schema: roleAttributeSchema });
+        let parsed = await decodeQuery(query, { schema: roleAttributeSchema, actor });
 
         // Compile the read permissions into a row condition (#3286 phase 3): the
         // authorization runs as WHERE, so pagination and totals stay exact. A

--- a/apps/server-core/src/core/entities/role-permission/schema.ts
+++ b/apps/server-core/src/core/entities/role-permission/schema.ts
@@ -8,12 +8,29 @@
 import { defineSchema } from '@rapiq/core';
 import type { RolePermission } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { role: EntityType.ROLE, permission: EntityType.PERMISSION };
 
 export const rolePermissionSchema = defineSchema<RolePermission>({
     name: EntityType.ROLE_PERMISSION,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'policyId',
+            'realmScope',
+            'permissionId',
+            'permissionRealmId',
+            'roleId',
+            'roleRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['roleId', 'permissionId'] },
-    relations: { allowed: ['role', 'permission'] },
+    relations: { allowed: ['role', 'permission'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { role: EntityType.ROLE, permission: EntityType.PERMISSION },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/role-permission/service.ts
+++ b/apps/server-core/src/core/entities/role-permission/service.ts
@@ -61,7 +61,7 @@ export class RolePermissionService extends JunctionEntityService implements IRol
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: rolePermissionSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: rolePermissionSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/role/schema.ts
+++ b/apps/server-core/src/core/entities/role/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { Role } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const roleSchema = defineSchema<Role>({
     name: EntityType.ROLE,
@@ -24,6 +27,8 @@ export const roleSchema = defineSchema<Role>({
         ],
     },
     filters: { allowed: ['id', 'name', 'target', 'realmId'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'name', 'updatedAt', 'createdAt'] },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/role/service.ts
+++ b/apps/server-core/src/core/entities/role/service.ts
@@ -52,7 +52,7 @@ export class RoleService extends AbstractEntityService implements IRoleService {
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: roleSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: roleSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/scope/schema.ts
+++ b/apps/server-core/src/core/entities/scope/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { Scope } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const scopeSchema = defineSchema<Scope>({
     name: EntityType.SCOPE,
@@ -24,6 +27,8 @@ export const scopeSchema = defineSchema<Scope>({
         ],
     },
     filters: { allowed: ['id', 'builtIn', 'name', 'realmId'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'name', 'updatedAt', 'createdAt'] },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/scope/service.ts
+++ b/apps/server-core/src/core/entities/scope/service.ts
@@ -51,7 +51,7 @@ export class ScopeService extends AbstractEntityService implements IScopeService
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: scopeSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: scopeSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/session/schema.ts
+++ b/apps/server-core/src/core/entities/session/schema.ts
@@ -9,6 +9,9 @@ import { defineSchema } from '@rapiq/core';
 import type { Session } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
 import { SESSION_FILTER_KEYS } from '../../authentication/session/types.ts';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const sessionSchema = defineSchema<Session>({
     name: EntityType.SESSION,
@@ -30,8 +33,8 @@ export const sessionSchema = defineSchema<Session>({
         ],
     },
     filters: { allowed: [...SESSION_FILTER_KEYS] },
-    relations: { allowed: ['realm'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['seenAt', 'expiresAt', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { realm: EntityType.REALM },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/session/service.ts
+++ b/apps/server-core/src/core/entities/session/service.ts
@@ -50,7 +50,7 @@ export class SessionService extends AbstractEntityService implements ISessionSer
         query: Record<string, any>,
         actor: ActorContext,
     ): Promise<EntityRepositoryFindManyResult<Session>> {
-        const parsed = decodeQuery(query, { schema: sessionSchema });
+        const parsed = await decodeQuery(query, { schema: sessionSchema, actor });
 
         let canReadAll = true;
         try {
@@ -266,7 +266,11 @@ export class SessionService extends AbstractEntityService implements ISessionSer
         await actor.permissionEvaluator.preEvaluate({ name: PermissionName.SESSION_DELETE });
 
         const sessions = await this.repository.findAllByQuery(
-            decodeQuery(query, { schema: sessionSchema, parameters: ['filters'] }),
+            await decodeQuery(query, {
+                schema: sessionSchema, 
+                parameters: ['filters'], 
+                actor, 
+            }),
         );
 
         let count = 0;

--- a/apps/server-core/src/core/entities/trust-anchor/schema.ts
+++ b/apps/server-core/src/core/entities/trust-anchor/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { TrustAnchor } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const trustAnchorSchema = defineSchema<TrustAnchor>({
     name: EntityType.TRUST_ANCHOR,
@@ -23,6 +26,8 @@ export const trustAnchorSchema = defineSchema<TrustAnchor>({
         ],
     },
     filters: { allowed: ['id', 'name', 'enabled', 'realmId'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'name', 'enabled', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/trust-anchor/service.ts
+++ b/apps/server-core/src/core/entities/trust-anchor/service.ts
@@ -66,7 +66,7 @@ export class TrustAnchorService extends AbstractEntityService implements ITrustA
     ): Promise<EntityRepositoryFindManyResult<TrustAnchor>> {
         await actor.permissionEvaluator.preEvaluateOneOf({ name: PERMISSION_NAMES });
 
-        let parsed = decodeQuery(query, { schema: trustAnchorSchema });
+        let parsed = await decodeQuery(query, { schema: trustAnchorSchema, actor });
         if (options.realmId) {
             parsed = appendQueryConditions(parsed, eq('realmId', options.realmId));
         }

--- a/apps/server-core/src/core/entities/user-attribute/schema.ts
+++ b/apps/server-core/src/core/entities/user-attribute/schema.ts
@@ -8,10 +8,26 @@
 import { defineSchema } from '@rapiq/core';
 import type { UserAttribute } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { user: EntityType.USER, realm: EntityType.REALM };
 
 export const userAttributeSchema = defineSchema<UserAttribute>({
     name: EntityType.USER_ATTRIBUTE,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'name',
+            'value',
+            'userId',
+            'realmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['id', 'name', 'userId', 'realmId'] },
+    relations: { allowed: ['user', 'realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: {
         allowed: [
             'id',
@@ -20,7 +36,8 @@ export const userAttributeSchema = defineSchema<UserAttribute>({
             'realmId',
             'createdAt',
             'updatedAt',
-        ], 
+        ],
     },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/user-attribute/service.ts
+++ b/apps/server-core/src/core/entities/user-attribute/service.ts
@@ -44,7 +44,7 @@ export class UserAttributeService extends AbstractEntityService implements IUser
             ],
         });
 
-        const parsed = decodeQuery(query, { schema: userAttributeSchema });
+        const parsed = await decodeQuery(query, { schema: userAttributeSchema, actor });
 
         // Compile the foreign-row gate into a row condition (#3286 phase 3),
         // mirroring canReadUserAttribute: own rows (the actor's userId) are

--- a/apps/server-core/src/core/entities/user-authenticator/schema.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { UserAuthenticator } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { user: EntityType.USER, realm: EntityType.REALM };
 
 export const userAuthenticatorSchema = defineSchema<UserAuthenticator>({
     name: EntityType.USER_AUTHENTICATOR,
@@ -25,6 +28,8 @@ export const userAuthenticatorSchema = defineSchema<UserAuthenticator>({
         ],
     },
     filters: { allowed: ['id', 'kind', 'confirmed', 'userId', 'realmId'] },
+    relations: { allowed: ['user', 'realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['createdAt', 'updatedAt', 'lastUsedAt'] },
     pagination: { maxLimit: 50 },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/user-authenticator/service.ts
+++ b/apps/server-core/src/core/entities/user-authenticator/service.ts
@@ -184,7 +184,7 @@ export class UserAuthenticatorService extends AbstractEntityService implements I
             await actor.permissionEvaluator.preEvaluate({ name: PermissionName.USER_AUTHENTICATOR_READ });
         }
 
-        const parsed = decodeQuery(query, { schema: userAuthenticatorSchema });
+        const parsed = await decodeQuery(query, { schema: userAuthenticatorSchema, actor });
         const findManyOptions = options.userId ? { owner: { userId: options.userId } } : {};
 
         // Own devices are ungated: the nested self read is already owner-scoped,

--- a/apps/server-core/src/core/entities/user-permission/schema.ts
+++ b/apps/server-core/src/core/entities/user-permission/schema.ts
@@ -8,12 +8,29 @@
 import { defineSchema } from '@rapiq/core';
 import type { UserPermission } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { user: EntityType.USER, permission: EntityType.PERMISSION };
 
 export const userPermissionSchema = defineSchema<UserPermission>({
     name: EntityType.USER_PERMISSION,
+    // see user-role schema — explicit root projection for include= decodes
+    fields: {
+        default: [
+            'id',
+            'policyId',
+            'realmScope',
+            'permissionId',
+            'permissionRealmId',
+            'userId',
+            'userRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['userId', 'permissionId'] },
-    relations: { allowed: ['user', 'permission'] },
+    relations: { allowed: ['user', 'permission'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { user: EntityType.USER, permission: EntityType.PERMISSION },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/user-permission/service.ts
+++ b/apps/server-core/src/core/entities/user-permission/service.ts
@@ -59,7 +59,7 @@ export class UserPermissionService extends JunctionEntityService implements IUse
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: userPermissionSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: userPermissionSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/user-role/schema.ts
+++ b/apps/server-core/src/core/entities/user-role/schema.ts
@@ -8,12 +8,29 @@
 import { defineSchema } from '@rapiq/core';
 import type { UserRole } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { user: EntityType.USER, role: EntityType.ROLE };
 
 export const userRoleSchema = defineSchema<UserRole>({
     name: EntityType.USER_ROLE,
+    // `default` pins an explicit root projection: an include= decodes the
+    // relation's fields, and the adapter's select-replace would otherwise
+    // drop every root column (incl. the id the DISTINCT wrapper needs).
+    fields: {
+        default: [
+            'id',
+            'roleId',
+            'roleRealmId',
+            'userId',
+            'userRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['roleId', 'userId'] },
-    relations: { allowed: ['user', 'role'] },
+    relations: { allowed: ['user', 'role'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { user: EntityType.USER, role: EntityType.ROLE },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/user-role/service.ts
+++ b/apps/server-core/src/core/entities/user-role/service.ts
@@ -50,7 +50,7 @@ export class UserRoleService extends JunctionEntityService implements IUserRoleS
             ],
         });
 
-        return this.repository.findMany(decodeQuery(query, { schema: userRoleSchema }));
+        return this.repository.findMany(await decodeQuery(query, { schema: userRoleSchema, actor }));
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/user/schema.ts
+++ b/apps/server-core/src/core/entities/user/schema.ts
@@ -8,6 +8,9 @@
 import { defineSchema } from '@rapiq/core';
 import type { User } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
+import { createRelationsReadGate } from '../../query/relations.ts';
+
+const schemaMapping = { realm: EntityType.REALM };
 
 export const userSchema = defineSchema<User>({
     name: EntityType.USER,
@@ -29,8 +32,8 @@ export const userSchema = defineSchema<User>({
         allowed: ['email'],
     },
     filters: { allowed: ['id', 'name', 'realmId'] },
-    relations: { allowed: ['realm'] },
+    relations: { allowed: ['realm'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['id', 'name', 'displayName', 'createdAt', 'updatedAt'] },
     pagination: { maxLimit: 50 },
-    schemaMapping: { realm: EntityType.REALM },
+    schemaMapping,
 });

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -54,7 +54,7 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
 
-        const parsed = decodeQuery(query, { schema: userSchema });
+        const parsed = await decodeQuery(query, { schema: userSchema, actor });
 
         // Compile the read permissions into a row condition (#3286 phase 3). The
         // own row is always readable, so the self short-circuit composes as an
@@ -148,7 +148,11 @@ export class UserService extends AbstractEntityService implements IUserService {
 
         const entity = await this.repository.findOne(
             idOrName,
-            decodeQuery(query, { schema: userSchema, parameters: ['fields', 'relations'] }),
+            await decodeQuery(query, {
+                schema: userSchema, 
+                parameters: ['fields', 'relations'], 
+                actor, 
+            }),
             realmId,
         );
         if (!entity) {

--- a/apps/server-core/src/core/query/index.ts
+++ b/apps/server-core/src/core/query/index.ts
@@ -6,4 +6,5 @@
  */
 
 export * from './module.ts';
+export * from './relations.ts';
 export * from './types.ts';

--- a/apps/server-core/src/core/query/module.ts
+++ b/apps/server-core/src/core/query/module.ts
@@ -37,7 +37,7 @@ import { userAttributeSchema } from '../entities/user-attribute/schema.ts';
 import { userAuthenticatorSchema } from '../entities/user-authenticator/schema.ts';
 import { userPermissionSchema } from '../entities/user-permission/schema.ts';
 import { userRoleSchema } from '../entities/user-role/schema.ts';
-import type { DecodeQueryOptions } from './types.ts';
+import type { DecodeQueryOptions, QueryDecodeContext } from './types.ts';
 
 /**
  * Registry of every entity schema — the server-side allow-list layer.
@@ -100,18 +100,27 @@ export const queryCodec = createURLCodec(schemaRegistry);
  * schema's allow-lists, defaults and pagination bounds are applied
  * here — downstream consumers (repository adapters) only execute the
  * returned query.
+ *
+ * Async because the schema validate hooks are: the relations read
+ * gate (`createRelationsReadGate`) awaits the actor's permission
+ * pre-gate per include, and rapiq refuses async validators on the
+ * synchronous decode path. Pass the acting identity via
+ * `options.actor` on every request-driven decode (authenticated or
+ * anonymous — the HTTP adapter always builds one); a decode without
+ * an actor is a system call and runs unrestricted.
  */
-export function decodeQuery<RECORD extends ObjectLiteral = ObjectLiteral>(
+export async function decodeQuery<RECORD extends ObjectLiteral = ObjectLiteral>(
     input: unknown,
     options: DecodeQueryOptions<RECORD>,
-) : Query {
+) : Promise<Query> {
     const normalized = isObject(input) || typeof input === 'string' ? input : {};
 
-    const parsed = queryCodec.decode(normalized, {
+    const parsed = await queryCodec.decodeAsync(normalized, {
         // Schema<RECORD> is invariant; the codec's non-generic options
         // accept Schema<ObjectLiteral>, so collapse the variance here.
         schema: options.schema as Schema<any> | string,
         parameters: options.parameters,
+        context: { actor: options.actor } satisfies QueryDecodeContext,
     });
 
     return parsed ?? new Query({});

--- a/apps/server-core/src/core/query/relations.ts
+++ b/apps/server-core/src/core/query/relations.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { KeyValidator } from '@rapiq/core';
+import { EntityType, PermissionName } from '@authup/core-kit';
+import type { QueryDecodeContext } from './types.ts';
+
+/**
+ * Read gate per include target: the permission disjunction an actor
+ * must hold (data-availability-derived pre-gate, issue #3290) for the
+ * target entity type to be joinable via `include=`. Mirrors each
+ * target service's own `getMany` read pre-gate, so "may list the
+ * entity type" and "may join it onto another list" stay one predicate.
+ * Policies are deliberately gated under the PERMISSION family — they
+ * are managed under the permission domain.
+ *
+ * Absent entries are ungated: `realm` (the realm list is public — the
+ * login realm chooser reads it anonymously) and `identityProvider`
+ * (the anonymous login page lists providers; its schema field
+ * allow-list is the safe-DTO layer).
+ */
+const RELATION_TARGET_READ_GATES : Partial<Record<`${EntityType}`, PermissionName[]>> = {
+    [EntityType.CLIENT]: [
+        PermissionName.CLIENT_READ,
+        PermissionName.CLIENT_UPDATE,
+        PermissionName.CLIENT_DELETE,
+    ],
+    [EntityType.USER]: [
+        PermissionName.USER_READ,
+        PermissionName.USER_UPDATE,
+        PermissionName.USER_DELETE,
+    ],
+    [EntityType.ROLE]: [
+        PermissionName.ROLE_READ,
+        PermissionName.ROLE_UPDATE,
+        PermissionName.ROLE_DELETE,
+    ],
+    [EntityType.SCOPE]: [
+        PermissionName.SCOPE_READ,
+        PermissionName.SCOPE_UPDATE,
+        PermissionName.SCOPE_DELETE,
+    ],
+    [EntityType.PERMISSION]: [
+        PermissionName.PERMISSION_READ,
+        PermissionName.PERMISSION_UPDATE,
+        PermissionName.PERMISSION_DELETE,
+    ],
+    [EntityType.POLICY]: [
+        PermissionName.PERMISSION_READ,
+        PermissionName.PERMISSION_UPDATE,
+        PermissionName.PERMISSION_DELETE,
+    ],
+};
+
+/**
+ * Build a rapiq `relations.validate` hook gating each include on the
+ * TARGET entity type's read permission (issue #3295): the actor must
+ * pass the derived pre-gate (`preEvaluateOneOf`, #3290) for the
+ * relation's mapped entity type — row data is unknown at decode time,
+ * so only a settled-false (the actor can never read that entity type)
+ * denies. A denial STRIPS the include silently (and rapiq prunes
+ * dotted filter/sort/field keys riding the denied relation path) —
+ * the same fail-soft flavor as the allow-lists, so a scoped reader
+ * degrades to the un-joined row shape instead of a 403.
+ *
+ * `mapping` is the schema's own relation → entity-type `schemaMapping`;
+ * rapiq invokes the hook per include segment against the schema
+ * governing it, so nested paths (`include=user.realm`) are gated hop
+ * by hop by each governing schema's own hook. Unmapped relations and
+ * ungated targets neutral-pass.
+ *
+ * Caller classes: a SYSTEM call (no actor in the decode context) is
+ * unrestricted — the gate neutral-passes. A REQUEST call always
+ * carries an actor (`buildActorContext` supplies one even for an
+ * anonymous request), so restriction attaches at the request
+ * boundary: an authenticated actor is gated by its grants, an
+ * anonymous actor holds none and every gated include strips. A gate
+ * evaluation failure fails closed (strip).
+ *
+ * Residual (upstream): a dotted filter/sort/field key whose relation
+ * is NOT explicitly included bypasses this hook — the SQL adapters
+ * auto-join such paths without a relations.validate pass
+ * (tada5hi/rapiq#815).
+ *
+ * NOTE: schemas import this file DIRECTLY (never the `core/query`
+ * barrel) — the barrel reaches `module.ts`, which imports every
+ * schema; importing it from a schema would create a TDZ cycle.
+ */
+export function createRelationsReadGate(
+    mapping: Record<string, `${EntityType}`>,
+) : KeyValidator<QueryDecodeContext | undefined> {
+    return async (name, context) => {
+        const target = mapping[name];
+        if (!target) {
+            return true;
+        }
+
+        const permissions = RELATION_TARGET_READ_GATES[target];
+        if (!permissions) {
+            return true;
+        }
+
+        if (!context || !context.actor) {
+            return true;
+        }
+
+        try {
+            await context.actor.permissionEvaluator.preEvaluateOneOf({ name: permissions });
+            return true;
+        } catch {
+            return false;
+        }
+    };
+}

--- a/apps/server-core/src/core/query/types.ts
+++ b/apps/server-core/src/core/query/types.ts
@@ -6,8 +6,21 @@
  */
 
 import type { ObjectLiteral, Parameter, Schema } from '@rapiq/core';
+import type { ActorContext } from '@authup/server-kit';
 
 export type QueryParameter = `${Parameter}`;
+
+/**
+ * Caller context threaded through the decode into every schema
+ * validate hook (rapiq `ParseQueryOptions['context']`). Carries the
+ * acting identity so per-key gates — the relations read gate — can
+ * consult its permissions. An actor-less context is a SYSTEM call
+ * and passes ungated; request surfaces always supply an actor (an
+ * anonymous one holds no grants, so gated includes strip).
+ */
+export type QueryDecodeContext = {
+    actor?: ActorContext,
+};
 
 export type DecodeQueryOptions<RECORD extends ObjectLiteral = ObjectLiteral> = {
     /**
@@ -23,4 +36,13 @@ export type DecodeQueryOptions<RECORD extends ObjectLiteral = ObjectLiteral> = {
      * affected row set.
      */
     parameters?: QueryParameter[],
+    /**
+     * The acting identity, forwarded to the schema validate hooks as
+     * the decode context. Every REQUEST decode must pass it — the
+     * HTTP adapter builds an actor for authenticated and anonymous
+     * requests alike, so restriction attaches at the request
+     * boundary. Omitting it marks a SYSTEM decode, which runs
+     * unrestricted.
+     */
+    actor?: ActorContext,
 };

--- a/apps/server-core/test/unit/core/query/module.spec.ts
+++ b/apps/server-core/test/unit/core/query/module.spec.ts
@@ -7,13 +7,17 @@
 
 import type { ICondition } from '@rapiq/core';
 import {
-    FilterCompoundOperator, 
-    eq, 
-    isFilter, 
+    FilterCompoundOperator,
+    eq,
+    isFilter,
     isFilters,
 } from '@rapiq/core';
+import { PermissionName } from '@authup/core-kit';
+import type { ActorContext } from '@authup/server-kit';
+import { FakePermissionEvaluator } from '@authup/server-test-kit';
 import { describe, expect, it } from 'vitest';
 import { roleSchema } from '../../../../src/core/entities/role/schema.ts';
+import { userRoleSchema } from '../../../../src/core/entities/user-role/schema.ts';
 import { appendQueryConditions, decodeQuery } from '../../../../src/core/query/index.ts';
 
 function collectFieldConditions(condition: ICondition): [string, unknown][] {
@@ -28,10 +32,14 @@ function collectFieldConditions(condition: ICondition): [string, unknown][] {
     return [];
 }
 
+function buildActor(evaluator: FakePermissionEvaluator): ActorContext {
+    return { permissionEvaluator: evaluator };
+}
+
 describe('core/query', () => {
-    it('should decode bracket and expression dialects into the same condition', () => {
-        const bracket = decodeQuery({ filter: { name: 'admin' } }, { schema: roleSchema });
-        const expression = decodeQuery(
+    it('should decode bracket and expression dialects into the same condition', async () => {
+        const bracket = await decodeQuery({ filter: { name: 'admin' } }, { schema: roleSchema });
+        const expression = await decodeQuery(
             { codec: 'url-expression', filter: "eq(name,'admin')" },
             { schema: roleSchema },
         );
@@ -40,8 +48,8 @@ describe('core/query', () => {
         expect(collectFieldConditions(expression.filters)).toEqual([['name', 'admin']]);
     });
 
-    it('should neither parse nor default masked parameters', () => {
-        const parsed = decodeQuery(
+    it('should neither parse nor default masked parameters', async () => {
+        const parsed = await decodeQuery(
             { filter: { name: 'admin' }, page: { limit: 10 } },
             { schema: roleSchema, parameters: ['filters'] },
         );
@@ -51,8 +59,8 @@ describe('core/query', () => {
         expect(parsed.pagination.offset).toBeUndefined();
     });
 
-    it('should append conditions without displacing client conditions', () => {
-        const parsed = decodeQuery({ filter: { realmId: 'client-realm' } }, { schema: roleSchema });
+    it('should append conditions without displacing client conditions', async () => {
+        const parsed = await decodeQuery({ filter: { realmId: 'client-realm' } }, { schema: roleSchema });
 
         const result = appendQueryConditions(parsed, eq('realmId', 'route-realm'));
 
@@ -65,16 +73,16 @@ describe('core/query', () => {
         expect(collectFieldConditions(parsed.filters)).toEqual([['realmId', 'client-realm']]);
     });
 
-    it('should append onto an empty filter tree', () => {
-        const parsed = decodeQuery({}, { schema: roleSchema });
+    it('should append onto an empty filter tree', async () => {
+        const parsed = await decodeQuery({}, { schema: roleSchema });
 
         const result = appendQueryConditions(parsed, eq('realmId', 'route-realm'));
 
         expect(collectFieldConditions(result.filters)).toEqual([['realmId', 'route-realm']]);
     });
 
-    it('should carry the other parameter nodes over by reference', () => {
-        const parsed = decodeQuery(
+    it('should carry the other parameter nodes over by reference', async () => {
+        const parsed = await decodeQuery(
             { page: { limit: 10 }, sort: '-name' },
             { schema: roleSchema },
         );
@@ -87,5 +95,96 @@ describe('core/query', () => {
         expect(result.pagination).toBe(parsed.pagination);
         expect(result.sorts).toBe(parsed.sorts);
         expect(result.pagination.limit).toEqual(10);
+    });
+
+    describe('relations read gate', () => {
+        it('should keep includes for an actor passing the target read gate', async () => {
+            const evaluator = new FakePermissionEvaluator();
+
+            const parsed = await decodeQuery(
+                { include: 'user,role' },
+                { schema: userRoleSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(parsed.relations.value.map((relation) => relation.name)).toEqual(['user', 'role']);
+            expect(evaluator.preEvaluateOneOfCalls.map((call) => call.name)).toEqual([
+                [
+                    PermissionName.USER_READ,
+                    PermissionName.USER_UPDATE,
+                    PermissionName.USER_DELETE,
+                ],
+                [
+                    PermissionName.ROLE_READ,
+                    PermissionName.ROLE_UPDATE,
+                    PermissionName.ROLE_DELETE,
+                ],
+            ]);
+        });
+
+        it('should strip includes whose target read gate settles false', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.deny('preEvaluateOneOf');
+
+            const parsed = await decodeQuery(
+                { include: 'user,role', filter: { userId: 'foo' } },
+                { schema: userRoleSchema, actor: buildActor(evaluator) },
+            );
+
+            // fail-soft: the include is dropped, the rest of the query survives
+            expect(parsed.relations.value).toEqual([]);
+            expect(collectFieldConditions(parsed.filters)).toEqual([['userId', 'foo']]);
+        });
+
+        it('should strip only the denied include', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.setBehavior(({ ctx }) => {
+                const names = Array.isArray(ctx.name) ? ctx.name : [ctx.name];
+                if (names.includes(PermissionName.USER_READ)) {
+                    throw new Error('denied');
+                }
+            });
+
+            const parsed = await decodeQuery(
+                { include: 'user,role' },
+                { schema: userRoleSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(parsed.relations.value.map((relation) => relation.name)).toEqual(['role']);
+        });
+
+        it('should prune dotted keys riding a denied include', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.deny('preEvaluateOneOf');
+
+            const parsed = await decodeQuery(
+                { include: 'user', filter: { 'user.name': 'admin' } },
+                { schema: userRoleSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(parsed.relations.value).toEqual([]);
+            expect(collectFieldConditions(parsed.filters)).toEqual([]);
+        });
+
+        it('should not gate an ungated target', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.denyAll();
+
+            const parsed = await decodeQuery(
+                { include: 'realm' },
+                { schema: roleSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(parsed.relations.value.map((relation) => relation.name)).toEqual(['realm']);
+            expect(evaluator.preEvaluateOneOfCalls).toEqual([]);
+        });
+
+        it('should run an actor-less (system) decode unrestricted', async () => {
+            const parsed = await decodeQuery(
+                { include: 'user,role' },
+                { schema: userRoleSchema },
+            );
+
+            expect(parsed.relations.value.map((relation) => relation.name)).toEqual(['user', 'role']);
+        });
     });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/include-authorization.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/include-authorization.spec.ts
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { PermissionName } from '@authup/core-kit';
+import { Client as HTTPClient } from '@authup/core-http-kit';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { createTestApplication } from '../../../../app';
+import { createFakeClient } from '../../../../utils';
+
+describe('http/controllers (include authorization)', () => {
+    const suite = createTestApplication();
+
+    let readerClient: HTTPClient;
+    let roleReaderClient: HTTPClient;
+    const knownSecret = 'include-gate-secret';
+
+    const createIdentity = async (permissionNames: PermissionName[]) => {
+        const created = await suite.client.client.create({
+            ...createFakeClient(),
+            authMethod: 'secret',
+            tokenBindingMethod: 'none',
+            secret: knownSecret,
+            secretHashed: false,
+            secretEncrypted: false,
+        });
+
+        for (const permissionName of permissionNames) {
+            const permission = await suite.client.permission.getOne(permissionName);
+            await suite.client.clientPermission.create({
+                clientId: created.id,
+                permissionId: permission.id,
+            });
+        }
+
+        const tokenResponse = await suite.client.token.createWithClientCredentials({
+            client_id: created.id,
+            client_secret: knownSecret,
+        });
+
+        const httpClient = new HTTPClient({ baseURL: suite.baseURL });
+        httpClient.setAuthorizationHeader({
+            type: 'Bearer',
+            token: tokenResponse.access_token,
+        });
+
+        return httpClient;
+    };
+
+    beforeAll(async () => {
+        await suite.setup();
+
+        readerClient = await createIdentity([
+            PermissionName.USER_ROLE_READ,
+        ]);
+        roleReaderClient = await createIdentity([
+            PermissionName.USER_ROLE_READ,
+            PermissionName.ROLE_READ,
+        ]);
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    it('should join includes for an actor holding the target read permissions', async () => {
+        const response = await suite.client.userRole.getMany({ relations: ['user', 'role'] });
+
+        expect(response.data.length).toBeGreaterThanOrEqual(1);
+        expect(response.data[0].user).toBeDefined();
+        expect(response.data[0].role).toBeDefined();
+    });
+
+    it('should strip includes for an actor without the target read permissions', async () => {
+        const response = await readerClient.userRole.getMany({ relations: ['user', 'role'] });
+
+        // fail-soft: the list itself succeeds, only the joins are dropped
+        expect(response.data.length).toBeGreaterThanOrEqual(1);
+        for (const row of response.data) {
+            expect(row.user).toBeUndefined();
+            expect(row.role).toBeUndefined();
+            expect(row.userId).toBeDefined();
+            expect(row.roleId).toBeDefined();
+        }
+    });
+
+    it('should strip only the includes whose target read gate settles false', async () => {
+        const response = await roleReaderClient.userRole.getMany({ relations: ['user', 'role'] });
+
+        expect(response.data.length).toBeGreaterThanOrEqual(1);
+        for (const row of response.data) {
+            expect(row.user).toBeUndefined();
+            expect(row.role).toBeDefined();
+        }
+    });
+});

--- a/packages/access/src/policy/built-in/realm-match/evaluator.ts
+++ b/packages/access/src/policy/built-in/realm-match/evaluator.ts
@@ -72,7 +72,6 @@ export class RealmMatchPolicyEvaluator implements IPolicyEvaluator {
         }
 
         const realmId = identity.realmId ?? null;
-        const realmName = identity.realmName ?? null;
 
         if (policy.scope) {
             const scope = normalizeRealmScope(policy.scope);
@@ -84,22 +83,33 @@ export class RealmMatchPolicyEvaluator implements IPolicyEvaluator {
             if (scope === RealmScope.ANY) {
                 // constant-true: nin([]) matches everything (rapiq ConstantPlan)
                 condition = nin(field, []);
-            } else if (scope === RealmScope.NONE || (realmId === null && realmName === null)) {
-                // no reach / realm-less actor — constant-false: in([]) matches nothing
-                condition = inArray(field, []);
             } else {
+                // The lowered column (default `realmId`) holds realm IDs — the resource
+                // realm is stamped from `entity.realmId`
+                // (AbstractEntityService.resourceRealmMatch), so the WHERE match compares
+                // that ID column against the actor's realm ID. The realm NAME is
+                // deliberately NOT pushed here: it never appears in a realmId column and
+                // would bind a non-uuid literal that postgres/mysql reject against a uuid
+                // column (the sqlite-only test suite masks this, since sqlite is untyped).
+                // Settled evaluation keeps the name-equality leniency for a name-stamped
+                // resource SCALAR — which has no row-column counterpart, so parity holds
+                // for realistic row-shaped data (see the exactness caveat above).
                 const terms : ICondition[] = [];
-                if (realmId !== null) {
+                if (scope !== RealmScope.NONE && realmId !== null) {
                     terms.push(eq(field, realmId));
-                }
-                if (realmName !== null) {
-                    terms.push(eq(field, realmName));
                 }
                 if (scope === RealmScope.OWN_OR_NULL) {
                     terms.push(eq(field, null));
                 }
 
-                condition = terms.length === 1 ? terms[0]! : or(...terms);
+                if (terms.length === 0) {
+                    // no reach / realm-less actor with no null branch — constant-false
+                    condition = inArray(field, []);
+                } else if (terms.length === 1) {
+                    condition = terms[0]!;
+                } else {
+                    condition = or(...terms);
+                }
             }
 
             return policy.invert ? not(condition) : condition;

--- a/packages/access/test/unit/policy/to-condition.spec.ts
+++ b/packages/access/test/unit/policy/to-condition.spec.ts
@@ -176,10 +176,15 @@ describe('src/policy (toCondition / WHERE pushdown)', () => {
     });
 
     describe('realm-match scope mode', () => {
+        // Realistic row shapes only: the lowered `realmId` column holds realm IDs.
+        // A realm NAME in that column ({ realmId: 'master' }) is deliberately NOT a
+        // test row — the condition intentionally does not push a name-equality term
+        // (it binds a non-uuid literal that postgres/mysql reject on a uuid column),
+        // so the settled-evaluation name-match leniency has no row-column counterpart.
+        // The dedicated "name value" test below pins that intended divergence.
         const rows = [
             { realmId: 'c641912c-21e5-4cb4-84b6-169e2b2bb023' },
             { realmId: '11111111-2222-4333-8444-555555555555' },
-            { realmId: 'master' },
             { realmId: null },
         ];
 
@@ -209,19 +214,31 @@ describe('src/policy (toCondition / WHERE pushdown)', () => {
         }
 
         it('should lower own reach', async () => {
-            await expectScopeParity('own', [true, false, true, false]);
+            await expectScopeParity('own', [true, false, false]);
         });
 
         it('should lower ownOrNull reach', async () => {
-            await expectScopeParity('ownOrNull', [true, false, true, true]);
+            await expectScopeParity('ownOrNull', [true, false, true]);
         });
 
         it('should lower any reach', async () => {
-            await expectScopeParity('any', [true, true, true, true]);
+            await expectScopeParity('any', [true, true, true]);
         });
 
         it('should lower none reach', async () => {
-            await expectScopeParity('none', [false, false, false, false]);
+            await expectScopeParity('none', [false, false, false]);
+        });
+
+        it('should not push a realm-name term onto the id column (postgres-safe)', async () => {
+            // The actor's realmName is 'master' (see identityData). The lowered own
+            // condition must compare the realmId column against the actor's realm ID
+            // ONLY — never bind the name literal, which would type-error on a uuid
+            // column. A row whose realmId happens to equal the name does not match.
+            const outcome = await engine.evaluate(scopePolicy('own'), context({ data: withIdentity() }));
+            const predicate = test(outcome.condition!);
+
+            expect(predicate({ realmId: 'master' })).toBe(false);
+            expect(predicate({ realmId: 'c641912c-21e5-4cb4-84b6-169e2b2bb023' })).toBe(true);
         });
 
         it('should keep the neutral-pass without withConditions', async () => {


### PR DESCRIPTION
Closes #3295. Closes #3286 — this is the final piece of the RFC; the deliberately-deferred residuals live upstream (tada5hi/rapiq#810 relation-scoped conditions, tada5hi/rapiq#815 dotted-key bypass).

## What

A rapiq `include=` on a list/read endpoint now runs the derived pre-gate (#3290) for the **target entity type's read permission** at decode time. Previously the `relations.allowed` lists bounded *what* is joinable, but not *who* may read it.

- `decodeQuery` is now **async** (`codec.decodeAsync` — the gate awaits the actor's pre-gate) and takes an `actor` option, threaded as the rapiq decode context (tada5hi/rapiq#806/#807 surface, shipped in 2.0.0-beta.5).
- Every schema's `relations.validate` is `createRelationsReadGate(schemaMapping)` (`core/query/relations.ts`): per include segment the relation maps to its target entity type and `preEvaluateOneOf` runs the type's read-permission disjunction. The gate map mirrors each target service's own `getMany` read gate; POLICY sits under the PERMISSION family; REALM and IDENTITY_PROVIDER stay ungated (both lists are anonymous surfaces). Nested paths (`include=user.realm`) gate hop by hop.
- **Deny = silent strip** (fail-soft, matching the allow-lists): the include — and every dotted filter/sort/field key riding the denied relation path — is pruned; the request succeeds with the un-joined row shape.
- **Caller classes**: a SYSTEM decode (no actor) runs unrestricted; every REQUEST decode passes the actor — `buildActorContext` supplies one for anonymous requests too (the authorization middleware sets the evaluator before the header check), so a guest's gated includes strip.

## Also fixed en route

- **Syntactic-fallback hole closed**: a schema without a `relations` key fell back to rapiq's syntactic name check, so role / scope / key / trust-anchor / role-attribute / user-attribute / user-authenticator silently accepted arbitrary includes ungated. Every schema now declares `relations` explicitly (`event` / `realm` pin `allowed: []` — their entities have no joinable relations, so a syntactic include died at the TypeORM join as a 500).
- **Latent 500 on every junction `include=` since #3278**: with no root `fields` declared, an include decoded relation-only fields and the typeorm adapter's `select()` replace dropped every root column — including the id TypeORM's DISTINCT-id pagination wrapper needs (`no such column: distinctAlias.userRole_id`). The 8 junction + 2 attribute schemas now pin complete `fields.default` lists (the consent-schema precedent). Note: these lists must enumerate every scalar column — boot validation checks key existence, not completeness.

## Known residual (upstream)

A dotted filter/sort/field key whose relation is NOT explicitly included bypasses the hook — the SQL adapters auto-join such paths without a `relations.validate` pass. Tracked as tada5hi/rapiq#815 (the removal trigger for the residual note in `.agents/architecture.md`).

## Tests

- `test/unit/core/query/module.spec.ts`: gate matrix — permitted include (+ asserted permission names), settled-false strip (query survives), per-relation partial strip, dotted-key pruning on a denied include, ungated target with a deny-all actor, actor-less (system) decode.
- `test/unit/http/controllers/entities/include-authorization.spec.ts`: end-to-end — admin gets joined `user`/`role`; a `USER_ROLE_READ`-only identity gets rows with both includes stripped; a `USER_ROLE_READ + ROLE_READ` identity keeps only `role`.
- Full server-core suite green (the two LDAP spec failures are the known stale-container issue, unrelated).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added actor-aware query processing so results and included relationships respect the caller’s permissions.
  * Unauthorized relationship includes are now silently removed while base records remain available.
  * Protected related fields in filters, sorting, and projections are also removed when access is denied.
  * Added explicit default projections to improve safe and consistent response data.
* **Bug Fixes**
  * Prevented unauthorized related data from being exposed through consent and session-management queries.
* **Tests**
  * Added coverage for allowed, denied, and partially denied relationship includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->