### PR TITLE
fix: reject childless composite policy instead of a silent un-satisfiable deny

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1208,7 +1208,14 @@ never masked to a settled value) and settles despite them only when no resolutio
 change the outcome; `invert` is **never applied to a pending result** — mask-then-negate ≠
 negate-then-mask was the pre-gate inversion bug this replaced. Server-core's
 `PermissionBindingPolicyEvaluator` propagates a pending junction policy as a pending grant
-term (the disjunction settles false only when every term settled).
+term (the disjunction settles false only when every term settled). A **childless**
+composite is rejected rather than settled: `CompositePolicyEvaluator` fails it closed with an
+explicit `PolicyIssueCode.INVALID` issue (regardless of `invert`, like an unregistered type)
+instead of the empty-issue `false` that made a bound permission read as opaquely "stale"
+(#3304); provisioning validation (`PolicyProvisioningValidator`) mirrors this and rejects a
+composite declared with no `children` at config-load time. The entity API create path is
+deliberately NOT gated — the admin UI creates a composite first, then attaches children via
+each child's `parentId`, so an empty composite is a valid intermediate there.
 
 `preEvaluate` passes `pendingPolicies: 'permit'` (a `PermissionEvaluationOptions` flag,
 default `'deny'`): a grant whose policy tree is pending passes the gate; only a tree that

--- a/apps/server-core/src/core/provisioning/entities/policy/validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/policy/validator.ts
@@ -5,15 +5,43 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { BuiltInPolicyType } from '@authup/access';
 import { PolicyValidator } from '@authup/core-kit';
 import { createValidator } from '@validup/zod';
-import { Container } from 'validup';
+import type { ContainerInput, ContainerRunOptions } from 'validup';
+import { Container, ValidupError, defineIssueItem } from 'validup';
 import { z } from 'zod';
 import { ProvisioningStrategyValidator } from '../../strategy/index.ts';
 import { createProvisioningEntitiesValidator } from '../utils.ts';
 import type { PolicyProvisioningEntity } from './types.ts';
 
 export class PolicyProvisioningValidator extends Container<PolicyProvisioningEntity> {
+    override async run(
+        input?: ContainerInput<PolicyProvisioningEntity>,
+        options?: ContainerRunOptions<PolicyProvisioningEntity>,
+    ): Promise<PolicyProvisioningEntity> {
+        const output = await super.run(input, options);
+
+        // A composite policy with no children can never be satisfied and makes
+        // any permission bound to it permanently un-grantable (#3304). Reject
+        // it up front so provisioning fails at config load with a clear
+        // message, rather than silently provisioning a "stale" permission that
+        // only fails — with an opaque empty-issue error — once evaluated.
+        if (
+            output.attributes?.type === BuiltInPolicyType.COMPOSITE &&
+            (!output.children || output.children.length === 0)
+        ) {
+            throw new ValidupError([
+                defineIssueItem({
+                    path: ['children'],
+                    message: 'A composite policy must define at least one child policy.',
+                }),
+            ]);
+        }
+
+        return output;
+    }
+
     protected initialize() {
         super.initialize();
 

--- a/apps/server-core/test/data/sources/file.mts
+++ b/apps/server-core/test/data/sources/file.mts
@@ -15,6 +15,15 @@ const DATA : RootProvisioningEntity = {
                 type: 'composite',
                 builtIn: true,
             },
+            children: [
+                {
+                    attributes: {
+                        name: 'file-policy-child',
+                        type: 'identity',
+                        builtIn: true,
+                    },
+                },
+            ],
         },
     ],
     roles: [

--- a/apps/server-core/test/unit/core/provisioning/entities/root-validator.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/entities/root-validator.spec.ts
@@ -183,6 +183,25 @@ describe('core/provisioning/entities/root-validator', () => {
         })).rejects.toThrow();
     });
 
+    it('should reject a childless composite policy', async () => {
+        await expect(run({
+            policies: [
+                { attributes: { name: 'empty-composite', type: BuiltInPolicyType.COMPOSITE } },
+            ],
+        })).rejects.toThrow();
+    });
+
+    it('should reject a composite policy with an empty children array', async () => {
+        await expect(run({
+            policies: [
+                {
+                    attributes: { name: 'empty-composite', type: BuiltInPolicyType.COMPOSITE },
+                    children: [],
+                },
+            ],
+        })).rejects.toThrow();
+    });
+
     it('should reject an invalid strategy', async () => {
         await expect(run({
             roles: [

--- a/packages/access/src/policy/built-in/composite/evaluator.ts
+++ b/packages/access/src/policy/built-in/composite/evaluator.ts
@@ -13,6 +13,7 @@ import { PolicyEngine } from '../../engine';
 import type { IPolicyEvaluator, PolicyEvaluationContext, PolicyEvaluationResult } from '../../evaluation';
 import { maybeInvertPolicyOutcome } from '../../helpers';
 import type { PolicyIssue } from '../../issue';
+import { PolicyIssueCode, definePolicyIssueItem } from '../../issue';
 import { CompositePolicyValidator } from './validator';
 
 export class CompositePolicyEvaluator implements IPolicyEvaluator {
@@ -25,6 +26,26 @@ export class CompositePolicyEvaluator implements IPolicyEvaluator {
     async evaluate(value: Record<string, any>, ctx: PolicyEvaluationContext): Promise<PolicyEvaluationResult> {
         // todo: catch errors + transform to issue(s)
         const policy = await this.validator.run(value);
+
+        // A composite policy with no children can never be satisfied — an empty
+        // UNANIMOUS/CONSENSUS settles false and an empty AFFIRMATIVE settles
+        // false — so a permission bound to one is permanently un-grantable.
+        // Fail closed with an explicit diagnostic instead of settling `false`
+        // with an empty issue list, which reads as an opaque "stale" permission
+        // (#3304). Like the engine's unregistered-type handling, this
+        // misconfiguration fails closed regardless of `invert`.
+        if (policy.children.length === 0) {
+            return {
+                success: false,
+                issues: [
+                    definePolicyIssueItem({
+                        code: PolicyIssueCode.INVALID,
+                        message: 'A composite policy must define at least one child policy.',
+                        path: ctx.path,
+                    }),
+                ],
+            };
+        }
 
         let count = 0;
         let pending = 0;

--- a/packages/access/test/unit/policy/composite.spec.ts
+++ b/packages/access/test/unit/policy/composite.spec.ts
@@ -138,6 +138,39 @@ describe('src/policy/composite (tri-state algebra)', () => {
         });
     });
 
+    describe('childless', () => {
+        it('should fail closed with a non-empty issue list', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.UNANIMOUS, []),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.pending).toBeFalsy();
+            expect(outcome.issues).toBeDefined();
+            expect(outcome.issues!.length).toBeGreaterThan(0);
+        });
+
+        it('should fail closed regardless of decision strategy', async () => {
+            for (const decisionStrategy of Object.values(DecisionStrategy)) {
+                const outcome = await engine.evaluate(
+                    composite(decisionStrategy, []),
+                    context(),
+                );
+                expect(outcome.success).toBeFalsy();
+                expect(outcome.pending).toBeFalsy();
+            }
+        });
+
+        it('should fail closed even when inverted', async () => {
+            const outcome = await engine.evaluate(
+                composite(DecisionStrategy.UNANIMOUS, [], true),
+                context(),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues!.length).toBeGreaterThan(0);
+        });
+    });
+
     describe('invert', () => {
         it('should never apply invert to a pending composite', async () => {
             const outcome = await engine.evaluate(


### PR DESCRIPTION
## Summary

Closes #3304.

A `composite` policy with **no children** settles `false` on every evaluation (empty UNANIMOUS/CONSENSUS → false, empty AFFIRMATIVE → false), so a permission bound to one is **permanently un-grantable** — for everyone, admin included. The failure surfaces only as an opaque `PERMISSION_EVALUATION_FAILED` with an **empty issue list**, so the permission reads as mysteriously "stale".

## Changes

- **`CompositePolicyEvaluator`** (`@authup/access`) now fails a childless composite **closed with an explicit `PolicyIssueCode.INVALID` issue** — regardless of `invert`, mirroring how the engine treats an unregistered policy type — instead of the empty-issue `false`.
- **`PolicyProvisioningValidator`** (`server-core`) **rejects a composite declared with no `children`** at config-load time, so a bad provisioning file fails fast with a clear message rather than silently provisioning an un-evaluatable permission.

## Why the entity/API create path is intentionally left ungated

The admin UI (`APolicyForm`) creates a composite **first**, then attaches children via each child's `parentId`, so an empty composite is a valid *intermediate* state there — gating create would break composite authoring. The two gates above cover the only two places where a childless composite is genuinely terminal: a complete provisioning declaration, and evaluation of a fully-loaded tree.

Distinct from #3302 / #3303 (which concern the permission-create wiring); together the three are the "how did a stale permission come to exist" surface.

## Tests

- `packages/access`: childless composite fails closed with a non-empty issue list (every decision strategy + inverted).
- `server-core`: provisioning validator rejects a childless composite (both absent and empty `children`).
- Reproduction fixture `test/data/sources/file.mts` updated to a valid (childed) composite.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Composite policies without child policies are now rejected during validation.
  * Empty composites fail closed with a clear `INVALID` policy issue instead of producing an ambiguous false result.
  * Behavior is consistent across decision strategies and inverted policies.

* **Documentation**
  * Clarified composite evaluation behavior when data is missing.
  * Documented the admin workflow for creating composites before attaching child policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->