### PR TITLE
fix: space the redirect-uri list off the grant-types selection

### DIFF
--- a/packages/client-web-kit/src/components/entities/client/AClientForm.vue
+++ b/packages/client-web-kit/src/components/entities/client/AClientForm.vue
@@ -496,7 +496,14 @@ export default defineComponent({
             </template>
         </div>
         <div class="flex-1 basis-0 px-2">
+            <!--
+                `AFormInputList`'s root carries no bottom margin (it is also
+                nested INSIDE a VCFormGroup elsewhere, where a margin would
+                double up), so a standalone use followed by a sibling has to
+                match the `mb-3` the theme puts on stacked form groups.
+            -->
             <AFormInputList
+                class="mb-3"
                 :names="redirectUris"
                 @changed="(value) => {
                     if (value.length === 0) {


### PR DESCRIPTION
Follow-up to #3348.

`AFormInputList`'s root is `flex flex-col gap-2` with no bottom margin, so in `AClientForm` it stacked flush against the control that follows it. This was already latent — the list previously abutted the description field — but #3348 put a new control directly beneath it and made it obvious.

The margin is deliberately absent from the component itself: `ARealmMatchPolicyForm` nests `AFormInputList` **inside** a `VCFormGroup`, and the kit theme (`packages/client-web-kit-theme/src/index.ts`) already gives every form group `mb-3`. Pushing the margin onto the component root would double-space that call site.

So it is applied at the call site instead, matching what the theme gives every sibling form group. The three remaining standalone uses (`AAttributeNamesPolicyForm`, `AIdentityPolicyForm`, `AIdentityProviderOAuth2ClientFields`) are last-in-container, where the missing margin has no visible effect.

## Verification

Mounted the form against the real `@vuecs/forms` and asserted the rendered root class: `"flex flex-col gap-2 mb-3"` — the fallthrough merges rather than replacing. Kit build clean (`vue-tsc`), full suite 156/156, eslint clean.

No permanent test added: asserting a margin utility class would fail on any legitimate restyle without catching a real defect. The reasoning lives in a comment at the call site so the next person does not "simplify" it onto the component root.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing around the redirect URI form field for a more consistent layout when displayed alongside other form sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->