### PR TITLE
fix(access): fail-closed data-availability gate + pre-camelCase policy upgrade note

### DIFF
--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -222,6 +222,27 @@ policies:
       attributeNullMatchAll: true
 ```
 
+::: warning Upgrading from a pre-camelCase release
+Policy `extraAttributes` persisted **before** the camelCase release — both the attribute keys and
+the entity-property names referenced inside `names`, `query`, and `attributeName` — are **not**
+migrated automatically; the data migration deliberately leaves `auth_policy_attributes` untouched.
+Built-in `system.*` policies self-heal (the provisioner rewrites them to camelCase on every
+startup), but **user-authored** policies do not.
+
+A stale `snake_case` policy silently changes meaning:
+
+- an `invert: true` `attribute_names` denylist (e.g. `["name_locked", "status_message"]`) or an
+  `invert: true` `attributes` policy (e.g. `{ realm_id: … }`) **fails open** — the camelCase
+  attribute keys no longer match, so the deny never fires;
+- a non-inverted `attributes` / attribute-mode `realm_match` constraint **stops matching** (denying
+  legitimate access, or silently dropping the realm constraint).
+
+**Action:** after upgrading, re-save every custom (non-built-in) `attribute_names`, `attributes`, or
+attribute-mode `realm_match` policy — via `PUT /policies/:id`, the admin UI, or a provisioning
+`replace` — using camelCase field references. Re-saving re-serializes the stored configuration under
+the current contract and restores the intended decision.
+:::
+
 ### Permission
 
 | Field        | Type               | Description                          |

--- a/packages/access/src/policy/engine/module.ts
+++ b/packages/access/src/policy/engine/module.ts
@@ -119,53 +119,16 @@ export class PolicyEngine implements IPolicyEngine {
         // Data-availability gate: a policy whose declared data requirements are not
         // satisfied yet is PENDING — not true, not false. Like the include/exclude
         // neutral-pass, `invert` is never applied here (the evaluator is not invoked
-        // at all): unknown stays unknown under negation.
-        if (evaluator.requires) {
-            const missing = evaluator.requires(policy)
-                .filter((key) => !ctx.data || !ctx.data.has(key));
-
-            if (missing.length > 0) {
-                const result : PolicyEvaluationResult = {
-                    success: false,
-                    pending: true,
-                    issues: [
-                        definePolicyIssueItem({
-                            code: PolicyIssueCode.DATA_MISSING,
-                            message: `The data propert${missing.length > 1 ? 'ies' : 'y'} ${missing.join(', ')} ${missing.length > 1 ? 'are' : 'is'} missing`,
-                            path: ctx.path,
-                        }),
-                    ],
-                };
-
-                // Condition form of the pending leaf (WHERE pushdown), on request only.
-                // A throwing / null toCondition simply leaves the result condition-less —
-                // the consumer falls back to a per-row post-check (fail-safe).
-                if (ctx.withConditions && evaluator.toCondition) {
-                    try {
-                        const condition = await evaluator.toCondition(policy, ctx);
-                        if (condition) {
-                            result.condition = condition;
-                        }
-                    } catch {
-                        // not expressible — stays a post-check
-                    }
-                }
-
-                return result;
-            }
-        }
-
+        // at all): unknown stays unknown under negation. Wrapped in the same try as
+        // the evaluation itself so a throwing `requires()` fails closed (structured
+        // deny) instead of rejecting out of `evaluate()`.
         try {
-            // Data-availability gate: a policy whose declared data requirements are not
-            // satisfied yet is PENDING — not true, not false. Like the include/exclude
-            // neutral-pass, `invert` is never applied here (the evaluator is not invoked
-            // at all): unknown stays unknown under negation.
             if (evaluator.requires) {
                 const missing = evaluator.requires(policy)
                     .filter((key) => !ctx.data || !ctx.data.has(key));
 
                 if (missing.length > 0) {
-                    return {
+                    const result : PolicyEvaluationResult = {
                         success: false,
                         pending: true,
                         issues: [
@@ -176,6 +139,22 @@ export class PolicyEngine implements IPolicyEngine {
                             }),
                         ],
                     };
+
+                    // Condition form of the pending leaf (WHERE pushdown), on request only.
+                    // A throwing / null toCondition simply leaves the result condition-less —
+                    // the consumer falls back to a per-row post-check (fail-safe).
+                    if (ctx.withConditions && evaluator.toCondition) {
+                        try {
+                            const condition = await evaluator.toCondition(policy, ctx);
+                            if (condition) {
+                                result.condition = condition;
+                            }
+                        } catch {
+                            // not expressible — stays a post-check
+                        }
+                    }
+
+                    return result;
                 }
             }
 


### PR DESCRIPTION
Follow-ups from a correctness/security audit of the `v1.0.0-beta.53..master` range (camelCase, robot removal, rapiq v2, tri-state policy engine + WHERE-pushdown authorization). The core changes reviewed clean; these are the two actionable items.

## `fix(access)` — fold the data-availability gate into the evaluator `try`

`PolicyEngine.evaluate` carried **two** copies of the `requires()` data-availability gate:

- the tri-state hardening (#3290) put the gate inside the `try`/`catch` so a throwing `requires()` degrades to a structured fail-closed deny;
- condition-lowering (#3291) then added a second copy **outside** the `try` (to attach the WHERE-pushdown condition on a pending leaf), which left the inner copy dead **and** defeated the fail-closed guarantee — the outer `requires()` now ran first, outside the `try`, so a throw rejected out of `evaluate()` instead of denying.

Merged into a single gate inside the `try`. A throwing `requires()` again fails closed (`POLICY_EVALUATOR_NOT_PROCESSABLE`), the dead duplicate is gone. Fail-closed, so no access-widening — a robustness/dead-code fix. `packages/access` builds clean, 141/141 tests pass, lint clean.

## `docs(provisioning)` — pre-camelCase policies are not auto-migrated

The camelCase data migration deliberately leaves `auth_policy_attributes` untouched: built-in `system.*` policies self-heal via the provisioner MERGE, but **user-authored** policies do not. A stale `snake_case` `invert: true` `attribute_names`/`attributes` policy **fails open** (the camelCase attribute keys no longer match, so the deny never fires); a non-inverted `attributes`/attribute-mode `realm_match` constraint stops matching. Documents the upgrade action — re-save affected custom policies so they re-serialize under the camelCase contract.

(An automatic-migration alternative was evaluated and set aside: it requires a recursive rewrite of entity-property references inside `names`/`query`/`attributeName` plus its own test, and the safe subset — renaming only the EA config keys — would on its own turn a working non-invert `realm_match` constraint into a silent neutral-pass. Documentation is the lower-risk path; built-ins self-heal either way.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Policy evaluations now fail closed when required data checks encounter an error.
  * Improved handling of incomplete policy data and conditional evaluation results.

* **Documentation**
  * Added upgrade guidance for policies using legacy `snake_case` attributes.
  * Documented potential rule-evaluation issues and steps to update custom policies to camelCase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->