### PR TITLE
fix: truncate the login-throttle key to the persisted actorName bound

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2994,7 +2994,12 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   identifier alone: account-lockout-DoS mitigation; no derivable IP → fail
   open) — and throws `LoginThrottledError` (HTTP **429**,
   `login_attempt_throttled`, `data.retryAfter`) before `authenticate` in the
-  HTTP password grant. Config `loginAttemptThrottleEnabled/Threshold/Window`;
+  HTTP password grant. The identifier half of the key is truncated to
+  `EVENT_ACTOR_NAME_MAX_LENGTH` — the same bound `EventService.record` applies
+  to the persisted `actorName`. A reader that matches stored rows by actor name
+  must normalize exactly like the writer, or an over-long identifier never
+  matches its own rows and the throttle silently fails open for it. Config
+  `loginAttemptThrottleEnabled/Threshold/Window`;
   enabling it with `eventLogEnabled=false` **fails loud at config time**. Basic
   auth is deliberately NOT throttled (recording/widening is a later call).
 - **Metrics (plan 058 Part 2):** `IAuthFlowMetrics` port (`core/metrics/`,

--- a/apps/server-core/src/core/authentication/login-throttle/service.ts
+++ b/apps/server-core/src/core/authentication/login-throttle/service.ts
@@ -7,6 +7,9 @@
 
 import { EventName } from '@authup/core-kit';
 import { LoginThrottledError } from '@authup/errors';
+// direct file import — the entities barrel reaches every entity service, and a
+// value import of it from here would pull that graph in at module init.
+import { EVENT_ACTOR_NAME_MAX_LENGTH } from '../../entities/event/constants.ts';
 import type { IEventRepository } from '../../entities/index.ts';
 import type { ILoginThrottleService, LoginThrottleServiceContext, LoginThrottleServiceOptions } from './types.ts';
 
@@ -47,7 +50,10 @@ export class LoginThrottleService implements ILoginThrottleService {
 
         const count = await this.repository.countRecent({
             name: EventName.LOGIN_FAILED,
-            actorName: ctx.identifier,
+            // the loginFailed rows are persisted with the actor name truncated
+            // to the column bound — an untruncated key would never match its
+            // own rows, silently failing open for over-long identifiers.
+            actorName: ctx.identifier.slice(0, EVENT_ACTOR_NAME_MAX_LENGTH),
             requestIpAddress: ctx.ipAddress,
             realmId: ctx.realmId,
             since: new Date(Date.now() - (windowSeconds * 1_000)).toISOString(),

--- a/apps/server-core/src/core/entities/event/constants.ts
+++ b/apps/server-core/src/core/entities/event/constants.ts
@@ -11,3 +11,11 @@
  * EVENT_LOG_RETENTION_DAYS, 0 = keep forever).
  */
 export const EVENT_LOG_RETENTION_DAYS_DEFAULT = 90;
+
+/**
+ * Column bound for the denormalized actor name. Shared by the write boundary
+ * (EventService.record truncates to it) and every reader that matches stored
+ * rows by actor name (the login throttle) so the two cannot drift — an
+ * untruncated lookup key never matches its own truncated rows.
+ */
+export const EVENT_ACTOR_NAME_MAX_LENGTH = 128;

--- a/apps/server-core/src/core/entities/event/service.ts
+++ b/apps/server-core/src/core/entities/event/service.ts
@@ -18,7 +18,7 @@ import type { Event } from '@authup/core-kit';
 import { EntityNotFoundError } from '@authup/errors';
 import { AbstractEntityService } from '@authup/server-kit';
 import type { ActorContext, EntityRepositoryFindManyResult, Logger } from '@authup/server-kit';
-import { EVENT_LOG_RETENTION_DAYS_DEFAULT } from './constants.ts';
+import { EVENT_ACTOR_NAME_MAX_LENGTH, EVENT_LOG_RETENTION_DAYS_DEFAULT } from './constants.ts';
 import { sanitizeEventData } from './sanitize.ts';
 import type {
     EventReadVisibility,
@@ -143,7 +143,7 @@ export class EventService extends AbstractEntityService implements IEventService
                 clientId: input.clientId ?? null,
                 actorType: input.actorType ?? null,
                 actorId: input.actorId ?? null,
-                actorName: truncate(input.actorName, 128),
+                actorName: truncate(input.actorName, EVENT_ACTOR_NAME_MAX_LENGTH),
                 requestPath: truncate(input.requestPath, 256),
                 requestMethod: truncate(input.requestMethod, 10),
                 requestIpAddress: truncate(input.requestIpAddress, 45),

--- a/apps/server-core/test/unit/core/authentication/login-throttle/service.spec.ts
+++ b/apps/server-core/test/unit/core/authentication/login-throttle/service.spec.ts
@@ -15,6 +15,7 @@ import {
     it,
 } from 'vitest';
 import { LoginThrottleService } from '../../../../../src/core/authentication/login-throttle/service.ts';
+import { EVENT_ACTOR_NAME_MAX_LENGTH } from '../../../../../src/core/entities/event/constants.ts';
 import type { LoginThrottleServiceOptions } from '../../../../../src/core/index.ts';
 import { FakeEventRepository } from '../../entities/event/fake-repository.ts';
 
@@ -131,6 +132,17 @@ describe('LoginThrottleService', () => {
             identifier: IDENTIFIER,
             ipAddress: IP,
             realmId: otherRealmId,
+        })).rejects.toSatisfy((e) => isLoginThrottledError(e));
+    });
+
+    it('matches rows of an over-long identifier truncated at the write boundary', async () => {
+        const identifier = 'a'.repeat(EVENT_ACTOR_NAME_MAX_LENGTH + 32);
+        seedFailures(THRESHOLD, { identifier: identifier.slice(0, EVENT_ACTOR_NAME_MAX_LENGTH) });
+
+        await expect(buildService().assertNotThrottled({
+            identifier,
+            ipAddress: IP,
+            realmId,
         })).rejects.toSatisfy((e) => isLoginThrottledError(e));
     });
 


### PR DESCRIPTION
Closes #3249.

## Context

The primary defect in #3249 — client-spoofable `X-Forwarded-For` — shipped in #3339 (configurable `trustProxy` contract, one config key threaded into the router). The default stays `trustProxy: true` by decision; operators pin `1` / `loopback` / a CIDR for the hardened posture, as the config reference documents.

This PR closes the issue's remaining "Related" item.

## Problem

`EventService.record` persists `actorName` truncated to 128 chars (the column bound), but `LoginThrottleService.assertNotThrottled` passed the raw canonicalized identifier to `countRecent`. An identifier longer than the bound therefore never matched its own `LOGIN_FAILED` rows — `count` stayed 0 and the throttle silently failed open for exactly that identifier.

## Fix

The bound becomes the shared `EVENT_ACTOR_NAME_MAX_LENGTH` constant (`core/entities/event/constants.ts`), applied by the writer and by the throttle key alike so the two cannot drift — same shape as the `CONSENT_SCOPE_MAX_LENGTH` precedent. The throttle imports the constants FILE directly rather than the entities barrel (a value import of the barrel would pull the whole entity-service graph in at module init).

## Tests

New case in `test/unit/core/authentication/login-throttle/service.spec.ts`: rows seeded as the writer would store them (truncated) are matched by a 160-char identifier. Verified as a real regression detector — it fails on the pre-fix code and passes after.

Full server-core suite green (167 files / 1780 tests).

Docs: the throttle bullet in `.agents/architecture.md` now states the writer/reader normalization contract.