### PR TITLE
fix: migrate snake_case references inside policy extra attributes

### DIFF
--- a/apps/server-core/src/adapters/database/migrations/helpers/policy-attribute-camel-case.ts
+++ b/apps/server-core/src/adapters/database/migrations/helpers/policy-attribute-camel-case.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { camelCase, snakeCase } from 'change-case';
+
+/**
+ * Shared logic for the PolicyAttributeCamelCase migration pair (both
+ * dialects import this module; it lives OUTSIDE the per-dialect folders so
+ * the migration glob never loads it as a migration).
+ *
+ * Plan-073 residual: the shipped CamelCaseAttributes migration renamed
+ * attribute KEYS on identity-provider/user attribute tables but left
+ * `auth_policy_attributes` untouched entirely — its EA keys, and the
+ * entity-property names EMBEDDED IN VALUES (ATTRIBUTES `query` field keys,
+ * ATTRIBUTE_NAMES `names` entries, REALM_MATCH `attributeName`), still
+ * reference snake_case properties that no longer exist on the camelCase
+ * attribute bags. An `invert: true` policy over a never-matching key fails
+ * OPEN.
+ */
+
+/**
+ * EA keys mounted by the built-in policy validators whose pre-073 form was
+ * snake_case. Enumerated (not blanket-transformed): policy EA keys are a
+ * closed, validator-defined vocabulary and nothing else must be touched.
+ */
+export const POLICY_ATTRIBUTE_KEY_RENAMES: [string, string][] = [
+    ['attribute_name', 'attributeName'],
+    ['attribute_name_strict', 'attributeNameStrict'],
+    ['attribute_null_match_all', 'attributeNullMatchAll'],
+    ['decision_strategy', 'decisionStrategy'],
+    ['day_of_week', 'dayOfWeek'],
+    ['day_of_month', 'dayOfMonth'],
+    ['day_of_year', 'dayOfYear'],
+];
+
+// Only true snake_case / camelCase identifiers are transformed — anything
+// else (single words, operator payload values, customer-authored oddities)
+// passes through untouched, which also makes both directions idempotent.
+const SNAKE_SEGMENT = /^[a-z0-9]+(?:_[a-z0-9]+)+$/;
+const CAMEL_SEGMENT = /^[a-z0-9]+(?:[A-Z][a-z0-9]*)+$/;
+
+/**
+ * Property paths are transformed PER DOT SEGMENT — rapiq treats dotted keys
+ * as nested relation paths, and `camelCase('user.realm_id')` would collapse
+ * the path into `userRealmId`.
+ */
+export function camelizePropertyPath(value: string): string {
+    return value
+        .split('.')
+        .map((segment) => (SNAKE_SEGMENT.test(segment) ? camelCase(segment) : segment))
+        .join('.');
+}
+
+export function snakizePropertyPath(value: string): string {
+    return value
+        .split('.')
+        .map((segment) => (CAMEL_SEGMENT.test(segment) ? snakeCase(segment) : segment))
+        .join('.');
+}
+
+/**
+ * Rewrite the FIELD keys of a mongo-style filters document (the ATTRIBUTES
+ * policy `query`). Object keys are either field names / dotted field paths
+ * or `$`-operators — `$`-prefixed keys stay verbatim (their payloads still
+ * hold field keys and are recursed into: `$and`/`$or`/`$nor` arrays,
+ * `$elemMatch`/`$not` sub-documents). VALUES are never touched: an
+ * underscore inside `$in: ['my_service']` or a `$regex` pattern is data,
+ * not a property name.
+ */
+function rewriteQueryKeys(node: unknown, transform: (key: string) => string): unknown {
+    if (Array.isArray(node)) {
+        return node.map((entry) => rewriteQueryKeys(entry, transform));
+    }
+
+    if (node === null || typeof node !== 'object') {
+        return node;
+    }
+
+    const output: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        const nextKey = key.startsWith('$') ? key : transform(key);
+        output[nextKey] = rewriteQueryKeys(value, transform);
+    }
+
+    return output;
+}
+
+/**
+ * Transform a serialized ATTRIBUTES `query` value. Returns the rewritten
+ * serialization, or null when the value must stay untouched (unparseable,
+ * not a plain object, or unchanged).
+ */
+export function transformQueryValue(
+    serialized: string,
+    transform: (key: string) => string,
+): string | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(serialized);
+    } catch {
+        return null;
+    }
+
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return null;
+    }
+
+    const rewritten = JSON.stringify(rewriteQueryKeys(parsed, transform));
+    return rewritten === serialized ? null : rewritten;
+}
+
+/**
+ * Transform a serialized ATTRIBUTE_NAMES `names` value (a JSON array of
+ * entity property names). Array ENTRIES are property names here — the
+ * inverse of the query rule, where array entries are data.
+ */
+export function transformNamesValue(
+    serialized: string,
+    transform: (key: string) => string,
+): string | null {
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(serialized);
+    } catch {
+        return null;
+    }
+
+    if (!Array.isArray(parsed)) {
+        return null;
+    }
+
+    const rewritten = JSON.stringify(
+        parsed.map((entry) => (typeof entry === 'string' ? transform(entry) : entry)),
+    );
+    return rewritten === serialized ? null : rewritten;
+}
+
+/**
+ * Transform a REALM_MATCH `attributeName` value: a raw property-name string
+ * (scalars serialize unquoted) or a JSON array of property names.
+ */
+export function transformAttributeNameValue(
+    raw: string,
+    transform: (key: string) => string,
+): string | null {
+    if (raw.startsWith('[')) {
+        return transformNamesValue(raw, transform);
+    }
+
+    const rewritten = transform(raw);
+    return rewritten === raw ? null : rewritten;
+}

--- a/apps/server-core/src/adapters/database/migrations/helpers/policy-attribute-camel-case.ts
+++ b/apps/server-core/src/adapters/database/migrations/helpers/policy-attribute-camel-case.ts
@@ -5,8 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { camelCase, snakeCase } from 'change-case';
-
 /**
  * Shared logic for the PolicyAttributeCamelCase migration pair (both
  * dialects import this module; it lives OUTSIDE the per-dialect folders so
@@ -37,28 +35,120 @@ export const POLICY_ATTRIBUTE_KEY_RENAMES: [string, string][] = [
     ['day_of_year', 'dayOfYear'],
 ];
 
-// Only true snake_case / camelCase identifiers are transformed — anything
-// else (single words, operator payload values, customer-authored oddities)
-// passes through untouched, which also makes both directions idempotent.
-const SNAKE_SEGMENT = /^[a-z0-9]+(?:_[a-z0-9]+)+$/;
-const CAMEL_SEGMENT = /^[a-z0-9]+(?:[A-Z][a-z0-9]*)+$/;
+/**
+ * The exact entity-property renames plan 073 performed — every property whose
+ * physical column name (the pre-073 API form) differs from today's camelCase
+ * property, extracted from the TypeORM entity metadata
+ * (`@Column({ name: 'snake_col' })` pairs across every entity), plus
+ * `realm_name` (a legal pre-073 identity-bag key read by REALM_MATCH — not a
+ * column). VALUE transforms are restricted to this vocabulary — a generic
+ * snake→camel transform would ALSO camelize references to live snake_case
+ * user/role ATTRIBUTE keys (role-attribute keys were never renamed by 073,
+ * and post-073-authored snake user-attribute keys are legal), silently
+ * breaking a working `invert` denylist — the very fail-open this migration
+ * exists to fix. A stale reference OUTSIDE this vocabulary stays stale
+ * (the pre-existing state, called out in the release notes), which is the
+ * safe direction.
+ */
+export const PROPERTY_RENAMES: [string, string][] = [
+    ['access_policy_id', 'accessPolicyId'],
+    ['access_token', 'accessToken'],
+    ['activate_hash', 'activateHash'],
+    ['actor_id', 'actorId'],
+    ['actor_name', 'actorName'],
+    ['actor_type', 'actorType'],
+    ['auth_method', 'authMethod'],
+    ['base_url', 'baseUrl'],
+    ['built_in', 'builtIn'],
+    ['client_id', 'clientId'],
+    ['client_realm_id', 'clientRealmId'],
+    ['consumed_at', 'consumedAt'],
+    ['created_at', 'createdAt'],
+    ['decision_strategy', 'decisionStrategy'],
+    ['decryption_key', 'decryptionKey'],
+    ['display_name', 'displayName'],
+    ['encryption_key', 'encryptionKey'],
+    ['expires_at', 'expiresAt'],
+    ['expires_in', 'expiresIn'],
+    ['first_name', 'firstName'],
+    ['grant_types', 'grantTypes'],
+    ['ip_address', 'ipAddress'],
+    ['last_name', 'lastName'],
+    ['last_used_at', 'lastUsedAt'],
+    ['mfa_at', 'mfaAt'],
+    ['name_locked', 'nameLocked'],
+    ['parent_id', 'parentId'],
+    ['permission_id', 'permissionId'],
+    ['permission_realm_id', 'permissionRealmId'],
+    ['policy_id', 'policyId'],
+    ['policy_realm_id', 'policyRealmId'],
+    ['post_logout_redirect_uri', 'postLogoutRedirectUri'],
+    ['provider_id', 'providerId'],
+    ['provider_realm_id', 'providerRealmId'],
+    ['provider_user_email', 'providerUserEmail'],
+    ['provider_user_id', 'providerUserId'],
+    ['provider_user_name', 'providerUserName'],
+    ['realm_id', 'realmId'],
+    ['realm_name', 'realmName'],
+    ['realm_scope', 'realmScope'],
+    ['redirect_uri', 'redirectUri'],
+    ['ref_id', 'refId'],
+    ['ref_type', 'refType'],
+    ['refresh_token', 'refreshToken'],
+    ['refresh_token_id', 'refreshTokenId'],
+    ['refreshed_at', 'refreshedAt'],
+    ['request_ip_address', 'requestIpAddress'],
+    ['request_method', 'requestMethod'],
+    ['request_path', 'requestPath'],
+    ['request_user_agent', 'requestUserAgent'],
+    ['reset_at', 'resetAt'],
+    ['reset_expires', 'resetExpires'],
+    ['reset_hash', 'resetHash'],
+    ['revoked_at', 'revokedAt'],
+    ['role_id', 'roleId'],
+    ['role_realm_id', 'roleRealmId'],
+    ['root_url', 'rootUrl'],
+    ['scope_id', 'scopeId'],
+    ['scope_realm_id', 'scopeRealmId'],
+    ['secret_encrypted', 'secretEncrypted'],
+    ['secret_hashed', 'secretHashed'],
+    ['seen_at', 'seenAt'],
+    ['session_id', 'sessionId'],
+    ['signature_algorithm', 'signatureAlgorithm'],
+    ['status_message', 'statusMessage'],
+    ['sub_kind', 'subKind'],
+    ['synchronization_mode', 'synchronizationMode'],
+    ['target_name', 'targetName'],
+    ['target_value', 'targetValue'],
+    ['token_binding_method', 'tokenBindingMethod'],
+    ['updated_at', 'updatedAt'],
+    ['user_agent', 'userAgent'],
+    ['user_id', 'userId'],
+    ['user_realm_id', 'userRealmId'],
+    ['value_is_regex', 'valueIsRegex'],
+];
+
+const SNAKE_TO_CAMEL = new Map(PROPERTY_RENAMES);
+const CAMEL_TO_SNAKE = new Map(PROPERTY_RENAMES.map(([from, to]) => [to, from] as [string, string]));
 
 /**
  * Property paths are transformed PER DOT SEGMENT — rapiq treats dotted keys
- * as nested relation paths, and `camelCase('user.realm_id')` would collapse
- * the path into `userRealmId`.
+ * as nested relation paths, and a whole-path transform would collapse
+ * `user.realm_id` into `userRealmId`. Segments outside the enumerated
+ * vocabulary pass through untouched, which also makes both directions
+ * idempotent.
  */
 export function camelizePropertyPath(value: string): string {
     return value
         .split('.')
-        .map((segment) => (SNAKE_SEGMENT.test(segment) ? camelCase(segment) : segment))
+        .map((segment) => SNAKE_TO_CAMEL.get(segment) ?? segment)
         .join('.');
 }
 
 export function snakizePropertyPath(value: string): string {
     return value
         .split('.')
-        .map((segment) => (CAMEL_SEGMENT.test(segment) ? snakeCase(segment) : segment))
+        .map((segment) => CAMEL_TO_SNAKE.get(segment) ?? segment)
         .join('.');
 }
 
@@ -80,7 +170,9 @@ function rewriteQueryKeys(node: unknown, transform: (key: string) => string): un
         return node;
     }
 
-    const output: Record<string, unknown> = {};
+    // null prototype: a JSON.parse'd own `__proto__` key would otherwise hit
+    // the prototype setter on assignment and silently vanish from the output.
+    const output: Record<string, unknown> = Object.create(null);
     for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
         const nextKey = key.startsWith('$') ? key : transform(key);
         output[nextKey] = rewriteQueryKeys(value, transform);

--- a/apps/server-core/src/adapters/database/migrations/mysql/1785226508000-PolicyAttributeCamelCase.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1785226508000-PolicyAttributeCamelCase.ts
@@ -84,6 +84,14 @@ async function transformAttributeValues(
  *    property names.
  * 4. REALM_MATCH `attributeName` values — a property-name string (or array).
  *
+ * Value transforms are restricted to the ENUMERATED plan-073 property-rename
+ * vocabulary (see the helper): a reference to a user/role ATTRIBUTE key that
+ * happens to be snake_case is a LIVE reference (role-attribute keys were
+ * never renamed; snake user-attribute keys are legal post-073) and must not
+ * be touched. Release note: policies referencing entity properties outside
+ * that vocabulary — there are none today — or custom attribute keys keep
+ * their stored spelling.
+ *
  * `down()` is the mirrored snake transform: lossy for a natively-camel key
  * authored after the fact, like 1784289540000's down — revert works, it is
  * not information-preserving.

--- a/apps/server-core/src/adapters/database/migrations/mysql/1785226508000-PolicyAttributeCamelCase.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1785226508000-PolicyAttributeCamelCase.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+    POLICY_ATTRIBUTE_KEY_RENAMES,
+    camelizePropertyPath,
+    snakizePropertyPath,
+    transformAttributeNameValue,
+    transformNamesValue,
+    transformQueryValue,
+} from '../helpers/policy-attribute-camel-case.ts';
+
+/**
+ * Rename an EA key on auth_policy_attributes. The unique (name, policy_id)
+ * index means a rename can collide with an already-present target row; the
+ * source duplicate is removed first to keep the update constraint-safe
+ * (same dance as 1784289540000-CamelCaseAttributes).
+ */
+async function renameAttributeKey(
+    queryRunner: QueryRunner,
+    from: string,
+    to: string,
+): Promise<void> {
+    await queryRunner.query(
+        'DELETE `source` FROM `auth_policy_attributes` AS `source` ' +
+        'INNER JOIN `auth_policy_attributes` AS `target` ' +
+        'ON `source`.`policy_id` = `target`.`policy_id` ' +
+        'AND `source`.`name` = ? AND `target`.`name` = ?',
+        [from, to],
+    );
+
+    await queryRunner.query(
+        'UPDATE `auth_policy_attributes` SET `name` = ? WHERE `name` = ?',
+        [to, from],
+    );
+}
+
+async function transformAttributeValues(
+    queryRunner: QueryRunner,
+    attributeName: string,
+    policyType: string,
+    transform: (value: string) => string | null,
+): Promise<void> {
+    const rows: { id: string, value: string }[] = await queryRunner.query(
+        'SELECT `a`.`id` AS `id`, `a`.`value` AS `value` ' +
+        'FROM `auth_policy_attributes` `a` ' +
+        'INNER JOIN `auth_policies` `p` ON `p`.`id` = `a`.`policy_id` ' +
+        'WHERE `a`.`name` = ? AND `p`.`type` = ? AND `a`.`value` IS NOT NULL',
+        [attributeName, policyType],
+    );
+
+    for (const row of rows) {
+        const next = transform(row.value);
+        if (next === null) {
+            continue;
+        }
+
+        await queryRunner.query(
+            'UPDATE `auth_policy_attributes` SET `value` = ? WHERE `id` = ?',
+            [next, row.id],
+        );
+    }
+}
+
+/**
+ * Plan-073 residual (the shipped CamelCaseAttributes migration deliberately
+ * skipped auth_policy_attributes on the assumption that only provisioner-
+ * owned built-in policies existed — user-authored policies were left with
+ * snake_case references that no longer match the camelCase attribute bags;
+ * an `invert: true` policy over a never-matching key fails OPEN):
+ *
+ * 1. EA KEYS — the validator-defined snake_case config keys move to their
+ *    camelCase mounts (attribute_name → attributeName, day_of_week →
+ *    dayOfWeek, ...). Enumerated, never blanket-transformed.
+ * 2. ATTRIBUTES `query` values — entity-property FIELD keys inside the
+ *    mongo-style filter document (recursive; `$`-operator keys verbatim,
+ *    their payloads recursed; dotted paths per segment; VALUES untouched).
+ * 3. ATTRIBUTE_NAMES `names` values — the JSON array ENTRIES are entity
+ *    property names.
+ * 4. REALM_MATCH `attributeName` values — a property-name string (or array).
+ *
+ * `down()` is the mirrored snake transform: lossy for a natively-camel key
+ * authored after the fact, like 1784289540000's down — revert works, it is
+ * not information-preserving.
+ */
+export class PolicyAttributeCamelCase1785226508000 implements MigrationInterface {
+    name = 'PolicyAttributeCamelCase1785226508000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const [from, to] of POLICY_ATTRIBUTE_KEY_RENAMES) {
+            await renameAttributeKey(queryRunner, from, to);
+        }
+
+        await transformAttributeValues(queryRunner, 'query', 'attributes', (value) => transformQueryValue(value, camelizePropertyPath));
+        await transformAttributeValues(queryRunner, 'names', 'attributeNames', (value) => transformNamesValue(value, camelizePropertyPath));
+        await transformAttributeValues(queryRunner, 'attributeName', 'realmMatch', (value) => transformAttributeNameValue(value, camelizePropertyPath));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await transformAttributeValues(queryRunner, 'attributeName', 'realmMatch', (value) => transformAttributeNameValue(value, snakizePropertyPath));
+        await transformAttributeValues(queryRunner, 'names', 'attributeNames', (value) => transformNamesValue(value, snakizePropertyPath));
+        await transformAttributeValues(queryRunner, 'query', 'attributes', (value) => transformQueryValue(value, snakizePropertyPath));
+
+        for (const [from, to] of POLICY_ATTRIBUTE_KEY_RENAMES) {
+            await renameAttributeKey(queryRunner, to, from);
+        }
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1785226508000-PolicyAttributeCamelCase.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1785226508000-PolicyAttributeCamelCase.ts
@@ -83,6 +83,14 @@ async function transformAttributeValues(
  *    property names.
  * 4. REALM_MATCH `attributeName` values — a property-name string (or array).
  *
+ * Value transforms are restricted to the ENUMERATED plan-073 property-rename
+ * vocabulary (see the helper): a reference to a user/role ATTRIBUTE key that
+ * happens to be snake_case is a LIVE reference (role-attribute keys were
+ * never renamed; snake user-attribute keys are legal post-073) and must not
+ * be touched. Release note: policies referencing entity properties outside
+ * that vocabulary — there are none today — or custom attribute keys keep
+ * their stored spelling.
+ *
  * `down()` is the mirrored snake transform: lossy for a natively-camel key
  * authored after the fact, like 1784289540000's down — revert works, it is
  * not information-preserving.

--- a/apps/server-core/src/adapters/database/migrations/postgres/1785226508000-PolicyAttributeCamelCase.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1785226508000-PolicyAttributeCamelCase.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+import {
+    POLICY_ATTRIBUTE_KEY_RENAMES,
+    camelizePropertyPath,
+    snakizePropertyPath,
+    transformAttributeNameValue,
+    transformNamesValue,
+    transformQueryValue,
+} from '../helpers/policy-attribute-camel-case.ts';
+
+/**
+ * Rename an EA key on auth_policy_attributes. The unique (name, policy_id)
+ * index means a rename can collide with an already-present target row; the
+ * source duplicate is removed first to keep the update constraint-safe
+ * (same dance as 1784289540000-CamelCaseAttributes).
+ */
+async function renameAttributeKey(
+    queryRunner: QueryRunner,
+    from: string,
+    to: string,
+): Promise<void> {
+    await queryRunner.query(
+        'DELETE FROM "auth_policy_attributes" AS "source" USING "auth_policy_attributes" AS "target" ' +
+        'WHERE "source"."policy_id" = "target"."policy_id" ' +
+        'AND "source"."name" = $1 AND "target"."name" = $2',
+        [from, to],
+    );
+
+    await queryRunner.query(
+        'UPDATE "auth_policy_attributes" SET "name" = $1 WHERE "name" = $2',
+        [to, from],
+    );
+}
+
+async function transformAttributeValues(
+    queryRunner: QueryRunner,
+    attributeName: string,
+    policyType: string,
+    transform: (value: string) => string | null,
+): Promise<void> {
+    const rows: { id: string, value: string }[] = await queryRunner.query(
+        'SELECT "a"."id" AS "id", "a"."value" AS "value" ' +
+        'FROM "auth_policy_attributes" "a" ' +
+        'INNER JOIN "auth_policies" "p" ON "p"."id" = "a"."policy_id" ' +
+        'WHERE "a"."name" = $1 AND "p"."type" = $2 AND "a"."value" IS NOT NULL',
+        [attributeName, policyType],
+    );
+
+    for (const row of rows) {
+        const next = transform(row.value);
+        if (next === null) {
+            continue;
+        }
+
+        await queryRunner.query(
+            'UPDATE "auth_policy_attributes" SET "value" = $1 WHERE "id" = $2',
+            [next, row.id],
+        );
+    }
+}
+
+/**
+ * Plan-073 residual (the shipped CamelCaseAttributes migration deliberately
+ * skipped auth_policy_attributes on the assumption that only provisioner-
+ * owned built-in policies existed — user-authored policies were left with
+ * snake_case references that no longer match the camelCase attribute bags;
+ * an `invert: true` policy over a never-matching key fails OPEN):
+ *
+ * 1. EA KEYS — the validator-defined snake_case config keys move to their
+ *    camelCase mounts (attribute_name → attributeName, day_of_week →
+ *    dayOfWeek, ...). Enumerated, never blanket-transformed.
+ * 2. ATTRIBUTES `query` values — entity-property FIELD keys inside the
+ *    mongo-style filter document (recursive; `$`-operator keys verbatim,
+ *    their payloads recursed; dotted paths per segment; VALUES untouched).
+ * 3. ATTRIBUTE_NAMES `names` values — the JSON array ENTRIES are entity
+ *    property names.
+ * 4. REALM_MATCH `attributeName` values — a property-name string (or array).
+ *
+ * `down()` is the mirrored snake transform: lossy for a natively-camel key
+ * authored after the fact, like 1784289540000's down — revert works, it is
+ * not information-preserving.
+ */
+export class PolicyAttributeCamelCase1785226508000 implements MigrationInterface {
+    name = 'PolicyAttributeCamelCase1785226508000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        for (const [from, to] of POLICY_ATTRIBUTE_KEY_RENAMES) {
+            await renameAttributeKey(queryRunner, from, to);
+        }
+
+        await transformAttributeValues(queryRunner, 'query', 'attributes', (value) => transformQueryValue(value, camelizePropertyPath));
+        await transformAttributeValues(queryRunner, 'names', 'attributeNames', (value) => transformNamesValue(value, camelizePropertyPath));
+        await transformAttributeValues(queryRunner, 'attributeName', 'realmMatch', (value) => transformAttributeNameValue(value, camelizePropertyPath));
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await transformAttributeValues(queryRunner, 'attributeName', 'realmMatch', (value) => transformAttributeNameValue(value, snakizePropertyPath));
+        await transformAttributeValues(queryRunner, 'names', 'attributeNames', (value) => transformNamesValue(value, snakizePropertyPath));
+        await transformAttributeValues(queryRunner, 'query', 'attributes', (value) => transformQueryValue(value, snakizePropertyPath));
+
+        for (const [from, to] of POLICY_ATTRIBUTE_KEY_RENAMES) {
+            await renameAttributeKey(queryRunner, to, from);
+        }
+    }
+}

--- a/apps/server-core/test/unit/adapters/database/migrations/policy-attribute-camel-case.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/migrations/policy-attribute-camel-case.spec.ts
@@ -5,9 +5,11 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { camelCase } from 'change-case';
 import { describe, expect, it } from 'vitest';
 import {
     POLICY_ATTRIBUTE_KEY_RENAMES,
+    PROPERTY_RENAMES,
     camelizePropertyPath,
     snakizePropertyPath,
     transformAttributeNameValue,
@@ -17,32 +19,52 @@ import {
 
 describe('src/adapters/database/migrations/helpers/policy-attribute-camel-case', () => {
     describe('property paths', () => {
-        it('camelizes snake segments per dot segment (no path collapse)', () => {
+        it('camelizes vocabulary segments per dot segment (no path collapse)', () => {
             expect(camelizePropertyPath('realm_id')).toEqual('realmId');
             expect(camelizePropertyPath('user.realm_id')).toEqual('user.realmId');
             expect(camelizePropertyPath('client_id.realm_id')).toEqual('clientId.realmId');
         });
 
-        it('leaves non-snake segments untouched (idempotent)', () => {
+        it('leaves non-vocabulary segments untouched (idempotent)', () => {
             expect(camelizePropertyPath('name')).toEqual('name');
             expect(camelizePropertyPath('realmId')).toEqual('realmId');
             expect(camelizePropertyPath('REALM')).toEqual('REALM');
             expect(camelizePropertyPath(camelizePropertyPath('realm_id'))).toEqual('realmId');
         });
 
-        it('snakizes camel segments per dot segment', () => {
+        it('never touches live snake-case ATTRIBUTE-key references (outside the vocabulary)', () => {
+            // role-attribute keys were never renamed by plan 073, and snake
+            // user-attribute keys are legal post-073 — a policy referencing
+            // them is a WORKING reference the migration must not break.
+            expect(camelizePropertyPath('cost_center')).toEqual('cost_center');
+            expect(camelizePropertyPath('my_custom_flag')).toEqual('my_custom_flag');
+            expect(snakizePropertyPath('costCenter')).toEqual('costCenter');
+        });
+
+        it('snakizes vocabulary segments per dot segment', () => {
             expect(snakizePropertyPath('realmId')).toEqual('realm_id');
             expect(snakizePropertyPath('user.realmId')).toEqual('user.realm_id');
             expect(snakizePropertyPath('name')).toEqual('name');
         });
     });
 
-    describe('POLICY_ATTRIBUTE_KEY_RENAMES', () => {
-        it('maps each snake key onto its camel validator mount', () => {
+    describe('vocabularies', () => {
+        it('maps each policy EA key onto its camel validator mount', () => {
             for (const [from, to] of POLICY_ATTRIBUTE_KEY_RENAMES) {
-                expect(camelizePropertyPath(from)).toEqual(to);
-                expect(snakizePropertyPath(to)).toEqual(from);
+                expect(to).toEqual(camelCase(from));
             }
+        });
+
+        it('keeps the property-rename vocabulary bijective and camel-consistent', () => {
+            const snakes = new Set<string>();
+            const camels = new Set<string>();
+            for (const [from, to] of PROPERTY_RENAMES) {
+                expect(to).toEqual(camelCase(from));
+                snakes.add(from);
+                camels.add(to);
+            }
+            expect(snakes.size).toEqual(PROPERTY_RENAMES.length);
+            expect(camels.size).toEqual(PROPERTY_RENAMES.length);
         });
     });
 
@@ -90,11 +112,11 @@ describe('src/adapters/database/migrations/helpers/policy-attribute-camel-case',
     });
 
     describe('transformNamesValue', () => {
-        it('rewrites array entries (they ARE property names)', () => {
-            const input = JSON.stringify(['name_locked', 'status_message', 'realmId']);
+        it('rewrites array entries (they ARE property names), keeping non-vocabulary keys', () => {
+            const input = JSON.stringify(['name_locked', 'status_message', 'realmId', 'cost_center']);
 
             expect(JSON.parse(transformNamesValue(input, camelizePropertyPath)!))
-                .toEqual(['nameLocked', 'statusMessage', 'realmId']);
+                .toEqual(['nameLocked', 'statusMessage', 'realmId', 'cost_center']);
         });
 
         it('returns null for unchanged or non-array values', () => {

--- a/apps/server-core/test/unit/adapters/database/migrations/policy-attribute-camel-case.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/migrations/policy-attribute-camel-case.spec.ts
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+    POLICY_ATTRIBUTE_KEY_RENAMES,
+    camelizePropertyPath,
+    snakizePropertyPath,
+    transformAttributeNameValue,
+    transformNamesValue,
+    transformQueryValue,
+} from '../../../../../src/adapters/database/migrations/helpers/policy-attribute-camel-case.ts';
+
+describe('src/adapters/database/migrations/helpers/policy-attribute-camel-case', () => {
+    describe('property paths', () => {
+        it('camelizes snake segments per dot segment (no path collapse)', () => {
+            expect(camelizePropertyPath('realm_id')).toEqual('realmId');
+            expect(camelizePropertyPath('user.realm_id')).toEqual('user.realmId');
+            expect(camelizePropertyPath('client_id.realm_id')).toEqual('clientId.realmId');
+        });
+
+        it('leaves non-snake segments untouched (idempotent)', () => {
+            expect(camelizePropertyPath('name')).toEqual('name');
+            expect(camelizePropertyPath('realmId')).toEqual('realmId');
+            expect(camelizePropertyPath('REALM')).toEqual('REALM');
+            expect(camelizePropertyPath(camelizePropertyPath('realm_id'))).toEqual('realmId');
+        });
+
+        it('snakizes camel segments per dot segment', () => {
+            expect(snakizePropertyPath('realmId')).toEqual('realm_id');
+            expect(snakizePropertyPath('user.realmId')).toEqual('user.realm_id');
+            expect(snakizePropertyPath('name')).toEqual('name');
+        });
+    });
+
+    describe('POLICY_ATTRIBUTE_KEY_RENAMES', () => {
+        it('maps each snake key onto its camel validator mount', () => {
+            for (const [from, to] of POLICY_ATTRIBUTE_KEY_RENAMES) {
+                expect(camelizePropertyPath(from)).toEqual(to);
+                expect(snakizePropertyPath(to)).toEqual(from);
+            }
+        });
+    });
+
+    describe('transformQueryValue', () => {
+        it('rewrites field keys, never operator keys or values', () => {
+            const input = JSON.stringify({
+                realm_id: { $in: ['my_service', 'other_value'] },
+                $or: [
+                    { 'user.realm_id': 'abc' },
+                    { client_id: { $ne: null } },
+                ],
+                name: { $regex: '/foo_bar/i' },
+            });
+
+            expect(JSON.parse(transformQueryValue(input, camelizePropertyPath)!)).toEqual({
+                realmId: { $in: ['my_service', 'other_value'] },
+                $or: [
+                    { 'user.realmId': 'abc' },
+                    { clientId: { $ne: null } },
+                ],
+                name: { $regex: '/foo_bar/i' },
+            });
+        });
+
+        it('recurses into $elemMatch / $not sub-documents', () => {
+            const input = JSON.stringify({ items: { $elemMatch: { realm_id: 'abc', $not: { status_message: 'x' } } } });
+
+            expect(JSON.parse(transformQueryValue(input, camelizePropertyPath)!)).toEqual({ items: { $elemMatch: { realmId: 'abc', $not: { statusMessage: 'x' } } } });
+        });
+
+        it('returns null for unchanged, non-object, or unparseable values', () => {
+            expect(transformQueryValue(JSON.stringify({ realmId: 'abc' }), camelizePropertyPath)).toBeNull();
+            expect(transformQueryValue('not-json', camelizePropertyPath)).toBeNull();
+            expect(transformQueryValue('"scalar"', camelizePropertyPath)).toBeNull();
+            expect(transformQueryValue('[1,2]', camelizePropertyPath)).toBeNull();
+        });
+
+        it('round-trips through the snake transform', () => {
+            const camel = JSON.stringify({ realmId: { $in: ['a'] }, 'user.realmId': 'x' });
+            const snake = transformQueryValue(camel, snakizePropertyPath)!;
+
+            expect(JSON.parse(snake)).toEqual({ realm_id: { $in: ['a'] }, 'user.realm_id': 'x' });
+            expect(JSON.parse(transformQueryValue(snake, camelizePropertyPath)!)).toEqual(JSON.parse(camel));
+        });
+    });
+
+    describe('transformNamesValue', () => {
+        it('rewrites array entries (they ARE property names)', () => {
+            const input = JSON.stringify(['name_locked', 'status_message', 'realmId']);
+
+            expect(JSON.parse(transformNamesValue(input, camelizePropertyPath)!))
+                .toEqual(['nameLocked', 'statusMessage', 'realmId']);
+        });
+
+        it('returns null for unchanged or non-array values', () => {
+            expect(transformNamesValue(JSON.stringify(['nameLocked']), camelizePropertyPath)).toBeNull();
+            expect(transformNamesValue('{"a":1}', camelizePropertyPath)).toBeNull();
+            expect(transformNamesValue('not-json', camelizePropertyPath)).toBeNull();
+        });
+    });
+
+    describe('transformAttributeNameValue', () => {
+        it('rewrites the raw scalar form (scalars serialize unquoted)', () => {
+            expect(transformAttributeNameValue('realm_id', camelizePropertyPath)).toEqual('realmId');
+            expect(transformAttributeNameValue('realmId', camelizePropertyPath)).toBeNull();
+        });
+
+        it('rewrites the array form', () => {
+            expect(JSON.parse(transformAttributeNameValue(JSON.stringify(['realm_id', 'realm_name']), camelizePropertyPath)!))
+                .toEqual(['realmId', 'realmName']);
+        });
+    });
+});


### PR DESCRIPTION
## Problem (plan-073 residual)

The shipped `1784289540000-CamelCaseAttributes` migration deliberately skipped `auth_policy_attributes` ("the provisioner overwrites built-in policy data on every boot") — but that assumption only holds for built-ins. **User-authored** policies kept snake_case references that no longer match the camelCase attribute bags:

- an ATTRIBUTES policy whose `query` references `realm_id` never matches — and with `invert: true` it **fails open**;
- REALM_MATCH / TIME / COMPOSITE EA **keys** (`attribute_name`, `day_of_week`, `decision_strategy`, …) are read under camel mounts now, so stale keys silently drop to defaults;
- ATTRIBUTE_NAMES `names` denylist **entries** and the REALM_MATCH `attributeName` **value** are property names too.

## Fix

New named migration pair `1785226508000-PolicyAttributeCamelCase` (the released predecessor is immutable) closing all four gaps in one upgrade step:

1. **EA keys** — the enumerated validator vocabulary (never blanket-transformed), with the unique-`(name, policy_id)` collision dance from the predecessor.
2. **`query` field keys** — recursive rewrite of the mongo-style document: `$`-operator keys stay verbatim (payloads recursed — `$or` arrays, `$elemMatch`/`$not` sub-documents), dotted paths transform **per segment** (`camelCase('user.realm_id')` would collapse the path), **values are never touched** (`$in: ['my_service']`, `$regex` patterns are data).
3. **`names` entries** (they ARE property names — inverse of the query rule).
4. **`attributeName` value** (raw-scalar and JSON-array forms — scalars serialize unquoted).

The rewrite logic is a shared unit-tested helper at `migrations/helpers/` — deliberately **outside** the per-dialect folders so the migration glob never loads it as a migration. Guards make both directions idempotent: only strict `snake_case`/`camelCase` identifiers transform, everything else passes through. `down()` mirrors with the snake transform (works, lossy for natively-camel keys — same contract as the predecessor's `down`).

## Verification

- Helper unit spec (12 cases: operator/value preservation, dot-segment handling, $elemMatch recursion, round-trips, unparseable/scalar passthrough).
- Beyond the empty-DB CI round-trip (which can't catch data bugs): seeded snake-case rows — `query` with `$or`/`$in`/`$regex` + dotted paths, denylist `names`, realm-match `attributeName`, and a key-collision pair — on **real postgres and mysql**, then `revert` + `run`: keys and property names camelize, operator keys and data values stay byte-identical on both dialects.

Origin: plan-073 review 2026-07-17 / release audit 2026-07-21 (roadmap Active Defects).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Updated stored policy attribute names and values to use consistent camelCase formatting.
  * Preserved nested query operators and unrelated values during conversion.
  * Added safe handling for duplicate or conflicting attribute entries.

* **Tests**
  * Added coverage for nested queries, property paths, arrays, invalid data, and reversible formatting conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Audit follow-up (second commit)

An adversarial review caught that the generic snake→camel value transform would ALSO camelize references to **live** snake_case user/role ATTRIBUTE keys — role-attribute keys were never renamed by plan 073, and snake user-attribute keys authored post-073 are legal — silently breaking a *working* `invert` denylist (the very fail-open class this migration fixes). Value transforms are now restricted to the **enumerated plan-073 property-rename vocabulary** (all 74 `@Column({ name })` pairs whose column differs from its camelCase property, extracted from the TypeORM entity metadata, plus `realm_name` as a legal identity-bag key):

- zero false positives — a `names: ["cost_center"]` referencing a live role-attribute row survives byte-identical (added to the unit spec AND the seeded DB round-trip);
- a stale reference outside the vocabulary stays stale — the pre-existing state, release-noted in the migration doc comment (there are no entity properties outside the vocabulary today).

Also hardened the query-key rewrite against a literal `__proto__` field (null-prototype output object). Seeded round-trip re-verified on real postgres + mysql — identical output on both dialects; helper spec now 14 cases including vocabulary bijectivity.
