### PR TITLE
fix: preserve API sub-path when building authorize & OAuth2 URLs

### DIFF
--- a/apps/client-web/components/sidebar.vue
+++ b/apps/client-web/components/sidebar.vue
@@ -6,6 +6,7 @@
   -->
 <script lang="ts">
 
+import { buildURL } from '@authup/kit';
 import { TranslatorTranslationAppKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { ITranslateT } from '@ilingo/vue';
 import {
@@ -42,7 +43,7 @@ export default defineNuxtComponent({
         });
 
         const api = injectHTTPClient();
-        const docsUrl = computed(() => new URL('docs/', api.getBaseURL()).href);
+        const docsUrl = computed(() => buildURL(api.getBaseURL(), 'docs/').href);
 
         const translate = useTranslator();
         const locale = injectTranslatorLocale();

--- a/apps/client-web/pages/clients/[id]/url.vue
+++ b/apps/client-web/pages/clients/[id]/url.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { defineQuery } from '@rapiq/core';
+import { buildURL } from '@authup/kit';
 import { TranslatorTranslationAppKey, TranslatorTranslationEntityKey, TranslatorTranslationNamespace } from '@authup/i18n';
 import { AClientScopes, useTranslations, useTranslationsForNamespace } from '@authup/client-web-kit';
 import type { Client, ClientScope } from '@authup/core-kit';
@@ -48,7 +49,7 @@ export default defineNuxtComponent({
         const config = useRuntimeConfig();
 
         const generatedUrl = computed(() => {
-            const link = new URL('authorize', config.public.apiUrl);
+            const link = buildURL(config.public.apiUrl as string, 'authorize');
             link.searchParams.set('client_id', props.entity.id);
             link.searchParams.set('response_type', 'code');
 
@@ -72,10 +73,10 @@ export default defineNuxtComponent({
             }
         };
 
-        const query = defineQuery<ClientScope>({
+        const query = computed(() => defineQuery<ClientScope>({
             filters: { clientId: props.entity.id },
             relations: ['scope'],
-        });
+        }));
 
         return {
             toggleScope,

--- a/packages/core-http-kit/src/client/module.ts
+++ b/packages/core-http-kit/src/client/module.ts
@@ -6,6 +6,7 @@
  */
 
 import { Client as BaseClient, HookName, isClientError } from 'hapic';
+import { buildURL } from '@authup/kit';
 import type { OAuth2JsonWebKey, OpenIDProviderMetadata } from '@authup/specs';
 import {
     ClientAPI,
@@ -114,7 +115,7 @@ export class Client extends BaseClient implements IClient {
             for (const key of keys) {
                 const value = options[key];
                 if (typeof value === 'string') {
-                    (options as Record<string, any>)[key] = new URL(value, baseURL).href;
+                    (options as Record<string, any>)[key] = buildURL(baseURL, value).href;
                 }
             }
         }

--- a/packages/core-http-kit/test/unit/endpoint-resolution.spec.ts
+++ b/packages/core-http-kit/test/unit/endpoint-resolution.spec.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { createFakeClient } from '../../src/testing';
+
+async function resolveEndpoints(baseURL: string) {
+    const client = createFakeClient({
+        baseURL,
+        handlers: { '*': () => ({ active: true }) },
+    });
+
+    await client.token.createWithClientCredentials({ client_id: 'id', client_secret: 'secret' });
+    await client.token.introspect({ token: 'x' });
+    await client.userInfo.get();
+
+    return {
+        authorize: client.authorize.buildURL(),
+        requested: client.requests.map((request) => request.url),
+    };
+}
+
+describe('src/client OAuth2 endpoint resolution', () => {
+    it('preserves a base URL sub-path (no trailing slash)', async () => {
+        const { authorize, requested } = await resolveEndpoints('https://example.com/api');
+
+        expect(authorize).toBe('https://example.com/api/authorize?response_type=code');
+        expect(requested).toEqual([
+            'https://example.com/api/token',
+            'https://example.com/api/token/introspect',
+            'https://example.com/api/users/@me',
+        ]);
+    });
+
+    it('preserves a base URL sub-path (with trailing slash)', async () => {
+        const { requested } = await resolveEndpoints('https://example.com/api/');
+
+        expect(requested[0]).toBe('https://example.com/api/token');
+    });
+
+    it('resolves against a root base URL', async () => {
+        const { authorize, requested } = await resolveEndpoints('https://example.com');
+
+        expect(authorize).toBe('https://example.com/authorize?response_type=code');
+        expect(requested).toEqual([
+            'https://example.com/token',
+            'https://example.com/token/introspect',
+            'https://example.com/users/@me',
+        ]);
+    });
+});

--- a/packages/kit/src/url.ts
+++ b/packages/kit/src/url.ts
@@ -9,6 +9,29 @@ export function makeURLPublicAccessible(url: string) {
     return url.replace('0.0.0.0', '127.0.0.1');
 }
 
+/**
+ * Resolve a relative `path` against a `base` URL **without dropping the base's
+ * final path segment**.
+ *
+ * The `URL` constructor treats the last segment of the base as a document and
+ * replaces it when the base has no trailing slash, so
+ * `new URL('authorize', 'https://acme.tld/api')` yields
+ * `https://acme.tld/authorize` — the `/api` sub-path is silently lost.
+ * Normalizing the base to a trailing slash (and stripping any leading slash off
+ * `path`, which would otherwise reset to the origin root) preserves the
+ * sub-path: `https://acme.tld/api/authorize`.
+ *
+ * A `URL` is returned so callers can mutate `searchParams` before reading
+ * `href`. An absent/invalid `base` throws, matching `new URL` semantics.
+ */
+export function buildURL(base: string | undefined, path: string): URL {
+    const normalizedBase = base && !base.endsWith('/') ?
+        `${base}/` :
+        base;
+
+    return new URL(path.replace(/^\/+/, ''), normalizedBase);
+}
+
 export function getURLBasePath(url?: string) : string {
     if (!url) {
         return '';

--- a/packages/kit/test/unit/url.spec.ts
+++ b/packages/kit/test/unit/url.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { getURLBasePath } from '../../src';
+import { buildURL, getURLBasePath } from '../../src';
 
 describe('getURLBasePath', () => {
     it('extracts the path prefix of a sub-path URL', () => {
@@ -38,5 +38,44 @@ describe('getURLBasePath', () => {
 
     it('ignores query and hash', () => {
         expect(getURLBasePath('https://example.com/auth?foo=bar#baz')).toBe('/auth');
+    });
+});
+
+describe('buildURL', () => {
+    it('preserves the base sub-path when it has no trailing slash', () => {
+        expect(buildURL('https://example.com/api', 'authorize').href)
+            .toBe('https://example.com/api/authorize');
+    });
+
+    it('preserves the base sub-path when it already ends with a slash', () => {
+        expect(buildURL('https://example.com/api/', 'authorize').href)
+            .toBe('https://example.com/api/authorize');
+    });
+
+    it('handles a base without a sub-path', () => {
+        expect(buildURL('https://example.com', 'authorize').href)
+            .toBe('https://example.com/authorize');
+    });
+
+    it('keeps a trailing slash on the appended path', () => {
+        expect(buildURL('https://example.com/api', 'docs/').href)
+            .toBe('https://example.com/api/docs/');
+    });
+
+    it('strips a leading slash off the path so the sub-path is not reset', () => {
+        expect(buildURL('https://example.com/api', '/authorize').href)
+            .toBe('https://example.com/api/authorize');
+    });
+
+    it('returns a mutable URL whose searchParams can be set', () => {
+        const url = buildURL('https://example.com/api', 'authorize');
+        url.searchParams.set('client_id', 'abc');
+
+        expect(url.href).toBe('https://example.com/api/authorize?client_id=abc');
+    });
+
+    it('throws for an absent or invalid base', () => {
+        expect(() => buildURL(undefined, 'authorize')).toThrow();
+        expect(() => buildURL('', 'authorize')).toThrow();
     });
 });


### PR DESCRIPTION
## Summary

`new URL(relativePath, base)` drops the base's **final path segment** when the base has no trailing slash, so an API served under a sub-path (`https://example.com/api`) silently loses it:

```js
new URL('authorize', 'https://example.com/api').href
// => "https://example.com/authorize"    ❌  ('/api' dropped)
```

This footgun appeared at several call sites, not just the one reported in #3298:

- **`clients/[id]/url.vue`** — the OAuth2 authorize-URL generator (the reported bug).
- **`components/sidebar.vue`** — the docs link (`new URL('docs/', api.getBaseURL())`).
- **`core-http-kit` `Client`** ⭐ — resolved **every** OAuth2 endpoint the same way (`authorize`, `token`, `token/introspect`, `users/@me`), so any consumer of the typed client with a sub-path API URL had broken token/authorize/introspect/userinfo endpoints. Higher-impact than the UI bug.

## Changes

- Add a shared **`buildURL(base, path)`** helper to `@authup/kit` (`packages/kit/src/url.ts`): normalizes the base to a trailing slash and strips a leading slash off `path`, returning a mutable `URL` for `searchParams` composition. (`server-core` already had a private `resolveURL` doing this — the pattern recurs, so it now lives in `kit`.)
- Route all three call sites through `buildURL`.
- Secondary fix from #3298: wrap the client-scope `query` in `computed` so it stays reactive to a changing entity id.

`login/index.vue` was reviewed and left unchanged — it resolves against `window.location.origin` (no path to drop), which is correct.

## Tests

- `packages/kit` — 7 new `buildURL` unit cases (sub-path with/without trailing slash, root base, leading-slash strip, mutable searchParams, invalid base). All 28 kit tests pass.
- `packages/core-http-kit` — new `endpoint-resolution.spec.ts` asserting the resolved OAuth2 endpoints preserve the sub-path (black-box via `FakeClient` request recording + `authorize.buildURL()`). All 21 tests pass.

Closes #3298

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent URL construction for API and OAuth endpoints, including base URLs with sub-paths.
  * Added a shared URL utility that preserves paths and supports query parameter updates.

* **Bug Fixes**
  * Fixed endpoint links that could lose part of the configured API base path.

* **Tests**
  * Added coverage for URL construction with trailing slashes, sub-paths, root URLs, query parameters, and invalid bases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->