### PR TITLE
fix: verify request credentials once across dispatch re-entries

### DIFF
--- a/.agents/references/routup.md
+++ b/.agents/references/routup.md
@@ -1,0 +1,14 @@
+# routup — reference mapping
+
+Upstream: `github.com/routup/routup` (tada5hi). HTTP framework under every
+`apps/server-core` route: `App` + `LinearRouter`, `@routup/decorators`
+controller mounting, `@routup/{basic,cors,rate-limit,prometheus,assets,swagger}`
+middlewares.
+
+| routup (source) | authup (consumer) | Notes |
+|---|---|---|
+| `App.runMatches` (`src/app/module.ts`) — the middleware/route dispatch walk | `app/modules/http/module.ts` (`new App()`), `app/modules/http/modules/middleware.ts` (`mountBefore` order) | routup 6.0.0 re-walked consumed match suffixes exponentially on response-less requests (2^k dispatches per match index — routup/routup#946); fixed in routup 6.1.0 (routup/routup#947, bumped 2026-07-28), which also made error flow FORWARD-ONLY: an ERROR handler registered before a later thrower is no longer accidentally revisited — authup mounts its error middleware last (`mountAfter`), so keep it there. `AuthorizationMiddleware.run` retains a per-request memo on `event.store` (`adapters/http/middleware/built-in/authorization/module.ts`) as defense in depth: credentials verify once even if a future mount/upstream change reintroduces re-entry. |
+| `@routup/decorators` plugin `flatten()` | `app/modules/http/modules/controller.ts` (single `router.use(decorators({...}))`) | Controller child-apps are FLATTENED into the root router at install time — one `App.dispatch`/`router.lookup` per request, no nested dispatch. Route templates readable from the root route table (used by `createRouteTemplateNormalizePath`, issue #3253). |
+| `Handler.dispatch` / `resolveHandlerResult` (`src/handler/module.ts`) | any `defineCoreHandler` in `adapters/http` | Contract: non-undefined return → response; `undefined` + `next()` called → downstream result; `undefined` + no `next()` → WAITS (until async `next()`, abort, or timeout → 408). There is no silent fall-through for undefined-return CORE handlers — fall-through happens only via method/type skip in the walk. |
+| `DispatcherEvent` store (`src/dispatcher/module.ts`) | `adapters/http/request/helpers/*` (`setRequestIdentity`, `setRequestRealmID`, …) | `event.store` is created once per request and shared by every handler facade (incl. dispatch re-entries) — the substrate for all symbol-keyed request state and the authorization memo. |
+| `getRequestIP` / `buildTrustProxyFn` (`src/utils`) + `AppOptions.trustProxy` | issue #3230 (XFF trust) | routup already supports express-style `trustProxy` (`boolean \| hops \| CIDR/'loopback' string \| string[] \| fn`, via `proxy-addr`) resolved from `new App({ trustProxy })` at every helper call site; per-call `{ trustProxy: true }` overrides the app option. `@routup/rate-limit`'s default `keyGenerator` hardcodes `{ trustProxy: true }` — needs an explicit `keyGenerator` to follow the app option. |

--- a/apps/server-core/src/adapters/http/middleware/built-in/authorization/module.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/authorization/module.ts
@@ -52,6 +52,8 @@ import {
 } from '../../../request/index.ts';
 import type { HTTPAuthorizationMiddlewareContext, HTTPAuthorizationMiddlewareOptions } from './types.ts';
 
+const runSymbol = Symbol('RAuthorizationMiddlewareRun');
+
 export class AuthorizationMiddleware {
     protected options: HTTPAuthorizationMiddlewareOptions;
 
@@ -96,7 +98,26 @@ export class AuthorizationMiddleware {
 
     // --------------------------------------
 
-    async run(event: IAppEvent) {
+    async run(event: IAppEvent): Promise<void> {
+        // routup's dispatch walk re-enters earlier middlewares once per
+        // remaining match when no handler produces a response — exponentially
+        // (routup/routup#946), so an unmatched authenticated request re-ran
+        // this middleware ~100+ times, re-verifying Basic credentials (bcrypt)
+        // on every re-entry (~4s per 404). Authorization is a pure function of
+        // the request: the first run's settlement — including a rejection —
+        // is authoritative, so memoize the promise on the request store (the
+        // store is shared by every re-entry of the same request).
+        const pending = event.store[runSymbol] as Promise<void> | undefined;
+        if (pending) {
+            return pending;
+        }
+
+        const promise = this.runInner(event);
+        event.store[runSymbol] = promise;
+        return promise;
+    }
+
+    protected async runInner(event: IAppEvent): Promise<void> {
         const requestAccessContext = new RequestPermissionEvaluator(
             event,
             this.permissionEvaluator,

--- a/apps/server-core/test/unit/adapters/http/middleware/built-in/authorization.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/middleware/built-in/authorization.spec.ts
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { PermissionMemoryProvider } from '@authup/access';
+import type { User } from '@authup/core-kit';
+import { IdentityType } from '@authup/core-kit';
+import { OAuth2SubKind, OAuth2TokenKind, isJWTError } from '@authup/specs';
+import {
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { AuthorizationMiddleware } from '../../../../../../src/adapters/http/middleware/built-in/authorization/module.ts';
+import { useRequestIdentity } from '../../../../../../src/adapters/http/request/index.ts';
+import {
+    FakeIdentityPermissionProvider,
+    FakeIdentityResolver,
+    FakeOAuth2TokenVerifier,
+    FakeSessionManager,
+} from '../../../../core/helpers/index.ts';
+import { createFakeEvent } from '../../request/fake-event.ts';
+
+const TOKEN = 'token-under-test';
+
+function createSuite() {
+    const tokenVerifier = new FakeOAuth2TokenVerifier();
+    const sessionManager = new FakeSessionManager();
+    const identityResolver = new FakeIdentityResolver();
+
+    const middleware = new AuthorizationMiddleware({
+        identityResolver,
+        identityPermissionProvider: new FakeIdentityPermissionProvider(),
+        sessionManager,
+        oauth2TokenVerifier: tokenVerifier,
+        permissionProvider: new PermissionMemoryProvider(),
+    });
+
+    return {
+        middleware, 
+        tokenVerifier, 
+        sessionManager, 
+        identityResolver,
+    };
+}
+
+/**
+ * routup's dispatch walk re-enters earlier middlewares once per remaining
+ * match when no handler produced a response (routup/routup#946) — on an
+ * unmatched route the authorization middleware used to re-verify the same
+ * credentials ~100+ times (~4s per authenticated 404). The run is memoized
+ * per request, so every re-entry settles from the first run.
+ */
+describe('src/adapters/http/middleware/built-in/authorization', () => {
+    it('verifies a bearer credential once across re-entries of the same request', async () => {
+        const suite = createSuite();
+
+        const realmId = randomUUID();
+        const user : User = {
+            id: randomUUID(),
+            name: 'jdoe',
+            nameLocked: false,
+            firstName: null,
+            lastName: null,
+            displayName: null,
+            email: 'jdoe@example.com',
+            password: null,
+            avatar: null,
+            cover: null,
+            resetHash: null,
+            resetAt: null,
+            resetExpires: null,
+            status: null,
+            statusMessage: null,
+            active: true,
+            activateHash: null,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            realmId,
+            realm: {
+                id: realmId,
+                name: 'master',
+                displayName: null,
+                description: null,
+                builtIn: true,
+                createdAt: '2026-01-01T00:00:00.000Z',
+                updatedAt: '2026-01-01T00:00:00.000Z',
+            },
+        };
+
+        const session = await suite.sessionManager.create({ sub: user.id, subKind: IdentityType.USER });
+        suite.tokenVerifier.seed(TOKEN, {
+            kind: OAuth2TokenKind.ACCESS,
+            realm_id: realmId,
+            session_id: session.id,
+            sub: user.id,
+            sub_kind: OAuth2SubKind.USER,
+        });
+        suite.identityResolver.setIdentity({
+            type: IdentityType.USER,
+            data: user,
+        });
+
+        const event = createFakeEvent({ headers: { authorization: `Bearer ${TOKEN}` } });
+
+        await suite.middleware.run(event);
+        await suite.middleware.run(event);
+
+        expect(suite.tokenVerifier.verifyCalls).toHaveLength(1);
+        expect(suite.identityResolver.resolveCalls).toHaveLength(1);
+        expect(suite.sessionManager.pingCalls).toHaveLength(1);
+        expect(useRequestIdentity(event)?.id).toEqual(user.id);
+    });
+
+    it('re-rejects an invalid credential from the memoized settlement', async () => {
+        const suite = createSuite();
+
+        const event = createFakeEvent({ headers: { authorization: 'Bearer not-a-valid-token' } });
+
+        await expect(suite.middleware.run(event)).rejects.toSatisfy(isJWTError);
+        await expect(suite.middleware.run(event)).rejects.toSatisfy(isJWTError);
+
+        expect(suite.tokenVerifier.verifyCalls).toHaveLength(1);
+    });
+
+    it('keeps separate requests independently verified', async () => {
+        const suite = createSuite();
+
+        const first = createFakeEvent({});
+        const second = createFakeEvent({});
+
+        await suite.middleware.run(first);
+        await suite.middleware.run(second);
+
+        // header-less runs verify nothing but still settle per request
+        expect(suite.tokenVerifier.verifyCalls).toHaveLength(0);
+        expect(first.store).not.toBe(second.store);
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/event.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/event.spec.ts
@@ -105,11 +105,6 @@ describe('src/http/controllers/entities/event', () => {
         expect(row.name).toEqual(EventName.LOGIN);
     });
 
-    // Generous timeout: an AUTHENTICATED request to an unmatched route is slow
-    // (~4s) in this app — the dispatcher's not-found walk re-enters the
-    // authorization middleware many times, re-verifying the Basic credentials
-    // each time. Pre-existing behavior (reproducible with any Basic-auth'd
-    // request to e.g. /unknown-path), unrelated to the audit surface.
     it('rejects write attempts (append-only surface)', async () => {
         const post = await httpRequest(suite, 'POST', '/events', {
             headers: { Authorization: adminAuthorization },
@@ -126,7 +121,7 @@ describe('src/http/controllers/entities/event', () => {
         // the row survives the delete attempt
         const { data: row } = await suite.client.event.getOne(data[0].id);
         expect(row.id).toEqual(data[0].id);
-    }, 30_000);
+    });
 
     it('never throttles repeated failures with the default config (throttle off)', async () => {
         const victim = createFakeUser();


### PR DESCRIPTION
## Problem

Authenticated requests to unmatched routes took **~4 seconds**: routup's match walk re-enters earlier middlewares once per remaining match when no handler produces a response — exponentially, 2^k dispatches for the handler at match index k (filed as routup/routup#946; measured `1,2,4,…,512` for 10 chained middlewares). The authorization middleware sits at index 8–9 of the root chain, so a single Basic-auth'd 404 re-verified the same credentials 128–256× (2 bcrypt compares + identity lookups each). `event.spec.ts` carried a 30s timeout + comment documenting exactly this.

## Fix

Memoize `AuthorizationMiddleware.run` per request: the settled promise is stored on `event.store` under a module-local symbol — the store is created once per request and shared by every re-entry — and every re-entry returns the first run's settlement (including a rejection, which re-throws identically). Same store-slot idiom as `setRequestIdentity` / `setRequestRealmID`.

## Root cause fixed upstream

The exponential walk itself is fixed in routup/routup#947 (consumed-continuation tracking in `runMatches`). This memo ships now against routup 6.0.0 and stays as defense in depth once the fixed release is bumped. Added `.agents/references/routup.md` with the dispatch-contract mapping per the upstream-libraries convention.

## Tests

- New `test/unit/adapters/http/middleware/built-in/authorization.spec.ts`: bearer verified once across re-entries of the same event (verify/resolve/ping all 1×), memoized rejection re-rejects without re-verification, separate requests stay independent.
- `event.spec.ts`: removed the 30s workaround timeout + stale comment — the append-only test now acts as a soft regression guard under the default 5s timeout.
- Full server-core suite green (1752 tests; the two `userinfo`/`mfa-login-ticket` failures seen mid-run were stale-dist artifacts on master, green after `npm run build`).

## Post-6.1.0 status

Rebased onto master with the routup 6.1.0 bump (#3342) merged. The memo is now pure **defense in depth** — 6.1.0's fixed dispatch walk runs the middleware once per request anyway — and the unit spec stays meaningful independently of routup's dispatch (it exercises `run()` twice directly), guarding against any future double-mount or upstream regression. `.agents/references/routup.md` updated: the fix is released/bumped, error flow is forward-only upstream (authup's error middleware mounts last — keep it there). Both touched specs re-verified green against installed 6.1.0.
