### PR TITLE
fix(server-core): roll back permission create when post-save wiring fails

### DIFF
--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -250,9 +250,28 @@ export class PermissionService extends AbstractEntityService implements IPermiss
         entity = this.repository.create(validated);
         entity = await this.repository.save(entity);
 
-        await this.assignDefaultPolicy(entity);
-        await this.assignToAdminRole(entity);
-        await this.assignToRealmAdminRoles(entity);
+        // The permission row is now committed, but its security wiring — the
+        // admin/realm_admin grants and the system.default binding — is written
+        // through separate repositories with no shared transaction. A failure
+        // partway through would strand the permission bound by system.default
+        // yet held by nobody, which the uniform member gate on
+        // POST /role-permissions then makes permanently un-grantable (#3303).
+        // Two safeguards:
+        //   1. Establish the grants BEFORE binding system.default, so even an
+        //      un-compensated interruption (a hard process crash) cannot produce
+        //      the bound-but-ungranted strand — at worst a benign, still-grantable
+        //      permission that lacks its baseline policy.
+        //   2. On any thrown failure, remove the just-created permission — its
+        //      CASCADE foreign keys drop any partial junction/binding rows — and
+        //      rethrow so the caller sees the failure instead of a stale record.
+        try {
+            await this.assignToAdminRole(entity);
+            await this.assignToRealmAdminRoles(entity);
+            await this.assignDefaultPolicy(entity);
+        } catch (e) {
+            await this.repository.remove(entity).catch(() => { /* best-effort rollback */ });
+            throw e;
+        }
 
         return {
             entity,

--- a/apps/server-core/test/unit/core/entities/permission/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/permission/service.spec.ts
@@ -180,6 +180,23 @@ describe('core/entities/permission/service', () => {
             await expect(
                 serviceWithoutAdmin.create({ name: 'stranded-perm' }, createAllowAllActor()),
             ).rejects.toThrow(/admin role is not provisioned/);
+
+            // The half-wired permission must be rolled back, not left committed.
+            expect(repository.getAll()).toHaveLength(0);
+        });
+
+        it('should roll back the created permission when post-save wiring fails', async () => {
+            const failure = new Error('binding write failed');
+            permissionPolicyRepository.save = async () => {
+                throw failure;
+            };
+
+            await expect(
+                service.create({ name: 'doomed-perm' }, createAllowAllActor()),
+            ).rejects.toThrow(failure);
+
+            // Compensating cleanup removed the committed permission row.
+            expect(repository.getAll()).toHaveLength(0);
         });
     });
 


### PR DESCRIPTION
## Summary

Closes #3303 — the transactional-safety sibling of #3302/#3306.

`PermissionService.save()` committed the permission row and then wrote its `system.default` binding and admin/realm_admin grants through **separate repositories with no shared transaction**, binding the policy *first*. A failure partway through stranded a permission that is gated by `system.default` (so the actor must already hold it) yet granted to nobody — which the uniform member gate on `POST /role-permissions` then makes **permanently un-grantable**, even by admin.

## Approach

The issue sanctions *"a single transaction **or** a compensating cleanup on failure"*. The hexagonal port design deliberately does not expose a shared transaction at the service layer (threading a `QueryRunner`/`EntityManager` through the five repository ports would break the clean abstraction), so this takes the compensating-cleanup route, with a reorder for defense in depth:

1. **Reorder** — establish the admin/realm_admin grants **before** binding `system.default`. Even the one window a cleanup can't cover (a hard process crash between DB writes) can then only yield a benign, still-grantable permission that lacks its baseline policy — never the bound-but-ungranted strand.
2. **Compensating cleanup** — wrap the post-save wiring in `try/catch`; on any thrown failure, `repository.remove(entity)` unwinds the committed row. Its `permission_id` foreign keys on `auth_permission_policies` and `auth_role_permissions` are both `ON DELETE CASCADE`, so any partial junction/binding rows drop with it. The original error is rethrown so the caller never sees a stale success.

Together with #3306 (fail-loud on unresolved admin role), both paths to the stranded state are now closed.

## Tests

`test/unit/core/entities/permission/service.spec.ts`:
- new test forcing a post-save wiring failure, asserting the permission is rolled back (empty store) and the error propagates;
- strengthened the #3302 "admin role not provisioned" test to assert the half-wired permission is rolled back rather than left committed.

27/27 service specs pass; `apps/server-core` build + ESLint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved permission creation reliability by preventing partially configured permissions when security setup fails.
  * Automatically rolls back newly created permissions if required role or policy assignments cannot be completed.
  * Preserves and reports the original setup error for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->