### PR TITLE
fix: gate client secret projection at the schema level

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -183,6 +183,57 @@ usable at the service level and nothing in core depends on TypeORM:
   strip). Every schema now declares `relations` explicitly (an omitted
   allow-list falls back to rapiq's syntactic name check — that hole is
   closed; `event`/`realm` pin `allowed: []`).
+- **Field authorization — gated columns (#3322)** — a schema may gate
+  individual columns via `fields.validateMany`
+  (`createFieldsReadGate(gates)` in `core/query/fields.ts`; schemas
+  import that FILE directly, same barrel-cycle rule as the relations
+  gate). rapiq invokes the batched hook once per (governing schema,
+  relation path) with the client-requested names — never schema
+  defaults — so a gate compiles the actor's permission disjunction
+  ONCE per query and an unqualified list costs nothing. A gate answers
+  `true`, `false` (strip), or an `ICondition` (rapiq #830/#837): the
+  column stays projected but is VISIBLE only on rows satisfying the
+  condition, uniformly at the query root and under any
+  `fields[relation]` position — which is what closes the
+  `GET /client-permissions?fields[client]=secret` bypass of
+  `ClientService`'s read path (the dotted field auto-joins `client`
+  with a per-column selection; the relations read gate still gates the
+  traversal itself). Enforcement is two-part: the rapiq SQL adapter
+  force-selects every column a condition reads (operand projection —
+  the condition cannot go into the statement, a TypeORM selection must
+  stay a bare column for hydration), and EVERY `findMany` adapter runs
+  its fetched rows through `redactFieldConditions(query, entities)`
+  (`app/modules/database/repositories/query.ts`, wrapping
+  `@rapiq/memory`'s `applyFieldConditions`) — failing values are
+  REDACTED, rows never drop, totals stay exact. The sweep is universal
+  because enforcement is fail-open by construction: a `findMany` that
+  skips the call ships the value. Author conditions FAIL-CLOSED over
+  missing columns (positive legs + a presence guard like
+  `ne('realmId', null)`): `@rapiq/memory` unifies a missing column
+  with `null`, so a negated leg — or an `ownOrNull` reach's
+  null-inclusive realm leg — would match an unfetched column.
+  Today's only gated column is `client.secret`: `allow` verdict →
+  ungated; otherwise visible iff NOT plaintext (`secret` null /
+  hashed / encrypted) OR covered by the compiled
+  `CLIENT_READ/UPDATE/DELETE` condition OR the actor's own client row
+  (self leg — preserves the service-level isMe contract in list
+  shape). SYSTEM decodes (no actor) pass ungated; a gate failure
+  strips the field. `ClientService.getMany`'s former WHERE-narrowing +
+  per-row loop are gone — rows are no longer dropped when `secret` is
+  selected, and a `post` verdict now strips plaintext values instead
+  of per-row evaluation (fail-closed). `getOne` keeps its isMe bypass
+  and post-fetch per-row check as the authoritative single-read path —
+  healed by the operand projection: a bare `fields=id,secret`
+  replace-projection used to strip `realmId`/flags so the check's
+  `resourceRealmMatch` neutral-passed and shipped a foreign plaintext
+  secret. Note: under an explicit `include=client` the relation joins
+  fully-selected and rapiq #831 drops the per-column dotted selects,
+  so a `select:false` column cannot ship through that form at all
+  today (`fields[relation]` silently ignored there — divergence filed
+  as tada5hi/rapiq#847); the gate covers it seamlessly if the adapter
+  ever reduces explicit-include joins. Specs:
+  `core/query/module.spec.ts` (verdict matrix),
+  `client-secret-projection.spec.ts` (HTTP acceptance).
 - **Junction/attribute schemas pin `fields.default`** — with no root fields
   declared, an `include=` decodes the relation's default fields ONLY, and
   the typeorm adapter's `select()` replace then drops every root column
@@ -1314,12 +1365,11 @@ alternative** service-side — `or(and(eq(sub), eq(subKind)), compiled.condition
 `EventService`'s probe-based `resolveReadVisibility` (random-foreign-realm
 `canReadRealm` probing) survives only as the `post` fallback — the compiled WHERE also
 covers junction ATTRIBUTES policies the probe's `policiesIncluded` deliberately
-excluded. `ClientService`'s gate is **projection-dependent secret visibility** (only
-plaintext-secret rows are hidden from unauthorized readers, and only when the
-(non-default) `secret` field is actually selected): it lowers to
-`or(not(and(ne('secret', null), eq('secretHashed', false), eq('secretEncrypted',
-false))), compiled.condition)`, applied only when the decoded projection includes
-`secret` — the default projection is never gated (exactly today's loop semantics).
+excluded. `ClientService`'s former projection-dependent secret gate moved OFF the
+service onto the client SCHEMA (#3322, see *Query IR flow → Field authorization*):
+`getMany` no longer composes a secret WHERE or per-row loop — the schema's
+`fields.validateMany` hook compiles the same permission disjunction into a per-row
+visibility condition on the `secret` field, and the repository layer redacts.
 The self-short-circuit / parent-permission gates (#3294) follow the same shape:
 `UserService` composes `or(eq('id', <actor user id>), compiled.condition)` (self term
 only for a user identity; `deny` → self term alone); `UserAttributeService` mirrors
@@ -2174,13 +2224,15 @@ reader could strip `realmId` and neutralize the realmScope reach factor
 null/global resource). The shared helper `applyRealmScopeSelect(qb, alias,
 extraColumns?)` (`app/modules/database/repositories/helpers.ts`) is called AFTER
 `applyQuery` in: `session` (`+ sub, subKind` — ownership check), `user`
-(`+ id` — self short-circuit), `client` (`+ secretHashed,
-secretEncrypted` — the plaintext-secret gate precondition), `role-attribute`,
+(`+ id` — self short-circuit), `role-attribute`,
 `user-attribute` (`+ userId` — isMe check; since #3295 the two attribute schemas
 declare `fields.default`, so the call dedupes against that projection). `role` / `scope` /
 `permission` / `policy` list paths carry no per-row realm gate (their
 `resourceRealmMatch` usages are write paths on server-loaded data), so they are
-deliberately not force-selected. The helper **dedupes against the already-applied
+deliberately not force-selected. `client` dropped out of the list with #3322 —
+its per-row secret gate moved onto the schema, whose visibility CONDITION gets its
+operand columns force-selected by the rapiq SQL adapter itself (see *Query IR flow
+→ Field authorization*). The helper **dedupes against the already-applied
 projection** (`qb.expressionMap.selects`) — TypeORM's `addSelect` is NOT a no-op
 for an already-selected column: it emits a second identically-aliased select, and
 under a join + take (TypeORM's DISTINCT id-subquery wrapper) postgres rejects the

--- a/apps/server-core/src/app/modules/authentication/repositories/session.ts
+++ b/apps/server-core/src/app/modules/authentication/repositories/session.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import type { EntityRepositoryFindManyResult, ICache } from '@authup/server-kit';
 import { buildCacheKey } from '@authup/server-kit';
 import type { Repository } from 'typeorm';
-import { applyQuery } from '../../database/repositories/query.ts';
+import { applyQuery, redactFieldConditions } from '../../database/repositories/query.ts';
 import type {
     ISessionRepository,
     SessionFindManyOptions,
@@ -76,7 +76,7 @@ export class SessionRepository implements ISessionRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client-permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client-permission/repository.ts
@@ -9,7 +9,7 @@ import type { ClientPermission } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientPermissionRepository } from '../../../../../core/entities/client-permission/types.ts';
 import { ClientPermissionEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class ClientPermissionRepositoryAdapter implements IClientPermissionRepos
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client-role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client-role/repository.ts
@@ -9,7 +9,7 @@ import type { ClientRole } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientRoleRepository } from '../../../../../core/entities/client-role/types.ts';
 import { ClientRoleEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class ClientRoleRepositoryAdapter implements IClientRoleRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client-scope/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client-scope/repository.ts
@@ -9,7 +9,7 @@ import type { ClientScope } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientScopeRepository } from '../../../../../core/entities/client-scope/types.ts';
 import { ClientScopeEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class ClientScopeRepositoryAdapter implements IClientScopeRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client/repository.ts
@@ -12,11 +12,11 @@ import { buildRedisKeyPath } from '@authup/server-kit';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
-import { applyRealmScopeSelect, isEntityUnique, translateWhereConditions } from '../helpers.ts';
+import { isEntityUnique, translateWhereConditions } from '../helpers.ts';
 import { loadBoundPermissions } from '../bindings.ts';
 import {
     CachePrefix,
@@ -47,12 +47,10 @@ export class ClientRepositoryAdapter implements IClientRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        applyRealmScopeSelect(qb, 'client', ['secretHashed', 'secretEncrypted']);
-
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -9,7 +9,7 @@ import type { Event } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { LessThan } from 'typeorm';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type {
     EventCountRecentFilter,
@@ -84,7 +84,7 @@ export class EventRepositoryAdapter implements IEventRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider-role-mapping/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider-role-mapping/repository.ts
@@ -9,7 +9,7 @@ import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IIdentityProviderRoleMappingRepository } from '../../../../../core/index.ts';
 import { IdentityProviderRoleMappingEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class IdentityProviderRoleMappingRepositoryAdapter implements IIdentityPr
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IIdentityProviderRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -43,7 +43,7 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/key/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/key/repository.ts
@@ -22,7 +22,7 @@ import { JWKType, JWKUse, JWTAlgorithm } from '@authup/specs';
 import type { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { Like } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import { getRandomValues } from 'uncrypto';
 import {
     DatabaseConflictError,
@@ -280,7 +280,7 @@ export class KeyRepositoryAdapter implements IKeyRepository, IKeyStore {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/permission-policy/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/permission-policy/repository.ts
@@ -9,7 +9,7 @@ import type { PermissionPolicy } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IPermissionPolicyRepository } from '../../../../../core/index.ts';
 import { PermissionPolicyEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class PermissionPolicyRepositoryAdapter implements IPermissionPolicyRepos
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IPermissionRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -42,7 +42,7 @@ export class PermissionRepositoryAdapter implements IPermissionRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IPolicyRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -44,7 +44,7 @@ export class PolicyRepositoryAdapter implements IPolicyRepository {
         await this.repository.extendManyWithEA(entities);
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/query.ts
+++ b/apps/server-core/src/app/modules/database/repositories/query.ts
@@ -6,7 +6,8 @@
  */
 
 import type { IQuery } from '@rapiq/core';
-import { Query } from '@rapiq/core';
+import { Query, hasFieldConditions } from '@rapiq/core';
+import { applyFieldConditions } from '@rapiq/memory';
 import { TypeormAdapter } from '@rapiq/typeorm';
 import type { SelectQueryBuilder } from 'typeorm';
 import type { EntityRepositoryPaginationMeta } from '@authup/server-kit';
@@ -21,6 +22,16 @@ import type { EntityRepositoryPaginationMeta } from '@authup/server-kit';
  * Joins triggered by the parsed relations replicate the DISTINCT-id
  * pattern: when the builder already groups by the root id, every join
  * contributes its own `GROUP BY <alias>.id`.
+ *
+ * Field visibility conditions (`IField.condition`, attached by a
+ * schema `fields.validateMany` gate) cannot go into the statement — a
+ * TypeORM selection must stay a bare column for entity hydration.
+ * The adapter projects the gated column unconditionally and
+ * force-selects every column its condition reads (rapiq#830's operand
+ * projection — the SQL counterpart of the plan-039 force-select
+ * discipline, so a sparse replace-projection can neither over-redact
+ * nor fail open on missing operands); the fetching adapter MUST then
+ * run the rows through `redactFieldConditions` before returning them.
  */
 export function applyQuery(
     queryBuilder: SelectQueryBuilder<any>,
@@ -40,4 +51,21 @@ export function applyQuery(
     const { pagination } = adapter.execute(query ?? new Query({}));
 
     return { pagination };
+}
+
+/**
+ * Enforce the field visibility conditions of a decoded query on
+ * already-fetched rows: a gated column is dropped from every row that
+ * fails its condition; no row is ever removed. The SQL execution path
+ * projects gated columns unconditionally, so EVERY `findMany` adapter
+ * must pass its fetched entities through this before returning them —
+ * enforcement is fail-open by construction (a skipped call ships the
+ * value). Condition-less queries pass through untouched.
+ */
+export function redactFieldConditions<T>(query: IQuery | undefined, data: T[]) : T[] {
+    if (!query || !hasFieldConditions(query.fields)) {
+        return data;
+    }
+
+    return applyFieldConditions(query.fields, data);
 }

--- a/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
@@ -12,7 +12,7 @@ import { InternalError } from '@authup/errors';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import { buildRedisKeyPath } from '@authup/server-kit';
 import type { IRealmRepository } from '../../../../../core/index.ts';
@@ -56,7 +56,7 @@ export class RealmRepositoryAdapter implements IRealmRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/role-attribute/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role-attribute/repository.ts
@@ -9,7 +9,7 @@ import type { RoleAttribute } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRoleAttributeRepository } from '../../../../../core/index.ts';
 import { RoleAttributeEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -33,7 +33,7 @@ export class RoleAttributeRepositoryAdapter implements IRoleAttributeRepository 
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/role-permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role-permission/repository.ts
@@ -9,7 +9,7 @@ import type { RolePermission } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRolePermissionRepository } from '../../../../../core/index.ts';
 import { RolePermissionEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class RolePermissionRepositoryAdapter implements IRolePermissionRepositor
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role/repository.ts
@@ -11,7 +11,7 @@ import type { PermissionPolicyBinding } from '@authup/access';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRealmRepository, IRoleRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -48,7 +48,7 @@ export class RoleRepositoryAdapter implements IRoleRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRealmRepository, IScopeRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -42,7 +42,7 @@ export class ScopeRepositoryAdapter implements IScopeRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/trust-anchor/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/trust-anchor/repository.ts
@@ -11,7 +11,7 @@ import { isUUID } from '@authup/kit';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import { DatabaseConflictError, RealmEntity, TrustAnchorEntity } from '../../../../../adapters/database/index.ts';
 import type { IRealmRepository, ITrustAnchorRepository } from '../../../../../core/index.ts';
 import { applyRealmScopeSelect, isEntityUnique, translateWhereConditions } from '../helpers.ts';
@@ -42,7 +42,7 @@ export class TrustAnchorRepositoryAdapter implements ITrustAnchorRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-attribute/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-attribute/repository.ts
@@ -9,7 +9,7 @@ import type { UserAttribute } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IUserAttributeRepository } from '../../../../../core/index.ts';
 import { UserAttributeEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -33,7 +33,7 @@ export class UserAttributeRepositoryAdapter implements IUserAttributeRepository 
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-authenticator/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-authenticator/repository.ts
@@ -8,7 +8,7 @@
 import type { UserAuthenticator, UserAuthenticatorKind } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type {
     IUserAuthenticatorRepository,
@@ -97,7 +97,7 @@ export class UserAuthenticatorRepositoryAdapter implements IUserAuthenticatorRep
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-permission/repository.ts
@@ -9,7 +9,7 @@ import type { UserPermission } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IUserPermissionRepository } from '../../../../../core/index.ts';
 import { UserPermissionEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class UserPermissionRepositoryAdapter implements IUserPermissionRepositor
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-role/repository.ts
@@ -9,7 +9,7 @@ import type { UserRole } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IUserRoleRepository } from '../../../../../core/index.ts';
 import { UserRoleEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -31,7 +31,7 @@ export class UserRoleRepositoryAdapter implements IUserRoleRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user/repository.ts
@@ -12,7 +12,7 @@ import { buildRedisKeyPath } from '@authup/server-kit';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery } from '../query.ts';
+import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRealmRepository, IUserRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -55,7 +55,7 @@ export class UserRepositoryAdapter implements IUserRepository {
         await this.repository.extendManyWithEA(entities);
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/oauth2/repositories/consent/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/consent/repository.ts
@@ -11,7 +11,7 @@ import { IdentityType  } from '@authup/core-kit';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import { buildRedisKeyPath } from '@authup/server-kit';
 import type { DataSource, Repository } from 'typeorm';
-import { applyQuery } from '../../../database/repositories/query.ts';
+import { applyQuery, redactFieldConditions } from '../../../database/repositories/query.ts';
 import { CachePrefix, ConsentEntity } from '../../../../../adapters/database/domains/index.ts';
 import { isUniqueConstraintDatabaseError } from '../../../../../adapters/database/errors/index.ts';
 import type {
@@ -70,7 +70,7 @@ export class ConsentRepositoryAdapter implements IConsentRepository {
         const [entities, total] = await qb.getManyAndCount();
 
         return {
-            data: entities,
+            data: redactFieldConditions(query, entities),
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/core/entities/client/constants.ts
+++ b/apps/server-core/src/core/entities/client/constants.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { PermissionName } from '@authup/core-kit';
+
+/**
+ * The client read-permission disjunction: holding ANY of these grants
+ * read access to client rows. Shared between `ClientService`'s
+ * getMany/getOne pre-gates and the schema-level `secret` visibility
+ * gate (issue #3322) — the two MUST evaluate the same disjunction, or
+ * listability and secret visibility silently diverge.
+ */
+export const CLIENT_READ_PERMISSIONS : PermissionName[] = [
+    PermissionName.CLIENT_READ,
+    PermissionName.CLIENT_UPDATE,
+    PermissionName.CLIENT_DELETE,
+];

--- a/apps/server-core/src/core/entities/client/index.ts
+++ b/apps/server-core/src/core/entities/client/index.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './constants.ts';
 export * from './service.ts';
 export * from './types.ts';
 export * from './web-client.ts';

--- a/apps/server-core/src/core/entities/client/schema.ts
+++ b/apps/server-core/src/core/entities/client/schema.ts
@@ -5,12 +5,77 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { defineSchema } from '@rapiq/core';
+import type { ICondition, KeyValidationVerdict } from '@rapiq/core';
+import {
+    and,
+    defineSchema,
+    eq,
+    ne,
+    or,
+} from '@rapiq/core';
 import type { Client } from '@authup/core-kit';
-import { EntityType } from '@authup/core-kit';
+import { EntityType, IdentityType, PermissionName } from '@authup/core-kit';
+import type { ActorContext } from '@authup/server-kit';
+import { createFieldsReadGate } from '../../query/fields.ts';
 import { createRelationsReadGate } from '../../query/relations.ts';
 
 const schemaMapping = { realm: EntityType.REALM, accessPolicy: EntityType.POLICY };
+
+/**
+ * Per-row visibility gate for the `secret` column (issue #3322) —
+ * schema-level, so it applies wherever the client schema governs a
+ * projection: the `/clients` root AND the `include=client` paths of
+ * client-permission / client-role / client-scope, which never run
+ * `ClientService`'s read path.
+ *
+ * Only rows exposing a PLAINTEXT secret are guarded: `null`, hashed
+ * and encrypted values stay visible to any actor that passed the read
+ * pre-gate (the historical service semantics). A plaintext value is
+ * additionally visible on the actor's OWN client row (the `getOne`
+ * isMe bypass, list-shaped) and on rows the compiled permission
+ * condition covers. A non-expressible (`post`) or settled-deny compile
+ * yields no permission leg — fail closed for plaintext rows rather
+ * than falling back to per-row evaluation.
+ *
+ * The outer `ne('realmId', null)` guard is semantically inert (clients
+ * are realm-bound) but makes the condition fail closed on rows whose
+ * gate columns were not fetched — an `ownOrNull` reach compiles to a
+ * null-inclusive realm leg that would otherwise MATCH a missing
+ * column. The SQL adapter force-selects every column the condition
+ * reads (rapiq#830's operand projection), so this is defense in depth.
+ */
+async function secretReadGate(actor: ActorContext) : Promise<KeyValidationVerdict> {
+    const compiled = await actor.permissionEvaluator.compile({
+        name: [
+            PermissionName.CLIENT_READ,
+            PermissionName.CLIENT_UPDATE,
+            PermissionName.CLIENT_DELETE,
+        ],
+    });
+    if (compiled.verdict === 'allow') {
+        return true;
+    }
+
+    const visible : ICondition[] = [
+        eq('secret', null),
+        eq('secretHashed', true),
+        eq('secretEncrypted', true),
+    ];
+
+    if (compiled.verdict === 'conditional') {
+        visible.push(compiled.condition);
+    }
+
+    if (
+        actor.identity &&
+        actor.identity.type === IdentityType.CLIENT &&
+        actor.identity.data.id
+    ) {
+        visible.push(eq('id', actor.identity.data.id));
+    }
+
+    return and(ne('realmId', null), or(...visible));
+}
 
 export const clientSchema = defineSchema<Client>({
     name: EntityType.CLIENT,
@@ -38,6 +103,7 @@ export const clientSchema = defineSchema<Client>({
             'createdAt',
         ],
         allowed: ['secret'],
+        validateMany: createFieldsReadGate({ secret: secretReadGate }),
     },
     filters: { allowed: ['id', 'name', 'realmId'] },
     relations: { allowed: ['realm', 'accessPolicy'], validate: createRelationsReadGate(schemaMapping) },

--- a/apps/server-core/src/core/entities/client/schema.ts
+++ b/apps/server-core/src/core/entities/client/schema.ts
@@ -14,10 +14,11 @@ import {
     or,
 } from '@rapiq/core';
 import type { Client } from '@authup/core-kit';
-import { EntityType, IdentityType, PermissionName } from '@authup/core-kit';
+import { EntityType, IdentityType } from '@authup/core-kit';
 import type { ActorContext } from '@authup/server-kit';
 import { createFieldsReadGate } from '../../query/fields.ts';
 import { createRelationsReadGate } from '../../query/relations.ts';
+import { CLIENT_READ_PERMISSIONS } from './constants.ts';
 
 const schemaMapping = { realm: EntityType.REALM, accessPolicy: EntityType.POLICY };
 
@@ -45,13 +46,7 @@ const schemaMapping = { realm: EntityType.REALM, accessPolicy: EntityType.POLICY
  * reads (rapiq#830's operand projection), so this is defense in depth.
  */
 async function secretReadGate(actor: ActorContext) : Promise<KeyValidationVerdict> {
-    const compiled = await actor.permissionEvaluator.compile({
-        name: [
-            PermissionName.CLIENT_READ,
-            PermissionName.CLIENT_UPDATE,
-            PermissionName.CLIENT_DELETE,
-        ],
-    });
+    const compiled = await actor.permissionEvaluator.compile({ name: CLIENT_READ_PERMISSIONS });
     if (compiled.verdict === 'allow') {
         return true;
     }

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -6,13 +6,6 @@
  */
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
-import {
-    and, 
-    eq, 
-    ne, 
-    not, 
-    or,
-} from '@rapiq/core';
 import { ValidatorGroup, isUUID } from '@authup/kit';
 import { EntityNotFoundError, ValidationError } from '@authup/errors';
 import {
@@ -27,7 +20,7 @@ import type { IRealmRepository } from '../realm/types.ts';
 import { AbstractEntityService } from '@authup/server-kit';
 import { ClientCredentialsService } from '../../authentication/credential/entities/client/module.ts';
 import type { IClientRepository, IClientService } from './types.ts';
-import { appendQueryConditions, decodeQuery } from '../../query/index.ts';
+import { decodeQuery } from '../../query/index.ts';
 import { clientSchema } from './schema.ts';
 
 export type ClientServiceContext = {
@@ -53,86 +46,21 @@ export class ClientService extends AbstractEntityService implements IClientServi
         query: Record<string, any>,
         actor: ActorContext,
     ): Promise<EntityRepositoryFindManyResult<Client>> {
-        const permissionNames = [
-            PermissionName.CLIENT_READ,
-            PermissionName.CLIENT_UPDATE,
-            PermissionName.CLIENT_DELETE,
-        ];
+        await actor.permissionEvaluator.preEvaluateOneOf({
+            name: [
+                PermissionName.CLIENT_READ,
+                PermissionName.CLIENT_UPDATE,
+                PermissionName.CLIENT_DELETE,
+            ],
+        });
 
-        await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
-
-        const parsed = await decodeQuery(query, { schema: clientSchema, actor });
-
-        // The per-row gate below only fires for rows exposing a PLAINTEXT secret,
-        // and only when the projection actually selects the (non-default) `secret`
-        // field — everything else lists freely. Compile the gate into WHERE
-        // (#3286 phase 3): a plaintext-secret row is visible iff the compiled
-        // permission condition covers it; rows without a plaintext secret always
-        // are. A non-expressible policy falls back to the per-row loop below.
-        const secretSelected = parsed.fields.value.some(
-            (field) => field.name === 'secret' && field.operator !== '-',
+        // The per-row `secret` visibility gate lives on the client SCHEMA
+        // (`fields.validateMany`, issue #3322), so it also covers the
+        // `include=client` paths served by other services; the repository
+        // layer redacts unauthorized values without dropping rows.
+        return this.repository.findMany(
+            await decodeQuery(query, { schema: clientSchema, actor }),
         );
-        const compiled = await actor.permissionEvaluator.compile({ name: permissionNames });
-        if (compiled.verdict !== 'post') {
-            let scoped = parsed;
-            if (secretSelected && compiled.verdict !== 'allow') {
-                const plaintextSecret = and(
-                    ne('secret', null),
-                    eq('secretHashed', false),
-                    eq('secretEncrypted', false),
-                );
-
-                scoped = appendQueryConditions(
-                    parsed,
-                    compiled.verdict === 'conditional' ?
-                        or(not(plaintextSecret), compiled.condition) :
-                        not(plaintextSecret),
-                );
-            }
-
-            return this.repository.findMany(scoped);
-        }
-
-        const {
-            data: entities,
-            meta,
-        } = await this.repository.findMany(parsed);
-        let { total } = meta;
-
-        const data: Client[] = [];
-        for (const entity of entities) {
-            if (
-                entity.secret &&
-                !entity.secretEncrypted &&
-                !entity.secretHashed
-            ) {
-                try {
-                    await actor.permissionEvaluator.evaluateOneOf({
-                        name: [
-                            PermissionName.CLIENT_READ,
-                            PermissionName.CLIENT_UPDATE,
-                            PermissionName.CLIENT_DELETE,
-                        ],
-                        data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
-                    });
-                    data.push(entity);
-                } catch {
-                    total -= 1;
-                }
-
-                continue;
-            }
-
-            data.push(entity);
-        }
-
-        return {
-            data,
-            meta: {
-                ...meta,
-                total, 
-            }, 
-        };
     }
 
     async getOne(

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -20,6 +20,7 @@ import type { IRealmRepository } from '../realm/types.ts';
 import { AbstractEntityService } from '@authup/server-kit';
 import { ClientCredentialsService } from '../../authentication/credential/entities/client/module.ts';
 import type { IClientRepository, IClientService } from './types.ts';
+import { CLIENT_READ_PERMISSIONS } from './constants.ts';
 import { decodeQuery } from '../../query/index.ts';
 import { clientSchema } from './schema.ts';
 
@@ -46,13 +47,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
         query: Record<string, any>,
         actor: ActorContext,
     ): Promise<EntityRepositoryFindManyResult<Client>> {
-        await actor.permissionEvaluator.preEvaluateOneOf({
-            name: [
-                PermissionName.CLIENT_READ,
-                PermissionName.CLIENT_UPDATE,
-                PermissionName.CLIENT_DELETE,
-            ],
-        });
+        await actor.permissionEvaluator.preEvaluateOneOf({ name: CLIENT_READ_PERMISSIONS });
 
         // The per-row `secret` visibility gate lives on the client SCHEMA
         // (`fields.validateMany`, issue #3322), so it also covers the
@@ -69,12 +64,6 @@ export class ClientService extends AbstractEntityService implements IClientServi
         query?: Record<string, any>,
         realmId?: string,
     ): Promise<Client> {
-        const permissionNames = [
-            PermissionName.CLIENT_READ,
-            PermissionName.CLIENT_UPDATE,
-            PermissionName.CLIENT_DELETE,
-        ];
-
         let isMe = !!actor.identity &&
             actor.identity.type === 'client' &&
             (
@@ -83,7 +72,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             );
 
         if (!isMe) {
-            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: CLIENT_READ_PERMISSIONS });
         }
 
         const entity = await this.repository.findOne(
@@ -101,7 +90,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         if (isMe && actor.identity!.data.id !== entity.id) {
             isMe = false;
-            await actor.permissionEvaluator.preEvaluateOneOf({ name: permissionNames });
+            await actor.permissionEvaluator.preEvaluateOneOf({ name: CLIENT_READ_PERMISSIONS });
         }
 
         if (
@@ -111,7 +100,7 @@ export class ClientService extends AbstractEntityService implements IClientServi
             !entity.secretHashed
         ) {
             await actor.permissionEvaluator.evaluateOneOf({
-                name: permissionNames,
+                name: CLIENT_READ_PERMISSIONS,
                 data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),
             });
         }

--- a/apps/server-core/src/core/query/fields.ts
+++ b/apps/server-core/src/core/query/fields.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type {
+    KeyValidationVerdict,
+    KeyValidationVerdictRecord,
+    KeyValidatorMany,
+} from '@rapiq/core';
+import type { ActorContext } from '@authup/server-kit';
+import type { QueryDecodeContext } from './types.ts';
+
+/**
+ * Per-field read gate: given the acting identity, answer with a
+ * {@link KeyValidationVerdict} for one gated column — `true` to project
+ * it, `false` to strip it, or an `ICondition` to project it visible
+ * only on rows satisfying the condition (rapiq attaches it to the
+ * `Field` node; the repository layer enforces it after the fetch via
+ * `redactFieldConditions`).
+ *
+ * A returned condition must be authored FAIL-CLOSED over incomplete
+ * rows: `@rapiq/memory` unifies a missing column with `null`, so a
+ * negative predicate (`not(...)`, `ne(...)`) over an unselected column
+ * evaluates true and ships the value. The SQL adapter force-selects
+ * every column a condition references (rapiq#830's operand
+ * projection), so this is defense in depth — but prefer positive legs
+ * (`eq(x, true)`) plus an outer presence guard (`ne('realmId', null)`)
+ * over negated trees.
+ */
+export type FieldReadGate = (actor: ActorContext) => Promise<KeyValidationVerdict> | KeyValidationVerdict;
+
+/**
+ * Build a rapiq `fields.validateMany` hook gating individual columns on
+ * a per-actor verdict (issue #3322): invoked once per (governing
+ * schema, relation path) with every client-requested field, so a gate
+ * can compile the actor's permission tree once per query instead of
+ * once per field. The batched form matters because the gate applies
+ * uniformly at the query ROOT and under any relation path — the
+ * position where `ClientPermissionService` & co. serve
+ * `include=client&fields[client]=secret` never runs the client
+ * service's own read path.
+ *
+ * Ungated fields accept. Schema defaults never reach the hook, so an
+ * unqualified list request costs no evaluation. Caller classes mirror
+ * the relations read gate: a SYSTEM decode (no actor in the context)
+ * is unrestricted; every REQUEST decode carries an actor (anonymous
+ * ones hold no grants). A gate failure fails closed (strip).
+ *
+ * NOTE: schemas import this file DIRECTLY (never the `core/query`
+ * barrel) — the barrel reaches `module.ts`, which imports every
+ * schema; importing it from a schema would create a TDZ cycle.
+ */
+export function createFieldsReadGate(
+    gates: Record<string, FieldReadGate>,
+) : KeyValidatorMany<QueryDecodeContext | undefined> {
+    return async (names, context) => {
+        const record : KeyValidationVerdictRecord = {};
+
+        for (const name of names) {
+            const gate = gates[name];
+            if (!gate || !context || !context.actor) {
+                record[name] = true;
+                continue;
+            }
+
+            try {
+                record[name] = await gate(context.actor);
+            } catch {
+                record[name] = false;
+            }
+        }
+
+        return record;
+    };
+}

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -57,11 +57,11 @@ describe('core/entities/client/service', () => {
             expect(result.data).toHaveLength(1);
         });
 
-        it('should filter out entities with plaintext secrets on per-record permission failure', async () => {
+        it('should list plaintext-secret rows without per-record evaluation (secret gate lives on the schema)', async () => {
             repository.seed([
                 createFakeClient({
                     name: 'safe',
-                    secret: null, 
+                    secret: null,
                 }),
                 createFakeClient({
                     name: 'secret-plain',
@@ -75,12 +75,12 @@ describe('core/entities/client/service', () => {
             actor.permissionEvaluator.deny('evaluateOneOf');
 
             const result = await service.getMany({}, actor);
-            expect(result.data).toHaveLength(1);
-            expect(result.data[0].name).toBe('safe');
-            expect(result.meta.total).toBe(1);
+            expect(result.data).toHaveLength(2);
+            expect(result.meta.total).toBe(2);
+            expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('does not gate the default projection (secret unselected) even on a compiled deny', async () => {
+        it('does not evaluate the secret gate for the default projection (secret unselected)', async () => {
             const rows = repository.seed([
                 createFakeClient({ name: 'safe', secret: null }),
                 createFakeClient({
@@ -92,26 +92,27 @@ describe('core/entities/client/service', () => {
             ]);
 
             const actor = createAllowAllActor();
-            actor.permissionEvaluator.setCompileResult({ verdict: 'deny' });
 
             const spy = vi.spyOn(repository, 'findMany');
             await service.getMany({}, actor);
 
-            // secret is not part of the default projection, so no row exposes a
-            // plaintext secret and nothing is gated — replay the built query
+            // secret is not part of the default projection, so the schema gate
+            // never fires — no compile, no condition, both rows list
             const query = spy.mock.calls[0]![0];
             const applied = applyQuery(query, rows);
             expect(applied.data).toHaveLength(2);
+            expect(actor.permissionEvaluator.compileCalls).toHaveLength(0);
             expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('gates plaintext-secret rows as WHERE when the projection selects secret', async () => {
+        it('redacts uncovered plaintext secrets instead of dropping rows when the projection selects secret', async () => {
             const realmA = randomUUID();
+            const realmB = randomUUID();
             const rows = repository.seed([
                 createFakeClient({
-                    name: 'safe', 
-                    secret: null, 
-                    realmId: realmA, 
+                    name: 'safe',
+                    secret: null,
+                    realmId: realmA,
                 }),
                 createFakeClient({
                     name: 'plain-covered',
@@ -125,12 +126,14 @@ describe('core/entities/client/service', () => {
                     secret: 'mysecret',
                     secretEncrypted: false,
                     secretHashed: false,
+                    realmId: realmB,
                 }),
                 createFakeClient({
                     name: 'hashed-foreign',
                     secret: '$2b$10$hash',
                     secretHashed: true,
                     secretEncrypted: false,
+                    realmId: realmB,
                 }),
             ]);
 
@@ -143,12 +146,20 @@ describe('core/entities/client/service', () => {
             const spy = vi.spyOn(repository, 'findMany');
             await service.getMany({ fields: '+secret' }, actor);
 
-            // only the uncovered PLAINTEXT row is hidden; hashed / secret-less
-            // rows list regardless of the compiled condition
+            // the schema gate rides the decoded query as a field visibility
+            // condition — replaying it drops the uncovered PLAINTEXT value
+            // while every row keeps listing; hashed / secret-less rows keep
+            // their value regardless of the compiled condition
             const query = spy.mock.calls[0]![0];
             const applied = applyQuery(query, rows);
             expect(applied.data.map((row) => row.name).sort())
-                .toEqual(['hashed-foreign', 'plain-covered', 'safe']);
+                .toEqual(['hashed-foreign', 'plain-covered', 'plain-foreign', 'safe']);
+
+            const byName = new Map(applied.data.map((row) => [row.name, row]));
+            expect(byName.get('safe')).toHaveProperty('secret', null);
+            expect(byName.get('plain-covered')).toHaveProperty('secret', 'mysecret');
+            expect(byName.get('plain-foreign')).not.toHaveProperty('secret');
+            expect(byName.get('hashed-foreign')).toHaveProperty('secret', '$2b$10$hash');
             expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
@@ -301,6 +312,35 @@ describe('core/entities/client/service', () => {
             actor.permissionEvaluator.deny('preEvaluateOneOf');
 
             await expect(service.getOne(target.id, actor)).rejects.toMatchObject({ code: ErrorCode.PERMISSION_DENIED });
+        });
+
+        it('should keep the secret field decodable for a permissionless self client (self leg)', async () => {
+            const entity = repository.seed(createFakeClient({
+                name: 'self-secret-projection',
+                secret: 'plain',
+                secretEncrypted: false,
+                secretHashed: false,
+            }));
+            const actor: FakeActorContext = {
+                permissionEvaluator: new FakePermissionEvaluator(),
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: entity.id, name: 'self-secret-projection' } as any,
+                },
+            };
+            actor.permissionEvaluator.denyAll();
+            actor.permissionEvaluator.setCompileResult({ verdict: 'deny' });
+
+            const findOneSpy = vi.spyOn(repository, 'findOne');
+            await service.getOne(entity.id, actor, { fields: '+secret' });
+
+            // the schema gate answers with a self-scoped CONDITION, never a
+            // bare reject — the field survives the decode, and getOne's own
+            // isMe bypass stays the authoritative single-read path
+            const [, query] = findOneSpy.mock.calls[0]!;
+            const secretField = query!.fields.value.find((field) => field.name === 'secret');
+            expect(secretField).toBeDefined();
+            expect(secretField!.condition).toBeDefined();
         });
 
         it('should skip post-load secret evaluation on self-access', async () => {

--- a/apps/server-core/test/unit/core/query/module.spec.ts
+++ b/apps/server-core/test/unit/core/query/module.spec.ts
@@ -12,10 +12,14 @@ import {
     isFilter,
     isFilters,
 } from '@rapiq/core';
-import { PermissionName } from '@authup/core-kit';
+import { IdentityType, PermissionName } from '@authup/core-kit';
+import type { Client } from '@authup/core-kit';
 import type { ActorContext } from '@authup/server-kit';
 import { FakePermissionEvaluator } from '@authup/server-test-kit';
+import { randomUUID } from 'node:crypto';
 import { describe, expect, it } from 'vitest';
+import { clientSchema } from '../../../../src/core/entities/client/schema.ts';
+import { clientPermissionSchema } from '../../../../src/core/entities/client-permission/schema.ts';
 import { roleSchema } from '../../../../src/core/entities/role/schema.ts';
 import { userRoleSchema } from '../../../../src/core/entities/user-role/schema.ts';
 import { appendQueryConditions, decodeQuery } from '../../../../src/core/query/index.ts';
@@ -224,6 +228,169 @@ describe('core/query', () => {
             );
 
             expect(parsed.relations.value.map((relation) => relation.name)).toEqual(['user', 'role']);
+        });
+    });
+
+    describe('fields read gate (client secret, #3322)', () => {
+        const CLIENT_PERMISSIONS = [
+            PermissionName.CLIENT_READ,
+            PermissionName.CLIENT_UPDATE,
+            PermissionName.CLIENT_DELETE,
+        ];
+
+        const findField = (parsed: Awaited<ReturnType<typeof decodeQuery>>, name: string) => parsed.fields.value
+            .find((field) => field.name === name);
+
+        it('should keep the secret unconditioned for an allow verdict', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.setCompileResult({ verdict: 'allow' });
+
+            const parsed = await decodeQuery(
+                { fields: '+secret' },
+                { schema: clientSchema, actor: buildActor(evaluator) },
+            );
+
+            const field = findField(parsed, 'secret');
+            expect(field).toBeDefined();
+            expect(field!.condition).toBeUndefined();
+            expect(evaluator.compileCalls.map((call) => call.name)).toEqual([CLIENT_PERMISSIONS]);
+        });
+
+        it('should attach a fail-closed condition for a conditional verdict', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', 'realm-a'),
+            });
+
+            const parsed = await decodeQuery(
+                { fields: '+secret' },
+                { schema: clientSchema, actor: buildActor(evaluator) },
+            );
+
+            const field = findField(parsed, 'secret');
+            expect(field!.condition).toBeDefined();
+            // realm presence guard, non-plaintext legs, then the compiled leg
+            expect(collectFieldConditions(field!.condition!)).toEqual([
+                ['realmId', null],
+                ['secret', null],
+                ['secretHashed', true],
+                ['secretEncrypted', true],
+                ['realmId', 'realm-a'],
+            ]);
+        });
+
+        it('should gate plaintext values without a permission leg on a non-lowerable (post) verdict', async () => {
+            const evaluator = new FakePermissionEvaluator();
+
+            const parsed = await decodeQuery(
+                { fields: '+secret' },
+                { schema: clientSchema, actor: buildActor(evaluator) },
+            );
+
+            const field = findField(parsed, 'secret');
+            expect(collectFieldConditions(field!.condition!)).toEqual([
+                ['realmId', null],
+                ['secret', null],
+                ['secretHashed', true],
+                ['secretEncrypted', true],
+            ]);
+        });
+
+        it('should keep a client identity\'s own row visible via a self leg', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.setCompileResult({ verdict: 'deny' });
+            const selfId = randomUUID();
+
+            const actor: ActorContext = {
+                permissionEvaluator: evaluator,
+                identity: {
+                    type: IdentityType.CLIENT,
+                    data: { id: selfId } as Client,
+                },
+            };
+
+            const parsed = await decodeQuery(
+                { fields: '+secret' },
+                { schema: clientSchema, actor },
+            );
+
+            const field = findField(parsed, 'secret');
+            expect(collectFieldConditions(field!.condition!)).toEqual([
+                ['realmId', null],
+                ['secret', null],
+                ['secretHashed', true],
+                ['secretEncrypted', true],
+                ['id', selfId],
+            ]);
+        });
+
+        it('should gate the secret at the include position of another schema', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.setCompileResult({
+                verdict: 'conditional',
+                condition: eq('realmId', 'realm-a'),
+            });
+
+            const parsed = await decodeQuery(
+                { include: 'client', fields: { client: 'secret' } },
+                { schema: clientPermissionSchema, actor: buildActor(evaluator) },
+            );
+
+            const field = findField(parsed, 'client.secret');
+            expect(field).toBeDefined();
+            expect(field!.condition).toBeDefined();
+            expect(collectFieldConditions(field!.condition!)).toContainEqual(['realmId', 'realm-a']);
+            expect(evaluator.compileCalls.map((call) => call.name)).toEqual([CLIENT_PERMISSIONS]);
+        });
+
+        it('should not fire for a projection without gated fields', async () => {
+            const evaluator = new FakePermissionEvaluator();
+
+            const parsed = await decodeQuery(
+                { fields: 'id,name' },
+                { schema: clientSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(findField(parsed, 'name')).toBeDefined();
+            expect(evaluator.compileCalls).toHaveLength(0);
+        });
+
+        it('should not fire for the default projection', async () => {
+            const evaluator = new FakePermissionEvaluator();
+
+            const parsed = await decodeQuery(
+                {},
+                { schema: clientSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(findField(parsed, 'secret')).toBeUndefined();
+            expect(evaluator.compileCalls).toHaveLength(0);
+        });
+
+        it('should run an actor-less (system) decode unrestricted', async () => {
+            const parsed = await decodeQuery(
+                { fields: '+secret' },
+                { schema: clientSchema },
+            );
+
+            const field = findField(parsed, 'secret');
+            expect(field).toBeDefined();
+            expect(field!.condition).toBeUndefined();
+        });
+
+        it('should strip the field when the gate itself fails', async () => {
+            const evaluator = new FakePermissionEvaluator();
+            evaluator.compile = async () => {
+                throw new Error('compile failed');
+            };
+
+            const parsed = await decodeQuery(
+                { fields: '+secret' },
+                { schema: clientSchema, actor: buildActor(evaluator) },
+            );
+
+            expect(findField(parsed, 'secret')).toBeUndefined();
         });
     });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/client-secret-projection.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/client-secret-projection.spec.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { PermissionName } from '@authup/core-kit';
+import { Client as HTTPClient } from '@authup/core-http-kit';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { createTestApplication } from '../../../../app';
+import {
+    createFakeClient,
+    createFakePermission,
+    createFakeRealm,
+    createFakeRole,
+    createFakeScope,
+    expectClientError,
+} from '../../../../utils';
+
+/**
+ * Schema-level `secret` projection gate (issue #3322): the per-row
+ * secret authorization applies wherever the CLIENT SCHEMA governs a
+ * projection — the `/clients` root and the `fields[client]` positions
+ * of client-permission / client-role / client-scope, which are served
+ * by other services and never ran `ClientService`'s read gate. Rows
+ * are never dropped; an unauthorized plaintext value is redacted.
+ *
+ * The gate-exercising shape is `fields[client]=id,secret` WITHOUT an
+ * explicit include (the dotted field auto-joins the relation with a
+ * per-column selection). Under an explicit `include=client` the
+ * relation is joined fully-selected and rapiq's #831 dedup drops the
+ * per-column selects, so the `select: false` secret never ships there
+ * at all — asserted as such below.
+ */
+describe('http/controllers (client secret projection)', () => {
+    const suite = createTestApplication();
+
+    let restrictedActor: HTTPClient;
+
+    let ownClientId: string;
+    let foreignClientId: string;
+    let foreignHashedClientId: string;
+
+    const ownClientSecret = 'secret-projection-own';
+    const foreignClientSecret = 'secret-projection-foreign';
+    const foreignHashedSecret = '$2b$10$secret-projection-hash';
+    const restrictedActorSecret = 'secret-projection-actor';
+
+    beforeAll(async () => {
+        await suite.setup();
+
+        const realmB = await suite.client.realm.create(createFakeRealm());
+
+        const ownClient = await suite.client.client.create({
+            ...createFakeClient(),
+            secret: ownClientSecret,
+            secretHashed: false,
+            secretEncrypted: false,
+        });
+        ownClientId = ownClient.id;
+
+        const foreignClient = await suite.client.client.create({
+            ...createFakeClient(),
+            realmId: realmB.id,
+            secret: foreignClientSecret,
+            secretHashed: false,
+            secretEncrypted: false,
+        });
+        foreignClientId = foreignClient.id;
+
+        const foreignHashedClient = await suite.client.client.create({
+            ...createFakeClient(),
+            realmId: realmB.id,
+            secret: foreignHashedSecret,
+            secretHashed: true,
+            secretEncrypted: false,
+        });
+        foreignHashedClientId = foreignHashedClient.id;
+
+        // global relation targets, bindable to clients of any realm
+        const permission = await suite.client.permission.create({
+            ...createFakePermission(),
+            realmId: null,
+        });
+        const role = await suite.client.role.create({
+            ...createFakeRole(),
+            realmId: null,
+        });
+        const scope = await suite.client.scope.create({
+            ...createFakeScope(),
+            realmId: null,
+        });
+
+        for (const clientId of [ownClientId, foreignClientId, foreignHashedClientId]) {
+            await suite.client.clientPermission.create({ clientId, permissionId: permission.id });
+            await suite.client.clientRole.create({ clientId, roleId: role.id });
+            await suite.client.clientScope.create({ clientId, scopeId: scope.id });
+        }
+
+        // a restricted actor in master holding the read grants at the
+        // default `own` realm scope — its compiled secret gate is
+        // conditional on the master realm
+        const restrictedClient = await suite.client.client.create({
+            ...createFakeClient(),
+            authMethod: 'secret',
+            tokenBindingMethod: 'none',
+            secret: restrictedActorSecret,
+            secretHashed: false,
+            secretEncrypted: false,
+        });
+        const grantNames = [
+            PermissionName.CLIENT_READ,
+            PermissionName.CLIENT_PERMISSION_CREATE,
+            PermissionName.CLIENT_ROLE_READ,
+        ];
+        for (const name of grantNames) {
+            const grant = await suite.client.permission.getOne(name);
+            await suite.client.clientPermission.create({
+                clientId: restrictedClient.id,
+                permissionId: grant.id,
+            });
+        }
+        const restrictedToken = await suite.client.token.createWithClientCredentials({
+            client_id: restrictedClient.id,
+            client_secret: restrictedActorSecret,
+        });
+        restrictedActor = new HTTPClient({ baseURL: suite.baseURL });
+        restrictedActor.setAuthorizationHeader({ type: 'Bearer', token: restrictedToken.access_token });
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    it('keeps the root secret projection working for an admin', async () => {
+        const response = await suite.client.client.getMany({
+            fields: ['+secret'],
+            filters: { id: [ownClientId, foreignClientId] },
+        });
+
+        expect(response.data).toHaveLength(2);
+        const byId = new Map(response.data.map((row) => [row.id, row]));
+        expect(byId.get(ownClientId)!.secret).toEqual(ownClientSecret);
+        expect(byId.get(foreignClientId)!.secret).toEqual(foreignClientSecret);
+    });
+
+    it('redacts a foreign plaintext secret at the root without dropping the row', async () => {
+        const response = await restrictedActor.client.getMany({
+            fields: ['+secret'],
+            filters: { id: [ownClientId, foreignClientId] },
+        });
+
+        // both rows keep listing — the gate hides the value, never the row
+        expect(response.data).toHaveLength(2);
+        const byId = new Map(response.data.map((row) => [row.id, row]));
+        expect(byId.get(ownClientId)!.secret).toEqual(ownClientSecret);
+        expect(byId.get(foreignClientId)!.secret).toBeUndefined();
+    });
+
+    it('redacts a foreign plaintext secret under a bare replace-projection', async () => {
+        // `fields=id,secret` REPLACES the default projection — the adapter
+        // force-selects the columns the gate condition reads (storage flags,
+        // realmId), otherwise the redaction would evaluate against missing
+        // columns and fail open
+        const response = await restrictedActor.client.getMany({
+            fields: ['id', 'secret'],
+            filters: { id: [ownClientId, foreignClientId] },
+        });
+
+        expect(response.data).toHaveLength(2);
+        const byId = new Map(response.data.map((row) => [row.id, row]));
+        expect(byId.get(ownClientId)!.secret).toEqual(ownClientSecret);
+        expect(byId.get(foreignClientId)!.secret).toBeUndefined();
+    });
+
+    it('keeps a foreign HASHED secret visible to a permitted reader', async () => {
+        const response = await restrictedActor.client.getMany({
+            fields: ['+secret'],
+            filters: { id: [foreignHashedClientId] },
+        });
+
+        expect(response.data).toHaveLength(1);
+        expect(response.data[0].secret).toEqual(foreignHashedSecret);
+    });
+
+    it('gates the client-permission fields[client] projection', async () => {
+        const response = await restrictedActor.clientPermission.getMany({
+            fields: { client: ['id', 'secret'] },
+            filters: { clientId: [ownClientId, foreignClientId] },
+        });
+
+        // the parent collection is unaffected by the gate
+        expect(response.data).toHaveLength(2);
+        const byClientId = new Map(response.data.map((row) => [row.clientId, row]));
+
+        const ownRow = byClientId.get(ownClientId)!;
+        expect(ownRow.client).toBeDefined();
+        expect(ownRow.client!.secret).toEqual(ownClientSecret);
+
+        const foreignRow = byClientId.get(foreignClientId)!;
+        expect(foreignRow.client).toBeDefined();
+        expect(foreignRow.client!.secret).toBeUndefined();
+    });
+
+    it('keeps a hashed secret visible on the client-permission fields[client] projection', async () => {
+        const response = await restrictedActor.clientPermission.getMany({
+            fields: { client: ['id', 'secret'] },
+            filters: { clientId: [foreignHashedClientId] },
+        });
+
+        expect(response.data).toHaveLength(1);
+        expect(response.data[0].client!.secret).toEqual(foreignHashedSecret);
+    });
+
+    it('gates the client-role fields[client] projection', async () => {
+        const response = await restrictedActor.clientRole.getMany({
+            fields: { client: ['id', 'secret'] },
+            filters: { clientId: [ownClientId, foreignClientId] },
+        });
+
+        expect(response.data).toHaveLength(2);
+        const byClientId = new Map(response.data.map((row) => [row.clientId, row]));
+        expect(byClientId.get(ownClientId)!.client!.secret).toEqual(ownClientSecret);
+        expect(byClientId.get(foreignClientId)!.client!.secret).toBeUndefined();
+    });
+
+    it('gates the client-scope fields[client] projection', async () => {
+        const response = await restrictedActor.clientScope.getMany({
+            fields: { client: ['id', 'secret'] },
+            filters: { clientId: [ownClientId, foreignClientId] },
+        });
+
+        expect(response.data).toHaveLength(2);
+        const byClientId = new Map(response.data.map((row) => [row.clientId, row]));
+        expect(byClientId.get(ownClientId)!.client!.secret).toEqual(ownClientSecret);
+        expect(byClientId.get(foreignClientId)!.client!.secret).toBeUndefined();
+    });
+
+    it('never ships a secret through an explicit include=client', async () => {
+        // under an explicit include the relation joins fully-selected and
+        // the per-column fields[client] selects are dropped (rapiq#831 —
+        // divergence tracked as rapiq#847), so the select:false secret
+        // cannot ship — for anyone. Should the adapter ever reduce
+        // explicit-include joins to per-column selections, the schema gate
+        // above takes over seamlessly.
+        const response = await restrictedActor.clientPermission.getMany({
+            relations: ['client'],
+            fields: { client: ['id', 'secret'] },
+            filters: { clientId: [ownClientId, foreignClientId] },
+        });
+
+        expect(response.data).toHaveLength(2);
+        for (const row of response.data) {
+            expect(row.client).toBeDefined();
+            expect(row.client!.secret).toBeUndefined();
+        }
+    });
+
+    it('denies a foreign single-read secret projection even under a bare replace-projection', async () => {
+        // regression: without the operand force-select, a bare
+        // `fields=id,secret` stripped realmId and the storage flags from the
+        // fetched row, so getOne's post-fetch realm gate neutral-passed and
+        // shipped the foreign plaintext secret
+        await expectClientError(
+            () => restrictedActor.client.getOne(foreignClientId, { fields: ['id', 'secret'] }),
+            { status: 403 },
+        );
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/realm-isolation-field-projection.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/realm-isolation-field-projection.spec.ts
@@ -181,8 +181,12 @@ describe('realm isolation (field projection)', () => {
         expect(ownEntity).toBeDefined();
         expect(ownEntity!.secret).toEqual(ownClientSecret);
 
+        // since #3322 the schema-level gate REDACTS the secret instead of
+        // dropping the row — the list stays complete, the value stays hidden
         const foreign = await actor.client.getMany({ filters: { id: foreignClientId }, fields: ['id', 'secret'] });
-        expect(foreign.data.some((entity) => entity.id === foreignClientId)).toBe(false);
+        const foreignEntity = foreign.data.find((entity) => entity.id === foreignClientId);
+        expect(foreignEntity).toBeDefined();
+        expect(foreignEntity!.secret).toBeUndefined();
     });
 
     it('keeps a foreign-realm role-attribute hidden even when a field projection is attempted', async () => {


### PR DESCRIPTION
Closes #3322

The per-row `client.secret` authorization moves off `ClientService` onto the **client schema**, using rapiq beta.10's condition-returning, batched `fields.validateMany` hook (tada5hi/rapiq#830 / #837). It now applies wherever the client schema governs a projection — the `/clients` root **and** the `fields[client]` positions of `client-permission` / `client-role` / `client-scope`, which are served by other services and never ran the service gate: `GET /client-permissions?fields[client]=secret` auto-joined the relation with a per-column selection and shipped foreign realms' plaintext secrets to any realm-scoped `CLIENT_READ` holder.

## How it works

- **`createFieldsReadGate`** (`core/query/fields.ts`) — a reusable `fields.validateMany` factory (same file-direct import rule as the relations read gate). Invoked once per (governing schema, relation path) with the client-requested names only, so the actor's permission tree compiles once per query and an unqualified `GET /clients` performs no evaluation.
- **Client `secret` gate** (`core/entities/client/schema.ts`) — compiles the `CLIENT_READ/UPDATE/DELETE` disjunction: `allow` → ungated; otherwise a per-row visibility condition — visible iff non-plaintext (`secret` null / hashed / encrypted) OR covered by the compiled permission condition OR the actor's own client row (self leg, preserving the service-level isMe contract in list shape). Authored fail-closed (`and(ne('realmId', null), or(...))`) because `@rapiq/memory` unifies missing columns with `null` and an `ownOrNull` reach compiles a null-inclusive realm leg.
- **`redactFieldConditions`** (`app/modules/database/repositories/query.ts`) — every `findMany` adapter (all 24) runs its fetched rows through `@rapiq/memory`'s `applyFieldConditions`: failing values are **redacted, rows never drop, totals stay exact**. The sweep is universal because enforcement is fail-open by construction — a skipped call ships the value. The SQL adapter itself force-selects every column a condition reads (rapiq's #830 operand projection), so bare replace-projections (`fields[client]=id,secret`) cannot starve the gate of its inputs.
- **`ClientService.getMany`** drops the root-side WHERE-narrowing and the `post`-verdict per-row loop (behaviour change called out in the issue: rows are no longer dropped when `secret` is selected — the value is redacted instead; a `post` verdict now fails closed for plaintext values). `getOne` keeps its isMe bypass + post-fetch check as the authoritative single-read path — and gets a bonus fix: a bare `fields=id,secret` replace-projection used to strip `realmId`/the storage flags from the fetched row, so the post-fetch realm gate neutral-passed and shipped a foreign plaintext secret; the operand projection re-arms it (now 403).
- The client adapter's `applyRealmScopeSelect` is removed — its purpose (feeding the service's per-row gate) is gone, and the condition's operand projection supersedes it.

## Acceptance

- [x] `GET /client-permissions?include=client&fields[client]=secret` does not expose a secret the actor may not read — under an explicit include the relation joins fully-selected and the per-column dotted selects are dropped (rapiq#831), so the `select:false` secret cannot ship there at all (divergence filed upstream as tada5hi/rapiq#847); the gate-exercising live shape is `fields[client]=secret` **without** include, covered per junction
- [x] the same holds for the `client-role` and `client-scope` paths
- [x] `GET /clients?fields=+secret` keeps working for an actor whose permission covers the row (admin + realm-scoped reader on own-realm rows, hashed values unaffected)
- [x] the parent collection is unaffected: no junction row disappears because of the gate
- [x] `GET /clients` with no `fields` performs no additional permission evaluation (hook never fires for schema defaults)

## Tests

- `core/query/module.spec.ts` — gate verdict matrix (allow / conditional / post / deny+self leg / include position / system decode / gate failure / no-fire cases)
- `client-secret-projection.spec.ts` (HTTP) — root + all three junction `fields[client]` paths, bare replace-projection, hashed visibility, explicit-include non-exposure, foreign single-read denial
- `client/service.spec.ts` — reworked getMany contract (redaction replay via `@rapiq/memory`, no compile on default projection) + self-leg decode pin
- `realm-isolation-field-projection.spec.ts` — updated to the redaction semantics (row listed, value hidden)

Full `apps/server-core` suite: 1740/1741 green (the one failure is the documented shared-admin session flake; passes in isolation).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added field-level authorization for sensitive client secret values, including nested projections and list queries.
  * Permitted fields show values; restricted plaintext secrets are redacted while rows remain visible to preserve result totals.
  * Adjusted secret visibility behavior to remove projection-dependent filtering in multi-record responses.

* **Bug Fixes**
  * Prevented unauthorized secret values from appearing in multi- and single-record responses.
  * Improved handling of realm-scoped and nested sensitive-field projections to ensure correct redaction.

* **Documentation / Tests**
  * Updated authorization documentation for field-gating and query/realm interaction.
  * Added/updated unit and controller tests for secret projection and field-gate behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Follow-ups (filed, out of scope here)

- #3328 — tighten hashed/encrypted secret visibility (kept at pre-existing parity in this PR: non-plaintext values stay visible to pre-gate-passing readers)
- #3329 — structurally enforce `redactFieldConditions` on every `findMany` path (this PR establishes the documented convention + full sweep)
- tada5hi/rapiq#847 — `fields[relation]` silently ignored under an explicit include (the "never ships a secret through an explicit include=client" test is the canary)
