### PR TITLE
fix(server-core): add fields projection to permissionSchema so include=permission hydrates

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -192,6 +192,18 @@ usable at the service level and nothing in core depends on TypeORM:
   fields; it must enumerate EVERY scalar column (boot validation checks
   key existence, not completeness — a column missing from `default`
   silently vanishes from the API response).
+- **EVERY include-target schema needs a `fields` block too** — the
+  mirror of the rule above for the relation *child*, not the junction
+  root. A schema with no `fields` selects all columns as a query root
+  but **nothing** as an include child, so the joined relation is never
+  hydrated and comes back `undefined` (the request still 200s — the
+  strip is silent). `permissionSchema` was the last offender (#3313:
+  `include=permission` dropped on client-/user-/role-permission even
+  for an actor holding `PERMISSION_READ` — a projection bug, not the
+  relations read gate). Every registered schema now declares `fields`;
+  plain include targets use `fields.allowed` (realm/role/scope/
+  permission), enumerating every scalar column so the root projection
+  is unchanged.
 - **Server-derived scopes ride `appendQueryConditions(query, ...conds)`**
   (core/query) — an immutable AND-wrap of the filter tree
   (`IFilters.and`, the wrap-and-inject primitive; parameter nodes carry

--- a/apps/server-core/src/core/entities/permission/schema.ts
+++ b/apps/server-core/src/core/entities/permission/schema.ts
@@ -11,6 +11,23 @@ import { EntityType } from '@authup/core-kit';
 
 export const permissionSchema = defineSchema<Permission>({
     name: EntityType.PERMISSION,
+    // explicit root projection so an include=permission decodes columns
+    // (a schema without fields selects all as a query root but nothing as
+    // an include child — see client-permission/user-role schema comments)
+    fields: {
+        allowed: [
+            'id',
+            'builtIn',
+            'name',
+            'displayName',
+            'description',
+            'decisionStrategy',
+            'clientId',
+            'realmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['id', 'displayName', 'name', 'builtIn', 'realmId'] },
     relations: { allowed: [] },
     sort: { allowed: ['id', 'name', 'createdAt', 'updatedAt'] },

--- a/apps/server-core/test/unit/http/controllers/entities/include-authorization.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/include-authorization.spec.ts
@@ -15,7 +15,12 @@ import {
     it,
 } from 'vitest';
 import { createTestApplication } from '../../../../app';
-import { createFakeClient } from '../../../../utils';
+import {
+    createFakeClient,
+    createFakePermission,
+    createFakeRole,
+    createFakeUser,
+} from '../../../../utils';
 
 describe('http/controllers (include authorization)', () => {
     const suite = createTestApplication();
@@ -101,5 +106,65 @@ describe('http/controllers (include authorization)', () => {
             expect(row.user).toBeUndefined();
             expect(row.role).toBeDefined();
         }
+    });
+
+    // regression: #3313 — permissionSchema had no fields projection, so
+    // include=permission was silently stripped on the permission-binding
+    // collections even for an actor holding PERMISSION_READ.
+    it('should join include=permission on client-permission for a permitted actor', async () => {
+        const permission = await suite.client.permission.create(createFakePermission());
+        const client = await suite.client.client.create(createFakeClient());
+        await suite.client.clientPermission.create({
+            clientId: client.id,
+            permissionId: permission.id,
+        });
+
+        const response = await suite.client.clientPermission.getMany({
+            relations: ['permission'],
+            filters: { clientId: client.id },
+        });
+
+        const row = response.data.find((r) => r.clientId === client.id);
+        expect(row).toBeDefined();
+        expect(row!.permission).toBeDefined();
+        expect(row!.permission!.name).toEqual(permission.name);
+    });
+
+    it('should join include=permission on user-permission for a permitted actor', async () => {
+        const permission = await suite.client.permission.create(createFakePermission());
+        const user = await suite.client.user.create(createFakeUser());
+        await suite.client.userPermission.create({
+            userId: user.id,
+            permissionId: permission.id,
+        });
+
+        const response = await suite.client.userPermission.getMany({
+            relations: ['permission'],
+            filters: { userId: user.id },
+        });
+
+        const row = response.data.find((r) => r.userId === user.id);
+        expect(row).toBeDefined();
+        expect(row!.permission).toBeDefined();
+        expect(row!.permission!.name).toEqual(permission.name);
+    });
+
+    it('should join include=permission on role-permission for a permitted actor', async () => {
+        const permission = await suite.client.permission.create(createFakePermission());
+        const role = await suite.client.role.create(createFakeRole());
+        await suite.client.rolePermission.create({
+            roleId: role.id,
+            permissionId: permission.id,
+        });
+
+        const response = await suite.client.rolePermission.getMany({
+            relations: ['permission'],
+            filters: { roleId: role.id },
+        });
+
+        const row = response.data.find((r) => r.roleId === role.id);
+        expect(row).toBeDefined();
+        expect(row!.permission).toBeDefined();
+        expect(row!.permission!.name).toEqual(permission.name);
     });
 });


### PR DESCRIPTION
## Summary

Fixes #3313. `include=permission` was **silently stripped** from the response of the permission-binding collection endpoints (`client-permission`, `user-permission`, `role-permission`) **even for an actor that holds `PERMISSION_READ`** (e.g. the `system`/admin client). The row came back with `permissionId` set but `permission === undefined`.

Root cause: `permissionSchema` (`apps/server-core/src/core/entities/permission/schema.ts`) was the only registered query schema with **no `fields` block**. A schema without an explicit root projection selects all columns when it is the *root* of a query, but selects **nothing** when it is an *include child* — so the joined `permission` relation had no columns selected and TypeORM never hydrated it. This is a **projection bug, not an authorization one** — the `relations.validate` read gate passes.

This surfaced downstream in FLAME Hub, whose `NodeClientService.assignPermissions` reads `cp.permission.name` and crashed with a `TypeError` inside a TypeORM `afterInsert` subscriber.

## Change

- Add an explicit `fields.allowed` block to `permissionSchema` enumerating **every scalar column** of the permission entity (`id`, `builtIn`, `name`, `displayName`, `description`, `decisionStrategy`, `clientId`, `realmId`, `createdAt`, `updatedAt`), matching the realm/role/scope plain-include-target convention. Enumerating all scalars keeps `GET /permissions` unchanged (same columns as the previous no-`fields` all-columns behavior) while letting the include child hydrate.
- **No other schema is affected**: `permission` was the only one of the 24 registered schemas missing a `fields` block (verified against `HEAD`).
- Add regression tests to `include-authorization.spec.ts` asserting `include=permission` hydrates on all three permission-binding collections for a permitted actor.
- Broaden the `.agents/architecture.md` query-IR note to capture the include-*target* facet (the mirror of the existing junction-*root* `fields.default` rule).

## Testing

- `include-authorization.spec.ts` — 6 passed (3 existing gate tests + 3 new regression tests)
- `permission` / `client-permission` / `user-permission` / `role-permission` controller specs + `core/query/module.spec.ts` — all green
- `npm run build`, `npm run check:types`, `eslint` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission details failing to load when included with client, user, or role permission records.
  * Included permissions now display their expected fields, including the permission name.

* **Documentation**
  * Added guidance for configuring schemas used as included relations.

* **Tests**
  * Added regression coverage for permission includes across permitted clients, users, and roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->