### PR TITLE
fix(authup): align plan spec regexes with the client.admin-console selector

### DIFF
--- a/apps/authup/test/unit/packages/plan.spec.ts
+++ b/apps/authup/test/unit/packages/plan.spec.ts
@@ -53,7 +53,7 @@ describe('src/packages/plan', () => {
     });
 
     it('should reject migration targeting client-admin-console', () => {
-        expect(() => resolveLaunchPlan('migration', ['client.admin-console'])).toThrow(/client\.console/);
+        expect(() => resolveLaunchPlan('migration', ['client.admin-console'])).toThrow(/client\.admin-console/);
     });
 
     it('should route healthcheck to server-core only', () => {
@@ -64,7 +64,7 @@ describe('src/packages/plan', () => {
     });
 
     it('should reject healthcheck targeting client-admin-console', () => {
-        expect(() => resolveLaunchPlan('healthcheck', ['client.admin-console'])).toThrow(/client\.console/);
+        expect(() => resolveLaunchPlan('healthcheck', ['client.admin-console'])).toThrow(/client\.admin-console/);
     });
 
     it('should fail for an unknown command', () => {


### PR DESCRIPTION
The #3370 amendment sweep renamed the string literals in `plan.spec.ts` but not the escaped regex literals (`/client\.console/` does not match a plain-text sed pattern), leaving two launcher unit tests failing on master:

- `should reject migration targeting client-admin-console`
- `should reject healthcheck targeting client-admin-console`

One-line fix: the `toThrow` regexes now expect `client\.admin-console`. Launcher suite back to 30/30.