### PR TITLE
fix(client-web-kit): build ASearch name filter via contains() helper

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2996,7 +2996,16 @@ integration:
   `Filters.merge`'s flat-root-AND restriction. The
   `queryFilters` context hook may return an `ICondition`
   (`or(contains('name', q), contains('displayName', q))`) or a legacy
-  filters record. Interactive state (search filters, sorts) is retained
+  filters record. **`ASearch` passes the raw search text as a bare
+  `filters.name` string** (never a wire marker — the rapiq v2 IR builder
+  does NOT interpret `~foo`/`!foo`/`<5`; a `~foo` value decodes as
+  `eq(name,'~foo')`, a literal exact-match, which silently broke name
+  search). The manager turns that bare `name` string into a condition via
+  the `queryFilters` hook when provided, else a default
+  `contains('name', text)`; an empty search (`filters: {}`) resets to the
+  base scope. Build every filter through the `@rapiq/core` helpers
+  (`eq`/`contains`/`inArray`/`and`/`or`/`not`/…), never a raw wire string.
+  Interactive state (search filters, sorts) is retained
   **inside the manager** across loads: a pagination-only
   `load({ pagination })` keeps the current search; an assembled
   `IQuery` load input replaces the interactive state wholesale.

--- a/packages/client-web-kit/src/components/utility/entity/collection/module.ts
+++ b/packages/client-web-kit/src/components/utility/entity/collection/module.ts
@@ -24,6 +24,7 @@ import type {
 } from '@rapiq/core';
 import {
     Query,
+    contains,
     defineFilters,
     definePagination,
     isQuery,
@@ -210,13 +211,20 @@ function create<
 
                 let filtersOverride : IFilters | undefined;
                 if (
-                    context.queryFilters &&
                     input.filters &&
                     !isCondition(input.filters) &&
                     hasOwnProperty(input.filters, 'name') &&
-                    typeof input.filters.name === 'string'
+                    typeof input.filters.name === 'string' &&
+                    input.filters.name.length > 0
                 ) {
-                    const transformed = context.queryFilters(input.filters.name);
+                    // Search input arrives as a bare `name` string. A raw wire
+                    // marker (`~text`) is NOT interpreted by the rapiq v2 IR
+                    // builder (it becomes eq('name','~text')), so build the
+                    // condition explicitly: the queryFilters hook when provided
+                    // (richer multi-field search), else a default substring match.
+                    const transformed = context.queryFilters ?
+                        context.queryFilters(input.filters.name) :
+                        contains('name', input.filters.name);
                     filtersOverride = defineFilters(
                         transformed as FiltersBuildInput | ICondition,
                     );

--- a/packages/client-web-kit/src/components/utility/search/module.ts
+++ b/packages/client-web-kit/src/components/utility/search/module.ts
@@ -50,7 +50,12 @@ export function buildListSearch(
         }
 
         return ctx.load({
-            filters: { name: text.length > 0 ? `~${text}` : text as any },
+            // Pass the raw search text. The rapiq v2 IR builder does NOT
+            // interpret wire markers (a `~text` value becomes eq('name',
+            // '~text'), not a substring match) — the collection turns this
+            // bare `name` string into a condition via the `contains` helper
+            // (or a per-entity queryFilters hook).
+            filters: text.length > 0 ? { name: text } : {},
             pagination: { offset: 0 },
         });
     });

--- a/packages/client-web-kit/test/unit/components/utility/entity-collection.spec.ts
+++ b/packages/client-web-kit/test/unit/components/utility/entity-collection.spec.ts
@@ -105,14 +105,14 @@ describe('defineEntityCollectionManager (rapiq IR composition)', () => {
         await flushPromises();
 
         await (wrapper.vm as any).load({
-            filters: { name: '~foo' },
+            filters: { name: 'foo' },
             pagination: { offset: 0 },
         });
 
         const requests = listRequests(httpClient.requests);
         expect(requests).toHaveLength(2);
         expect(requests[1].searchParams.get('filter'))
-            .toEqual("and(eq(name,'~foo'),in(realmId,'realm-1',null))");
+            .toEqual("and(contains(name,'foo'),in(realmId,'realm-1',null))");
 
         // even an input targeting the scoped field only narrows further
         await (wrapper.vm as any).load({ filters: { realmId: 'other' } });
@@ -127,7 +127,7 @@ describe('defineEntityCollectionManager (rapiq IR composition)', () => {
         await flushPromises();
 
         await (wrapper.vm as any).load({
-            filters: { name: '~foo' },
+            filters: { name: 'foo' },
             pagination: { offset: 0 },
         });
         await (wrapper.vm as any).load({ pagination: { offset: 10 } });
@@ -135,8 +135,20 @@ describe('defineEntityCollectionManager (rapiq IR composition)', () => {
         const requests = listRequests(httpClient.requests);
         expect(requests).toHaveLength(3);
         expect(requests[2].searchParams.get('filter'))
-            .toEqual("and(eq(name,'~foo'),in(realmId,'realm-1',null))");
+            .toEqual("and(contains(name,'foo'),in(realmId,'realm-1',null))");
         expect(requests[2].searchParams.get('page[offset]')).toEqual('10');
+    });
+
+    it('clearing the search (empty filters) resets to the base scope', async () => {
+        const { wrapper, httpClient } = mountCollection({ query: { filters: { realmId: ['realm-1', null] } } });
+        await flushPromises();
+
+        await (wrapper.vm as any).load({ filters: { name: 'foo' } });
+        await (wrapper.vm as any).load({ filters: {} });
+
+        const requests = listRequests(httpClient.requests);
+        expect(requests[2].searchParams.get('filter'))
+            .toEqual("in(realmId,'realm-1',null)");
     });
 
     it('queryFilters may return a compound condition (OR search)', async () => {
@@ -157,7 +169,7 @@ describe('defineEntityCollectionManager (rapiq IR composition)', () => {
         const { wrapper, httpClient } = mountCollection({ query: { filters: { realmId: ['realm-1', null] } } });
         await flushPromises();
 
-        await (wrapper.vm as any).load({ filters: { name: '~foo' } });
+        await (wrapper.vm as any).load({ filters: { name: 'foo' } });
         await (wrapper.vm as any).load(defineQuery<Role>({ filters: { displayName: 'bar' } }));
 
         const requests = listRequests(httpClient.requests);


### PR DESCRIPTION
## Problem

Every `<ASearch>` box in the UI authored a raw rapiq **wire-format marker** as the filter value:

```ts
// packages/client-web-kit/src/components/utility/search/module.ts
filters: { name: text.length > 0 ? `~${text}` : text as any }
```

The wire markers (`~`, `!`, `<`, …) are the URL codec's *serialization dialect*; the **rapiq v2 IR builder does not interpret them**. Verified against `@rapiq/core@2.0.0-beta.6` + `@rapiq/codec-url`:

```
defineQuery({ filters: { name: '~foo' } })
  → encode → filter=eq(name,'~foo')
  → server decode → eq('name','~foo')      // literal exact-match
```

So typing "foo" searched for a name **exactly equal to the string `~foo`** → matched nothing. **Name search has been silently broken across the whole UI** since the rapiq v2 expression-dialect migration.

## Fix

- **`search/module.ts`** — pass the raw search text as a bare `filters.name` string (no marker); an empty search sends `{}` to reset. Dropped the `as any`.
- **`collection/module.ts`** — the manager turns a bare `name` string into a real condition via the existing `queryFilters` hook when provided, else defaults to `contains('name', text)`. This also revives the documented-but-unreachable `queryFilters` seam. `ASearch` was the only caller passing `filters` into a collection `load`, so there is no exact-match caller to regress.
- **`entity-collection.spec.ts`** — updated the three tests that pinned the buggy `eq(name,'~foo')` to the correct `contains(name,'foo')`, plus a new empty-search-resets test.
- Updated `.agents/architecture.md` Collections section to record the raw-text + default-`contains` contract and the "never author a raw wire marker, use the helpers" rule.

## Verification

- `npm run build -w packages/client-web-kit` ✓
- Full `client-web-kit` suite: 151/151 ✓
- ESLint ✓