### PR TITLE
fix: bind the login-throttle window start as a UTC literal

### DIFF
--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -93,9 +93,17 @@ export class EventRepositoryAdapter implements IEventRepository {
     }
 
     async countRecent(filter: EventCountRecentFilter): Promise<number> {
+        // created_at is stamped by the DATABASE server's (UTC) clock, while a
+        // bound Date object is serialized by the pg/mysql drivers in the
+        // HOST's local timezone — on a non-UTC host that shifts the window by
+        // the UTC offset (postgres: `timestamp without time zone` discards
+        // the offset marker entirely). Bind a UTC wall-clock literal instead;
+        // all three dialects parse it identically.
+        const since = new Date(filter.since).toISOString().replace('T', ' ').replace('Z', '');
+
         const qb = this.repository.createQueryBuilder('event')
             .where('event.name = :name', { name: filter.name })
-            .andWhere('event.createdAt > :since', { since: new Date(filter.since) });
+            .andWhere('event.createdAt > :since', { since });
 
         if (filter.actorName) {
             qb.andWhere('event.actorName = :actorName', { actorName: filter.actorName });

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -93,12 +93,15 @@ export class EventRepositoryAdapter implements IEventRepository {
     }
 
     async countRecent(filter: EventCountRecentFilter): Promise<number> {
-        // created_at is stamped by the DATABASE server's (UTC) clock, while a
-        // bound Date object is serialized by the pg/mysql drivers in the
-        // HOST's local timezone — on a non-UTC host that shifts the window by
-        // the UTC offset (postgres: `timestamp without time zone` discards
-        // the offset marker entirely). Bind a UTC wall-clock literal instead;
-        // all three dialects parse it identically.
+        // created_at is stamped by the DATABASE server's clock (assumed UTC —
+        // the shipped compose files and deployment posture; a non-UTC DB
+        // server shifts the window regardless of what we bind), while a bound
+        // Date object is serialized by the pg/mysql drivers in the HOST's
+        // local timezone — on a non-UTC host that shifts the window by the
+        // UTC offset (postgres: `timestamp without time zone` discards the
+        // offset marker entirely). Bind a UTC wall-clock literal instead:
+        // pg/mysql cast it as a wall-clock timestamp, sqlite compares it
+        // lexicographically against the same format `datetime('now')` stores.
         const since = new Date(filter.since).toISOString().replace('T', ' ').replace('Z', '');
 
         const qb = this.repository.createQueryBuilder('event')

--- a/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { Event } from '@authup/core-kit';
+import { EventName, EventScope } from '@authup/core-kit';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { EventEntity } from '../../../../../src/adapters/database/domains/index.ts';
+import { EventRepositoryAdapter } from '../../../../../src/app/modules/database/repositories/index.ts';
+import { createTestDatabaseApplication } from '../../../../app';
+
+const IP = '203.0.113.7';
+
+describe('app/modules/database/repositories/event', () => {
+    const suite = createTestDatabaseApplication();
+
+    let repository : EventRepositoryAdapter;
+
+    beforeAll(async () => {
+        await suite.setup();
+
+        repository = new EventRepositoryAdapter(
+            suite.dataSource.getRepository<Event>(EventEntity),
+        );
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    const record = async (actorName: string) => {
+        // created_at is deliberately left unset — it is stamped by the
+        // DATABASE server's clock (the column DEFAULT), which is exactly the
+        // value countRecent's window comparison must agree with. Stamping it
+        // app-side here would hide a host-vs-database timezone mismatch.
+        await repository.save(repository.create({
+            id: randomUUID(),
+            scope: EventScope.OAUTH2,
+            name: EventName.LOGIN_FAILED,
+            actorName,
+            requestIpAddress: IP,
+            expiring: false,
+        }));
+    };
+
+    it('counts a just-written row inside the window (host-timezone independent)', async () => {
+        // the login-throttle window: the bound `since` must compare correctly
+        // against the DB-clock-stamped created_at regardless of the HOST's
+        // timezone. Pre-fix, a Date object bound on a non-UTC host shifted
+        // the window by the UTC offset and the throttle never tripped on
+        // postgres/mysql.
+        const actorName = `throttle-probe-${randomUUID()}`;
+        await record(actorName);
+        await record(actorName);
+
+        const count = await repository.countRecent({
+            name: EventName.LOGIN_FAILED,
+            actorName,
+            requestIpAddress: IP,
+            since: new Date(Date.now() - 60_000).toISOString(),
+        });
+
+        expect(count).toEqual(2);
+    });
+
+    it('excludes rows older than the window start', async () => {
+        const actorName = `throttle-probe-${randomUUID()}`;
+        await record(actorName);
+
+        const count = await repository.countRecent({
+            name: EventName.LOGIN_FAILED,
+            actorName,
+            requestIpAddress: IP,
+            since: new Date(Date.now() + 60_000).toISOString(),
+        });
+
+        expect(count).toEqual(0);
+    });
+});

--- a/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
@@ -19,6 +19,14 @@ import { EventEntity } from '../../../../../src/adapters/database/domains/index.
 import { EventRepositoryAdapter } from '../../../../../src/app/modules/database/repositories/index.ts';
 import { createTestDatabaseApplication } from '../../../../app';
 
+// Force a non-UTC host timezone for THIS worker: the defect this spec pins
+// (a bound Date serialized in host-local time against the DB-clock-stamped
+// created_at) is invisible on a UTC host — and CI runs UTC. Etc/GMT-2 is
+// UTC+2 (POSIX inverted sign), reproducing the positive-offset failure mode
+// (window start lands in the future → count 0 → throttle never trips).
+// Set before the suite connects so the mysql2/pg drivers serialize under it.
+process.env.TZ = 'Etc/GMT-2';
+
 const IP = '203.0.113.7';
 
 describe('app/modules/database/repositories/event', () => {


### PR DESCRIPTION
## Problem

The failed-login throttle (plan 053) never trips on PostgreSQL when the server host runs a non-UTC timezone. `EventRepositoryAdapter.countRecent` bound a JS `Date` object — the only such site in the repo — against the DB-native `created_at` timestamp:

- `created_at` is stamped by the **database server's (UTC) clock** (column `DEFAULT now()` / `CURRENT_TIMESTAMP(6)`; TypeORM emits literal `DEFAULT` for undefined create-date columns).
- The pg driver serializes a bound `Date` from **local** getters with a host offset suffix, and postgres coerces the untyped param to `timestamp without time zone` — silently discarding the offset. On a UTC+2 host the window start lands 2h in the future → count is always 0 → no 429.
- mysql2 (`timezone: 'local'`) serializes local wall-clock with no offset marker at all — same failure class.
- sqlite only worked by accident: TypeORM's sqlite driver converts a bound `Date` to a UTC string itself (`mixedDateToUtcDatetimeString`).

## Fix

Bind that same UTC wall-clock literal explicitly (`toISOString()` with `T`/`Z` stripped) — all three dialects parse it identically, and the host-timezone dependency is gone. Every other time comparison in the repo targets `varchar(28)` ISO columns with ISO-string binds and is unaffected.

## Tests

New DB-level regression spec `test/unit/app/modules/database/event-repository.spec.ts` exercising `countRecent` boundaries against the suite dialect with `created_at` left to the column DEFAULT (stamping it app-side would hide the mismatch). Verified from a CEST host: **red pre-fix / green post-fix on postgres**; green on mysql and sqlite. The existing `grant-password-throttle.spec.ts` (previously failing under `test:psql`) passes on all three dialects.

Origin: pre-existing defect surfaced by plan-073's `test:psql` run (roadmap Active Defects).