### PR TITLE
fix: provision client scopes into the client_scope junction

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -784,11 +784,11 @@ The provisioning system declaratively synchronizes entities (permissions, roles,
 
 ### Layers
 
-- **core/provisioning/entities/**: Provisioning entity types and validators (what can be provisioned)
+- **core/provisioning/entities/**: Provisioning entity types and validators (what can be provisioned). A client declares `permissions` / `roles` (define new client-scoped ones) plus `globalPermissions` / `realmPermissions` / `globalRoles` / `realmRoles` / `globalScopes` / `realmScopes` (assign existing). Every assign list lands in the matching junction table
 - **core/provisioning/strategy/**: Strategy types (`createOnly`, `merge`, `replace`, `absent`) and normalization
 - **core/provisioning/synchronizer/**: Business logic that applies strategies and manages relations
-  - `entity-resolver.ts`: `ProvisioningEntityResolver<T>` — resolves Permission/Role entities by name with wildcard support and scope filtering (global, realm, client)
-  - `junction-synchronizer.ts`: `ProvisioningJunctionSynchronizer<T>` — ensures junction entries (e.g. RolePermission, UserRole) exist between owner and target entities
+  - `entity-resolver.ts`: `ProvisioningEntityResolver<T>` — resolves Permission/Role/Scope entities by name with wildcard support and scope filtering (global, realm, client). The client dimension is always pinned so a client-ownable entity never resolves another owner's rows; entities without one (scope) opt out via `{ clientScoped: false }`, since the predicate would not compile against their table
+  - `junction-synchronizer.ts`: `ProvisioningJunctionSynchronizer<T>` — ensures junction entries (e.g. RolePermission, UserRole, ClientScope) exist between owner and target entities
   - `{entity}/module.ts`: Per-entity synchronizer composing resolver + junction helpers
 - **app/modules/provisioning/sources/**: Data sources that produce `RootProvisioningEntity`
   - `default/`: Built-in defaults (system policies, admin user, system client, all permissions/scopes)
@@ -827,7 +827,9 @@ dropped from the validator output) are validated via
 `ProvisionerModule` runs (1) `GraphProvisioningSynchronizer`, (2) backfill via `assignDefaultPolicy` (config-gated, deprecated).
 
 `GraphProvisioningSynchronizer` processes in order: policies → permissions → roles → scopes → realms.
-`RealmProvisioningSynchronizer` processes per realm: clients → permissions → roles → users → scopes.
+`RealmProvisioningSynchronizer` processes per realm: scopes → clients → permissions → roles → users.
+Scopes run first because they are leaf entities carrying no relations of their
+own, and a client in the same realm block may bind them via `realmScopes`.
 
 ### Per-Realm Public `web` Client
 
@@ -842,8 +844,17 @@ endpoint — the `/authorize` verifier already resolves clients via
   `authMethod: 'none'`, `tokenBindingMethod: 'none'`, `builtIn: true`, `active: true`,
   `grantTypes: 'authorization_code refresh_token'` (an enforced allowlist —
   see *Per-client grant allowlist* under the token-endpoint section),
-  `scope: 'global openid'`, `redirectUri` = one `<origin>/**` wildcard per
-  trusted app origin (matched by `isSimpleMatch`).
+  `redirectUri` = one `<origin>/**` wildcard per trusted app origin (matched
+  by `isSimpleMatch`).
+- **Scopes** (`WEB_CLIENT_SCOPE_NAMES` = `global` + `openid`) are bound as
+  `auth_client_scopes` rows. That junction is the only source `/authorize`
+  reads scopes from (`OAuth2ScopeRepository.findByClientId`). The `Client.scope` column carries
+  the same list but is descriptive only: nothing on any production path reads
+  it. Writing the column alone left the client with an empty granted set, so a
+  standard OIDC `scope=openid` request failed with `insufficient_scope` while
+  only requests carrying `global` passed via the verifier's bypass (#3347).
+  The junction rows are additive: a scope an admin bound by hand survives the
+  next boot.
 - **App origins** come from `getAppOrigins(config)` = publicUrl's origin +
   `config.trustedOrigins` merged verbatim. A `trustedOrigins` entry may carry
   an http(s) scheme (contributes exactly that origin; other protocols are
@@ -872,8 +883,13 @@ endpoint — the `/authorize` verifier already resolves clients via
   2. **Runtime** — `RealmService.save()` calls `ensureForRealm` when it *creates*
      a new realm, via the injected `webClientProvisioner` (system-level, ungated —
      a realm creator may lack `CLIENT_CREATE`). Not called on update.
-  Idempotent; guarded on `builtIn` — a non-built-in client named `web` is never
-  overwritten (skip + warn).
+  Idempotent. The attribute MERGE is dirty-checked to keep a steady-state boot
+  free of redundant UPDATEs, but the scope binding runs unconditionally. An
+  instance provisioned before the junction rows existed carries a current
+  client with no scopes at all. `web` is a reserved name, so the row belongs
+  to the system whatever state it is in: a non-built-in client named `web`
+  predates the reservation and is taken over (overwrite + warn) rather than
+  left to shadow the realm's login client.
 - **Guardrails:** `web` and `system` are reserved client names — `ClientService.save()`
   rejects API attempts to create/rename a client onto them (`CLIENT_RESERVED_NAMES`).
   The client validator strips `builtIn` on create/update, so no API caller can

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -974,6 +974,13 @@ export class HTTPControllerModule {
         const logger = container.resolve(LoggerInjectionKey);
         const webClientProvisioner = new WebClientProvisioner({
             clientRepository,
+            scopeRepository: new ScopeRepositoryAdapter({
+                repository: container.resolve<Repository<Scope>>(ScopeEntity),
+                realmRepository,
+            }),
+            clientScopeRepository: new ClientScopeRepositoryAdapter(
+                container.resolve<Repository<ClientScope>>(ClientScopeEntity),
+            ),
             appOrigins: getAppOrigins(config),
             logger,
         });

--- a/apps/server-core/src/app/modules/provisioning/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/module.ts
@@ -8,6 +8,7 @@ import type {
     Client,
     ClientPermission,
     ClientRole,
+    ClientScope,
     PermissionPolicy,
     Realm,
     Role,
@@ -21,6 +22,7 @@ import {
     ClientEntity,
     ClientPermissionEntity,
     ClientRoleEntity,
+    ClientScopeEntity,
     PermissionEntity,
     RealmEntity,
     RoleEntity,
@@ -51,6 +53,7 @@ import {
     ClientPermissionRepositoryAdapter,
     ClientRepositoryAdapter,
     ClientRoleRepositoryAdapter,
+    ClientScopeRepositoryAdapter,
     KeyRepositoryAdapter,
     PermissionPolicyRepositoryAdapter,
     PermissionRepositoryAdapter,
@@ -137,6 +140,13 @@ export class ProvisionerModule implements IModule {
             repository: container.resolve<Repository<Client>>(ClientEntity),
             realmRepository,
         });
+        const scopeRepository = new ScopeRepositoryAdapter({
+            repository: container.resolve<Repository<Scope>>(ScopeEntity),
+            realmRepository,
+        });
+        const clientScopeRepository = new ClientScopeRepositoryAdapter(
+            container.resolve<Repository<ClientScope>>(ClientScopeEntity),
+        );
 
         const permissionSynchronizer = new PermissionProvisioningSynchronizer({
             repository: permissionRepository,
@@ -160,9 +170,11 @@ export class ProvisionerModule implements IModule {
             clientPermissionRepository: new ClientPermissionRepositoryAdapter(
                 container.resolve<Repository<ClientPermission>>(ClientPermissionEntity),
             ),
+            clientScopeRepository,
 
             roleRepository,
             permissionRepository,
+            scopeRepository,
 
             roleSynchronizer,
             permissionSynchronizer,
@@ -183,11 +195,6 @@ export class ProvisionerModule implements IModule {
             clientRepository,
             roleRepository,
             permissionRepository,
-        });
-
-        const scopeRepository = new ScopeRepositoryAdapter({
-            repository: container.resolve<Repository<Scope>>(ScopeEntity),
-            realmRepository,
         });
 
         const scopeSynchronizer = new ScopeProvisioningSynchronizer({ repository: scopeRepository });
@@ -219,6 +226,8 @@ export class ProvisionerModule implements IModule {
         // ---------------------------------------------------------------
         const webClientProvisioner = new WebClientProvisioner({
             clientRepository,
+            scopeRepository,
+            clientScopeRepository,
             appOrigins: getAppOrigins(config),
             logger: container.resolve(LoggerInjectionKey),
         });

--- a/apps/server-core/src/core/entities/client/web-client.ts
+++ b/apps/server-core/src/core/entities/client/web-client.ts
@@ -13,28 +13,46 @@ import {
 } from '@authup/core-kit';
 import type { Client, Realm } from '@authup/core-kit';
 import type { Logger } from '@authup/server-kit';
+import type { IClientScopeRepository } from '../client-scope/types.ts';
+import type { IScopeRepository } from '../scope/types.ts';
 import type { IClientRepository, IWebClientProvisioner } from './types.ts';
 
 export type WebClientProvisionerContext = {
     clientRepository: IClientRepository;
+    scopeRepository: IScopeRepository;
+    clientScopeRepository: IClientScopeRepository;
     appOrigins: string[];
     logger?: Logger;
 };
+
+/**
+ * The scopes a realm's public `web` client is granted.
+ *
+ * `global` lets the issued token drive the management API (parity with the
+ * legacy password-grant admin login); `openid` yields the id-token.
+ */
+export const WEB_CLIENT_SCOPE_NAMES: string[] = [
+    ScopeName.GLOBAL,
+    ScopeName.OPEN_ID,
+];
 
 /**
  * Build the attribute set for a realm's public `web` client.
  *
  * Public (PKCE) client used by authup's own client-web and any downstream
  * UI embedding client-web-kit. `builtIn` makes it auto-consent in the
- * /authorize flow and protects it from the API reserved-name guard. The
- * `global` scope lets the issued token drive the management API (parity
- * with the legacy password-grant admin login); `openid` for the id-token.
+ * /authorize flow and protects it from the API reserved-name guard.
  *
  * `grantTypes` is an enforced allowlist (`assertClientGrantAllowed` at the
  * /token grants and the /authorize code-request verifier; null = allow-all),
  * so it must list every flow the client uses. `redirectUri` and
  * `postLogoutRedirectUri` are each one `<origin>/**` wildcard per trusted
  * origin (matched by isSimpleMatch).
+ *
+ * The `scope` column is descriptive only. Scope authorization resolves
+ * through the `auth_client_scopes` junction, which
+ * `WebClientProvisioner.ensureForRealm` fills from
+ * {@see WEB_CLIENT_SCOPE_NAMES}.
  */
 export function buildWebClientAttributes(
     realm: Realm | { id: string },
@@ -50,7 +68,7 @@ export function buildWebClientAttributes(
         builtIn: true,
         active: true,
         grantTypes: 'authorization_code refresh_token',
-        scope: `${ScopeName.GLOBAL} ${ScopeName.OPEN_ID}`,
+        scope: WEB_CLIENT_SCOPE_NAMES.join(' '),
         redirectUri: originPatterns,
         postLogoutRedirectUri: originPatterns,
     };
@@ -59,17 +77,40 @@ export function buildWebClientAttributes(
 export class WebClientProvisioner implements IWebClientProvisioner {
     protected clientRepository: IClientRepository;
 
+    protected scopeRepository: IScopeRepository;
+
+    protected clientScopeRepository: IClientScopeRepository;
+
     protected appOrigins: string[];
 
     protected logger?: Logger;
 
     constructor(ctx: WebClientProvisionerContext) {
         this.clientRepository = ctx.clientRepository;
+        this.scopeRepository = ctx.scopeRepository;
+        this.clientScopeRepository = ctx.clientScopeRepository;
         this.appOrigins = ctx.appOrigins;
         this.logger = ctx.logger;
     }
 
     async ensureForRealm(realm: Realm | { id: string }): Promise<void> {
+        const client = await this.ensureClient(realm);
+
+        // Always run, even when the attributes were already up to date: an
+        // instance provisioned before the junction rows existed carries a
+        // steady-state client with no scopes at all.
+        await this.ensureScopes(client);
+    }
+
+    /**
+     * Upsert the client row itself.
+     *
+     * `web` is a reserved client name (`CLIENT_RESERVED_NAMES`), so the row
+     * belongs to the system whatever state it is in. A non-built-in one
+     * predates the reservation and is taken over rather than left to shadow
+     * the realm's login client.
+     */
+    protected async ensureClient(realm: Realm | { id: string }): Promise<Client> {
         const attributes = buildWebClientAttributes(realm, this.appOrigins);
 
         const existing = await this.clientRepository.findOneBy({
@@ -78,17 +119,6 @@ export class WebClientProvisioner implements IWebClientProvisioner {
         });
 
         if (existing) {
-            // Never overwrite a non-builtIn client that happens to be named
-            // `web` — that would be a user-owned client. Skip and warn.
-            if (!existing.builtIn) {
-                if (this.logger) {
-                    this.logger.warn(
-                        `Skipping web client provisioning for realm ${realm.id}: a non-built-in client named '${CLIENT_WEB_NAME}' already exists.`,
-                    );
-                }
-                return;
-            }
-
             // MERGE: refresh attributes (e.g. redirectUri) when config
             // changes. Dirty-check first — the attributes are deterministic
             // from config, so a steady-state boot would otherwise issue one
@@ -96,15 +126,62 @@ export class WebClientProvisioner implements IWebClientProvisioner {
             const isDirty = (Object.keys(attributes) as (keyof Client)[])
                 .some((key) => existing[key] !== attributes[key]);
             if (!isDirty) {
-                return;
+                return existing;
+            }
+
+            if (!existing.builtIn && this.logger) {
+                this.logger.warn(
+                    `Taking over the non-built-in client named '${CLIENT_WEB_NAME}' in realm ${realm.id}: the name is reserved for the built-in web client.`,
+                );
             }
 
             const merged = this.clientRepository.merge(existing, attributes);
-            await this.clientRepository.save(merged);
-            return;
+            return this.clientRepository.save(merged);
         }
 
         const entity = this.clientRepository.create(attributes);
-        await this.clientRepository.save(entity);
+        return this.clientRepository.save(entity);
+    }
+
+    /**
+     * Bind the built-in global scopes through `auth_client_scopes`. That
+     * junction is the only source the /authorize code-request verifier reads
+     * scopes from.
+     *
+     * Additive like the attribute MERGE above: an extra scope an admin bound
+     * by hand is left in place.
+     */
+    protected async ensureScopes(client: Client): Promise<void> {
+        for (const name of WEB_CLIENT_SCOPE_NAMES) {
+            const scope = await this.scopeRepository.findOneBy({
+                name,
+                realmId: null,
+            });
+
+            if (!scope) {
+                if (this.logger) {
+                    this.logger.warn(
+                        `Skipping scope '${name}' for the web client of realm ${client.realmId}: the scope is not provisioned.`,
+                    );
+                }
+                continue;
+            }
+
+            const existing = await this.clientScopeRepository.findOneBy({
+                clientId: client.id,
+                scopeId: scope.id,
+            });
+
+            if (existing) {
+                continue;
+            }
+
+            await this.clientScopeRepository.save(this.clientScopeRepository.create({
+                clientId: client.id,
+                clientRealmId: client.realmId,
+                scopeId: scope.id,
+                scopeRealmId: scope.realmId,
+            }));
+        }
     }
 }

--- a/apps/server-core/src/core/entities/client/web-client.ts
+++ b/apps/server-core/src/core/entities/client/web-client.ts
@@ -129,13 +129,34 @@ export class WebClientProvisioner implements IWebClientProvisioner {
                 return existing;
             }
 
-            if (!existing.builtIn && this.logger) {
-                this.logger.warn(
-                    `Taking over the non-built-in client named '${CLIENT_WEB_NAME}' in realm ${realm.id}: the name is reserved for the built-in web client.`,
-                );
+            let target = existing;
+
+            if (!existing.builtIn) {
+                if (this.logger) {
+                    this.logger.warn(
+                        `Taking over the non-built-in client named '${CLIENT_WEB_NAME}' in realm ${realm.id}: the name is reserved for the built-in web client.`,
+                    );
+                }
+
+                // The takeover makes the client public, so a secret it carried
+                // as a confidential client can never authenticate it again.
+                // Drop it instead of leaving the material at rest.
+                //
+                // The row has to be re-read WITH the secret for that: `secret`
+                // is a `select: false` column, so the loaded entity carries no
+                // value for it and typeorm's changed-column diff would not
+                // emit the null. Re-reading is confined to this branch, and
+                // the secret stays out of `buildWebClientAttributes` for the
+                // same reason (an undefined-vs-null compare would read as
+                // dirty on every boot).
+                target = await this.clientRepository.findOneWithSecret({ id: existing.id }) || existing;
+                target.secret = null;
+                target.secretHashed = false;
+                target.secretEncrypted = false;
             }
 
-            const merged = this.clientRepository.merge(existing, attributes);
+            const merged = this.clientRepository.merge(target, attributes);
+
             return this.clientRepository.save(merged);
         }
 

--- a/apps/server-core/src/core/provisioning/entities/client/relations-validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/client/relations-validator.ts
@@ -47,5 +47,13 @@ export class ClientProvisioningRelationsValidator extends Container<ClientProvis
         this.mount('globalRoles', { optional: true }, createValidator(
             z.array(z.string()),
         ));
+
+        this.mount('realmScopes', { optional: true }, createValidator(
+            z.array(z.string()),
+        ));
+
+        this.mount('globalScopes', { optional: true }, createValidator(
+            z.array(z.string()),
+        ));
     }
 }

--- a/apps/server-core/src/core/provisioning/entities/client/types.ts
+++ b/apps/server-core/src/core/provisioning/entities/client/types.ts
@@ -42,6 +42,18 @@ export type ClientProvisioningRelations = {
      */
     globalRoles?: string[],
 
+    // ------------------------------------------
+
+    /**
+     * Assign client to scopes of same realm.
+     */
+    realmScopes?: string[],
+
+    /**
+     * Assign client to global scopes.
+     */
+    globalScopes?: string[],
+
 };
 
 export type ClientProvisioningEntity = BaseProvisioningEntity<Client> & {

--- a/apps/server-core/src/core/provisioning/synchronizer/client/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/client/module.ts
@@ -6,10 +6,12 @@
  */
 
 import type {
-    ClientPermission, 
-    ClientRole, 
-    Permission, 
+    ClientPermission,
+    ClientRole,
+    ClientScope,
+    Permission,
     Role,
+    Scope,
 } from '@authup/core-kit';
 import { pickRecord } from '@authup/kit';
 import type { IClientRepository } from '../../../entities/index.ts';
@@ -30,9 +32,13 @@ export class ClientProvisioningSynchronizer extends BaseProvisioningSynchronizer
 
     protected roleResolver: ProvisioningEntityResolver<Role>;
 
+    protected scopeResolver: ProvisioningEntityResolver<Scope>;
+
     protected permissionJunction: ProvisioningJunctionSynchronizer<ClientPermission>;
 
     protected roleJunction: ProvisioningJunctionSynchronizer<ClientRole>;
+
+    protected scopeJunction: ProvisioningJunctionSynchronizer<ClientScope>;
 
     protected permissionSynchronizer: IProvisioningSynchronizer<PermissionProvisioningEntity>;
 
@@ -45,6 +51,7 @@ export class ClientProvisioningSynchronizer extends BaseProvisioningSynchronizer
 
         this.permissionResolver = new ProvisioningEntityResolver(ctx.permissionRepository);
         this.roleResolver = new ProvisioningEntityResolver(ctx.roleRepository);
+        this.scopeResolver = new ProvisioningEntityResolver(ctx.scopeRepository, { clientScoped: false });
 
         this.permissionJunction = new ProvisioningJunctionSynchronizer({
             repository: ctx.clientPermissionRepository,
@@ -53,6 +60,11 @@ export class ClientProvisioningSynchronizer extends BaseProvisioningSynchronizer
         });
         this.roleJunction = new ProvisioningJunctionSynchronizer({
             repository: ctx.clientRoleRepository,
+            ownerKey: 'clientId',
+            ownerRealmKey: 'clientRealmId',
+        });
+        this.scopeJunction = new ProvisioningJunctionSynchronizer({
+            repository: ctx.clientScopeRepository,
             ownerKey: 'clientId',
             ownerRealmKey: 'clientRealmId',
         });
@@ -142,6 +154,29 @@ export class ClientProvisioningSynchronizer extends BaseProvisioningSynchronizer
                 roles,
                 'roleId',
                 'roleRealmId',
+            );
+        }
+
+        // Scopes (Global + Realm). The junction is the only source the
+        // /authorize code-request verifier reads scopes from.
+        const scopes = [
+            ...await this.scopeResolver.resolveGlobal(
+                input.relations && input.relations.globalScopes,
+            ),
+            ...(attributes.realmId ?
+                await this.scopeResolver.resolveRealm(
+                    input.relations && input.relations.realmScopes,
+                    attributes.realmId,
+                ) :
+                []),
+        ];
+
+        if (scopes.length > 0) {
+            await this.scopeJunction.synchronize(
+                attributes,
+                scopes,
+                'scopeId',
+                'scopeRealmId',
             );
         }
 

--- a/apps/server-core/src/core/provisioning/synchronizer/client/types.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/client/types.ts
@@ -9,8 +9,10 @@ import type {
     IClientPermissionRepository,
     IClientRepository,
     IClientRoleRepository,
+    IClientScopeRepository,
     IPermissionRepository,
     IRoleRepository,
+    IScopeRepository,
 } from '../../../entities/index.ts';
 import type { PermissionProvisioningEntity } from '../../entities/permission';
 import type { RoleProvisioningEntity } from '../../entities/role';
@@ -20,9 +22,11 @@ export type ClientProvisioningSynchronizerContext = {
     clientRepository: IClientRepository,
     clientRoleRepository: IClientRoleRepository,
     clientPermissionRepository: IClientPermissionRepository,
+    clientScopeRepository: IClientScopeRepository,
 
     roleRepository: IRoleRepository,
     permissionRepository: IPermissionRepository,
+    scopeRepository: IScopeRepository,
 
     roleSynchronizer: IProvisioningSynchronizer<RoleProvisioningEntity>,
     permissionSynchronizer: IProvisioningSynchronizer<PermissionProvisioningEntity>,

--- a/apps/server-core/src/core/provisioning/synchronizer/entity-resolver.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/entity-resolver.ts
@@ -7,77 +7,58 @@
 
 import type { ObjectLiteral } from '@authup/kit';
 import type { IEntityRepository } from '@authup/server-kit';
+import type { ProvisioningEntityResolverOptions } from './types.ts';
 
 export class ProvisioningEntityResolver<T extends ObjectLiteral = ObjectLiteral> {
     protected repository: IEntityRepository<T>;
 
-    constructor(repository: IEntityRepository<T>) {
+    protected clientScoped: boolean;
+
+    constructor(repository: IEntityRepository<T>, options: ProvisioningEntityResolverOptions = {}) {
         this.repository = repository;
+        this.clientScoped = options.clientScoped ?? true;
     }
 
     async resolveGlobal(names?: string[]): Promise<T[]> {
-        if (!names || names.length === 0) {
-            return [];
-        }
-
-        names = names.map((name) => name.trim().toLowerCase());
-
-        const hasWildcard = names.includes('*');
-        if (hasWildcard) {
-            return this.repository.findManyBy({
-                realmId: null,
-                clientId: null,
-            });
-        }
-
-        return this.repository.findManyBy({
-            name: names,
-            realmId: null,
-            clientId: null,
-        });
+        return this.resolve(names, { realmId: null });
     }
 
     async resolveRealm(names: string[] | undefined, realmId: string): Promise<T[]> {
-        if (!names || names.length === 0) {
-            return [];
-        }
-
-        names = names.map((name) => name.trim().toLowerCase());
-
-        const hasWildcard = names.includes('*');
-        if (hasWildcard) {
-            return this.repository.findManyBy({
-                realmId,
-                clientId: null,
-            });
-        }
-
-        return this.repository.findManyBy({
-            name: names,
-            realmId,
-            clientId: null,
-        });
+        return this.resolve(names, { realmId });
     }
 
     async resolveClient(names: string[] | undefined, realmId: string, clientId: string): Promise<T[]> {
+        return this.resolve(names, { realmId }, clientId);
+    }
+
+    protected async resolve(
+        names: string[] | undefined,
+        where: Record<string, any>,
+        clientId: string | null = null,
+    ): Promise<T[]> {
         if (!names || names.length === 0) {
             return [];
         }
 
         names = names.map((name) => name.trim().toLowerCase());
 
-        const hasWildcard = names.includes('*');
-        if (hasWildcard) {
-            return this.repository.findManyBy({
-                realmId,
+        // A client-ownable entity must never resolve another owner's rows, so
+        // the client dimension is always pinned. Entities without one (scope)
+        // opt out, because the predicate would not compile against the table.
+        const conditions = this.clientScoped ?
+            {
+                ...where,
                 clientId,
-            });
+            } :
+            where;
+
+        if (names.includes('*')) {
+            return this.repository.findManyBy(conditions);
         }
 
         return this.repository.findManyBy({
+            ...conditions,
             name: names,
-            realmId,
-            clientId,
         });
     }
 }

--- a/apps/server-core/src/core/provisioning/synchronizer/index.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/index.ts
@@ -14,4 +14,5 @@ export * from './realm/index.ts';
 export * from './role/index.ts';
 export * from './root/index.ts';
 export * from './scope/index.ts';
+export * from './types.ts';
 export * from './user/index.ts';

--- a/apps/server-core/src/core/provisioning/synchronizer/realm/module.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/realm/module.ts
@@ -78,6 +78,18 @@ export class RealmProvisioningSynchronizer extends BaseProvisioningSynchronizer<
             attributes = await this.repository.save(this.repository.create(input.attributes));
         }
 
+        // Scopes first: they are leaf entities carrying no relations of their
+        // own, and a client below may bind them through `realmScopes`.
+        if (input.relations && input.relations.scopes) {
+            const scopes = input.relations.scopes.map((child) => {
+                child.attributes.realmId = attributes.id;
+                child.attributes.realm = attributes;
+                return child;
+            });
+
+            await this.scopeSynchronizer.synchronizeMany(scopes);
+        }
+
         if (input.relations && input.relations.clients) {
             const clients = input.relations.clients.map(
                 (child) => {
@@ -118,16 +130,6 @@ export class RealmProvisioningSynchronizer extends BaseProvisioningSynchronizer<
             });
 
             await this.userSynchronizer.synchronizeMany(users);
-        }
-
-        if (input.relations && input.relations.scopes) {
-            const scopes = input.relations.scopes.map((child) => {
-                child.attributes.realmId = attributes.id;
-                child.attributes.realm = attributes;
-                return child;
-            });
-
-            await this.scopeSynchronizer.synchronizeMany(scopes);
         }
 
         return {

--- a/apps/server-core/src/core/provisioning/synchronizer/types.ts
+++ b/apps/server-core/src/core/provisioning/synchronizer/types.ts
@@ -1,0 +1,17 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+export type ProvisioningEntityResolverOptions = {
+    /**
+     * Whether the resolved entity carries a `clientId` column.
+     *
+     * Permissions and roles are client-ownable, so their lookups pin the
+     * client dimension. Scopes have none, so leaving the predicate in would
+     * make the query fail against the table. Defaults to true.
+     */
+    clientScoped?: boolean
+};

--- a/apps/server-core/test/data/sources/file.mts
+++ b/apps/server-core/test/data/sources/file.mts
@@ -53,7 +53,16 @@ const DATA : RootProvisioningEntity = {
                     { attributes: { name: 'foo' } },
                 ],
                 clients: [
-                    { attributes: { name: 'foo' } },
+                    {
+                        attributes: { name: 'foo' },
+                        relations: {
+                            globalScopes: ['foo'],
+                            realmScopes: ['realm-scope'],
+                        },
+                    },
+                ],
+                scopes: [
+                    { attributes: { name: 'realm-scope' } },
                 ],
                 roles: [
                     {

--- a/apps/server-core/test/unit/core/entities/client/web-client.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/web-client.spec.ts
@@ -8,6 +8,8 @@
 import { randomUUID } from 'node:crypto';
 import { Query } from '@rapiq/core';
 import { CLIENT_WEB_NAME, ScopeName } from '@authup/core-kit';
+import type { ClientScope } from '@authup/core-kit';
+import { FakeEntityRepository } from '@authup/server-test-kit';
 import {
     beforeEach,
     describe,
@@ -15,9 +17,11 @@ import {
     it,
 } from 'vitest';
 import {
+    WEB_CLIENT_SCOPE_NAMES,
     WebClientProvisioner,
     buildWebClientAttributes,
 } from '../../../../../src/core/entities/client/web-client.ts';
+import { FakeScopeRepository } from '../scope/fake-repository.ts';
 import { FakeClientRepository } from './fake-repository.ts';
 
 describe('core/entities/client/web-client', () => {
@@ -43,12 +47,35 @@ describe('core/entities/client/web-client', () => {
 
     describe('WebClientProvisioner.ensureForRealm', () => {
         let repository: FakeClientRepository;
+        let scopeRepository: FakeScopeRepository;
+        let clientScopeRepository: FakeEntityRepository<ClientScope>;
         let provisioner: WebClientProvisioner;
+
+        const readScopeNames = async (clientId: string) => {
+            const rows = await clientScopeRepository.findManyBy({ clientId });
+            const scopes = await Promise.all(
+                rows.map((row) => scopeRepository.findOneById(row.scopeId)),
+            );
+
+            return scopes.map((scope) => scope!.name).sort();
+        };
 
         beforeEach(() => {
             repository = new FakeClientRepository();
+            scopeRepository = new FakeScopeRepository();
+            clientScopeRepository = new FakeEntityRepository<ClientScope>();
+
+            // The built-in scopes are provisioned globally (realmId: null).
+            scopeRepository.seed(WEB_CLIENT_SCOPE_NAMES.map((name) => ({
+                name,
+                realmId: null,
+                builtIn: true,
+            })));
+
             provisioner = new WebClientProvisioner({
                 clientRepository: repository,
+                scopeRepository,
+                clientScopeRepository,
                 appOrigins,
             });
         });
@@ -68,6 +95,48 @@ describe('core/entities/client/web-client', () => {
             expect(created!.tokenBindingMethod).toBe('none');
         });
 
+        // Regression (#3347): the declared `global openid` used to land in the
+        // dead `scope` column only, leaving the client with no junction rows.
+        // That junction is the sole source /authorize resolves scopes from.
+        it('should bind the built-in scopes through the junction', async () => {
+            const realmId = randomUUID();
+            await provisioner.ensureForRealm({ id: realmId });
+
+            const client = await repository.findOneBy({
+                name: CLIENT_WEB_NAME,
+                realmId,
+            });
+
+            expect(await readScopeNames(client!.id)).toEqual(
+                [...WEB_CLIENT_SCOPE_NAMES].sort(),
+            );
+
+            const rows = await clientScopeRepository.findManyBy({ clientId: client!.id });
+            expect(rows.every((row) => row.clientRealmId === realmId)).toBe(true);
+            expect(rows.every((row) => row.scopeRealmId === null)).toBe(true);
+        });
+
+        it('should backfill missing scope rows for an already-provisioned client', async () => {
+            const realmId = randomUUID();
+            await provisioner.ensureForRealm({ id: realmId });
+
+            const client = await repository.findOneBy({
+                name: CLIENT_WEB_NAME,
+                realmId,
+            });
+
+            // Drop the rows an instance provisioned before #3347 never had:
+            // the client attributes are already current, so the dirty-check
+            // short-circuits and the scopes must still be restored.
+            clientScopeRepository.clear();
+
+            await provisioner.ensureForRealm({ id: realmId });
+
+            expect(await readScopeNames(client!.id)).toEqual(
+                [...WEB_CLIENT_SCOPE_NAMES].sort(),
+            );
+        });
+
         it('should be idempotent across repeated runs', async () => {
             const realmId = randomUUID();
 
@@ -80,6 +149,48 @@ describe('core/entities/client/web-client', () => {
             );
 
             expect(webClients).toHaveLength(1);
+            expect(clientScopeRepository.getAll()).toHaveLength(WEB_CLIENT_SCOPE_NAMES.length);
+        });
+
+        it('should keep a scope bound by hand', async () => {
+            const realmId = randomUUID();
+            await provisioner.ensureForRealm({ id: realmId });
+
+            const client = await repository.findOneBy({
+                name: CLIENT_WEB_NAME,
+                realmId,
+            });
+            const extra = scopeRepository.seed({
+                name: 'custom',
+                realmId,
+            });
+            clientScopeRepository.seed({
+                clientId: client!.id,
+                clientRealmId: realmId,
+                scopeId: extra.id,
+                scopeRealmId: realmId,
+            });
+
+            await provisioner.ensureForRealm({ id: realmId });
+
+            expect(await readScopeNames(client!.id)).toEqual(
+                [...WEB_CLIENT_SCOPE_NAMES, 'custom'].sort(),
+            );
+        });
+
+        it('should skip an unprovisioned scope', async () => {
+            const realmId = randomUUID();
+            scopeRepository.clear();
+
+            await provisioner.ensureForRealm({ id: realmId });
+
+            const client = await repository.findOneBy({
+                name: CLIENT_WEB_NAME,
+                realmId,
+            });
+
+            expect(client).not.toBeNull();
+            expect(clientScopeRepository.getAll()).toHaveLength(0);
         });
 
         it('should refresh redirectUri on an existing built-in web client', async () => {
@@ -93,7 +204,7 @@ describe('core/entities/client/web-client', () => {
                     authMethod: 'none',
                     tokenBindingMethod: 'none',
                     redirectUri: 'http://stale.example.com/**',
-                } as any,
+                },
             ]);
 
             await provisioner.ensureForRealm({ id: realmId });
@@ -108,7 +219,10 @@ describe('core/entities/client/web-client', () => {
             );
         });
 
-        it('should not overwrite a non-built-in client named web', async () => {
+        // `web` is a reserved client name, so the row belongs to the system: a
+        // non-built-in one predates the reservation and must not shadow the
+        // realm's login client.
+        it('should take over a non-built-in client named web', async () => {
             const realmId = randomUUID();
             repository.seed([
                 {
@@ -119,7 +233,7 @@ describe('core/entities/client/web-client', () => {
                     authMethod: 'secret',
                     tokenBindingMethod: 'none',
                     redirectUri: 'http://user-owned.example.com/**',
-                } as any,
+                },
             ]);
 
             await provisioner.ensureForRealm({ id: realmId });
@@ -129,9 +243,14 @@ describe('core/entities/client/web-client', () => {
                 realmId,
             });
 
-            expect(existing!.builtIn).toBe(false);
-            expect(existing!.authMethod).toBe('secret');
-            expect(existing!.redirectUri).toBe('http://user-owned.example.com/**');
+            expect(existing!.builtIn).toBe(true);
+            expect(existing!.authMethod).toBe('none');
+            expect(existing!.redirectUri).toBe(
+                'http://localhost:3000/**,https://app.example.com/**',
+            );
+            expect(await readScopeNames(existing!.id)).toEqual(
+                [...WEB_CLIENT_SCOPE_NAMES].sort(),
+            );
         });
     });
 });

--- a/apps/server-core/test/unit/core/entities/client/web-client.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/web-client.spec.ts
@@ -232,6 +232,7 @@ describe('core/entities/client/web-client', () => {
                     builtIn: false,
                     authMethod: 'secret',
                     tokenBindingMethod: 'none',
+                    secret: 'legacy-secret',
                     redirectUri: 'http://user-owned.example.com/**',
                 },
             ]);
@@ -248,6 +249,9 @@ describe('core/entities/client/web-client', () => {
             expect(existing!.redirectUri).toBe(
                 'http://localhost:3000/**,https://app.example.com/**',
             );
+            // the client is public now, so its secret can never authenticate
+            // it again and must not stay at rest
+            expect(existing!.secret).toBeNull();
             expect(await readScopeNames(existing!.id)).toEqual(
                 [...WEB_CLIENT_SCOPE_NAMES].sort(),
             );

--- a/apps/server-core/test/unit/core/entities/scope/fake-repository.ts
+++ b/apps/server-core/test/unit/core/entities/scope/fake-repository.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Scope } from '@authup/core-kit';
+import { FakeEntityRepository } from '@authup/server-test-kit';
+import type { IScopeRepository } from '../../../../../src/core/entities/scope/types.ts';
+
+export class FakeScopeRepository extends FakeEntityRepository<Scope> implements IScopeRepository {
+    async checkUniqueness(): Promise<void> {
+        // no-op
+    }
+}

--- a/apps/server-core/test/unit/core/entities/scope/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/scope/service.spec.ts
@@ -7,7 +7,6 @@
 
 import { randomUUID } from 'node:crypto';
 import { PermissionName } from '@authup/core-kit';
-import type { Scope } from '@authup/core-kit';
 import {
     beforeEach, 
     describe, 
@@ -16,9 +15,7 @@ import {
 } from 'vitest';
 import { ErrorCode } from '@authup/errors';
 import { ScopeService } from '../../../../../src/core/entities/scope/service.ts';
-import type { IScopeRepository } from '../../../../../src/core/entities/scope/types.ts';
 import { 
-    FakeEntityRepository, 
     createAllowAllActor, 
     createDenyAllActor, 
     createMasterRealmActor, 
@@ -26,12 +23,7 @@ import {
 } from '@authup/server-test-kit';
 import { FakeRealmRepository } from '../realm/fake-repository.ts';
 import { createFakeScope } from '../../../../utils/domains/index.ts';
-
-class FakeScopeRepository extends FakeEntityRepository<Scope> implements IScopeRepository {
-    async checkUniqueness(): Promise<void> {
-        // no-op
-    }
-}
+import { FakeScopeRepository } from './fake-repository.ts';
 
 describe('core/entities/scope/service', () => {
     let repository: FakeScopeRepository;

--- a/apps/server-core/test/unit/core/provisioning/synchronizer/entity-resolver.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/synchronizer/entity-resolver.spec.ts
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { ObjectLiteral } from '@authup/kit';
+import { FakeEntityRepository } from '@authup/server-test-kit';
+import { 
+    beforeEach, 
+    describe, 
+    expect, 
+    it, 
+} from 'vitest';
+import { ProvisioningEntityResolver } from '../../../../../src/core/provisioning/synchronizer/entity-resolver.ts';
+
+class RecordingRepository extends FakeEntityRepository<ObjectLiteral> {
+    public calls: Record<string, any>[] = [];
+
+    async findManyBy(where: Record<string, any>): Promise<ObjectLiteral[]> {
+        this.calls.push(where);
+        return [];
+    }
+}
+
+describe('core/provisioning/synchronizer/entity-resolver', () => {
+    let repository: RecordingRepository;
+
+    const realmId = 'realm-1';
+    const clientId = 'client-1';
+
+    beforeEach(() => {
+        repository = new RecordingRepository();
+    });
+
+    describe('client-scoped (permissions, roles)', () => {
+        let resolver: ProvisioningEntityResolver;
+
+        beforeEach(() => {
+            resolver = new ProvisioningEntityResolver(repository);
+        });
+
+        it.each([
+            ['no names', undefined],
+            ['empty names', []],
+        ])('should short-circuit on %s', async (_label, names) => {
+            expect(await resolver.resolveGlobal(names)).toEqual([]);
+            expect(await resolver.resolveRealm(names, realmId)).toEqual([]);
+            expect(await resolver.resolveClient(names, realmId, clientId)).toEqual([]);
+            expect(repository.calls).toHaveLength(0);
+        });
+
+        // The client dimension must stay pinned: without it a global lookup
+        // would also match another client's rows.
+        it('should pin realm and client for a global lookup', async () => {
+            await resolver.resolveGlobal(['foo']);
+
+            expect(repository.calls[0]).toEqual({
+                name: ['foo'],
+                realmId: null,
+                clientId: null,
+            });
+        });
+
+        it('should pin realm and client for a realm lookup', async () => {
+            await resolver.resolveRealm(['foo'], realmId);
+
+            expect(repository.calls[0]).toEqual({
+                name: ['foo'],
+                realmId,
+                clientId: null,
+            });
+        });
+
+        it('should pin the owning client for a client lookup', async () => {
+            await resolver.resolveClient(['foo'], realmId, clientId);
+
+            expect(repository.calls[0]).toEqual({
+                name: ['foo'],
+                realmId,
+                clientId,
+            });
+        });
+
+        it('should drop the name predicate on a wildcard', async () => {
+            await resolver.resolveGlobal(['*']);
+            await resolver.resolveRealm(['*'], realmId);
+            await resolver.resolveClient(['*'], realmId, clientId);
+
+            expect(repository.calls).toEqual([
+                {
+                    realmId: null,
+                    clientId: null,
+                },
+                {
+                    realmId,
+                    clientId: null,
+                },
+                {
+                    realmId,
+                    clientId,
+                },
+            ]);
+        });
+
+        it('should canonicalize names', async () => {
+            await resolver.resolveGlobal([' Foo ', 'BAR']);
+
+            expect(repository.calls[0].name).toEqual(['foo', 'bar']);
+        });
+    });
+
+    // Scopes carry no `clientId` column, so the pinned predicate would not
+    // compile against the table.
+    describe('not client-scoped (scopes)', () => {
+        let resolver: ProvisioningEntityResolver;
+
+        beforeEach(() => {
+            resolver = new ProvisioningEntityResolver(repository, { clientScoped: false });
+        });
+
+        it('should omit the client predicate entirely', async () => {
+            await resolver.resolveGlobal(['foo']);
+            await resolver.resolveRealm(['foo'], realmId);
+            await resolver.resolveGlobal(['*']);
+
+            expect(repository.calls).toEqual([
+                {
+                    name: ['foo'],
+                    realmId: null,
+                },
+                {
+                    name: ['foo'],
+                    realmId,
+                },
+                { realmId: null },
+            ]);
+        });
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
@@ -12,8 +12,9 @@ import {
     it,
 } from 'vitest';
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
-import { ScopeName } from '@authup/core-kit';
+import { CLIENT_WEB_NAME, REALM_MASTER_NAME, ScopeName } from '@authup/core-kit';
 import { OAuth2AuthorizationResponseType } from '@authup/specs';
+import { generateOAuth2CodeVerifier } from '../../../../../src/core';
 import { createFakeClient, expectClientError } from '../../../../utils';
 import { createTestApplication } from '../../../../app';
 
@@ -94,6 +95,36 @@ describe('src/http/controllers/token', () => {
                 (issue) => issue.path.includes('response_type'),
             )).toBe(true);
         }
+    });
+
+    // Regression (#3347): the per-realm built-in `web` client declared its
+    // scopes in the `scope` column only and held no auth_client_scopes rows,
+    // so the verifier saw an empty granted set. A plain OIDC scope=openid
+    // request failed with insufficient_scope; only requests carrying `global`
+    // slipped through, via the verifier's bypass.
+    it('should authorize the built-in web client with scope=openid alone', async () => {
+        const { data: realm } = await suite.client.realm.getOne(REALM_MASTER_NAME);
+        const { data: webClients } = await suite.client.client.getMany({
+            filters: {
+                name: CLIENT_WEB_NAME,
+                realmId: realm.id,
+            },
+        });
+
+        expect(webClients).toHaveLength(1);
+
+        // the web client is public: PKCE + state are mandatory, and its
+        // redirect patterns cover the trusted dev origin
+        const response = await suite.client.authorize.confirm({
+            response_type: OAuth2AuthorizationResponseType.CODE,
+            client_id: webClients[0].id,
+            redirect_uri: 'http://localhost:3000/login/callback',
+            scope: ScopeName.OPEN_ID,
+            state: generateOAuth2CodeVerifier(),
+            code_challenge: generateOAuth2CodeVerifier(),
+        });
+
+        expect(new URL(response.url).searchParams.get('code')).toBeTruthy();
     });
 
     it('should NOT advertise implicit/hybrid response types in discovery', async () => {

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -9,12 +9,15 @@ import { BuiltInPolicyType, SystemPolicyName } from '@authup/access';
 import type { CompositePolicy } from '@authup/access';
 import { DecisionStrategy } from '@authup/kit';
 import type {
- 
-    Permission, 
-    PermissionPolicy, 
-    Realm, 
-    Role, 
+
+    Client,
+    ClientScope,
+    Permission,
+    PermissionPolicy,
+    Realm,
+    Role,
 } from '@authup/core-kit';
+import { CLIENT_WEB_NAME, REALM_MASTER_NAME } from '@authup/core-kit';
 import type { DataSource, Repository } from 'typeorm';
 import { IsNull } from 'typeorm';
 import {
@@ -26,6 +29,8 @@ import {
 } from 'vitest';
 import {
     CacheModule, 
+    ClientEntity,
+    ClientScopeEntity,
     ConfigModule,
     DefaultProvisioningSource,
     FileProvisioningSource,
@@ -38,7 +43,7 @@ import {
 } from '../../../src/index.ts';
 import { Container } from 'eldin';
 import type { IContainer } from 'eldin';
-import { PolicyProvisioningSynchronizer } from '../../../src/core/index.ts';
+import { PolicyProvisioningSynchronizer, WEB_CLIENT_SCOPE_NAMES } from '../../../src/core/index.ts';
 import type { PolicyProvisioningEntity } from '../../../src/core/provisioning/entities/policy/index.ts';
 import { PolicyRepository } from '../../../src/adapters/database/domains/index.ts';
 import {
@@ -157,6 +162,60 @@ describe('app/modules/provisioning', () => {
             policyId: filePolicy!.id,
         });
         expect(junction).toBeDefined();
+    });
+
+    // The junction is the only source /authorize resolves client scopes from,
+    // so a declared scope that never reaches it is not granted at all (#3347).
+    it('should bind declared client scopes through the junction', async () => {
+        const provisioning = new ProvisionerModule([
+            new FileProvisioningSource({ cwd: 'test/data/sources' }),
+        ]);
+        await provisioning.setup(di);
+
+        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
+        const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
+        const clientScopeRepository = di.resolve<Repository<ClientScope>>(ClientScopeEntity);
+
+        const realm = await realmRepository.findOneBy({ name: 'foo' });
+        const client = await clientRepository.findOneBy({
+            name: 'foo',
+            realmId: realm!.id,
+        });
+
+        const rows = await clientScopeRepository.find({
+            where: { clientId: client!.id },
+            relations: { scope: true },
+        });
+
+        expect(rows.map((row) => row.scope.name).sort()).toEqual(['foo', 'realm-scope']);
+    });
+
+    // Every realm carries a public `web` client, and its provisioned scopes
+    // must reach the junction as well (#3347).
+    it('should bind the web client scopes through the junction', async () => {
+        const provisioning = new ProvisionerModule([
+            new DefaultProvisioningSource(),
+        ]);
+        await provisioning.setup(di);
+
+        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
+        const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
+        const clientScopeRepository = di.resolve<Repository<ClientScope>>(ClientScopeEntity);
+
+        const realm = await realmRepository.findOneBy({ name: REALM_MASTER_NAME });
+        const client = await clientRepository.findOneBy({
+            name: CLIENT_WEB_NAME,
+            realmId: realm!.id,
+        });
+
+        const rows = await clientScopeRepository.find({
+            where: { clientId: client!.id },
+            relations: { scope: true },
+        });
+
+        expect(rows.map((row) => row.scope.name).sort()).toEqual(
+            [...WEB_CLIENT_SCOPE_NAMES].sort(),
+        );
     });
 
     // ---------------------------------------------------------------

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -17,7 +17,12 @@ import type {
     Realm,
     Role,
 } from '@authup/core-kit';
-import { CLIENT_WEB_NAME, REALM_MASTER_NAME } from '@authup/core-kit';
+import {
+    CLIENT_WEB_NAME,
+    ClientAuthMethod,
+    ClientTokenBindingMethod,
+    REALM_MASTER_NAME,
+} from '@authup/core-kit';
 import type { DataSource, Repository } from 'typeorm';
 import { IsNull } from 'typeorm';
 import {
@@ -162,58 +167,91 @@ describe('app/modules/provisioning', () => {
             policyId: filePolicy!.id,
         });
         expect(junction).toBeDefined();
-    });
 
-    // The junction is the only source /authorize resolves client scopes from,
-    // so a declared scope that never reaches it is not granted at all (#3347).
-    it('should bind declared client scopes through the junction', async () => {
-        const provisioning = new ProvisionerModule([
-            new FileProvisioningSource({ cwd: 'test/data/sources' }),
-        ]);
-        await provisioning.setup(di);
-
-        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
+        // The junction is the only source /authorize resolves client scopes
+        // from, so a declared scope that never reaches it is not granted at
+        // all (#3347). The fixture client declares one global and one realm
+        // scope, and realm scopes must synchronize before the realm's clients
+        // for the latter to resolve.
         const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
         const clientScopeRepository = di.resolve<Repository<ClientScope>>(ClientScopeEntity);
 
-        const realm = await realmRepository.findOneBy({ name: 'foo' });
         const client = await clientRepository.findOneBy({
             name: 'foo',
             realmId: realm!.id,
         });
 
-        const rows = await clientScopeRepository.find({
+        const clientScopes = await clientScopeRepository.find({
             where: { clientId: client!.id },
             relations: { scope: true },
         });
 
-        expect(rows.map((row) => row.scope.name).sort()).toEqual(['foo', 'realm-scope']);
+        expect(clientScopes.map((row) => row.scope.name).sort()).toEqual(['foo', 'realm-scope']);
     });
 
-    // Every realm carries a public `web` client, and its provisioned scopes
-    // must reach the junction as well (#3347).
-    it('should bind the web client scopes through the junction', async () => {
+    // Every realm carries a public `web` client whose provisioned scopes must
+    // reach the junction (#3347). `web` is also a reserved client name, so a
+    // non-built-in row predates the reservation and must not shadow the
+    // realm's login client.
+    it('should provision the web client of every realm with its scopes', async () => {
+        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
+        const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
+        const clientScopeRepository = di.resolve<Repository<ClientScope>>(ClientScopeEntity);
+
+        // A legacy realm holding a confidential client on the reserved name.
+        const legacyRealm = await realmRepository.save(realmRepository.create({ name: 'takeover' }));
+        await clientRepository.save(clientRepository.create({
+            name: CLIENT_WEB_NAME,
+            realmId: legacyRealm.id,
+            builtIn: false,
+            authMethod: ClientAuthMethod.SECRET,
+            tokenBindingMethod: ClientTokenBindingMethod.NONE,
+            secret: 'legacy-secret',
+            secretHashed: false,
+            redirectUri: 'http://user-owned.example.com/**',
+        }));
+
         const provisioning = new ProvisionerModule([
             new DefaultProvisioningSource(),
         ]);
         await provisioning.setup(di);
 
-        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
-        const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
-        const clientScopeRepository = di.resolve<Repository<ClientScope>>(ClientScopeEntity);
+        const readScopeNames = async (clientId: string) => {
+            const rows = await clientScopeRepository.find({
+                where: { clientId },
+                relations: { scope: true },
+            });
 
-        const realm = await realmRepository.findOneBy({ name: REALM_MASTER_NAME });
-        const client = await clientRepository.findOneBy({
+            return rows.map((row) => row.scope.name).sort();
+        };
+
+        const masterRealm = await realmRepository.findOneBy({ name: REALM_MASTER_NAME });
+        const masterWebClient = await clientRepository.findOneBy({
             name: CLIENT_WEB_NAME,
-            realmId: realm!.id,
+            realmId: masterRealm!.id,
         });
 
-        const rows = await clientScopeRepository.find({
-            where: { clientId: client!.id },
-            relations: { scope: true },
-        });
+        expect(await readScopeNames(masterWebClient!.id)).toEqual(
+            [...WEB_CLIENT_SCOPE_NAMES].sort(),
+        );
 
-        expect(rows.map((row) => row.scope.name).sort()).toEqual(
+        // `secret` is a select:false column, so read it back explicitly.
+        const legacyClient = await clientRepository
+            .createQueryBuilder('client')
+            .addSelect('client.secret')
+            .where('client.name = :name', { name: CLIENT_WEB_NAME })
+            .andWhere('client.realmId = :realmId', { realmId: legacyRealm.id })
+            .getOne();
+
+        expect(legacyClient!.builtIn).toBe(true);
+        expect(legacyClient!.authMethod).toBe(ClientAuthMethod.NONE);
+        expect(legacyClient!.redirectUri).not.toBe('http://user-owned.example.com/**');
+
+        // The client is public now, so the secret can never authenticate it
+        // again and must not stay at rest.
+        expect(legacyClient!.secret).toBeNull();
+
+        expect(await readScopeNames(legacyClient!.id)).toEqual(
             [...WEB_CLIENT_SCOPE_NAMES].sort(),
         );
     });

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -336,6 +336,12 @@ Clients (OAuth2 applications) must be nested inside a realm.
 | `realmPermissions`  | `string[]`                    | Assign realm permissions. `'*'` = all.                  |
 | `globalRoles`       | `string[]`                    | Assign global roles. `'*'` = all.                       |
 | `realmRoles`        | `string[]`                    | Assign realm roles. `'*'` = all.                        |
+| `globalScopes`      | `string[]`                    | Assign global scopes. `'*'` = all.                      |
+| `realmScopes`       | `string[]`                    | Assign realm scopes. `'*'` = all.                       |
+
+Assigned scopes are what the authorization endpoint grants the client. A client
+with none of them can only be authorized for requests that include the `global`
+scope.
 
 ## Strategies
 


### PR DESCRIPTION
Closes #3347 (provisioning half; the dead-column removal is deliberately out of scope, see below).

## The bug

`buildWebClientAttributes` wrote the per-realm `web` client's intended scopes into `auth_clients.scope`, but `/authorize` resolves scopes exclusively through the `auth_client_scopes` junction (`OAuth2ScopeRepository.findByClientId`). No junction rows were ever created, so the declared `global openid` was never enforced.

With an empty granted set the code-request verifier behaves like this:

| Request | Outcome |
|---|---|
| `scope=global openid` | passes, via the `global` bypass |
| `scope=openid` | `insufficient_scope` |
| no `scope` param | code issued with `scope=''` |

Authup's own clients always send `global openid`, so the gap only surfaced for a non-kit RP performing a standard OIDC `scope=openid` request against a realm's built-in `web` client.

## Changes

- **`WebClientProvisioner.ensureForRealm`** binds `global` + `openid` as `auth_client_scopes` rows, driven by a shared `WEB_CLIENT_SCOPE_NAMES` so the descriptive column cannot drift from what is actually granted. The binding runs outside the attribute dirty-check: an instance provisioned before the rows existed carries an up-to-date client with no scopes at all, and must be backfilled on the next boot. Additive like the attribute merge, so a scope an admin bound by hand survives.
- **`ClientProvisioningRelations` gains `globalScopes` / `realmScopes`.** There was no provisioning path to `auth_client_scopes` for any client, not just `web` (the contributing factor named in the issue).
- **Realm-level scopes now synchronize before the realm's clients.** Otherwise a `realmScopes` entry could not reference a scope declared in the same realm block. Scopes are leaf entities with no relations of their own, so moving them first is safe.
- **`ProvisioningEntityResolver` takes a `clientScoped` option.** `auth_scopes` has no `clientId` column, so the always-pinned client predicate would not compile against it.
- **An existing client named `web` is taken over rather than skipped.** The name is reserved (`CLIENT_RESERVED_NAMES`), so a non-built-in row predates the reservation and must not shadow the realm's login client. Note the consequence: such a client is converted to public / `builtIn` with the trusted-origin redirect patterns, so an integration still using it with a secret stops working.

## Verification

- `authorize.spec.ts` gains the issue's exact reproduction (`scope=openid` alone against the master realm's `web` client). Confirmed red with the scope binding disabled, green with it.
- Unit coverage for junction binding, backfill of an already-current client, idempotency, hand-bound scope preservation, unprovisioned-scope skip, and the takeover.
- `provisioning.spec.ts` covers both file-declared client scopes and the `web` client end to end.
- Full server-core suite green (1787 tests), plus build, `check:types` and eslint.

## Out of scope

The dead columns (`Client.scope`, `baseUrl`, `rootUrl`) are untouched. Dropping them needs a generated migration on top of #3352, and the decision applies to all three at once. `Client.scope` is now documented in code and in `.agents/architecture.md` as descriptive only, with the junction named as the authorization source.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clients can now be provisioned with global and realm-specific scopes.
  * Built-in web clients automatically receive and maintain their required scope assignments.
  * Existing clients missing scope assignments are updated automatically.

* **Bug Fixes**
  * Corrected authorization for the web client when requesting OpenID scope.
  * Preserved manually assigned scopes and skipped unavailable scopes safely.

* **Documentation**
  * Added provisioning guidance for configuring client scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->