### PR TITLE
fix(server-core): add fields projection to permissionSchema so includ…

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -192,6 +192,18 @@ usable at the service level and nothing in core depends on TypeORM:
   fields; it must enumerate EVERY scalar column (boot validation checks
   key existence, not completeness — a column missing from `default`
   silently vanishes from the API response).
+- **EVERY include-target schema needs a `fields` block too** — the
+  mirror of the rule above for the relation *child*, not the junction
+  root. A schema with no `fields` selects all columns as a query root
+  but **nothing** as an include child, so the joined relation is never
+  hydrated and comes back `undefined` (the request still 200s — the
+  strip is silent). `permissionSchema` was the last offender (#3313:
+  `include=permission` dropped on client-/user-/role-permission even
+  for an actor holding `PERMISSION_READ` — a projection bug, not the
+  relations read gate). Every registered schema now declares `fields`;
+  plain include targets use `fields.allowed` (realm/role/scope/
+  permission), enumerating every scalar column so the root projection
+  is unchanged.
 - **Server-derived scopes ride `appendQueryConditions(query, ...conds)`**
   (core/query) — an immutable AND-wrap of the filter tree
   (`IFilters.and`, the wrap-and-inject primitive; parameter nodes carry

--- a/apps/server-core/src/core/entities/permission/schema.ts
+++ b/apps/server-core/src/core/entities/permission/schema.ts
@@ -11,6 +11,23 @@ import { EntityType } from '@authup/core-kit';
 
 export const permissionSchema = defineSchema<Permission>({
     name: EntityType.PERMISSION,
+    // explicit root projection so an include=permission decodes columns
+    // (a schema without fields selects all as a query root but nothing as
+    // an include child — see client-permission/user-role schema comments)
+    fields: {
+        allowed: [
+            'id',
+            'builtIn',
+            'name',
+            'displayName',
+            'description',
+            'decisionStrategy',
+            'clientId',
+            'realmId',
+            'createdAt',
+            'updatedAt',
+        ],
+    },
     filters: { allowed: ['id', 'displayName', 'name', 'builtIn', 'realmId'] },
     relations: { allowed: [] },
     sort: { allowed: ['id', 'name', 'createdAt', 'updatedAt'] },

--- a/apps/server-core/test/unit/http/controllers/entities/include-authorization.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/include-authorization.spec.ts
@@ -15,7 +15,12 @@ import {
     it,
 } from 'vitest';
 import { createTestApplication } from '../../../../app';
-import { createFakeClient } from '../../../../utils';
+import {
+    createFakeClient,
+    createFakePermission,
+    createFakeRole,
+    createFakeUser,
+} from '../../../../utils';
 
 describe('http/controllers (include authorization)', () => {
     const suite = createTestApplication();
@@ -101,5 +106,65 @@ describe('http/controllers (include authorization)', () => {
             expect(row.user).toBeUndefined();
             expect(row.role).toBeDefined();
         }
+    });
+
+    // regression: #3313 — permissionSchema had no fields projection, so
+    // include=permission was silently stripped on the permission-binding
+    // collections even for an actor holding PERMISSION_READ.
+    it('should join include=permission on client-permission for a permitted actor', async () => {
+        const permission = await suite.client.permission.create(createFakePermission());
+        const client = await suite.client.client.create(createFakeClient());
+        await suite.client.clientPermission.create({
+            clientId: client.id,
+            permissionId: permission.id,
+        });
+
+        const response = await suite.client.clientPermission.getMany({
+            relations: ['permission'],
+            filters: { clientId: client.id },
+        });
+
+        const row = response.data.find((r) => r.clientId === client.id);
+        expect(row).toBeDefined();
+        expect(row!.permission).toBeDefined();
+        expect(row!.permission!.name).toEqual(permission.name);
+    });
+
+    it('should join include=permission on user-permission for a permitted actor', async () => {
+        const permission = await suite.client.permission.create(createFakePermission());
+        const user = await suite.client.user.create(createFakeUser());
+        await suite.client.userPermission.create({
+            userId: user.id,
+            permissionId: permission.id,
+        });
+
+        const response = await suite.client.userPermission.getMany({
+            relations: ['permission'],
+            filters: { userId: user.id },
+        });
+
+        const row = response.data.find((r) => r.userId === user.id);
+        expect(row).toBeDefined();
+        expect(row!.permission).toBeDefined();
+        expect(row!.permission!.name).toEqual(permission.name);
+    });
+
+    it('should join include=permission on role-permission for a permitted actor', async () => {
+        const permission = await suite.client.permission.create(createFakePermission());
+        const role = await suite.client.role.create(createFakeRole());
+        await suite.client.rolePermission.create({
+            roleId: role.id,
+            permissionId: permission.id,
+        });
+
+        const response = await suite.client.rolePermission.getMany({
+            relations: ['permission'],
+            filters: { roleId: role.id },
+        });
+
+        const row = response.data.find((r) => r.roleId === role.id);
+        expect(row).toBeDefined();
+        expect(row!.permission).toBeDefined();
+        expect(row!.permission!.name).toEqual(permission.name);
     });
 });


### PR DESCRIPTION
…e=permission hydrates

permissionSchema was the only registered query schema without a `fields` block. A schema with no fields selects all columns as a query root but nothing as an include child, so `include=permission` on the client-/user-/role-permission collections was silently stripped — the row came back with permissionId set but permission === undefined, even for an actor holding PERMISSION_READ. This is a projection bug, not the relations read gate (which passes).

Add an explicit `fields.allowed` block enumerating every scalar column of the permission entity, matching the realm/role/scope plain-include-target convention. Enumerating all scalars keeps GET /permissions unchanged while letting the include child hydrate.

Closes #3313

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed permission relationships not appearing in certain authorized requests using includes.
  * Permission details are now correctly returned when fetching client, user, and role permissions.
  * Added explicit permission field selection to ensure related data is hydrated consistently.

* **Documentation**
  * Documented schema requirements for include targets and their field projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->