### PR TITLE
refactor(config): migrate to the confinity v2 api

### DIFF
--- a/apps/authup/package.json
+++ b/apps/authup/package.json
@@ -63,7 +63,7 @@
         "@authup/kit": "^1.0.0-beta.56",
         "@authup/server-core": "^1.0.0-beta.56",
         "citty": "^0.2.2",
-        "confinity": "^1.0.0",
+        "confinity": "^2.0.0",
         "consola": "^3.4.0",
         "locter": "^4.1.0",
         "resolve-package-path": "^4.0.3"

--- a/apps/authup/src/config/module.ts
+++ b/apps/authup/src/config/module.ts
@@ -6,7 +6,7 @@
  */
 
 import { isObject } from '@authup/kit';
-import { Container } from 'confinity';
+import { FSStore } from 'confinity';
 import {
     CLIENT_WEB_PORT_DEFAULT,
     LISTEN_HOST_DEFAULT,
@@ -81,20 +81,24 @@ export function normalizeClientWebSection(input: unknown) : ClientWebSectionConf
 export async function readLauncherConfig(
     options: LauncherConfigReadOptions = {},
 ) : Promise<LauncherConfig> {
-    const container = new Container({
+    const store = new FSStore({
         prefix: 'authup',
         cwd: options.directory,
     });
 
     if (options.file) {
-        await container.loadFile(options.file);
+        await store.loadFile(options.file);
     } else {
-        await container.load();
+        await store.load();
     }
 
+    // `getSync` after the explicit load, not `get`. In confinity v2 `get` is
+    // asynchronous, and both normalizers take `unknown` — so a missing `await`
+    // would compile cleanly, hand them a Promise, and silently start every
+    // service on its defaults.
     return {
-        serverCore: normalizeServerCoreSection(container.get('server.core')),
-        clientWeb: normalizeClientWebSection(container.get('client.web')),
+        serverCore: normalizeServerCoreSection(store.getSync('server.core')),
+        clientWeb: normalizeClientWebSection(store.getSync('client.web')),
     };
 }
 

--- a/apps/server-core/package.json
+++ b/apps/server-core/package.json
@@ -97,7 +97,7 @@
         "better-sqlite3": "^13.0.1",
         "change-case": "^5.4.4",
         "citty": "^0.2.2",
-        "confinity": "^1.0.0",
+        "confinity": "^2.0.0",
         "dotenv": "^17.4.1",
         "dycraft": "^1.1.0",
         "eldin": "^1.2.0",

--- a/apps/server-core/src/app/modules/config/read/fs.ts
+++ b/apps/server-core/src/app/modules/config/read/fs.ts
@@ -5,25 +5,60 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { Container } from 'confinity';
+import { FSStore } from 'confinity';
+import { isObject, merge } from 'smob';
 import type { ConfigInput } from '../types.ts';
 import type { ConfigReadFsOptions } from './types.ts';
 
+/**
+ * Resolve one infrastructure section (`db`, `redis`, `smtp`), which may be
+ * declared at the top level (shared), under `server.*` or under `server.core.*`.
+ *
+ * Keys are ordered **least specific first**. Two objects are merged, so a
+ * shared base survives while the more specific declaration wins per key; a
+ * scalar (a `redis://…` connection string, say) replaces whatever preceded it.
+ * That is what "the most specific declaration wins" means for a section the
+ * documentation explicitly describes as shared — `db.type` set once at the top
+ * level still applies when only `db.database` is overridden per component.
+ *
+ * confinity v1 applied exactly this precedence inside `get([...keys])`; v2
+ * removed the array form, so it is spelled out here instead.
+ */
+function readSection<T>(store: FSStore, keys: string[]) : T | undefined {
+    let output : unknown;
+
+    for (const key of keys) {
+        const value = store.getSync(key);
+        if (typeof value === 'undefined') {
+            continue;
+        }
+
+        output = isObject(value) && isObject(output) ?
+            merge(value, output) :
+            value;
+    }
+
+    return output as T | undefined;
+}
+
 export async function readConfigRawFromFS(options: ConfigReadFsOptions = {}) {
-    const container = new Container({
+    const store = new FSStore({
         prefix: 'authup',
         cwd: options.cwd,
     });
 
     if (options.file) {
-        await container.loadFile(options.file);
+        await store.loadFile(options.file);
     } else {
-        await container.load();
+        await store.load();
     }
 
-    const raw : ConfigInput = container.get('server.core') || {};
+    // Read synchronously after the explicit load. `get` is asynchronous in
+    // confinity v2, and a missing `await` would hand a Promise to code that
+    // only checks whether it received an object.
+    const raw : ConfigInput = store.getSync<ConfigInput>('server.core') || {};
 
-    const db = container.get([
+    const db = readSection<ConfigInput['db']>(store, [
         'db',
         'server.db',
         'server.core.db',
@@ -32,7 +67,7 @@ export async function readConfigRawFromFS(options: ConfigReadFsOptions = {}) {
         raw.db = db;
     }
 
-    const redis = container.get([
+    const redis = readSection<ConfigInput['redis']>(store, [
         'redis',
         'server.redis',
         'server.core.redis',
@@ -41,7 +76,7 @@ export async function readConfigRawFromFS(options: ConfigReadFsOptions = {}) {
         raw.redis = redis;
     }
 
-    const smtp = container.get([
+    const smtp = readSection<ConfigInput['smtp']>(store, [
         'smtp',
         'server.smtp',
         'server.core.smtp',

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
                 "@authup/kit": "^1.0.0-beta.56",
                 "@authup/server-core": "^1.0.0-beta.56",
                 "citty": "^0.2.2",
-                "confinity": "^1.0.0",
+                "confinity": "^2.0.0",
                 "consola": "^3.4.0",
                 "locter": "^4.1.0",
                 "resolve-package-path": "^4.0.3"
@@ -156,7 +156,7 @@
                 "better-sqlite3": "^13.0.1",
                 "change-case": "^5.4.4",
                 "citty": "^0.2.2",
-                "confinity": "^1.0.0",
+                "confinity": "^2.0.0",
                 "dotenv": "^17.4.1",
                 "dycraft": "^1.1.0",
                 "eldin": "^1.2.0",
@@ -13436,13 +13436,13 @@
             "license": "ISC"
         },
         "node_modules/confinity": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/confinity/-/confinity-1.0.0.tgz",
-            "integrity": "sha512-gezK+jv8c/zWoMA/LG14DaMkm/K6FX6Atd1qsWn9nX6LxqB9XBTPX3SNjDsqm1UE3PPnWzwKYXBt5StH9nB16g==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/confinity/-/confinity-2.0.0.tgz",
+            "integrity": "sha512-zvWcc7bgkoFQ2J+PETJW/emAujxNCzh49WdtzQDFSVrtd9FicNijtxvfnBkbbqpRXspFTjTKVRGKeTMpRKmLvg==",
             "license": "MIT",
             "dependencies": {
                 "locter": "^4.1.0",
-                "pathtrace": "^2.2.0",
+                "pathtrace": "^2.2.1",
                 "smob": "^1.6.2"
             },
             "engines": {
@@ -22554,9 +22554,9 @@
             "license": "MIT"
         },
         "node_modules/pathtrace": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.0.tgz",
-            "integrity": "sha512-HbWXrGk6NYlvwvDSX6JVpbGXTAgqAXhpYmgK5P0PPrGQ0//smfXQ8/SIP+fC3HueG+007KDDRNQHTgr1q7D0gg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.1.tgz",
+            "integrity": "sha512-NgmSwfSTcQZF+r90cUa/mkacIEObkd7FLjQNHsLXXOxmtTYDFWz9mV9aElPVx3wwj2dS5/y2exqJUz+7aUxnKg==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22554,9 +22554,9 @@
             "license": "MIT"
         },
         "node_modules/pathtrace": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.1.tgz",
-            "integrity": "sha512-NgmSwfSTcQZF+r90cUa/mkacIEObkd7FLjQNHsLXXOxmtTYDFWz9mV9aElPVx3wwj2dS5/y2exqJUz+7aUxnKg==",
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/pathtrace/-/pathtrace-2.2.2.tgz",
+            "integrity": "sha512-2uXz62JShMMoFuDgTsUiW4sJnDfDdGLQLcw7scE4pOWfH7cBrKf1LRKho8xHwbkomY/rFbCNJT47UNUNvwvTBQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=22.0.0"


### PR DESCRIPTION
Migrates both confinity call sites to the v2 API. **Behaviour is unchanged** — the existing config tests pass untouched, and no test was modified.

confinity **v2.0.0 is published**, so this is ready to merge. `package.json` and `package-lock.json` both move to `^2.0.0`; the lock also pins **`pathtrace@2.2.2`**, which confinity 2.0.0 pulls in transitively.

> [!NOTE]
> The pathtrace pin is load-bearing, not housekeeping. `pathtrace@2.2.1` stopped resolving accessors declared on a class prototype, so policy evaluation against `RequestIdentity` (`id`, `realmId`, `clientId`, `type`, `realmName` are all prototype getters) returned nothing and every permission check failed with `The evaluation of permission user_create failed`. Fixed in [tada5hi/pathtrace#188](https://github.com/tada5hi/pathtrace/pull/188), released as 2.2.2. The lock pins it so `npm ci` cannot resolve back to the broken patch. This was never a problem with the migration itself — the same failure reproduces on `master` with 2.2.1 installed.

## What changed

**`Container` is no longer the loadable unit.** In v2 it is a read-only *view* over a store, so both sites construct an `FSStore` directly. Nothing crosses a boundary here, so there is nothing to wrap.

**Reads use `getSync` after the explicit load, not `get`.** This is the important one. `get` kept its v1 name but is now asynchronous, and both launcher normalizers take `unknown`:

```ts
normalizeServerCoreSection(store.get('server.core'))   // compiles clean, passes a Promise
```

`unknown` accepts a Promise, `isObject` accepts a Promise, `toRecord` then yields `{}`, and the supervisor starts every service on `SERVER_CORE_PORT_DEFAULT` / `start123` with no exception and no log line. Since both sites already load explicitly, `getSync` sidesteps the whole class.

## The one part that is not a mechanical swap

`get([...keys])` was removed in v2. The obvious replacement is a `??` chain, and **it would have been wrong here.**

For `db`/`redis`/`smtp` the docs say the top level is a *shared* base and "the most specific declaration wins" — meaning per key, not wholesale. That is what `get([...])` did internally: merge objects, later key wins. A first-match chain drops the shared keys entirely.

The repo already has fixtures for exactly this:

```dotenv
# test/data/config/authup.server.conf
db.type=mysql
db.database=default

# test/data/config/authup.server.core.conf
db.database=core
```

and a test asserting the merged outcome:

```ts
expect(config.db!.type).toEqual('mysql');      // shared base survives
expect(config.db!.database).toEqual('core');   // specific override wins
```

With a `??` chain that test fails — `AssertionError: expected undefined to deeply equal 'mysql'`. A real deployment would get a database with no `type`, silently falling back to the default driver.

So `readSection` spells the precedence out explicitly (least specific first; objects merge, a scalar such as a `redis://…` string replaces). Same behaviour as v1, now visible at the call site instead of hidden in the dependency.

## Verification

Run against the **published** `confinity@2.0.0` / `pathtrace@2.2.2` tarballs, not a local build:

- `apps/server-core` config suite — 35 passed, including the merge assertion above
- `apps/authup` suite — 30 passed
- `tsc -p tsconfig.test.json` clean for both apps
- ESLint clean on both changed files

- `apps/server-core` token workflow suites — 17 files / 85 passed (these are the ones 2.2.1 broke)

No test changes were needed, which is the point: this is an API migration, not a behaviour change.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading of server and client configuration from configuration files.
  * Configuration values are now merged consistently across general and section-specific settings.
  * Reduced the risk of applications starting with unintended default settings when configuration files are present.
  * Improved handling of database, Redis, and SMTP settings across supported configuration locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
