### PR TITLE
fix: a user (or client) never moves between realms

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -995,6 +995,57 @@ if (!validated.realmId && actor.identity) {
 
 To create a global entity (`realmId: null`), the caller must explicitly pass `realmId: null`. The policy engine controls whether the actor is authorized to do so.
 
+### Realm immutability (an entity never moves between realms)
+
+An entity's realm is fixed at creation. Every entity validator mounts `realmId`
+for `CREATE` / `PROVISIONING` only, so a `realmId` submitted on `POST /<entity>/:id`
+is silently stripped by the validator and `merge()` never sees it. There is no
+"move to another realm" operation and none is planned.
+
+The reason is denormalization. A user's realm is copied into
+`auth_user_roles.user_realm_id`, `auth_user_permissions.user_realm_id` and
+`auth_identity_provider_accounts.user_realm_id`, and every per-user child row
+carries its own `realm_id` (`auth_user_attributes`, `auth_user_authenticators`,
+`auth_sessions`, `auth_consents`). A client's realm is copied the same way into
+`auth_client_roles` / `auth_client_permissions` / `auth_client_scopes`. Those
+copies are what the `realmScope` reach factor evaluates against
+(`JunctionEntityService.junctionResourceRealm`), so moving the parent row alone
+would leave every grant and child row stranded in the old realm: still
+readable/writable by the old realm's admins, invisible to the new one. A real
+move would have to rewrite all of them plus re-verify that the target realm
+actually holds the referenced roles, permissions and scopes.
+
+Consequences to keep in mind when touching these paths:
+
+- The realm-scoped lookup in `save()` (`where.realmId = <resolved body/route realm>`)
+  means an update carrying a **foreign** realm key finds nothing:
+  `POST /users/:id` answers `404` rather than moving the row. That is also the
+  correct answer for the nested `/realms/:realmId/users/:id` mount (the row is
+  not in that realm), and it deliberately reveals nothing about the row's real
+  realm.
+- The `PUT /<entity>/:key` upsert takes the same scoped lookup, so a foreign
+  realm key makes it miss. **Only a NAME key may then create** ("ensure an
+  entity with this name exists in this realm"); a UUID key addresses one
+  specific row, so a miss is `EntityNotFoundError` instead. Without that rule
+  the upsert answered a realm change by writing a **second** row (a fresh id,
+  same name) into the target realm, which reads like a move in the
+  realm-scoped UI. The guard is one condition
+  (`if (!entity && (options.updateOnly || where.id))`) in every `save()` that
+  upserts: role, user, scope, permission, client, policy, realm, plus
+  `IdentityProviderController.write()`.
+- Realm pickers in the kit's entity forms are **create-time controls**
+  (`AUserForm`, `AClientForm`, `APolicyBasicForm`, ... all gate them on
+  `!isEditing`). Rendering one on an existing record promises a move the API
+  will not perform.
+- The `*_SELF_MANAGE` denylists (`system.user-names-self-manage`,
+  `system.client-names-self-manage`) list `realmId` as well, so the strip is
+  backed by an explicit policy rejection on the self-edit path.
+
+Pinned by *should strip realmId at UPDATE for realm bound entities*
+(`packages/core-kit/test/unit/domains/validator-groups.spec.ts`) and *should not
+move the user to another realm*
+(`apps/server-core/test/unit/core/entities/user/service.spec.ts`).
+
 ### Realm reach is a coarse `realmScope` enum on the grant (NOT a policy)
 
 There is no special "master realm" bypass, and realm reach is **not** a policy. Each

--- a/apps/client-web/pages/settings/index/index.vue
+++ b/apps/client-web/pages/settings/index/index.vue
@@ -26,7 +26,7 @@ export default defineComponent({
 
         const {
             user,
-            userId,
+            realmId,
         } = storeToRefs(store);
 
         const translationsDefault = useTranslations([
@@ -53,7 +53,7 @@ export default defineComponent({
 
         return {
             user,
-            userId,
+            realmId,
             handleUpdated,
             handleFailed,
             translationsDefault,
@@ -68,7 +68,7 @@ export default defineComponent({
         </h6>
         <UserForm
             :can-manage="false"
-            :realm-id="userId"
+            :realm-id="realmId"
             :entity="user"
             @updated="handleUpdated"
             @failed="handleFailed"

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -433,7 +433,9 @@ export class IdentityProviderController {
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -154,7 +154,9 @@ export class ClientService extends AbstractEntityService implements IClientServi
             }
 
             entity = await this.repository.findOneWithSecret(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/permission/service.ts
+++ b/apps/server-core/src/core/entities/permission/service.ts
@@ -185,7 +185,9 @@ export class PermissionService extends AbstractEntityService implements IPermiss
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/policy/service.ts
+++ b/apps/server-core/src/core/entities/policy/service.ts
@@ -131,7 +131,9 @@ export class PolicyService extends AbstractEntityService implements IPolicyServi
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -104,7 +104,9 @@ export class RealmService extends AbstractEntityService implements IRealmService
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/role/service.ts
+++ b/apps/server-core/src/core/entities/role/service.ts
@@ -121,7 +121,9 @@ export class RoleService extends AbstractEntityService implements IRoleService {
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/scope/service.ts
+++ b/apps/server-core/src/core/entities/scope/service.ts
@@ -120,7 +120,9 @@ export class ScopeService extends AbstractEntityService implements IScopeService
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -220,7 +220,9 @@ export class UserService extends AbstractEntityService implements IUserService {
             }
 
             entity = await this.repository.findOneBy(where);
-            if (!entity && options.updateOnly) {
+            // Only a NAME key may upsert-create. A UUID addresses one specific
+            // row, so a miss is a 404 (creating would write a different id).
+            if (!entity && (options.updateOnly || where.id)) {
                 throw new EntityNotFoundError();
             }
         } else if (options.updateOnly) {

--- a/apps/server-core/test/unit/core/entities/user/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user/service.spec.ts
@@ -338,6 +338,40 @@ describe('core/entities/user/service', () => {
             const result = await service.update(entity.id, { password: 'new-pass-123' }, createAllowAllActor());
             expect(result.password).toMatch(/^\$2[aby]\$/);
         });
+
+        // The realm is immutable after creation. The junction rows and every
+        // per-user child table denormalize it, so a move would strand them.
+        it('should ignore a submitted realmId that matches the own realm', async () => {
+            const realm = realmRepository.getMasterRealm();
+            const entity = repository.seed(createFakeUser({ realmId: realm.id }));
+
+            const result = await service.update(
+                entity.id,
+                {
+                    displayName: 'New Display',
+                    realmId: realm.id,
+                },
+                createAllowAllActor(),
+            );
+
+            expect(result.displayName).toBe('New Display');
+            expect(result.realmId).toBe(realm.id);
+        });
+
+        it('should not move the user to another realm', async () => {
+            const realm = realmRepository.getMasterRealm();
+            const [target] = realmRepository.seed([{
+                id: randomUUID(),
+                name: 'target',
+            }]);
+            const entity = repository.seed(createFakeUser({ realmId: realm.id }));
+
+            await expect(
+                service.update(entity.id, { realmId: target.id }, createAllowAllActor()),
+            ).rejects.toMatchObject({ code: ErrorCode.ENTITY_NOT_FOUND });
+
+            expect((await repository.findOneById(entity.id))!.realmId).toBe(realm.id);
+        });
     });
 
     describe('self-edit fallback', () => {

--- a/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user.spec.ts
@@ -5,17 +5,24 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import {
-    afterAll, 
-    beforeAll, 
-    describe, 
-    expect, 
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
     it,
 } from 'vitest';
 import type { User } from '@authup/core-kit';
 import type { UserCreatePayload } from '@authup/core-http-kit';
+import { ErrorCode } from '@authup/errors';
 import { createTestApplication } from '../../../../app';
-import { createFakeUser, expectPropertiesEqualToSrc } from '../../../../utils';
+import {
+    createFakeRealm,
+    createFakeUser,
+    expectClientError,
+    expectPropertiesEqualToSrc,
+} from '../../../../utils';
 
 describe('src/http/controllers/user', () => {
     const suite = createTestApplication();
@@ -134,5 +141,48 @@ describe('src/http/controllers/user', () => {
 
         expect(response.name).toEqual(name);
         expect(response.id).toEqual(id);
+    });
+
+    it('should not create with put when the key is an unknown id', async () => {
+        await expectClientError(
+            () => suite.client.user.createOrUpdate(randomUUID(), createFakeUser()),
+            {
+                status: 404,
+                code: ErrorCode.ENTITY_NOT_FOUND,
+            },
+        );
+    });
+
+    // A user never moves between realms. The realm-scoped lookup in save()
+    // misses on a foreign realm, and the upsert must NOT fall through to its
+    // create branch: that would write a second user (a fresh id, same name)
+    // into the target realm, which reads like a move in the realm-scoped UI.
+    it('should not create a copy with put when the realm does not match', async () => {
+        const { data: realm } = await suite.client.realm.create(createFakeRealm());
+        const { data: user } = await suite.client.user.create(createFakeUser());
+
+        await expectClientError(
+            () => suite.client.user.createOrUpdate(user.id, {
+                name: user.name,
+                email: user.email,
+                realmId: realm.id,
+            }),
+            {
+                status: 404,
+                code: ErrorCode.ENTITY_NOT_FOUND,
+            },
+        );
+
+        const { data: rows } = await suite.client.user.getMany({
+            filters: { name: user.name },
+            fields: ['id', 'name', 'realmId'],
+        });
+
+        expect(rows).toHaveLength(1);
+        expect(rows[0].id).toEqual(user.id);
+        expect(rows[0].realmId).toEqual(user.realmId);
+
+        await suite.client.user.delete(user.id);
+        await suite.client.realm.delete(realm.id);
     });
 });

--- a/packages/client-web-kit/src/components/entities/user/AUserForm.vue
+++ b/packages/client-web-kit/src/components/entities/user/AUserForm.vue
@@ -93,7 +93,16 @@ export default defineComponent({
         const updatedAt = useUpdatedAt(() => props.entity);
 
         const isRealmLocked = computed(() => !!props.realmId);
-        const showRealmPicker = computed(() => props.canManage && !isRealmLocked.value);
+
+        // A user keeps the realm it was created in, so the picker is a
+        // create-time control only (see the realm-immutability rule in
+        // .agents/architecture.md). The API mounts realmId for CREATE alone,
+        // and the junction rows plus every per-user child table denormalize
+        // it, so offering the picker on an existing record would promise a
+        // move the server can not perform.
+        const showRealmPicker = computed(() => props.canManage &&
+            !isRealmLocked.value &&
+            !isEditing.value);
 
         function initForm() {
             if (

--- a/packages/core-kit/src/domains/client/validator.ts
+++ b/packages/core-kit/src/domains/client/validator.ts
@@ -193,6 +193,12 @@ export class ClientValidator extends Container<Client> {
 
         // ----------------------------------------------
 
+        // A client keeps the realm it was created in. UPDATE deliberately has
+        // no mount, so a submitted realmId is stripped instead of moving the
+        // row: the junction tables (client_role.client_realm_id,
+        // client_permission.client_realm_id, client_scope.client_realm_id)
+        // denormalize the realm, and a move would strand all of them in the
+        // old realm.
         this.mount(
             'realmId',
             {

--- a/packages/core-kit/src/domains/user/validator.ts
+++ b/packages/core-kit/src/domains/user/validator.ts
@@ -145,6 +145,13 @@ export class UserValidator extends Container<User> {
             createValidator(z.boolean()),
         );
 
+        // A user keeps the realm it was created in. UPDATE deliberately has no
+        // mount, so a submitted realmId is stripped instead of moving the row:
+        // the junction tables (user_role.user_realm_id,
+        // user_permission.user_realm_id, identity_provider_account.user_realm_id)
+        // and every per-user child table (sessions, consents, attributes,
+        // authenticators) denormalize the realm, and a move would strand all of
+        // them in the old realm.
         this.mount(
             'realmId',
             {

--- a/packages/core-kit/test/unit/domains/validator-groups.spec.ts
+++ b/packages/core-kit/test/unit/domains/validator-groups.spec.ts
@@ -66,6 +66,32 @@ describe('domains/validator-groups', () => {
         expect(provisioned.builtIn).toBe(true);
     });
 
+    it('should strip realmId at UPDATE for realm bound entities', async () => {
+        const realmId = '9f0b7e2c-4d3a-4a1e-9f6c-5b0d2a7e1c34';
+
+        const validators = [new UserValidator(), new ClientValidator()];
+        for (const validator of validators) {
+            const created = await validator.run(
+                {
+                    name: 'foo',
+                    email: 'foo@example.com',
+                    realmId,
+                },
+                { group: ValidatorGroup.CREATE },
+            );
+            expect(created.realmId).toEqual(realmId);
+
+            const updated = await validator.run(
+                {
+                    displayName: 'Foo',
+                    realmId,
+                },
+                { group: ValidatorGroup.UPDATE },
+            );
+            expect(updated).not.toHaveProperty('realmId');
+        }
+    });
+
     it('should require email at CREATE but not at PROVISIONING', async () => {
         const validator = new UserValidator();
 


### PR DESCRIPTION
`AUserForm` offered a realm picker on an existing user, which suggested a user can be
moved to another realm. It can not, and the surrounding behaviour was confusing rather
than safe. This makes the invariant explicit, documented and tested.

## What was actually possible

Every entity validator mounts `realmId` for `CREATE` / `PROVISIONING` only, so the field
is stripped on update and `merge()` never sees it. Verified against the three paths:

| call | before |
|---|---|
| `POST /users/:id`, same `realmId` | 202, realm unchanged (field stripped) |
| `POST /users/:id`, foreign `realmId` | 404, because `save()` scopes the lookup by the submitted realm |
| `PUT /users/:id`, foreign `realmId` | **201 with a second user** (fresh id, same name) in the target realm |

So no move, but the last row is close enough to look like one in the realm-scoped admin
list, and the picker promised something the API would never do.

## Changes

**The realm is a create-time choice.** `AUserForm`'s picker is gated on `!isEditing`, as
in `AClientForm`, `APolicyBasicForm`, `AKeyForm` and `ATrustAnchorForm`. It was the only
entity form missing the gate. The settings page passed `userId` where a realm id belongs,
which stayed harmless only because a bogus id resolves to no realm; that is fixed too.

**Only a name key may upsert-create.** A UUID addresses one specific row, so a miss is
`EntityNotFoundError` instead of a create:

```ts
if (!entity && (options.updateOnly || where.id)) {
    throw new EntityNotFoundError();
}
```

Applied to the role, user, scope, permission, client, policy and realm services plus
`IdentityProviderController.write()`. `PUT /<entity>/<name>` keeps its "ensure this name
exists in this realm" semantic, including the realm create path the realm docs rely on.

**Why it matters.** A user's realm is copied into `auth_user_roles.user_realm_id`,
`auth_user_permissions.user_realm_id` and
`auth_identity_provider_accounts.user_realm_id`, and every per-user child row carries its
own `realm_id` (attributes, authenticators, sessions, consents). A client's realm is
copied the same way into the client junctions. Those copies are what the `realmScope`
reach factor evaluates, so moving the parent row alone would leave every grant and child
row stranded in the old realm.

## Tests

- `validator-groups.spec.ts`: the UPDATE strip for both realm-bound validators.
- `user/service.spec.ts`: a foreign `realmId` does not move the row.
- `user.spec.ts` (HTTP): an unknown UUID key returns 404, and a PUT with a foreign realm
  returns 404 while leaving exactly one user row in its original realm. Both confirmed red
  without the guard.

Full server-core suite (168 files / 1798 tests), core-kit and client-web-kit suites green,
plus `nuxi typecheck` on client-web.

## Not included

`UserUpdatePayload` and its siblings still advertise `realmId` through
`Partial<XCreatePayload>`, so the typed client compiles a field the server strips.
Deliberately left as is: tightening it is a compile-time break for consumers and the strip
is now documented and pinned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Realm selection is now available only when creating users and clients, preventing changes during edits.
  - Realm assignments remain fixed after creation.
  - Updates targeting records by UUID now return “not found” instead of creating unintended records.

- **Bug Fixes**
  - Prevented users and clients from being moved between realms through updates.
  - Corrected settings to use the appropriate realm identifier.
  - Name-based upserts continue to work as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->