### PR TITLE
fix(deps): bump routup to v6.1.0

### DIFF
--- a/apps/server-core/package.json
+++ b/apps/server-core/package.json
@@ -115,7 +115,7 @@
         "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "reflect-metadata": "^0.2.2",
-        "routup": "^6.0.0",
+        "routup": "^6.1.0",
         "smob": "^1.6.1",
         "tsyringe": "^4.10.0",
         "typeorm": "1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,7 +367,7 @@
                 "prom-client": "^15.1.3",
                 "qrcode": "^1.5.4",
                 "reflect-metadata": "^0.2.2",
-                "routup": "^6.0.0",
+                "routup": "^6.1.0",
                 "smob": "^1.6.1",
                 "tsyringe": "^4.10.0",
                 "typeorm": "1.1.0",
@@ -13708,6 +13708,19 @@
                 "node": "^14.18.0 || >=16.10.0"
             }
         },
+        "node_modules/content-disposition": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-2.0.1.tgz",
+            "integrity": "sha512-e+H0ZXHSWYrENhQzw1LPuP4oF5MzVKmDU6d3hxlvaPEYLLg62MxtQNPRx4SYSuYJSBUgnQIG4HIN2tEtNv7Dog==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
         "node_modules/conventional-changelog-angular": {
             "version": "8.3.1",
             "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
@@ -24701,27 +24714,40 @@
             "license": "MIT"
         },
         "node_modules/routup": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/routup/-/routup-6.0.0.tgz",
-            "integrity": "sha512-iEaJFoo9NX/h6KEP5Mg/tRBos7kNhZMc+cjzPjxS7Kf6jLZqjrZH/9LXOPwwtZrq2vKUbs3o4ZpjDSFHCukKTA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/routup/-/routup-6.1.0.tgz",
+            "integrity": "sha512-90bJfkWelZzTR5gzfNn1zn3Lf07gerfgnpNTTx16+3iJ8bcdyluMC4aXRfvsjHqh6/rV/Qk73gxkNzRTWDXD8A==",
             "license": "MIT",
             "workspaces": [
                 "docs"
             ],
             "dependencies": {
-                "@ebec/core": "^1.1.0",
-                "@ebec/http": "^4.1.0",
+                "@ebec/core": "^1.2.0",
+                "@ebec/http": "^4.2.0",
+                "content-disposition": "^2.0.1",
                 "mime-explorer": "^1.1.0",
                 "negotiator": "^1.0.0",
                 "path-to-regexp": "^8.4.2",
                 "proxy-addr": "^2.0.7",
                 "quick-lru": "^7.3.0",
                 "smob": "^1.6.2",
-                "srvx": "^0.11.15",
+                "srvx": "^0.12.4",
                 "uncrypto": "^0.1.3"
             },
             "engines": {
                 "node": ">=22.0.0"
+            }
+        },
+        "node_modules/routup/node_modules/srvx": {
+            "version": "0.12.4",
+            "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.12.4.tgz",
+            "integrity": "sha512-RixzFlMn3dvzDTpKIAXhXrqL4cy6vScNCP0VVwgVbUBU94o+DiXLsFnAZetbyKAEnK6Ox3hzHXWGsyv/Iibv7g==",
+            "license": "MIT",
+            "bin": {
+                "srvx": "bin/srvx.mjs"
+            },
+            "engines": {
+                "node": ">=20.16.0"
             }
         },
         "node_modules/run-applescript": {
@@ -25350,6 +25376,7 @@
             "version": "0.11.22",
             "resolved": "https://registry.npmjs.org/srvx/-/srvx-0.11.22.tgz",
             "integrity": "sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==",
+            "dev": true,
             "license": "MIT",
             "bin": {
                 "srvx": "bin/srvx.mjs"


### PR DESCRIPTION
Picks up [routup/routup#947](https://github.com/routup/routup/pull/947) (issue [#946](https://github.com/routup/routup/issues/946)): `App.runMatches` no longer re-walks consumed match suffixes, so response-less requests dispatch each middleware exactly **once** instead of 2^k times.

## Verified against the installed release

- Dispatch-count reproducer on the installed 6.1.0: matched `1,1,…,1`, unmatched `1,1,…,1` (was `1,2,4,…,512`).
- Full server-core suite green: **1749/1749** (the mid-verification SSR-page 500s were a local `dist/ui` wipe from a partial rebuild — the known nx-build gotcha — unrelated to the bump; green after `build:ui`).

## Effects

- The duplicated access-log lines and skewed per-dispatch prometheus observations on unmatched routes disappear.
- The authorization middleware's per-request memo (#3338) becomes inert defense in depth and stays.
- Release-note awareness from upstream: error flow is now forward-only (an ERROR handler registered before a later thrower is no longer accidentally revisited) — authup mounts its error middleware last (`mountAfter`), so it is unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal routing dependency to the latest compatible minor release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->