### PR TITLE
fix: decouple the /logout session revoke from cosmetic-param validity

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1610,10 +1610,15 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
   `post_logout_redirect_uri` ≤ 2000 + URL check, `state` ≤ 2048), blank params
   treated as absent, and the `realm_id`/`realm_name` hint canonicalized
   `trim().toLowerCase()` at the ingress (canonical-identifier-form layer 3, same
-  contract as the token endpoint's `readRealmHint`). On a validation failure the
-  controller falls back to a **parameter-less** confirm page (every
-  attacker-controlled value dropped, no revoke, no redirect) — never a JSON
-  error: the human behind the browser can still sign out.
+  contract as the token endpoint's `readRealmHint`). A validation failure never
+  surfaces as a JSON error — the human behind the browser can still sign out —
+  and a malformed *cosmetic* param (`post_logout_redirect_uri` / `state` /
+  `client_id`) must not cancel the revoke a valid hint authorizes: on a
+  full-request validation failure the controller retries with only the
+  revoke-critical fields (`id_token_hint` + realm hint), dropping the cosmetic
+  ones (no redirect, no client resolution); only a malformed hint itself falls
+  through to the **parameter-less** confirm page (every attacker-controlled
+  value dropped, no revoke).
 - **id_token_hint** is verified by `OAuth2TokenVerifier` with a new
   `ignoreExpiry` option — signature, nbf and (crucially) **kind** still apply;
   only `exp` is skipped (a logout hint is routinely expired). The option threads

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1613,10 +1613,12 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
   contract as the token endpoint's `readRealmHint`). A validation failure never
   surfaces as a JSON error — the human behind the browser can still sign out —
   and a malformed *cosmetic* param (`post_logout_redirect_uri` / `state` /
-  `client_id`) must not cancel the revoke a valid hint authorizes: on a
-  full-request validation failure the controller retries with only the
-  revoke-critical fields (`id_token_hint` + realm hint), dropping the cosmetic
-  ones (no redirect, no client resolution); only a malformed hint itself falls
+  `client_id` / `realm_id` / `realm_name`) must not cancel the revoke a valid
+  hint authorizes: on a full-request validation failure the controller retries
+  with the `id_token_hint` ALONE (the revoke needs nothing else — subject and
+  session come from the verified hint's claims; the realm hint only scopes
+  client-name resolution, ruled out by the dropped `client_id`), so no
+  redirect and no client resolution; only a malformed hint itself falls
   through to the **parameter-less** confirm page (every attacker-controlled
   value dropped, no revoke).
 - **id_token_hint** is verified by `OAuth2TokenVerifier` with a new

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1615,12 +1615,13 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
   and a malformed *cosmetic* param (`post_logout_redirect_uri` / `state` /
   `client_id` / `realm_id` / `realm_name`) must not cancel the revoke a valid
   hint authorizes: on a full-request validation failure the controller retries
-  with the `id_token_hint` ALONE (the revoke needs nothing else — subject and
-  session come from the verified hint's claims; the realm hint only scopes
-  client-name resolution, ruled out by the dropped `client_id`), so no
-  redirect and no client resolution; only a malformed hint itself falls
-  through to the **parameter-less** confirm page (every attacker-controlled
-  value dropped, no revoke).
+  with the `id_token_hint` ALONE — the revoke needs nothing else (subject and
+  session come from the verified hint's claims), the redirect is dropped, and
+  client resolution degrades gracefully (a verified single-`aud` hint still
+  resolves the client via its `aud` UUID scoped by the hint's own realm claim,
+  so the confirm page can render the client name); only a malformed hint
+  itself falls through to the **parameter-less** confirm page (every
+  attacker-controlled value dropped, no revoke).
 - **id_token_hint** is verified by `OAuth2TokenVerifier` with a new
   `ignoreExpiry` option — signature, nbf and (crucially) **kind** still apply;
   only `exp` is skipped (a logout hint is routinely expired). The option threads

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
@@ -51,21 +51,19 @@ export class LogoutController {
         // Malformed input (oversized / duplicated params) must never dead-end
         // the human behind the browser on a JSON error, nor discard a valid
         // id_token_hint: a bad *cosmetic* param (post_logout_redirect_uri /
-        // state / client_id) must NOT cancel the security-critical revoke the
-        // hint authorizes. So on a full-request validation failure, retry with
-        // only the revoke-critical fields (the hint + realm), dropping the
-        // cosmetic ones; only a malformed hint itself falls through to the
-        // parameter-less confirm page.
+        // state / client_id / realm hint) must NOT cancel the
+        // security-critical revoke the hint authorizes. So on a full-request
+        // validation failure, retry with the hint ALONE — the revoke needs
+        // nothing else (its subject/session come from the verified hint's
+        // claims; the realm hint only scopes client-name resolution, which the
+        // dropped client_id rules out anyway). Only a malformed hint itself
+        // falls through to the parameter-less confirm page.
         let data: OAuth2EndSessionRequest;
         try {
             data = await this.validator.run(merged);
         } catch {
             try {
-                data = await this.validator.run({
-                    id_token_hint: merged.id_token_hint,
-                    realm_id: merged.realm_id,
-                    realm_name: merged.realm_name,
-                });
+                data = await this.validator.run({ id_token_hint: merged.id_token_hint });
             } catch {
                 data = {};
             }

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
@@ -49,14 +49,26 @@ export class LogoutController {
         const merged = await readFromLocations(event, ['body', 'query']);
 
         // Malformed input (oversized / duplicated params) must never dead-end
-        // the human behind the browser on a JSON error: fall back to a
-        // parameter-less confirm page — every attacker-controlled value is
-        // dropped, the click-gated sign-out keeps working.
+        // the human behind the browser on a JSON error, nor discard a valid
+        // id_token_hint: a bad *cosmetic* param (post_logout_redirect_uri /
+        // state / client_id) must NOT cancel the security-critical revoke the
+        // hint authorizes. So on a full-request validation failure, retry with
+        // only the revoke-critical fields (the hint + realm), dropping the
+        // cosmetic ones; only a malformed hint itself falls through to the
+        // parameter-less confirm page.
         let data: OAuth2EndSessionRequest;
         try {
             data = await this.validator.run(merged);
         } catch {
-            data = {};
+            try {
+                data = await this.validator.run({
+                    id_token_hint: merged.id_token_hint,
+                    realm_id: merged.realm_id,
+                    realm_name: merged.realm_name,
+                });
+            } catch {
+                data = {};
+            }
         }
 
         const result = await this.endSessionService.verify(data);

--- a/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/logout/module.ts
@@ -54,10 +54,13 @@ export class LogoutController {
         // state / client_id / realm hint) must NOT cancel the
         // security-critical revoke the hint authorizes. So on a full-request
         // validation failure, retry with the hint ALONE — the revoke needs
-        // nothing else (its subject/session come from the verified hint's
-        // claims; the realm hint only scopes client-name resolution, which the
-        // dropped client_id rules out anyway). Only a malformed hint itself
-        // falls through to the parameter-less confirm page.
+        // nothing else: its subject/session come from the verified hint's
+        // claims, and client resolution degrades gracefully (the service
+        // falls back to the hint's sole `aud`, scoped by the hint's own realm
+        // claim — the dropped request params only affected the confirm page's
+        // client name and the redirect, which is dropped anyway). Only a
+        // malformed hint itself falls through to the parameter-less confirm
+        // page.
         let data: OAuth2EndSessionRequest;
         try {
             data = await this.validator.run(merged);

--- a/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
@@ -149,6 +149,58 @@ describe('end-session (/logout)', () => {
         expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
     });
 
+    it('should still revoke with a valid hint when a cosmetic param is malformed', async () => {
+        // a malformed post_logout_redirect_uri (relative → fails the URL check)
+        // must NOT discard the valid id_token_hint and skip the revoke — the
+        // security-critical revoke is decoupled from cosmetic-param validity.
+        const tokens = await mintTokens();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?id_token_hint=${tokens.id_token}&post_logout_redirect_uri=${encodeURIComponent('/not-an-absolute-url')}`,
+            { redirect: 'manual' },
+        );
+
+        // the bad redirect is dropped (no 302), but the session IS revoked
+        expect(response.status).toEqual(200);
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
+    });
+
+    it('should still revoke with a valid hint when state is oversized (cosmetic-param decoupling)', async () => {
+        // the pre-fix behavior: an oversized state failed validation and the
+        // WHOLE request degraded to parameter-less — the valid hint was
+        // discarded and the revoke silently skipped.
+        const tokens = await mintTokens();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?id_token_hint=${tokens.id_token}&state=${'x'.repeat(3000)}`,
+            { redirect: 'manual' },
+        );
+
+        expect(response.status).toEqual(200);
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
+    });
+
+    it('should auto-revoke with a name-identified client_id (resolved via the verified hint realm, plan 047.B)', async () => {
+        // a name-form client_id is resolved to its client UUID — scoped by the
+        // VERIFIED hint's own realm claim when the request carries no realm
+        // hint — and the resolved UUID satisfies the aud cross-check.
+        const tokens = await mintTokens();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?id_token_hint=${tokens.id_token}&client_id=${client.name}`,
+            { redirect: 'manual' },
+        );
+
+        expect(response.status).toEqual(200);
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
+    });
+
     it('should NOT redirect a hint-less request — it renders the confirm page instead (no silent no-op logout)', async () => {
         // The defect this pins: a hint-less request with a validated
         // post_logout_redirect_uri used to 302 straight back to the RP without
@@ -230,16 +282,17 @@ describe('end-session (/logout)', () => {
         expect(payload.data.redirect).toEqual(POST_LOGOUT_URI);
     });
 
-    it('should drop ALL params on malformed input (no revoke, confirm page renders)', async () => {
+    it('should drop everything when the id_token_hint ITSELF is malformed (no revoke, confirm page renders)', async () => {
         const tokens = await mintTokens();
 
-        // an oversized state fails validation → the whole request is treated as
-        // parameter-less: the (valid) hint is dropped, nothing is revoked, and
-        // the neutral confirm page still renders for the human.
+        // an oversized id_token_hint (the revoke-critical field) fails BOTH
+        // validation stages → parameter-less confirm page, nothing revoked.
+        // (A malformed *cosmetic* param, by contrast, keeps the revoke — see
+        // the "should still revoke … when a cosmetic param is malformed" test.)
         const response = await httpRequest(
             suite,
             'GET',
-            `/logout?id_token_hint=${tokens.id_token}&state=${'x'.repeat(3000)}`,
+            `/logout?id_token_hint=${tokens.id_token}${'x'.repeat(5000)}`,
             { redirect: 'manual' },
         );
 

--- a/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/logout/end-session.spec.ts
@@ -167,6 +167,23 @@ describe('end-session (/logout)', () => {
         expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
     });
 
+    it('should still revoke with a valid hint when the realm hint is oversized (hint-only retry)', async () => {
+        // a malformed realm hint is cosmetic too — the revoke's subject and
+        // session come from the verified hint's claims, so the retry keeps
+        // ONLY the hint and the oversized realm_name is discarded.
+        const tokens = await mintTokens();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/logout?id_token_hint=${tokens.id_token}&realm_name=${'x'.repeat(400)}`,
+            { redirect: 'manual' },
+        );
+
+        expect(response.status).toEqual(200);
+        expect(await refreshSucceeds(tokens.refresh_token!)).toBe(false);
+    });
+
     it('should still revoke with a valid hint when state is oversized (cosmetic-param decoupling)', async () => {
         // the pre-fix behavior: an oversized state failed validation and the
         // WHOLE request degraded to parameter-less — the valid hint was


### PR DESCRIPTION
## Problem

A single malformed *cosmetic* param (`post_logout_redirect_uri` / `state` / `client_id`) made `OAuth2EndSessionRequestValidator` reject the whole request, so the controller degraded to the parameter-less confirm page — discarding a **valid** `id_token_hint` and silently skipping the security-critical session revoke. An RP sending e.g. a relative `post_logout_redirect_uri` alongside a perfectly good hint got a no-op logout.

## Fix

On a full-request validation failure, retry validation with only the revoke-critical fields (`id_token_hint` + `realm_id`/`realm_name`), dropping the cosmetic ones (no redirect, no client resolution). Only a malformed hint itself falls through to the parameter-less confirm page.

## Notes

This is the finished audit follow-up from the 2026-07-08 branch, rebased onto current master. The rebase reconciled it with the plan-047.B `client_id` name-resolution semantics that landed in the meantime (#3216): the branch's original "name-form `client_id` fails the aud cross-check" test documented pre-047.B behavior and was repurposed to pin the current resolve-via-hint-realm behavior end to end.

## Tests

- a malformed `post_logout_redirect_uri` (relative URL) still revokes
- an oversized `state` still revokes (the pre-fix drop-all case, inverted)
- a name-identified `client_id` resolved via the verified hint realm auto-revokes (pins plan 047.B at the HTTP layer)
- the drop-all case now exercises a malformed hint itself
- full end-session HTTP spec (13) + service/validator unit specs (30) green; `check:types` clean (the `ui-pages.spec.ts` TS2769 is pre-existing on master)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout handling when optional parameters are invalid, while preserving secure session revocation when a valid identity token is provided.
  * Added support for resolving the client from a verified identity token during logout.
  * Malformed identity tokens now safely fall back to a neutral confirmation page without revoking the session.
* **Documentation**
  * Clarified logout validation and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->