### PR TITLE
feat: provision per-app system clients (admin-console, account-console)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1962,8 +1962,9 @@ neutral message: no identity/policy detail, no enumeration oracle).
   gate), stays **out** of the anonymous `GET /authorize` `ClientSummary` DTO,
   and is mounted `{ optional: true, nullable }` in every validator group so
   admins can set/clear it. `buildSystemClientAttributes` deliberately omits the
-  key — the provisioner MERGE would otherwise wipe an admin-set policy on the
-  per-realm `web` client every boot. The admin form binds it via
+  key — the provisioner MERGE would otherwise wipe an admin-set policy on
+  each per-realm system client (`web`, `admin-console`, `account-console`)
+  every boot. The admin form binds it via
   `APolicyPicker` in `AClientForm`. Client caches mean a policy
   (re)assignment lags ≤60s at `/token` (`CachePrefix.CLIENT` query cache).
 - **Observability (leg-scoped):** a denial at the **interactive
@@ -2120,7 +2121,8 @@ at both chokepoints:
 Unknown values in the column are inert (they can only narrow, never widen). A
 refresh rejected this way is a plain `unauthorized_client` — **not** replay
 detection, so no family revocation; restoring the grant type restores service.
-The provisioned per-realm `web` client lists `authorization_code refresh_token`
+Each provisioned per-realm system client (`web`, `admin-console`,
+`account-console`) lists `authorization_code refresh_token`
 (refreshed by `SystemClientProvisioner`'s MERGE on startup).
 
 **Admin UI:** `AClientForm` renders the column as a `<VCFormCheckboxGroup>` over

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -739,7 +739,7 @@ threads instances through constructor/context args:
   type from `@authup/server-kit`) explicitly: middlewares take it via options
   (`createLoggerMiddleware({ env, logger })`, `registerErrorMiddleware(router,
   { logger })`), core services via their context (`RealmService` /
-  `WebClientProvisioner` accept optional `logger`). A service without a logger
+  `SystemClientProvisioner` accept optional `logger`). A service without a logger
   simply stays silent (`this.logger?.warn(...)` guard style).
 - **Domain events** — `DomainEventPublisher` (from `@authup/server-kit`,
   optional `logger` ctx) aggregates `IDomainEventHandler`s
@@ -832,7 +832,7 @@ on.
 `CLIENT_RESERVED_NAMES` (`system`, `web`) is **not** enforced here. It stays
 a `ClientService.save()` (API-path) guard, because provisioning bypasses the
 service. Declaring either name is allowed and partially effective. See
-*Per-Realm Public `web` Client* below for which attributes a declaration can
+*Per-Realm System Clients* below for which attributes a declaration can
 and cannot set.
 
 ### Synchronization Order
@@ -844,22 +844,42 @@ and cannot set.
 Scopes run first because they are leaf entities carrying no relations of their
 own, and a client in the same realm block may bind them via `realmScopes`.
 
-### Per-Realm Public `web` Client
+### Per-Realm System Clients (`web`, `admin-console`, `account-console`)
 
-Every realm auto-provisions a public OAuth2 client named **`web`** (constant
-`CLIENT_WEB_NAME` in `@authup/core-kit`) used by authup's own client-admin-console and any
-downstream UI embedding `client-web-kit`. It powers the realm-selection login
-flow (auth-code + PKCE), so there is no per-realm FK, no migration, and no new
-endpoint — the `/authorize` verifier already resolves clients via
-`findOneByIdOrName('web', realmId)`.
+Every realm auto-provisions three public OAuth2 clients (plan 079;
+`SYSTEM_CLIENT_DEFINITIONS` in `core/entities/client/system-clients.ts`,
+name constants in `@authup/core-kit`):
 
-- **Attributes** (`buildWebClientAttributes`, `core/entities/client/web-client.ts`):
+- **`web`** (`CLIENT_WEB_NAME`) — downstream UIs embedding `client-web-kit`.
+- **`admin-console`** (`CLIENT_ADMIN_CONSOLE_NAME`) — authup's own admin
+  console (`apps/client-admin-console`; its login sends `client_id=admin-console`,
+  runtime-overridable via `NUXT_PUBLIC_CLIENT_ID`).
+- **`account-console`** (`CLIENT_ACCOUNT_CONSOLE_NAME`) — the account
+  self-service surface (plan 080). Provisioned ahead of the surface: `web`'s
+  `<origin>/**` patterns already cover every path it can redirect to, so the
+  inert row adds no redirect surface.
+
+The split exists for admission control (`accessPolicyId` per app — restrict
+the admin console without touching downstream logins; keep it OPEN until the
+account surface ships, since users still need the console's settings pages),
+per-app session/audit attribution by `clientId`, and per-app
+grant/redirect/logout allowlists. Each client powers the realm-selection
+login flow (auth-code + PKCE), so there is no per-realm FK, no migration, and
+no new endpoint — the `/authorize` verifier already resolves clients via
+`findOneByIdOrName(name, realmId)`.
+
+- **Attributes** (`buildSystemClientAttributes(definition, realm, appOrigins)`):
   `authMethod: 'none'`, `tokenBindingMethod: 'none'`, `builtIn: true`, `active: true`,
   `grantTypes: 'authorization_code refresh_token'` (an enforced allowlist —
   see *Per-client grant allowlist* under the token-endpoint section),
   `redirectUri` = one `<origin>/**` wildcard per trusted app origin (matched
-  by `isSimpleMatch`).
-- **Scopes** (`WEB_CLIENT_SCOPE_NAMES` = `global` + `openid`) are bound as
+  by `isSimpleMatch`) — deliberately the SHARED app-origin set for every
+  definition, since `redirectUri` is MERGE-owned: a separately-hosted surface
+  (plan 078 "relocatable by choice") registers its origin via
+  `TRUSTED_ORIGINS`, never by editing the client row. `displayName` is seeded
+  at CREATE only (never re-asserted), so admins can relabel.
+- **Scopes** (`SYSTEM_CLIENT_SCOPE_NAMES` = `global` + `openid`, per
+  definition) are bound as
   `auth_client_scopes` rows. That junction is the only source `/authorize`
   reads scopes from (`OAuth2ScopeRepository.findByClientId`). The `Client.scope` column carries
   the same list but is descriptive only: nothing on any production path reads
@@ -881,29 +901,30 @@ endpoint — the `/authorize` verifier already resolves clients via
   map is the compile-time exhaustiveness guard — an unmounted Config key fails
   the build instead of being silently stripped), making
   `parseConfig`/`normalizeConfig` async. `TRUSTED_ORIGINS` (env, comma-separated) is
-  **security-sensitive**: the `web` client is `builtIn` (auto-consent) + `global`
+  **security-sensitive**: every system client is `builtIn` (auto-consent) + `global`
   scope, so any allowlisted origin can obtain a full-permission user token.
   The origin list does NOT drive CORS — CORS reflects any origin by default
   (auth is header-based only, and OAuth2 clients are registered at runtime on
   domains unknown at startup; an explicit allowlist can be set via the
   `middlewareCors` config options). In non-production,
   `http://localhost:3000` is dev-seeded so client-admin-console works on first run.
-- **Provisioning (`WebClientProvisioner.ensureForRealm`)** is the single upsert
-  mechanism, run two ways and sharing the same factory so they can't drift:
+- **Provisioning (`SystemClientProvisioner.ensureForRealm`)** is the single
+  upsert mechanism — it loops `SYSTEM_CLIENT_DEFINITIONS` — run two ways and
+  sharing the same factory so they can't drift:
   1. **Startup** — `ProvisionerModule` lists every realm (incl. pre-existing)
-     after the graph sync and upserts each realm's `web` client (MERGE — refreshes
-     `redirectUri` when config changes).
+     after the graph sync and upserts each realm's system clients (MERGE —
+     refreshes `redirectUri` when config changes).
   2. **Runtime** — `RealmService.save()` calls `ensureForRealm` when it *creates*
-     a new realm, via the injected `webClientProvisioner` (system-level, ungated —
+     a new realm, via the injected `systemClientProvisioner` (system-level, ungated —
      a realm creator may lack `CLIENT_CREATE`). Not called on update.
   Idempotent. The attribute MERGE is dirty-checked to keep a steady-state boot
   free of redundant UPDATEs, but the scope binding runs unconditionally. An
   instance provisioned before the junction rows existed carries a current
-  client with no scopes at all. `web` is a reserved name, so the row belongs
-  to the system whatever state it is in: a non-built-in client named `web`
-  predates the reservation and is taken over (overwrite + warn) rather than
-  left to shadow the realm's login client.
-- **The ten attributes in `buildWebClientAttributes` are owned by the
+  client with no scopes at all. Every system client name is reserved, so the
+  row belongs to the system whatever state it is in: a non-built-in client
+  squatting one predates the reservation and is taken over (overwrite + warn)
+  rather than left to shadow the realm's system client.
+- **The ten attributes in `buildSystemClientAttributes` are owned by the
   provisioner and reassert on every boot.** Whatever writes a different value
   to `name`, `realmId`, `authMethod`, `tokenBindingMethod`, `builtIn`,
   `active`, `grantTypes`, `scope`, `redirectUri` or `postLogoutRedirectUri`,
@@ -911,14 +932,16 @@ endpoint — the `/authorize` verifier already resolves clients via
   no error (the takeover `warn` above fires only for a non-`builtIn` row).
   Redirect patterns are configured through `trustedOrigins`, not per client.
   Everything outside that set survives a boot and is the supported way to
-  extend the client: `displayName`, `description`, `baseUrl`, `rootUrl`,
+  extend the client: `displayName` (seeded from the definition at create,
+  then admin-owned), `description`, `baseUrl`, `rootUrl`,
   `accessPolicyId` (deliberately omitted from the builder so an admin-set
   policy is not wiped), and every junction row, since `ensureScopes` only
   inserts what is missing and never deletes.
-- **Guardrails:** `web` and `system` are reserved client names — `ClientService.save()`
+- **Guardrails:** `system`, `web`, `admin-console` and `account-console` are
+  reserved client names — `ClientService.save()`
   rejects API attempts to create/rename a client onto them (`CLIENT_RESERVED_NAMES`).
   An existing `builtIn` row keeping its own name is exempt, so an admin holding
-  `CLIENT_UPDATE` can edit the provisioned `web` client through the API; only
+  `CLIENT_UPDATE` can edit a provisioned system client through the API; only
   the owned attributes above snap back on the next boot.
   The client validator strips `builtIn` on create/update, so no API caller can
   self-assign it — only provisioned clients are `builtIn`. The SSR `AuthorizeForm`
@@ -1516,7 +1539,8 @@ This split is cohort-universal: Keycloak, Authentik, Zitadel, Casdoor and Dex
 all serve login/consent from the IdP origin.
 
 **client-admin-console is an ordinary OAuth2 RP** — an admin console authenticating via
-auth-code + PKCE against the per-realm public `web` client, with no privileged
+auth-code + PKCE against the per-realm public `admin-console` client (plan 079;
+downstream kit apps keep riding `web`), with no privileged
 channel into server-core. It is deliberately NOT merged into server-core
 today. The recorded long-term endpoint — deferred until after the planned
 server+worker split — is folding the admin UI into server-core as a **static
@@ -1826,9 +1850,9 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
   `ClientSummary` DTO, **added** to the client repository `fields.default`
   allow-list so reads return it). The migration is folded into the
   still-unreleased `1783325495597-Default.ts` (both dialects, up/down verified
-  by the `tests-migrations` round-trip). `buildWebClientAttributes` sets it to
+  by the `tests-migrations` round-trip). `buildSystemClientAttributes` sets it to
   the same `<origin>/**`-per-app-origin patterns as `redirectUri`, so
-  `WebClientProvisioner`'s MERGE widens it on the next startup. `AClientForm`
+  `SystemClientProvisioner`'s MERGE widens it on the next startup. `AClientForm`
   renders it as its own `AFormInputList`, deliberately a **second** list rather
   than a shared one — the whole point of the split is that a login redirect
   does not imply a logout redirect, so the two allow-lists must be editable
@@ -1937,7 +1961,7 @@ neutral message: no identity/policy detail, no enumeration oracle).
   ATTRIBUTE_NAMES denylist (a self-managing client cannot change its own
   gate), stays **out** of the anonymous `GET /authorize` `ClientSummary` DTO,
   and is mounted `{ optional: true, nullable }` in every validator group so
-  admins can set/clear it. `buildWebClientAttributes` deliberately omits the
+  admins can set/clear it. `buildSystemClientAttributes` deliberately omits the
   key — the provisioner MERGE would otherwise wipe an admin-set policy on the
   per-realm `web` client every boot. The admin form binds it via
   `APolicyPicker` in `AClientForm`. Client caches mean a policy
@@ -2097,7 +2121,7 @@ Unknown values in the column are inert (they can only narrow, never widen). A
 refresh rejected this way is a plain `unauthorized_client` — **not** replay
 detection, so no family revocation; restoring the grant type restores service.
 The provisioned per-realm `web` client lists `authorization_code refresh_token`
-(refreshed by `WebClientProvisioner`'s MERGE on startup).
+(refreshed by `SystemClientProvisioner`'s MERGE on startup).
 
 **Admin UI:** `AClientForm` renders the column as a `<VCFormCheckboxGroup>` over
 the closed `OAuth2TokenGrant` vocabulary (the only strings

--- a/apps/authup/test/unit/packages/plan.spec.ts
+++ b/apps/authup/test/unit/packages/plan.spec.ts
@@ -53,7 +53,7 @@ describe('src/packages/plan', () => {
     });
 
     it('should reject migration targeting client-admin-console', () => {
-        expect(() => resolveLaunchPlan('migration', ['client.admin-console'])).toThrow(/client\.console/);
+        expect(() => resolveLaunchPlan('migration', ['client.admin-console'])).toThrow(/client\.admin-console/);
     });
 
     it('should route healthcheck to server-core only', () => {
@@ -64,7 +64,7 @@ describe('src/packages/plan', () => {
     });
 
     it('should reject healthcheck targeting client-admin-console', () => {
-        expect(() => resolveLaunchPlan('healthcheck', ['client.admin-console'])).toThrow(/client\.console/);
+        expect(() => resolveLaunchPlan('healthcheck', ['client.admin-console'])).toThrow(/client\.admin-console/);
     });
 
     it('should fail for an unknown command', () => {

--- a/apps/client-admin-console/nuxt.config.ts
+++ b/apps/client-admin-console/nuxt.config.ts
@@ -7,6 +7,7 @@
 
 import type { ModuleOptions } from '@authup/client-web-nuxt';
 import { API_URL_DEFAULT } from '@authup/core-http-kit';
+import { CLIENT_ADMIN_CONSOLE_NAME } from '@authup/core-kit';
 import path from 'node:path';
 import { defineNuxtConfig } from 'nuxt/config';
 import tailwindcss from '@tailwindcss/vite';
@@ -92,6 +93,11 @@ export default defineNuxtConfig({
             apiUrl: process.env.API_URL || API_URL_DEFAULT,
             publicUrl: process.env.PUBLIC_URL || 'http://localhost:3000',
             cookieDomain: process.env.COOKIE_DOMAIN,
+            // The OAuth2 client the console authenticates against — the
+            // per-realm built-in `admin-console` client (plan 079).
+            // Runtime-overridable via NUXT_PUBLIC_CLIENT_ID for forks that
+            // register their own client.
+            clientId: process.env.CLIENT_ID || CLIENT_ADMIN_CONSOLE_NAME,
         },
     },
 

--- a/apps/client-admin-console/pages/login/index.vue
+++ b/apps/client-admin-console/pages/login/index.vue
@@ -1,7 +1,6 @@
 <script lang="ts">
 /* global window */
 import type { Realm } from '@authup/core-kit';
-import { CLIENT_WEB_NAME } from '@authup/core-kit';
 import {
     ARealmGrid,
     buildAuthorizeURL,
@@ -83,18 +82,20 @@ export default defineNuxtComponent({
                     target = `${url.pathname}${url.search}${url.hash}`;
                 }
 
+                const clientId = runtimeConfig.public.clientId as string;
+
                 saveAuthorizationRequest({
                     state,
                     code_verifier: pkce.code_verifier,
                     redirect_uri: redirectUri,
-                    client_id: CLIENT_WEB_NAME,
+                    client_id: clientId,
                     realm_id: realm.id,
                     target,
                 });
 
                 window.location.href = buildAuthorizeURL({
                     baseURL: runtimeConfig.public.apiUrl as string,
-                    clientId: CLIENT_WEB_NAME,
+                    clientId,
                     realmId: realm.id,
                     redirectUri,
                     scope: 'global openid',

--- a/apps/client-admin-console/pages/logout.vue
+++ b/apps/client-admin-console/pages/logout.vue
@@ -31,7 +31,7 @@ export default defineNuxtComponent({
             //
             // Deliberately NO client_id: omitting it lets the server resolve
             // the client from the hint's sole aud (the client UUID). A
-            // name-identified client_id (`web`) would work too since plan 047.B
+            // name-identified client_id (`admin-console`) would work too since plan 047.B
             // (resolved to its UUID before the aud cross-check), but omission
             // stays the simplest correct call.
             window.location.href = buildEndSessionURL({

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -144,6 +144,7 @@ import {
     RoleService,
     ScopeService,
     SessionService,
+    SystemClientProvisioner,
     TrustAnchorService,
     UserAttributeService,
     UserAuthenticator,
@@ -151,7 +152,6 @@ import {
     UserPermissionService,
     UserRoleService,
     UserService,
-    WebClientProvisioner,
 } from '../../../../core/index.ts';
 import { AuthenticationInjectionKey } from '../../authentication/index.ts';
 import { OAuth2InjectionToken } from '../../oauth2/index.ts';
@@ -972,7 +972,7 @@ export class HTTPControllerModule {
             realmRepository,
         });
         const logger = container.resolve(LoggerInjectionKey);
-        const webClientProvisioner = new WebClientProvisioner({
+        const systemClientProvisioner = new SystemClientProvisioner({
             clientRepository,
             scopeRepository: new ScopeRepositoryAdapter({
                 repository: container.resolve<Repository<Scope>>(ScopeEntity),
@@ -991,7 +991,7 @@ export class HTTPControllerModule {
 
         const service = new RealmService({
             repository,
-            webClientProvisioner,
+            systemClientProvisioner,
             keyProvisioner,
             logger,
         });

--- a/apps/server-core/src/app/modules/provisioning/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/module.ts
@@ -74,7 +74,7 @@ import path from 'node:path';
 import { ConfigInjectionKey, getAppOrigins } from '../config/index.ts';
 import { SymmetricCipher } from '@authup/server-kit';
 import { LoggerInjectionKey } from '../logger/index.ts';
-import { WebClientProvisioner } from '../../../core/entities/client/index.ts';
+import { SystemClientProvisioner } from '../../../core/entities/client/index.ts';
 import { KeyProvisioner } from '../../../core/key/index.ts';
 import { CompositeProvisioningSource, FileProvisioningSource } from './sources/index.ts';
 
@@ -220,11 +220,12 @@ export class ProvisionerModule implements IModule {
         await rootSynchronizer.synchronize(data);
 
         // ---------------------------------------------------------------
-        // Per-realm public `web` client. Single provisioning mechanism:
-        // list every realm (incl. pre-existing) and upsert its web client.
+        // Per-realm system clients (web, admin-console, account-console).
+        // Single provisioning mechanism: list every realm (incl.
+        // pre-existing) and upsert its clients.
         // Idempotent; guarded on builtIn inside the provisioner.
         // ---------------------------------------------------------------
-        const webClientProvisioner = new WebClientProvisioner({
+        const systemClientProvisioner = new SystemClientProvisioner({
             clientRepository,
             scopeRepository,
             clientScopeRepository,
@@ -249,7 +250,7 @@ export class ProvisionerModule implements IModule {
 
         const realms = await realmRepository.find();
         for (const realm of realms) {
-            await webClientProvisioner.ensureForRealm(realm);
+            await systemClientProvisioner.ensureForRealm(realm);
             await keyProvisioner.ensureForRealm(realm);
         }
 

--- a/apps/server-core/src/core/entities/client/index.ts
+++ b/apps/server-core/src/core/entities/client/index.ts
@@ -8,5 +8,5 @@
 export * from './constants.ts';
 export * from './service.ts';
 export * from './types.ts';
-export * from './web-client.ts';
+export * from './system-clients.ts';
 export * from './schema.ts';

--- a/apps/server-core/src/core/entities/client/system-clients.ts
+++ b/apps/server-core/src/core/entities/client/system-clients.ts
@@ -6,6 +6,8 @@
  */
 
 import {
+    CLIENT_ACCOUNT_CONSOLE_NAME,
+    CLIENT_ADMIN_CONSOLE_NAME,
     CLIENT_WEB_NAME,
     ClientAuthMethod,
     ClientTokenBindingMethod,
@@ -15,9 +17,9 @@ import type { Client, Realm } from '@authup/core-kit';
 import type { Logger } from '@authup/server-kit';
 import type { IClientScopeRepository } from '../client-scope/types.ts';
 import type { IScopeRepository } from '../scope/types.ts';
-import type { IClientRepository, IWebClientProvisioner } from './types.ts';
+import type { IClientRepository, ISystemClientProvisioner, SystemClientDefinition } from './types.ts';
 
-export type WebClientProvisionerContext = {
+export type SystemClientProvisionerContext = {
     clientRepository: IClientRepository;
     scopeRepository: IScopeRepository;
     clientScopeRepository: IClientScopeRepository;
@@ -26,55 +28,93 @@ export type WebClientProvisionerContext = {
 };
 
 /**
- * The scopes a realm's public `web` client is granted.
+ * The scopes every system client is granted.
  *
  * `global` lets the issued token drive the management API (parity with the
  * legacy password-grant admin login); `openid` yields the id-token.
  */
-export const WEB_CLIENT_SCOPE_NAMES: string[] = [
+export const SYSTEM_CLIENT_SCOPE_NAMES: string[] = [
     ScopeName.GLOBAL,
     ScopeName.OPEN_ID,
 ];
 
 /**
- * Build the attribute set for a realm's public `web` client.
+ * The public (PKCE) clients provisioned for every realm (plan 079):
  *
- * Public (PKCE) client used by authup's own client-admin-console and any downstream
- * UI embedding client-web-kit. `builtIn` makes it auto-consent in the
- * /authorize flow and protects it from the API reserved-name guard.
+ * - `web` — downstream UIs embedding client-web-kit,
+ * - `admin-console` — authup's own admin console (apps/client-admin-console),
+ * - `account-console` — the account self-service surface (plan 080; the
+ *   row is provisioned ahead of the surface — `web`'s `<origin>/**`
+ *   patterns already cover every path it can redirect to, so an inert row
+ *   adds no redirect surface).
+ *
+ * `displayName` is seeded at CREATE only and never re-asserted by the
+ * MERGE, so an admin may relabel a client without the next boot undoing it.
+ */
+export const SYSTEM_CLIENT_DEFINITIONS: SystemClientDefinition[] = [
+    {
+        name: CLIENT_WEB_NAME,
+        displayName: 'Web',
+        scopeNames: SYSTEM_CLIENT_SCOPE_NAMES,
+    },
+    {
+        name: CLIENT_ADMIN_CONSOLE_NAME,
+        displayName: 'Admin Console',
+        scopeNames: SYSTEM_CLIENT_SCOPE_NAMES,
+    },
+    {
+        name: CLIENT_ACCOUNT_CONSOLE_NAME,
+        displayName: 'Account Console',
+        scopeNames: SYSTEM_CLIENT_SCOPE_NAMES,
+    },
+];
+
+/**
+ * Build the MERGE-owned attribute set for a realm's system client.
+ *
+ * `builtIn` makes the client auto-consent in the /authorize flow and
+ * protects it from the API reserved-name guard.
  *
  * `grantTypes` is an enforced allowlist (`assertClientGrantAllowed` at the
  * /token grants and the /authorize code-request verifier; null = allow-all),
  * so it must list every flow the client uses. `redirectUri` and
  * `postLogoutRedirectUri` are each one `<origin>/**` wildcard per trusted
- * origin (matched by isSimpleMatch).
+ * origin (matched by isSimpleMatch) — deliberately the shared app-origin
+ * set for every definition: `redirectUri` is re-asserted on each boot, so a
+ * separately-hosted surface (plan 078 "relocatable by choice") registers
+ * its origin via TRUSTED_ORIGINS rather than editing the client row.
  *
  * The `scope` column is descriptive only. Scope authorization resolves
  * through the `auth_client_scopes` junction, which
- * `WebClientProvisioner.ensureForRealm` fills from
- * {@see WEB_CLIENT_SCOPE_NAMES}.
+ * `SystemClientProvisioner.ensureForRealm` fills from the definition's
+ * `scopeNames`.
+ *
+ * `accessPolicyId` and `displayName` are deliberately NOT part of this set:
+ * the MERGE must neither wipe an admin-bound access policy nor undo a
+ * relabel.
  */
-export function buildWebClientAttributes(
+export function buildSystemClientAttributes(
+    definition: SystemClientDefinition,
     realm: Realm | { id: string },
     appOrigins: string[],
 ): Partial<Client> {
     const originPatterns = appOrigins.map((origin) => `${origin}/**`).join(',');
 
     return {
-        name: CLIENT_WEB_NAME,
+        name: definition.name,
         realmId: realm.id,
         authMethod: ClientAuthMethod.NONE,
         tokenBindingMethod: ClientTokenBindingMethod.NONE,
         builtIn: true,
         active: true,
         grantTypes: 'authorization_code refresh_token',
-        scope: WEB_CLIENT_SCOPE_NAMES.join(' '),
+        scope: definition.scopeNames.join(' '),
         redirectUri: originPatterns,
         postLogoutRedirectUri: originPatterns,
     };
 }
 
-export class WebClientProvisioner implements IWebClientProvisioner {
+export class SystemClientProvisioner implements ISystemClientProvisioner {
     protected clientRepository: IClientRepository;
 
     protected scopeRepository: IScopeRepository;
@@ -85,7 +125,7 @@ export class WebClientProvisioner implements IWebClientProvisioner {
 
     protected logger?: Logger;
 
-    constructor(ctx: WebClientProvisionerContext) {
+    constructor(ctx: SystemClientProvisionerContext) {
         this.clientRepository = ctx.clientRepository;
         this.scopeRepository = ctx.scopeRepository;
         this.clientScopeRepository = ctx.clientScopeRepository;
@@ -94,27 +134,32 @@ export class WebClientProvisioner implements IWebClientProvisioner {
     }
 
     async ensureForRealm(realm: Realm | { id: string }): Promise<void> {
-        const client = await this.ensureClient(realm);
+        for (const definition of SYSTEM_CLIENT_DEFINITIONS) {
+            const client = await this.ensureClient(definition, realm);
 
-        // Always run, even when the attributes were already up to date: an
-        // instance provisioned before the junction rows existed carries a
-        // steady-state client with no scopes at all.
-        await this.ensureScopes(client);
+            // Always run, even when the attributes were already up to date:
+            // an instance provisioned before the junction rows existed
+            // carries a steady-state client with no scopes at all.
+            await this.ensureScopes(definition, client);
+        }
     }
 
     /**
      * Upsert the client row itself.
      *
-     * `web` is a reserved client name (`CLIENT_RESERVED_NAMES`), so the row
-     * belongs to the system whatever state it is in. A non-built-in one
+     * Every system client name is reserved (`CLIENT_RESERVED_NAMES`), so the
+     * row belongs to the system whatever state it is in. A non-built-in one
      * predates the reservation and is taken over rather than left to shadow
-     * the realm's login client.
+     * the realm's system client.
      */
-    protected async ensureClient(realm: Realm | { id: string }): Promise<Client> {
-        const attributes = buildWebClientAttributes(realm, this.appOrigins);
+    protected async ensureClient(
+        definition: SystemClientDefinition,
+        realm: Realm | { id: string },
+    ): Promise<Client> {
+        const attributes = buildSystemClientAttributes(definition, realm, this.appOrigins);
 
         const existing = await this.clientRepository.findOneBy({
-            name: CLIENT_WEB_NAME,
+            name: definition.name,
             realmId: realm.id,
         });
 
@@ -122,7 +167,7 @@ export class WebClientProvisioner implements IWebClientProvisioner {
             // MERGE: refresh attributes (e.g. redirectUri) when config
             // changes. Dirty-check first — the attributes are deterministic
             // from config, so a steady-state boot would otherwise issue one
-            // redundant UPDATE (bumping updatedAt) per realm.
+            // redundant UPDATE (bumping updatedAt) per client and realm.
             const isDirty = (Object.keys(attributes) as (keyof Client)[])
                 .some((key) => existing[key] !== attributes[key]);
             if (!isDirty) {
@@ -134,7 +179,7 @@ export class WebClientProvisioner implements IWebClientProvisioner {
             if (!existing.builtIn) {
                 if (this.logger) {
                     this.logger.warn(
-                        `Taking over the non-built-in client named '${CLIENT_WEB_NAME}' in realm ${realm.id}: the name is reserved for the built-in web client.`,
+                        `Taking over the non-built-in client named '${definition.name}' in realm ${realm.id}: the name is reserved for a built-in system client.`,
                     );
                 }
 
@@ -146,8 +191,8 @@ export class WebClientProvisioner implements IWebClientProvisioner {
                 // is a `select: false` column, so the loaded entity carries no
                 // value for it and typeorm's changed-column diff would not
                 // emit the null. Re-reading is confined to this branch, and
-                // the secret stays out of `buildWebClientAttributes` for the
-                // same reason (an undefined-vs-null compare would read as
+                // the secret stays out of `buildSystemClientAttributes` for
+                // the same reason (an undefined-vs-null compare would read as
                 // dirty on every boot).
                 target = await this.clientRepository.findOneWithSecret({ id: existing.id }) || existing;
                 target.secret = null;
@@ -160,20 +205,23 @@ export class WebClientProvisioner implements IWebClientProvisioner {
             return this.clientRepository.save(merged);
         }
 
-        const entity = this.clientRepository.create(attributes);
+        const entity = this.clientRepository.create({
+            ...attributes,
+            displayName: definition.displayName,
+        });
         return this.clientRepository.save(entity);
     }
 
     /**
-     * Bind the built-in global scopes through `auth_client_scopes`. That
+     * Bind the definition's scopes through `auth_client_scopes`. That
      * junction is the only source the /authorize code-request verifier reads
      * scopes from.
      *
      * Additive like the attribute MERGE above: an extra scope an admin bound
      * by hand is left in place.
      */
-    protected async ensureScopes(client: Client): Promise<void> {
-        for (const name of WEB_CLIENT_SCOPE_NAMES) {
+    protected async ensureScopes(definition: SystemClientDefinition, client: Client): Promise<void> {
+        for (const name of definition.scopeNames) {
             const scope = await this.scopeRepository.findOneBy({
                 name,
                 realmId: null,
@@ -182,7 +230,7 @@ export class WebClientProvisioner implements IWebClientProvisioner {
             if (!scope) {
                 if (this.logger) {
                     this.logger.warn(
-                        `Skipping scope '${name}' for the web client of realm ${client.realmId}: the scope is not provisioned.`,
+                        `Skipping scope '${name}' for the ${definition.name} client of realm ${client.realmId}: the scope is not provisioned.`,
                     );
                 }
                 continue;

--- a/apps/server-core/src/core/entities/client/types.ts
+++ b/apps/server-core/src/core/entities/client/types.ts
@@ -11,11 +11,24 @@ import type { PermissionPolicyBinding } from '@authup/access';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository  } from '@authup/server-kit';
 
 /**
- * Ensures a realm has its system-provisioned public `web` client.
- * Used by startup provisioning (every realm) and the runtime realm-create
- * hook (a single realm). System-level — never gated on an actor.
+ * One system-provisioned public client (plan 079): `web`, `admin-console`
+ * or `account-console`. `displayName` is seeded at CREATE only; the
+ * MERGE-owned attribute set is derived per definition by
+ * `buildSystemClientAttributes`.
  */
-export interface IWebClientProvisioner {
+export type SystemClientDefinition = {
+    name: string;
+    displayName: string;
+    scopeNames: string[];
+};
+
+/**
+ * Ensures a realm has its system-provisioned public clients (`web`,
+ * `admin-console`, `account-console`). Used by startup provisioning
+ * (every realm) and the runtime realm-create hook (a single realm).
+ * System-level — never gated on an actor.
+ */
+export interface ISystemClientProvisioner {
     ensureForRealm(realm: Realm | { id: string }): Promise<void>;
 }
 

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -16,7 +16,7 @@ import {
 import type { Realm } from '@authup/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult, Logger  } from '@authup/server-kit';
 import { AbstractEntityService } from '@authup/server-kit';
-import type { IWebClientProvisioner } from '../client/types.ts';
+import type { ISystemClientProvisioner } from '../client/types.ts';
 import type { IKeyProvisioner } from '../../key/types.ts';
 import type { IRealmRepository, IRealmService } from './types.ts';
 import { decodeQuery } from '../../query/index.ts';
@@ -24,7 +24,7 @@ import { realmSchema } from './schema.ts';
 
 export type RealmServiceContext = {
     repository: IRealmRepository;
-    webClientProvisioner?: IWebClientProvisioner;
+    systemClientProvisioner?: ISystemClientProvisioner;
     keyProvisioner?: IKeyProvisioner;
     logger?: Logger;
 };
@@ -34,7 +34,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
 
     protected validator: RealmValidator;
 
-    protected webClientProvisioner?: IWebClientProvisioner;
+    protected systemClientProvisioner?: ISystemClientProvisioner;
 
     protected keyProvisioner?: IKeyProvisioner;
 
@@ -43,7 +43,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
     constructor(ctx: RealmServiceContext) {
         super();
         this.repository = ctx.repository;
-        this.webClientProvisioner = ctx.webClientProvisioner;
+        this.systemClientProvisioner = ctx.systemClientProvisioner;
         this.keyProvisioner = ctx.keyProvisioner;
         this.logger = ctx.logger;
         this.validator = new RealmValidator();
@@ -157,19 +157,20 @@ export class RealmService extends AbstractEntityService implements IRealmService
         entity = this.repository.create(validated);
         await this.repository.save(entity);
 
-        // Provision the realm's public `web` client via the system-level
-        // provisioner (NOT clientService.create) — it must not be gated on
-        // the actor's CLIENT_CREATE, since a realm creator may lack it.
-        // Realm creation must stay atomic from the caller's perspective: the
-        // realm is already persisted, so a provisioning failure is logged and
-        // swallowed (startup provisioning reconciles every realm's web client).
-        if (this.webClientProvisioner) {
+        // Provision the realm's system clients (web, admin-console,
+        // account-console) via the system-level provisioner (NOT
+        // clientService.create) — it must not be gated on the actor's
+        // CLIENT_CREATE, since a realm creator may lack it. Realm creation
+        // must stay atomic from the caller's perspective: the realm is
+        // already persisted, so a provisioning failure is logged and
+        // swallowed (startup provisioning reconciles every realm's clients).
+        if (this.systemClientProvisioner) {
             try {
-                await this.webClientProvisioner.ensureForRealm(entity);
+                await this.systemClientProvisioner.ensureForRealm(entity);
             } catch (e) {
                 if (this.logger) {
                     this.logger.warn(
-                        `Failed to provision web client for realm ${entity.id}: ${e instanceof Error ? e.message : String(e)}`,
+                        `Failed to provision system clients for realm ${entity.id}: ${e instanceof Error ? e.message : String(e)}`,
                     );
                 }
             }

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -9,7 +9,7 @@ import { randomUUID } from 'node:crypto';
 import { eq, isQuery } from '@rapiq/core';
 import { applyQuery } from '@rapiq/adapter-memory';
 import {
-    CLIENT_SYSTEM_NAME,
+    CLIENT_RESERVED_NAMES,
     CLIENT_WEB_NAME,
     IdentityType,
     PermissionName,
@@ -626,19 +626,12 @@ describe('core/entities/client/service', () => {
     });
 
     describe('guardrails', () => {
-        it('should reject creating a client with the reserved name "web"', async () => {
+        // Covers every reserved system-client name — incl. the plan-079
+        // additions admin-console / account-console.
+        it.each(CLIENT_RESERVED_NAMES)('should reject creating a client with the reserved name "%s"', async (name) => {
             await expect(
                 service.create(
-                    createFakeClient({ name: CLIENT_WEB_NAME }),
-                    createAllowAllActor(),
-                ),
-            ).rejects.toMatchObject({ code: ErrorCode.BAD_REQUEST });
-        });
-
-        it('should reject creating a client with the reserved name "system"', async () => {
-            await expect(
-                service.create(
-                    createFakeClient({ name: CLIENT_SYSTEM_NAME }),
+                    createFakeClient({ name }),
                     createAllowAllActor(),
                 ),
             ).rejects.toMatchObject({ code: ErrorCode.BAD_REQUEST });

--- a/apps/server-core/test/unit/core/entities/client/system-clients.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/system-clients.spec.ts
@@ -7,7 +7,12 @@
 
 import { randomUUID } from 'node:crypto';
 import { Query } from '@rapiq/core';
-import { CLIENT_WEB_NAME, ScopeName } from '@authup/core-kit';
+import {
+    CLIENT_ACCOUNT_CONSOLE_NAME,
+    CLIENT_ADMIN_CONSOLE_NAME,
+    CLIENT_WEB_NAME,
+    ScopeName,
+} from '@authup/core-kit';
 import type { ClientScope } from '@authup/core-kit';
 import { FakeEntityRepository } from '@authup/server-test-kit';
 import {
@@ -17,20 +22,32 @@ import {
     it,
 } from 'vitest';
 import {
-    WEB_CLIENT_SCOPE_NAMES,
-    WebClientProvisioner,
-    buildWebClientAttributes,
-} from '../../../../../src/core/entities/client/web-client.ts';
+    SYSTEM_CLIENT_DEFINITIONS,
+    SYSTEM_CLIENT_SCOPE_NAMES,
+    SystemClientProvisioner,
+    buildSystemClientAttributes,
+} from '../../../../../src/core/entities/client/system-clients.ts';
 import { FakeScopeRepository } from '../scope/fake-repository.ts';
 import { FakeClientRepository } from './fake-repository.ts';
 
-describe('core/entities/client/web-client', () => {
+const webDefinition = SYSTEM_CLIENT_DEFINITIONS
+    .find((definition) => definition.name === CLIENT_WEB_NAME)!;
+
+describe('core/entities/client/system-clients', () => {
     const appOrigins = ['http://localhost:3000', 'https://app.example.com'];
 
-    describe('buildWebClientAttributes', () => {
+    it('should declare the web, admin-console and account-console clients', () => {
+        expect(SYSTEM_CLIENT_DEFINITIONS.map((definition) => definition.name)).toEqual([
+            CLIENT_WEB_NAME,
+            CLIENT_ADMIN_CONSOLE_NAME,
+            CLIENT_ACCOUNT_CONSOLE_NAME,
+        ]);
+    });
+
+    describe('buildSystemClientAttributes', () => {
         it('should build a public built-in client with wildcard redirect uris', () => {
             const realmId = randomUUID();
-            const attributes = buildWebClientAttributes({ id: realmId }, appOrigins);
+            const attributes = buildSystemClientAttributes(webDefinition, { id: realmId }, appOrigins);
 
             expect(attributes.name).toBe(CLIENT_WEB_NAME);
             expect(attributes.realmId).toBe(realmId);
@@ -43,13 +60,36 @@ describe('core/entities/client/web-client', () => {
                 'http://localhost:3000/**,https://app.example.com/**',
             );
         });
+
+        // Every definition shares the app-origin redirect set on purpose:
+        // redirectUri is re-asserted each boot, so a separately-hosted
+        // surface registers its origin via TRUSTED_ORIGINS (plan 078
+        // "relocatable by choice") instead of editing the client row.
+        it('should apply the definition name onto the shared attribute shape', () => {
+            const realmId = randomUUID();
+
+            for (const definition of SYSTEM_CLIENT_DEFINITIONS) {
+                const attributes = buildSystemClientAttributes(definition, { id: realmId }, appOrigins);
+
+                expect(attributes.name).toBe(definition.name);
+                expect(attributes.builtIn).toBe(true);
+                expect(attributes.authMethod).toBe('none');
+                expect(attributes.grantTypes).toBe('authorization_code refresh_token');
+                expect(attributes.redirectUri).toBe(
+                    'http://localhost:3000/**,https://app.example.com/**',
+                );
+                // seeded at CREATE only, never part of the MERGE-owned set
+                expect(attributes.displayName).toBeUndefined();
+                expect(attributes.accessPolicyId).toBeUndefined();
+            }
+        });
     });
 
-    describe('WebClientProvisioner.ensureForRealm', () => {
+    describe('SystemClientProvisioner.ensureForRealm', () => {
         let repository: FakeClientRepository;
         let scopeRepository: FakeScopeRepository;
         let clientScopeRepository: FakeEntityRepository<ClientScope>;
-        let provisioner: WebClientProvisioner;
+        let provisioner: SystemClientProvisioner;
 
         const readScopeNames = async (clientId: string) => {
             const rows = await clientScopeRepository.findManyBy({ clientId });
@@ -66,13 +106,13 @@ describe('core/entities/client/web-client', () => {
             clientScopeRepository = new FakeEntityRepository<ClientScope>();
 
             // The built-in scopes are provisioned globally (realmId: null).
-            scopeRepository.seed(WEB_CLIENT_SCOPE_NAMES.map((name) => ({
+            scopeRepository.seed(SYSTEM_CLIENT_SCOPE_NAMES.map((name) => ({
                 name,
                 realmId: null,
                 builtIn: true,
             })));
 
-            provisioner = new WebClientProvisioner({
+            provisioner = new SystemClientProvisioner({
                 clientRepository: repository,
                 scopeRepository,
                 clientScopeRepository,
@@ -80,40 +120,45 @@ describe('core/entities/client/web-client', () => {
             });
         });
 
-        it('should create the web client when none exists', async () => {
+        it('should create every system client when none exists', async () => {
             const realmId = randomUUID();
             await provisioner.ensureForRealm({ id: realmId });
 
-            const created = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
-                realmId,
-            });
+            for (const definition of SYSTEM_CLIENT_DEFINITIONS) {
+                const created = await repository.findOneBy({
+                    name: definition.name,
+                    realmId,
+                });
 
-            expect(created).not.toBeNull();
-            expect(created!.builtIn).toBe(true);
-            expect(created!.authMethod).toBe('none');
-            expect(created!.tokenBindingMethod).toBe('none');
+                expect(created, definition.name).not.toBeNull();
+                expect(created!.builtIn).toBe(true);
+                expect(created!.authMethod).toBe('none');
+                expect(created!.tokenBindingMethod).toBe('none');
+                expect(created!.displayName).toBe(definition.displayName);
+            }
         });
 
         // Regression (#3347): the declared `global openid` used to land in the
         // dead `scope` column only, leaving the client with no junction rows.
         // That junction is the sole source /authorize resolves scopes from.
-        it('should bind the built-in scopes through the junction', async () => {
+        it('should bind the built-in scopes through the junction for every client', async () => {
             const realmId = randomUUID();
             await provisioner.ensureForRealm({ id: realmId });
 
-            const client = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
-                realmId,
-            });
+            for (const definition of SYSTEM_CLIENT_DEFINITIONS) {
+                const client = await repository.findOneBy({
+                    name: definition.name,
+                    realmId,
+                });
 
-            expect(await readScopeNames(client!.id)).toEqual(
-                [...WEB_CLIENT_SCOPE_NAMES].sort(),
-            );
+                expect(await readScopeNames(client!.id)).toEqual(
+                    [...definition.scopeNames].sort(),
+                );
 
-            const rows = await clientScopeRepository.findManyBy({ clientId: client!.id });
-            expect(rows.every((row) => row.clientRealmId === realmId)).toBe(true);
-            expect(rows.every((row) => row.scopeRealmId === null)).toBe(true);
+                const rows = await clientScopeRepository.findManyBy({ clientId: client!.id });
+                expect(rows.every((row) => row.clientRealmId === realmId)).toBe(true);
+                expect(rows.every((row) => row.scopeRealmId === null)).toBe(true);
+            }
         });
 
         it('should backfill missing scope rows for an already-provisioned client', async () => {
@@ -133,7 +178,7 @@ describe('core/entities/client/web-client', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             expect(await readScopeNames(client!.id)).toEqual(
-                [...WEB_CLIENT_SCOPE_NAMES].sort(),
+                [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
             );
         });
 
@@ -144,12 +189,17 @@ describe('core/entities/client/web-client', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const result = await repository.findMany(new Query({}));
-            const webClients = result.data.filter(
-                (c) => c.name === CLIENT_WEB_NAME && c.realmId === realmId,
-            );
+            for (const definition of SYSTEM_CLIENT_DEFINITIONS) {
+                const clients = result.data.filter(
+                    (c) => c.name === definition.name && c.realmId === realmId,
+                );
 
-            expect(webClients).toHaveLength(1);
-            expect(clientScopeRepository.getAll()).toHaveLength(WEB_CLIENT_SCOPE_NAMES.length);
+                expect(clients, definition.name).toHaveLength(1);
+            }
+
+            expect(clientScopeRepository.getAll()).toHaveLength(
+                SYSTEM_CLIENT_DEFINITIONS.length * SYSTEM_CLIENT_SCOPE_NAMES.length,
+            );
         });
 
         it('should keep a scope bound by hand', async () => {
@@ -174,7 +224,7 @@ describe('core/entities/client/web-client', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             expect(await readScopeNames(client!.id)).toEqual(
-                [...WEB_CLIENT_SCOPE_NAMES, 'custom'].sort(),
+                [...SYSTEM_CLIENT_SCOPE_NAMES, 'custom'].sort(),
             );
         });
 
@@ -193,7 +243,7 @@ describe('core/entities/client/web-client', () => {
             expect(clientScopeRepository.getAll()).toHaveLength(0);
         });
 
-        it('should refresh redirectUri on an existing built-in web client', async () => {
+        it('should refresh redirectUri on an existing built-in client', async () => {
             const realmId = randomUUID();
             repository.seed([
                 {
@@ -219,24 +269,25 @@ describe('core/entities/client/web-client', () => {
             );
         });
 
-        // The MERGE writes only the keys buildWebClientAttributes carries, so
-        // everything else survives a boot. That is the documented way to
-        // extend the client (provisioning file or API), and accessPolicyId is
-        // deliberately kept out of the builder for exactly this reason.
+        // The MERGE writes only the keys buildSystemClientAttributes carries,
+        // so everything else survives a boot. That is the documented way to
+        // extend a system client (provisioning file or API); accessPolicyId
+        // and displayName are deliberately kept out of the builder for
+        // exactly this reason.
         it('should keep attributes it does not own', async () => {
             const realmId = randomUUID();
             const accessPolicyId = randomUUID();
             repository.seed([
                 {
                     id: randomUUID(),
-                    name: CLIENT_WEB_NAME,
+                    name: CLIENT_ADMIN_CONSOLE_NAME,
                     realmId,
                     builtIn: true,
                     authMethod: 'none',
                     tokenBindingMethod: 'none',
                     redirectUri: 'http://stale.example.com/**',
-                    displayName: 'Example Login',
-                    description: 'the realm login client',
+                    displayName: 'Operators Only',
+                    description: 'the realm operator console',
                     baseUrl: 'https://app.example.com',
                     accessPolicyId,
                 },
@@ -245,28 +296,28 @@ describe('core/entities/client/web-client', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const updated = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ADMIN_CONSOLE_NAME,
                 realmId,
             });
 
             expect(updated!.redirectUri).toBe(
                 'http://localhost:3000/**,https://app.example.com/**',
             );
-            expect(updated!.displayName).toBe('Example Login');
-            expect(updated!.description).toBe('the realm login client');
+            expect(updated!.displayName).toBe('Operators Only');
+            expect(updated!.description).toBe('the realm operator console');
             expect(updated!.baseUrl).toBe('https://app.example.com');
             expect(updated!.accessPolicyId).toBe(accessPolicyId);
         });
 
-        // `web` is a reserved client name, so the row belongs to the system: a
-        // non-built-in one predates the reservation and must not shadow the
-        // realm's login client.
-        it('should take over a non-built-in client named web', async () => {
+        // Every system client name is reserved, so the row belongs to the
+        // system: a non-built-in one predates the reservation and must not
+        // shadow the realm's system client.
+        it('should take over a non-built-in client squatting a reserved name', async () => {
             const realmId = randomUUID();
             repository.seed([
                 {
                     id: randomUUID(),
-                    name: CLIENT_WEB_NAME,
+                    name: CLIENT_ADMIN_CONSOLE_NAME,
                     realmId,
                     builtIn: false,
                     authMethod: 'secret',
@@ -279,7 +330,7 @@ describe('core/entities/client/web-client', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const existing = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ADMIN_CONSOLE_NAME,
                 realmId,
             });
 
@@ -292,7 +343,7 @@ describe('core/entities/client/web-client', () => {
             // it again and must not stay at rest
             expect(existing!.secret).toBeNull();
             expect(await readScopeNames(existing!.id)).toEqual(
-                [...WEB_CLIENT_SCOPE_NAMES].sort(),
+                [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
             );
         });
     });

--- a/apps/server-core/test/unit/core/entities/realm/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/realm/service.spec.ts
@@ -24,9 +24,9 @@ import {
 } from '@authup/server-test-kit';
 import { createFakeRealm } from '../../../../utils/domains/index.ts';
 import type { Realm } from '@authup/core-kit';
-import type { IWebClientProvisioner } from '../../../../../src/core/entities/client/types.ts';
+import type { ISystemClientProvisioner } from '../../../../../src/core/entities/client/types.ts';
 
-class RecordingWebClientProvisioner implements IWebClientProvisioner {
+class RecordingSystemClientProvisioner implements ISystemClientProvisioner {
     public calls: string[] = [];
 
     async ensureForRealm(realm: Realm | { id: string }): Promise<void> {
@@ -110,10 +110,10 @@ describe('core/entities/realm/service', () => {
         });
 
         it('should ensure a web client for the new realm when a provisioner is wired', async () => {
-            const webClientProvisioner = new RecordingWebClientProvisioner();
+            const systemClientProvisioner = new RecordingSystemClientProvisioner();
             service = new RealmService({
                 repository,
-                webClientProvisioner,
+                systemClientProvisioner,
             });
 
             const result = await service.create(
@@ -121,14 +121,14 @@ describe('core/entities/realm/service', () => {
                 createAllowAllActor(),
             );
 
-            expect(webClientProvisioner.calls).toEqual([result.id]);
+            expect(systemClientProvisioner.calls).toEqual([result.id]);
         });
 
         it('should not ensure a web client when updating an existing realm', async () => {
-            const webClientProvisioner = new RecordingWebClientProvisioner();
+            const systemClientProvisioner = new RecordingSystemClientProvisioner();
             service = new RealmService({
                 repository,
-                webClientProvisioner,
+                systemClientProvisioner,
             });
 
             const entity = repository.seed(createFakeRealm({
@@ -138,7 +138,7 @@ describe('core/entities/realm/service', () => {
 
             await service.update(entity.id, { description: 'updated description' }, createAllowAllActor());
 
-            expect(webClientProvisioner.calls).toEqual([]);
+            expect(systemClientProvisioner.calls).toEqual([]);
         });
 
         it('should still persist the realm when web-client provisioning fails', async () => {
@@ -146,7 +146,7 @@ describe('core/entities/realm/service', () => {
             // a provisioner failure is logged + swallowed, not propagated.
             service = new RealmService({
                 repository,
-                webClientProvisioner: {
+                systemClientProvisioner: {
                     async ensureForRealm() {
                         throw new Error('provisioning boom');
                     },

--- a/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
@@ -12,10 +12,16 @@ import {
     it,
 } from 'vitest';
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
-import { CLIENT_WEB_NAME, REALM_MASTER_NAME, ScopeName } from '@authup/core-kit';
+import {
+    CLIENT_ACCOUNT_CONSOLE_NAME,
+    CLIENT_ADMIN_CONSOLE_NAME,
+    CLIENT_WEB_NAME,
+    REALM_MASTER_NAME,
+    ScopeName,
+} from '@authup/core-kit';
 import { OAuth2AuthorizationResponseType } from '@authup/specs';
 import { generateOAuth2CodeVerifier } from '../../../../../src/core';
-import { createFakeClient, expectClientError } from '../../../../utils';
+import { createFakeClient, createFakeRealm, expectClientError } from '../../../../utils';
 import { createTestApplication } from '../../../../app';
 
 describe('src/http/controllers/token', () => {
@@ -125,6 +131,39 @@ describe('src/http/controllers/token', () => {
         });
 
         expect(new URL(response.url).searchParams.get('code')).toBeTruthy();
+    });
+
+    // Plan 079: the console authenticates against the per-realm built-in
+    // `admin-console` client, addressed exactly like the console does it —
+    // name form plus realm hint (a bare name is ambiguous, every realm has
+    // one).
+    it('should authorize the built-in admin-console client by name and realm hint', async () => {
+        const { data: realm } = await suite.client.realm.getOne(REALM_MASTER_NAME);
+
+        const response = await suite.client.authorize.confirm({
+            response_type: OAuth2AuthorizationResponseType.CODE,
+            client_id: CLIENT_ADMIN_CONSOLE_NAME,
+            realm_id: realm.id,
+            redirect_uri: 'http://localhost:3000/login/callback',
+            scope: `${ScopeName.GLOBAL} ${ScopeName.OPEN_ID}`,
+            state: generateOAuth2CodeVerifier(),
+            code_challenge: generateOAuth2CodeVerifier(),
+        });
+
+        expect(new URL(response.url).searchParams.get('code')).toBeTruthy();
+    });
+
+    // Plan 079: creating a realm through the API eagerly provisions its
+    // system clients (the startup backfill only covers pre-existing realms).
+    it('should provision the system clients for a realm created via the API', async () => {
+        const { data: realm } = await suite.client.realm.create(createFakeRealm());
+
+        for (const name of [CLIENT_WEB_NAME, CLIENT_ADMIN_CONSOLE_NAME, CLIENT_ACCOUNT_CONSOLE_NAME]) {
+            const { data: clients } = await suite.client.client.getMany({ filters: { name, realmId: realm.id } });
+
+            expect(clients, name).toHaveLength(1);
+            expect(clients[0].builtIn).toBe(true);
+        }
     });
 
     it('should NOT advertise implicit/hybrid response types in discovery', async () => {

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -18,6 +18,8 @@ import type {
     Role,
 } from '@authup/core-kit';
 import {
+    CLIENT_ACCOUNT_CONSOLE_NAME,
+    CLIENT_ADMIN_CONSOLE_NAME,
     CLIENT_WEB_NAME,
     ClientAuthMethod,
     ClientTokenBindingMethod,
@@ -48,7 +50,7 @@ import {
 } from '../../../src/index.ts';
 import { Container } from 'eldin';
 import type { IContainer } from 'eldin';
-import { PolicyProvisioningSynchronizer, WEB_CLIENT_SCOPE_NAMES } from '../../../src/core/index.ts';
+import { PolicyProvisioningSynchronizer, SYSTEM_CLIENT_SCOPE_NAMES } from '../../../src/core/index.ts';
 import type { PolicyProvisioningEntity } from '../../../src/core/provisioning/entities/policy/index.ts';
 import { PolicyRepository } from '../../../src/adapters/database/domains/index.ts';
 import {
@@ -244,7 +246,7 @@ describe('app/modules/provisioning', () => {
         });
 
         expect(await readScopeNames(masterWebClient!.id)).toEqual(
-            [...WEB_CLIENT_SCOPE_NAMES].sort(),
+            [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
         );
 
         // `secret` is a select:false column, so read it back explicitly.
@@ -264,8 +266,28 @@ describe('app/modules/provisioning', () => {
         expect(legacyClient!.secret).toBeNull();
 
         expect(await readScopeNames(legacyClient!.id)).toEqual(
-            [...WEB_CLIENT_SCOPE_NAMES].sort(),
+            [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
         );
+
+        // Plan 079: every realm additionally carries the admin-console and
+        // account-console system clients, scopes bound and displayName
+        // seeded at create.
+        for (const name of [CLIENT_ADMIN_CONSOLE_NAME, CLIENT_ACCOUNT_CONSOLE_NAME]) {
+            for (const realm of [masterRealm!, legacyRealm]) {
+                const client = await clientRepository.findOneBy({
+                    name,
+                    realmId: realm.id,
+                });
+
+                expect(client, `${name} in ${realm.name}`).not.toBeNull();
+                expect(client!.builtIn).toBe(true);
+                expect(client!.authMethod).toBe(ClientAuthMethod.NONE);
+                expect(client!.displayName).not.toBeNull();
+                expect(await readScopeNames(client!.id)).toEqual(
+                    [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
+                );
+            }
+        }
     });
 
     // ---------------------------------------------------------------

--- a/docs/src/guide/deployment/configuration-client-admin-console.md
+++ b/docs/src/guide/deployment/configuration-client-admin-console.md
@@ -23,6 +23,10 @@ NUXT_PUBLIC_API_URL=http://localhost:3001
 NUXT_PUBLIC_PUBLIC_URL=http://localhost:3000
 # Optional: widen the session cookie domain (e.g. .example.com).
 NUXT_PUBLIC_COOKIE_DOMAIN=
+# The OAuth2 client the console authenticates against. Defaults to the
+# per-realm built-in admin-console client; override only for a fork that
+# registers its own client.
+NUXT_PUBLIC_CLIENT_ID=admin-console
 ````
 :::
 

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -20,8 +20,10 @@ Every realm automatically gets three built-in, public OAuth2 clients:
 All three authenticate end users via the authorization-code flow with PKCE.
 Splitting them keeps concerns separate per application: sessions and audit
 events carry the client they were issued for, and an access policy bound to
-`admin-console` restricts who may obtain tokens for the admin console without
-affecting logins of your own applications riding `web`.
+`admin-console` restricts who may newly log in to the admin console without
+affecting logins of your own applications riding `web`. The policy gates
+admission (the authorization-code flow and code redemption), not tokens that
+were already issued.
 
 The clients are provisioned for every existing realm on startup and for any
 realm created at runtime. Provisioning is idempotent: re-runs refresh the
@@ -48,13 +50,19 @@ attempting to create or rename a client to one of them returns a
 
 ::: tip Restricting the admin console
 Binding an access policy to the `admin-console` client (its `accessPolicyId`)
-denies token issuance for the admin console to identities that fail the
-policy. Note the gate evaluates identity data only (realm, identity type,
-time windows, compositions thereof); role-membership conditions are not
-expressible there yet. Also keep in mind that regular users currently use
-the admin console's settings pages for password, MFA and session
-self-service, so a restrictive policy locks them out of those until the
-dedicated account surface ships.
+denies new authorization-code admission (and code redemption) for the admin
+console to identities that fail the policy. It is admission control, not
+continuous enforcement: the `refresh_token` grant is not re-evaluated, so
+already-issued refresh tokens keep working until they expire. To evict an
+identity that was admitted before the policy changed, revoke its sessions
+(`DELETE /sessions?filter[clientId]=...` or the sessions UI).
+
+Two more caveats: the gate evaluates identity data only (realm, identity
+type, time windows, compositions thereof); role-membership conditions are
+not expressible there yet. And regular users currently use the admin
+console's settings pages for password, MFA and session self-service, so a
+restrictive policy locks them out of those until the dedicated account
+surface ships.
 :::
 
 ### Extending a system client

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -7,22 +7,31 @@ On every server startup, the provisioning system synchronizes the declared state
 Built-in defaults (admin user, admin role, system permissions) are always applied first.
 Your custom provisioning files are merged on top.
 
-## Per-Realm Public `web` Client
+## Per-Realm System Clients
 
-Every realm automatically gets a built-in, public OAuth2 client named `web`.
-This is the client the web UI (`client-admin-console`) uses to log users in via the
-authorization-code flow with PKCE — selecting a realm on the login screen
-redirects the browser to `/authorize?client_id=web&realm_id=<id>`.
+Every realm automatically gets three built-in, public OAuth2 clients:
 
-The client is provisioned for every existing realm on startup and for any
+| Name              | Used by                                                          |
+|-------------------|------------------------------------------------------------------|
+| `web`             | Your own applications embedding `@authup/client-web-kit`         |
+| `admin-console`   | Authup's admin console: selecting a realm on its login screen redirects the browser to `/authorize?client_id=admin-console&realm_id=<id>` |
+| `account-console` | Authup's account self-service surface (upcoming; the client is provisioned ahead of it) |
+
+All three authenticate end users via the authorization-code flow with PKCE.
+Splitting them keeps concerns separate per application: sessions and audit
+events carry the client they were issued for, and an access policy bound to
+`admin-console` restricts who may obtain tokens for the admin console without
+affecting logins of your own applications riding `web`.
+
+The clients are provisioned for every existing realm on startup and for any
 realm created at runtime. Provisioning is idempotent: re-runs refresh the
-client's `redirectUri` allowlist but never duplicate it.
+`redirectUri` allowlists but never duplicate anything.
 
-Its attributes are fixed:
+Their attributes are fixed (identical for all three, except `name`):
 
 | Attribute         | Value                                                              |
 |-------------------|--------------------------------------------------------------------|
-| `name`            | `web`                                                              |
+| `name`            | `web` / `admin-console` / `account-console`                        |
 | `authMethod`      | `none` (public — no secret, PKCE required)                        |
 | `tokenBindingMethod` | `none`                                                         |
 | `builtIn`         | `true`                                                            |
@@ -32,11 +41,23 @@ Its attributes are fixed:
 | `redirectUri`     | `<origin>/**` for every trusted app origin (see below)            |
 | `postLogoutRedirectUri` | the same `<origin>/**` patterns                             |
 
-Because the `web` client is built-in and `builtIn` is stripped from any
-client you create yourself, the name `web` (and `system`) is reserved —
-attempting to create or rename a client to it returns a `400 Bad Request`.
+Because the system clients are built-in and `builtIn` is stripped from any
+client you create yourself, their names (and `system`) are reserved —
+attempting to create or rename a client to one of them returns a
+`400 Bad Request`.
 
-### Extending the `web` client
+::: tip Restricting the admin console
+Binding an access policy to the `admin-console` client (its `accessPolicyId`)
+denies token issuance for the admin console to identities that fail the
+policy. Note the gate evaluates identity data only (realm, identity type,
+time windows, compositions thereof); role-membership conditions are not
+expressible there yet. Also keep in mind that regular users currently use
+the admin console's settings pages for password, MFA and session
+self-service, so a restrictive policy locks them out of those until the
+dedicated account surface ships.
+:::
+
+### Extending a system client
 
 The attributes above are derived from configuration and are reasserted on
 every start. Writing a different value to any of them, from a provisioning
@@ -44,10 +65,12 @@ file or through the API, is reverted at the next boot and no error is
 raised. Redirect patterns in particular are configured through
 `trustedOrigins` (below), not per client.
 
-Every other attribute is left untouched and survives a restart. A
-provisioning file may therefore declare a `web` client to set `displayName`,
-`description`, `baseUrl`, `rootUrl` or `accessPolicyId`, and to assign
-additional roles, permissions and scopes:
+Every other attribute is left untouched and survives a restart —
+`displayName` is seeded once at creation (`Web`, `Admin Console`,
+`Account Console`) and then belongs to you. A provisioning file may
+therefore declare a system client to set `displayName`, `description`,
+`baseUrl`, `rootUrl` or `accessPolicyId`, and to assign additional roles,
+permissions and scopes:
 
 ```yaml
 realms:
@@ -64,8 +87,8 @@ realms:
 Scope assignments are additive. The built-in `global` and `openid` bindings
 are re-created when missing, and nothing is ever removed. Declaring
 `builtIn: true` is optional but keeps the first boot free of a takeover
-warning, which is logged when a client named `web` is found without the
-flag.
+warning, which is logged when a client on a reserved name is found without
+the flag.
 
 ### Trusted app origins
 
@@ -81,7 +104,7 @@ startup; an explicit allowlist can be configured via the `middlewareCors`
 options.)
 
 ::: danger Security
-The `web` client is built-in with the `global` scope, so **any** allowlisted
+The system clients are built-in with the `global` scope, so **any** allowlisted
 origin can complete a login and obtain a full-permission token. Only add
 origins you fully control to `trustedOrigins`. In non-production, the
 client-admin-console dev origin (`http://localhost:3000`) is seeded automatically so

--- a/packages/core-kit/src/domains/client/constants.ts
+++ b/packages/core-kit/src/domains/client/constants.ts
@@ -11,10 +11,23 @@
 export const CLIENT_SYSTEM_NAME = 'system';
 
 /**
- * The public OAuth2 client provisioned for every realm. Shared by
- * authup's own client-web and any downstream UI embedding client-web-kit.
+ * The public OAuth2 client provisioned for every realm for downstream
+ * UIs embedding client-web-kit. Authup's own surfaces use the dedicated
+ * admin-console / account-console clients instead.
  */
 export const CLIENT_WEB_NAME = 'web';
+
+/**
+ * The public OAuth2 client provisioned for every realm for authup's own
+ * admin console (apps/client-admin-console).
+ */
+export const CLIENT_ADMIN_CONSOLE_NAME = 'admin-console';
+
+/**
+ * The public OAuth2 client provisioned for every realm for authup's
+ * account self-service surface (served by server-core).
+ */
+export const CLIENT_ACCOUNT_CONSOLE_NAME = 'account-console';
 
 /**
  * How an OAuth client authenticates at the token endpoint.
@@ -43,4 +56,6 @@ export const CLIENT_CERTIFICATE_URI_PREFIX = 'urn:authup:client:';
 export const CLIENT_RESERVED_NAMES = [
     CLIENT_SYSTEM_NAME,
     CLIENT_WEB_NAME,
+    CLIENT_ADMIN_CONSOLE_NAME,
+    CLIENT_ACCOUNT_CONSOLE_NAME,
 ];


### PR DESCRIPTION
## What (plan 079)

Every realm now provisions **three** builtIn public PKCE clients instead of one:

| Client | Used by |
|---|---|
| `web` | Downstream apps embedding `client-web-kit` (unchanged behavior) |
| `admin-console` | The admin console's own login (`client_id=admin-console`, runtime-overridable via `NUXT_PUBLIC_CLIENT_ID`) |
| `account-console` | The upcoming account self-service surface — provisioned ahead of it (`web`'s `<origin>/**` patterns already cover every path it can redirect to, so the inert row adds no redirect surface) |

## Why

- **Admission control**: an access policy bound to `admin-console` gates who may obtain tokens for the admin console without touching downstream logins. Left **open by default** — regular users still need the console's settings pages until the account surface ships; the restriction recipe (and its identity-data-only caveat) is documented in the provisioning guide.
- **Attribution**: sessions and audit events carry the app they were issued for; per-app force-logout via `filter[clientId]`.
- **Blast-radius split**: per-app `grantTypes`, token-binding and post-logout allowlists.

## How

- `web-client.ts` → `core/entities/client/system-clients.ts`: definition-driven `SYSTEM_CLIENT_DEFINITIONS` + `SystemClientProvisioner` (same MERGE-owned attributes, dirty-check, takeover-and-warn, additive scope binding; both invocation sites — startup backfill + realm-create hook — unchanged).
- `displayName` is seeded at CREATE only, never re-asserted; `accessPolicyId` stays out of the MERGE-owned set.
- Redirect patterns stay the shared app-origin set for all three (deliberate: `redirectUri` is boot-reasserted, so a separately-hosted surface registers its origin via `TRUSTED_ORIGINS`).
- `CLIENT_RESERVED_NAMES` grows to `system, web, admin-console, account-console`.
- Docs: provisioning guide section rewritten (three clients + admission recipe), console configuration page documents `NUXT_PUBLIC_CLIENT_ID`, `.agents/architecture.md` updated.

## Compat

No data migration. Existing `web`-bound sessions and refresh tokens keep working and age out; new console logins ride `admin-console`. A new console against an older server-core fails with `invalid_client` — releases are lockstep, noting it regardless.

## Verification

- Full server-core suite: 169 files / 1810 tests green (one `key.spec` failure in the first run reproduced the known shared-sqlite parallel-boot flake; passes in isolation and in the full rerun).
- New/extended specs: provisioner definition matrix (create × merge × takeover × scopes × displayName-seeded-once), reserved names via `it.each(CLIENT_RESERVED_NAMES)`, e2e authorize with `client_id=admin-console` + realm hint, e2e system-client provisioning on API realm-create, DB-level startup backfill for all three clients.
- core-kit tests green; eslint clean.

Base #3370 has merged; this PR now targets master directly (rebased, single commit).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated `web`, `admin-console`, and `account-console` clients for each realm.
  - Added configurable OAuth client selection for the admin console, defaulting to `admin-console`.
  - Added support for authorizing built-in console clients and provisioning them during realm creation.

- **Documentation**
  - Updated provisioning, security, deployment, and client configuration guidance for the expanded system-client model.

- **Bug Fixes**
  - Improved client takeover, scope assignment, redirect refresh, and reserved-name handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->