### PR TITLE
fix(server-core): fail loud when admin role is unresolved on permission create

### DIFF
--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -318,11 +318,16 @@ export class PermissionService extends AbstractEntityService implements IPermiss
     /**
      * Assign a newly created permission to the global admin role.
      * The admin role receives every permission without policy restrictions.
+     *
+     * Throws when the admin role is not provisioned: without an admin grant the
+     * permission is bound by `system.default` yet held by nobody, and the uniform
+     * member gate on junction creation makes it permanently un-grantable (even by
+     * admin). Fail loud so the stranded state is surfaced instead of swallowed.
      */
     private async assignToAdminRole(permission: Permission): Promise<void> {
         const adminRole = await this.roleRepository.findOneByName(ROLE_ADMIN_NAME);
         if (!adminRole) {
-            return;
+            throw new AuthupError(`The ${ROLE_ADMIN_NAME} role is not provisioned. Cannot grant the created permission to the administrator role.`);
         }
 
         const existing = await this.rolePermissionRepository.findOneBy({

--- a/apps/server-core/test/unit/core/entities/permission/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/permission/service.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import { PermissionName } from '@authup/core-kit';
+import { PermissionName, ROLE_ADMIN_NAME } from '@authup/core-kit';
 import type {
     PermissionPolicy,
     RolePermission,
@@ -17,7 +17,7 @@ import {
     expect, 
     it,
 } from 'vitest';
-import { SystemPolicyName } from '@authup/access';
+import { RealmScope, SystemPolicyName } from '@authup/access';
 import { ErrorCode } from '@authup/errors';
 import { PermissionService } from '../../../../../src/core/entities/permission/service.ts';
 import {
@@ -48,6 +48,12 @@ describe('core/entities/permission/service', () => {
         repository = new FakePermissionRepository();
         realmRepository = new FakeRealmRepository();
         roleRepository = new FakeRoleRepository();
+        roleRepository.seed([{
+            id: randomUUID(),
+            name: ROLE_ADMIN_NAME,
+            builtIn: true,
+            realmId: null,
+        }]);
         rolePermissionRepository = new FakeEntityRepository<RolePermission>();
         policyRepository = new FakePolicyRepository();
         policyRepository.seed([{
@@ -146,6 +152,34 @@ describe('core/entities/permission/service', () => {
             const junctions = permissionPolicyRepository.getAll();
             expect(junctions).toHaveLength(1);
             expect(junctions[0].policyId).toBe(defaultPolicyId);
+        });
+
+        it('should grant the created permission to the admin role', async () => {
+            const permission = await service.create(
+                { name: 'new-perm' },
+                createAllowAllActor(),
+            );
+
+            const grants = rolePermissionRepository.getAll();
+            const adminGrant = grants.find((g) => g.permissionId === permission.id);
+            expect(adminGrant).toBeDefined();
+            expect(adminGrant!.realmScope).toBe(RealmScope.ANY);
+        });
+
+        it('should throw when the admin role is not provisioned', async () => {
+            const emptyRoleRepository = new FakeRoleRepository();
+            const serviceWithoutAdmin = new PermissionService({
+                repository,
+                realmRepository,
+                roleRepository: emptyRoleRepository,
+                rolePermissionRepository,
+                policyRepository,
+                permissionPolicyRepository,
+            });
+
+            await expect(
+                serviceWithoutAdmin.create({ name: 'stranded-perm' }, createAllowAllActor()),
+            ).rejects.toThrow(/admin role is not provisioned/);
         });
     });
 


### PR DESCRIPTION
## Summary

Fixes #3302.

`PermissionService.assignToAdminRole()` silently `return`ed when the global `admin` role could not be resolved, leaving a freshly-created permission bound by `system.default` yet granted to nobody. Because it runs *after* the permission row is committed and after `system.default` is bound, a missed lookup produced a permission that:

- has a security policy requiring the actor to already hold it (`system.default` → `system.permission-binding`), but
- is held by no one.

`RolePermissionService.create()`'s uniform member gate then requires already holding the permission to attach it to any role — a bootstrap deadlock that not even `admin` can recover via the API, while the create still reported `201`.

## Change

Throw instead of swallowing, mirroring the sibling `assignDefaultPolicy()` in the same file, which already fails loud when *its* provisioning invariant (the `system.default` policy) is missing.

The `admin` role is a guaranteed global (`realmId: null`) built-in provisioned at startup (idempotent MERGE), and `findOneByName('admin')` with no realm arg reliably resolves it regardless of the permission's realm. So an unresolved lookup only occurs in a genuinely misconfigured deployment (renamed/deleted admin role) and should be surfaced, not masked.

Logging was considered instead of throwing, but `PermissionService` has no injected logger, and a warning would still return a broken permission as success. Throwing is both simpler and consistent with the existing in-file precedent.

## Out of scope

The related non-atomic post-save wiring in `save()` (the permission row is committed before these wiring steps run) is a separate issue, noted as such in #3302; the sibling `assignDefaultPolicy()` shares the same characteristic.

## Tests

- Seeded the `admin` role in the spec `beforeEach` (existing create/save/realm-defaulting tests were unknowingly exercising the silent-skip path).
- Added a positive test: the created permission receives an `admin` grant with `realmScope: any`.
- Added the fail-loud test: `create` rejects when the `admin` role is absent.

Verification: 26/26 permission service tests pass, 9/9 permission HTTP controller tests pass (real provisioned-DB create path, unaffected), `check:types` and ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Permission creation now reports a clear error when the built-in administrator role is not provisioned, instead of silently continuing.
  * Newly created permissions are automatically assigned to the administrator role with access across all realms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->