### PR TITLE
feat: let attributeNames policy evaluate a list of attribute names

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1228,7 +1228,18 @@ The policy engine is tri-state: a policy whose declared data requirements
 (`IPolicyEvaluator.requires?(value)` — PolicyData keys, checked by the engine before
 invoking the evaluator) are not satisfied by the current bag returns
 `{ success: false, pending: true }` instead of evaluating against missing data. Built-in
-`requires`: identity → `[IDENTITY]`; attributes / attributeNames → `[ATTRIBUTES]`;
+`requires`: identity → `[IDENTITY]`; attributes → `[ATTRIBUTES]`; attributeNames →
+**none — it reports pending itself** (issue #3321: the policy settles against EITHER
+data key — a `string[]` projection/fieldset under its own `ATTRIBUTE_NAMES` key ("may
+this actor project these field names", the rapiq `fields.validateMany` consumer) and/or
+the `ATTRIBUTES` record, enforced conjunctively when both are present and deduplicated
+per key; the engine's requires-gate is AND-semantics over the declared keys, so an
+either-or requirement is inexpressible there and the evaluator returns
+`{ success: false, pending: true }` itself when neither key is present — precedented by
+the composite algebra / permission-binding pending propagation, and every consumer reads
+the result flag, not the mechanism. Per-key `invert`, issue paths and the empty-input
+pass are identical for both sources; the shared ATTRIBUTES bag — which realm-match /
+ABAC settle against — is never fed fabricated row data);
 permissionBinding → `[PERMISSION_BINDING]` (IDENTITY deliberately not declared — a missing
 identity must stay a settled deny so a scope-restricted bearer fails the pre-gate through
 `system.default`); realmMatch → `[IDENTITY]` in scope mode (the `realmMatch` resource key

--- a/docs/src/sdks/javascript/access/permission-checker.md
+++ b/docs/src/sdks/javascript/access/permission-checker.md
@@ -87,8 +87,8 @@ complete data remains the authority (there, pending counts as a denial).
 await evaluator.preEvaluate({
     name: 'user_update',
 });
-// success — the attributeNames policy needs `attributes`,
-// which is not available yet: it stays pending and passes the gate
+// success — the attributeNames policy needs `attributes` (or `attributeNames`),
+// neither of which is available yet: it stays pending and passes the gate
 
 const data = new PolicyData();
 data.set('attributes', { name: 'admin', foo: 'bar' });

--- a/docs/src/sdks/javascript/access/policies.md
+++ b/docs/src/sdks/javascript/access/policies.md
@@ -118,12 +118,23 @@ The list of supported operators:
 
 ## AttributeNames
 
-The Attribute Names Policy restricts the set of allowed keys in the `attributes` key of the policy data.
+The Attribute Names Policy restricts a set of attribute names. It evaluates whichever
+policy-data source is available:
+
+- the `attributeNames` data key — a plain list of attribute names (a projection / fieldset)
+- the `attributes` data key — the keys of an attribute record
+
+When both keys are present, both are enforced; when neither is present, the policy stays
+pending.
 
 **`Config`**
 ```typescript
 export interface AttributeNamesPolicy {
     names: string[],
+    /**
+     * default: false — treat `names` as a denylist instead of an allowlist.
+     */
+    invert?: boolean | null,
 }
 ```
 
@@ -138,6 +149,26 @@ data.set('attributes', {
     name: 'Peter',
     age: 15,
 });
+
+evaluator.evaluate(
+    {
+        names: ['name', 'age']
+    },
+    definePolicyEvaluationContext({ data }),
+)
+```
+
+With the `attributeNames` data key the same policy evaluates a list of attribute names
+instead of an attribute record — useful to answer *"may this actor project these field
+names?"* before any row data exists (e.g. validating a requested fieldset):
+
+```typescript
+import { AttributeNamesPolicyEvaluator, PolicyData, definePolicyEvaluationContext } from '@authup/access';
+
+const evaluator = new AttributeNamesPolicyEvaluator();
+
+const data = new PolicyData();
+data.set('attributeNames', ['name', 'age']);
 
 evaluator.evaluate(
     {

--- a/packages/access/src/policy/built-in/attribute-names/evaluator.ts
+++ b/packages/access/src/policy/built-in/attribute-names/evaluator.ts
@@ -23,37 +23,82 @@ export class AttributeNamesPolicyEvaluator implements IPolicyEvaluator {
         this.attributesEvaluator = new AttributesPolicyEvaluator();
     }
 
-    requires() : string[] {
-        return [BuiltInPolicyType.ATTRIBUTES];
-    }
-
     async evaluate(value: Record<string, any>, ctx: PolicyEvaluationContext): Promise<PolicyEvaluationResult> {
-        // todo: catch errors + transform to issue(s)
-        const policy = await this.validator.run(value);
+        // The policy settles against EITHER data key: the ATTRIBUTE_NAMES key carries a
+        // plain projection/fieldset (string[]) — "may this actor project these field
+        // names", answerable before any row exists — while the ATTRIBUTES record keeps
+        // its established key semantics. The tri-state lives HERE instead of a
+        // `requires()` declaration: the engine's requires-gate is AND-semantics over the
+        // declared keys, so declaring both would pend every bag carrying only one of
+        // them. Checked before the validator run so gate-style calls with an empty bag
+        // stay cheap.
+        const hasNames = ctx.data.has(BuiltInPolicyType.ATTRIBUTE_NAMES);
+        const hasAttributes = ctx.data.has(BuiltInPolicyType.ATTRIBUTES);
 
-        const data = await this.attributesEvaluator.accessData(ctx);
-        if (!data) {
+        if (!hasNames && !hasAttributes) {
             return {
                 success: false,
+                pending: true,
                 issues: [
                     definePolicyIssueItem({
                         code: PolicyIssueCode.DATA_MISSING,
-                        message: 'The data property attributes is missing',
+                        message: 'The data property attributeNames or attributes is missing',
                         path: ctx.path,
                     }),
                 ],
             };
         }
 
-        // Nested paths are a deliberate feature: an attribute object like
-        // `{user: {name: 'x'}}` flattens to `{'user.name': 'x'}` and is matched
-        // against `names` entries with dotted notation. Allowlists/denylists
-        // that need to govern nested fields must use the dotted-path form
-        // (e.g. `'user.realmId'`); a top-level entry like `'realmId'` will
-        // NOT catch a nested `user.realmId` write — that's by design, the
-        // policy is precise about which path it covers.
-        const attributes = flattenObject(data);
-        const keys = Object.keys(attributes);
+        // todo: catch errors + transform to issue(s)
+        const policy = await this.validator.run(value);
+
+        // Conjunctive over the available sources: when both keys are present BOTH are
+        // enforced — a reused bag that carries a projection alongside row attributes can
+        // never weaken an existing record gate. Keys are deduplicated so a name present
+        // in both sources yields one issue.
+        const keys = new Set<string>();
+
+        if (hasNames) {
+            // Non-string entries fail closed as invalid data — silently skipping
+            // them would fail open in denylist (invert) mode.
+            const data = ctx.data.get(BuiltInPolicyType.ATTRIBUTE_NAMES);
+            if (
+                !Array.isArray(data) ||
+                data.some((entry) => typeof entry !== 'string')
+            ) {
+                return {
+                    success: false,
+                    issues: [
+                        definePolicyIssueItem({
+                            code: PolicyIssueCode.DATA_INVALID,
+                            message: 'The data property attributeNames must be a list of attribute names',
+                            path: ctx.path,
+                        }),
+                    ],
+                };
+            }
+
+            for (const entry of data) {
+                keys.add(entry);
+            }
+        }
+
+        if (hasAttributes) {
+            const data = await this.attributesEvaluator.accessData(ctx);
+            if (data) {
+                // Nested paths are a deliberate feature: an attribute object like
+                // `{user: {name: 'x'}}` flattens to `{'user.name': 'x'}` and is matched
+                // against `names` entries with dotted notation. Allowlists/denylists
+                // that need to govern nested fields must use the dotted-path form
+                // (e.g. `'user.realmId'`); a top-level entry like `'realmId'` will
+                // NOT catch a nested `user.realmId` write — that's by design, the
+                // policy is precise about which path it covers.
+                const attributes = flattenObject(data);
+                for (const key of Object.keys(attributes)) {
+                    keys.add(key);
+                }
+            }
+        }
 
         // `invert` is consumed per-key, NOT at the result level:
         //   - allowlist (default): a key NOT in `names` is denied

--- a/packages/access/test/unit/policy/attribute-names.spec.ts
+++ b/packages/access/test/unit/policy/attribute-names.spec.ts
@@ -8,11 +8,16 @@
 import { describe, expect, it } from 'vitest';
 import type { AttributeNamesPolicy } from '../../../src';
 import {
-    AttributeNamesPolicyEvaluator, 
+    AttributeNamesPolicyEvaluator,
     AttributeNamesPolicyValidator,
+    BuiltInPolicyType,
     PolicyData,
+    PolicyEngine,
+    PolicyIssueCode,
     definePolicyEvaluationContext,
+    definePolicyWithType,
 } from '../../../src';
+import { PolicyDefaultEvaluators } from '../../../src/policy/constants.ts';
 
 const evaluator = new AttributeNamesPolicyEvaluator();
 
@@ -53,7 +58,7 @@ describe('src/policy/attribute-names', () => {
         expect(output.foo).toBeUndefined();
     });
 
-    it('should fail with missing context', async () => {
+    it('should report pending with missing context', async () => {
         const policy : AttributeNamesPolicy = {
             invert: false,
             names: ['foo', 'bar'],
@@ -61,6 +66,8 @@ describe('src/policy/attribute-names', () => {
 
         const outcome = await evaluator.evaluate(policy, definePolicyEvaluationContext());
         expect(outcome.success).toBeFalsy();
+        expect(outcome.pending).toBeTruthy();
+        expect(outcome.issues![0].code).toEqual(PolicyIssueCode.DATA_MISSING);
     });
 
     it('should fail with unknown attributes', async () => {
@@ -135,5 +142,195 @@ describe('src/policy/attribute-names', () => {
             }),
         );
         expect(outcome.success).toBeFalsy();
+    });
+
+    describe('attributeNames data key (projection mode)', () => {
+        it('should succeed with permitted names', async () => {
+            const policy : AttributeNamesPolicy = { names: ['foo', 'bar'] };
+
+            const outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['foo', 'bar'] }) }),
+            );
+            expect(outcome.success).toBeTruthy();
+        });
+
+        it('should fail with a name outside the allowlist', async () => {
+            const policy : AttributeNamesPolicy = { names: ['foo', 'bar'] };
+
+            const outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['foo', 'baz'] }) }),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues).toHaveLength(1);
+            expect(outcome.issues![0].code).toEqual(PolicyIssueCode.EVALUATION_DENIED);
+            expect(outcome.issues![0].path).toEqual(['baz']);
+        });
+
+        it('should apply invert per name (denylist)', async () => {
+            const policy : AttributeNamesPolicy = {
+                invert: true,
+                names: ['secret'],
+            };
+
+            let outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['secret'] }) }),
+            );
+            expect(outcome.success).toBeFalsy();
+
+            outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['title'] }) }),
+            );
+            expect(outcome.success).toBeTruthy();
+        });
+
+        it('should succeed with an empty projection', async () => {
+            const policy : AttributeNamesPolicy = { names: ['foo'] };
+
+            let outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: [] }) }),
+            );
+            expect(outcome.success).toBeTruthy();
+
+            outcome = await evaluator.evaluate(
+                { ...policy, invert: true },
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: [] }) }),
+            );
+            expect(outcome.success).toBeTruthy();
+        });
+
+        it('should fail with malformed projection data', async () => {
+            const policy : AttributeNamesPolicy = { names: ['foo'] };
+
+            let outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: { foo: true } }) }),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues![0].code).toEqual(PolicyIssueCode.DATA_INVALID);
+
+            outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['foo', 42] }) }),
+            );
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues![0].code).toEqual(PolicyIssueCode.DATA_INVALID);
+        });
+
+        it('should enforce both sources when both are present', async () => {
+            const policy : AttributeNamesPolicy = { names: ['foo'] };
+
+            let outcome = await evaluator.evaluate(policy, definePolicyEvaluationContext({
+                data: new PolicyData({
+                    attributeNames: ['foo'],
+                    attributes: { secret: 'x' },
+                }),
+            }));
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues![0].path).toEqual(['secret']);
+
+            outcome = await evaluator.evaluate(policy, definePolicyEvaluationContext({
+                data: new PolicyData({
+                    attributeNames: ['secret'],
+                    attributes: { foo: 'bar' },
+                }),
+            }));
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues![0].path).toEqual(['secret']);
+
+            outcome = await evaluator.evaluate(policy, definePolicyEvaluationContext({
+                data: new PolicyData({
+                    attributeNames: ['foo'],
+                    attributes: { foo: 'bar' },
+                }),
+            }));
+            expect(outcome.success).toBeTruthy();
+        });
+
+        it('should deduplicate a name present in both sources', async () => {
+            const policy : AttributeNamesPolicy = {
+                invert: true,
+                names: ['secret'],
+            };
+
+            const outcome = await evaluator.evaluate(policy, definePolicyEvaluationContext({
+                data: new PolicyData({
+                    attributeNames: ['secret'],
+                    attributes: { secret: 'x' },
+                }),
+            }));
+            expect(outcome.success).toBeFalsy();
+            expect(outcome.issues).toHaveLength(1);
+        });
+
+        it('should answer both questions with the same policy', async () => {
+            const policy : AttributeNamesPolicy = {
+                invert: true,
+                names: ['secret'],
+            };
+
+            let outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributes: { name: 'admin' } }) }),
+            );
+            expect(outcome.success).toBeTruthy();
+
+            outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['name'] }) }),
+            );
+            expect(outcome.success).toBeTruthy();
+
+            outcome = await evaluator.evaluate(
+                policy,
+                definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['secret'] }) }),
+            );
+            expect(outcome.success).toBeFalsy();
+        });
+
+        describe('engine data-availability (tri-state)', () => {
+            const engine = new PolicyEngine(PolicyDefaultEvaluators);
+
+            it('should report pending when neither data key is present', async () => {
+                const policy = definePolicyWithType(BuiltInPolicyType.ATTRIBUTE_NAMES, { names: ['foo'] } satisfies AttributeNamesPolicy);
+
+                const outcome = await engine.evaluate(policy, definePolicyEvaluationContext());
+                expect(outcome.success).toBeFalsy();
+                expect(outcome.pending).toBeTruthy();
+            });
+
+            it('should settle against the names key', async () => {
+                const policy = definePolicyWithType(BuiltInPolicyType.ATTRIBUTE_NAMES, { names: ['foo'] } satisfies AttributeNamesPolicy);
+
+                let outcome = await engine.evaluate(
+                    policy,
+                    definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['foo'] }) }),
+                );
+                expect(outcome.success).toBeTruthy();
+                expect(outcome.pending).toBeFalsy();
+
+                outcome = await engine.evaluate(
+                    policy,
+                    definePolicyEvaluationContext({ data: new PolicyData({ attributeNames: ['bar'] }) }),
+                );
+                expect(outcome.success).toBeFalsy();
+                expect(outcome.pending).toBeFalsy();
+            });
+
+            it('should settle against the attributes key', async () => {
+                const policy = definePolicyWithType(BuiltInPolicyType.ATTRIBUTE_NAMES, { names: ['foo'] } satisfies AttributeNamesPolicy);
+
+                const outcome = await engine.evaluate(
+                    policy,
+                    definePolicyEvaluationContext({ data: new PolicyData({ attributes: { foo: 'bar' } }) }),
+                );
+                expect(outcome.success).toBeTruthy();
+                expect(outcome.pending).toBeFalsy();
+            });
+        });
     });
 });


### PR DESCRIPTION
## Summary

Implements #3321, with one design change settled during implementation: **data-driven source selection instead of a config discriminator**. The policy has no `source` field — it settles against whichever policy-data key is available:

- **`attributeNames` key** — a plain `string[]` projection/fieldset: *"may this actor project these field names"*, answerable before any row exists (the rapiq `fields.validateMany` consumer, tada5hi/rapiq#830). Skips `flattenObject` entirely.
- **`attributes` key** — the record mode, byte-identical to before (flatten, dotted nested paths).
- **Both present → both enforced** (conjunctive, deduplicated per key). Strict names-over-attributes precedence would let a bag carrying both keys skip the record check — strictly more permissive than today; the conjunctive rule is identical for every existing single-key bag and fail-closed for the degenerate case.
- **Neither present → the evaluator itself returns `{ success: false, pending: true }`**. `requires()` is removed: the engine gate is AND-semantics over declared keys, so an either-or requirement is inexpressible there (declaring both keys would pend — and thus deny — every normal write-path bag at full `evaluate()`). In-evaluator pending is precedented (composite algebra, permission-binding grant terms); every consumer reads the result flag, not the mechanism, so `preEvaluate`/`pendingPolicies: 'permit'` behavior is unchanged.

Why no config discriminator: the two questions ("may this actor write these values" / "may this actor project these field names") are properties of the **call site**, not the policy. Data-driven selection lets one policy answer both — the persisted self-manage denylists gate projections as-is, with no second policy row, no EA/validator/UI surface, no new dimension in policy equality.

## Details

- Per-key `invert`, issue paths (`[...ctx.path, key]`) and the empty-input vacuous pass are shared by both sources.
- Malformed projection data (non-array, or non-string entries) fails closed with `DATA_INVALID` — silently skipping entries would fail open in denylist (`invert`) mode.
- `AttributesPolicyEvaluator.accessData` is untouched; realm-match and row-value ABAC never see fabricated row data (the issue's core soundness point).
- Docs: `policies.md` (both-source semantics + projection example), `permission-checker.md` pending wording, `.agents/architecture.md` tri-state section.

## Tests

- New projection-mode coverage: allowlist/denylist, issue path/code, empty projection, malformed data, conjunctive both-present + dedup, same-policy-answers-both-questions, engine tri-state (pending when neither key present, settles against either).
- `packages/access`: 155/155. Full `apps/server-core` suite: 1721/1721 (the record-mode consumers — self-manage denylists, permission binding, preEvaluate gates — are exercised end-to-end there).

closes #3321

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Attribute-name policies can now evaluate field projections before full attribute data is available.
  * Policies support allowlist and denylist behavior through the `invert` option.
  * Attribute names can be supplied directly or derived from available attribute data, with duplicate names handled consistently.

* **Bug Fixes**
  * Policies now remain pending when required attribute data is unavailable instead of being treated as absent.
  * Invalid attribute-name data is rejected with a clear validation result.
  * Updated documentation and examples explain pending evaluation and projection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->