### PR TITLE
feat!: wildcard realm provisioning, remove the web system client

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -872,7 +872,7 @@ one into every realm would fight the system MERGE on every boot).
 Scopes run first because they are leaf entities carrying no relations of their
 own, and a client in the same realm block may bind them via `realmScopes`.
 
-### Wildcard Realm Entry (`realms[].name: "*"`, plan 082)
+### Wildcard Realm Entry (`realms[].attributes.name: "*"`, plan 082)
 
 A `realms[]` entry whose name is the literal `*` (`REALM_WILDCARD_NAME`,
 `core/provisioning/constants.ts`) is a SELECTOR over realms, not a realm

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -854,11 +854,14 @@ offending **file path** plus every issue rendered as
 with several mounted files a bad entry aborted the boot with nothing to act
 on.
 
-`CLIENT_RESERVED_NAMES` (`system`, `web`) is **not** enforced here. It stays
-a `ClientService.save()` (API-path) guard, because provisioning bypasses the
-service. Declaring either name is allowed and partially effective. See
-*Per-Realm System Clients* below for which attributes a declaration can
-and cannot set.
+`CLIENT_RESERVED_NAMES` (`system`, `admin-console`, `account-console`) is
+**not** enforced for explicit realm blocks. It stays a `ClientService.save()`
+(API-path) guard, because provisioning bypasses the service. Declaring a
+reserved name there is allowed and partially effective — see *Per-Realm
+System Clients* below for which attributes a declaration can and cannot set.
+A WILDCARD realm entry (below) is the exception: reserved client names are
+rejected at config load (new surface, no BC concern — a template stamping
+one into every realm would fight the system MERGE on every boot).
 
 ### Synchronization Order
 
@@ -869,19 +872,81 @@ and cannot set.
 Scopes run first because they are leaf entities carrying no relations of their
 own, and a client in the same realm block may bind them via `realmScopes`.
 
-### Per-Realm System Clients (`web`, `admin-console`, `account-console`)
+### Wildcard Realm Entry (`realms[].name: "*"`, plan 082)
 
-Every realm auto-provisions three public OAuth2 clients (plan 079;
+A `realms[]` entry whose name is the literal `*` (`REALM_WILDCARD_NAME`,
+`core/provisioning/constants.ts`) is a SELECTOR over realms, not a realm
+declaration: its relations (clients / roles / scopes / permissions / users)
+are ensured in **every** realm — existing at boot, new at creation. This is
+the operator surface that replaced the removed `web` system client (declare
+a downstream login client once, get it in every realm), and the mechanism
+behind the realm-admin-in-every-realm recipe (a wildcard user with
+`globalRoles: [realm_admin]`, issue #2927). YAML note: a bare `*` is an
+alias token, so it must be quoted (`name: "*"`).
+
+- **Relations-only:** a wildcard entry may carry nothing but
+  `attributes.name` and `relations`; realm-level attributes and a
+  realm-level `strategy` are rejected at validation
+  (`RealmWildcardProvisioningValidator`, dispatched by
+  `RealmProvisioningValidator.run` on the literal name; a partial pattern
+  like `tenant-*` fails the regular name check). Child strategies keep the
+  full vocabulary: `createOnly` (default — seed once, realm admins own the
+  row), `merge`/`replace` (reassert per boot on every realm), `absent`
+  (sweep the named entity out of every realm).
+- **Mechanism (expansion + fan-out):** `ProvisionerModule.setup` extracts
+  the wildcard entries after the composite load (folding multiples via the
+  shared merge helpers in `core/provisioning/merge/`), deep-merges the
+  folded entry UNDER every explicit realm entry (explicit wins per
+  attribute, relation lists union, the explicit child's strategy wins —
+  exactly the composite-source rules; a sequential run-after was rejected
+  because `createOnly` is first-writer-wins while `merge` is
+  last-writer-wins, so no ordering satisfies "explicit wins" for both), and
+  lets the graph sync cover declared realms in one pass. Realms without an
+  explicit entry get the entry applied by the startup backfill loop; realms
+  created at runtime via `RealmService.save` get it through the
+  DI-registered `WildcardRealmProvisioner`
+  (`ProvisioningInjectionKey.WildcardRealmProvisioner`, resolved lazily at
+  request time by `createRealmController` since HTTP has no boot-order
+  dependency on provisioning). One provisioner instance serves both paths.
+- **Clone per realm (load-bearing):** `RealmProvisioningSynchronizer`
+  MUTATES its input (realmId stamping onto child attribute objects; the
+  `replace` branch writes the resolved row id back), so
+  `WildcardRealmProvisioner` deep-clones the entry per realm application —
+  a shared object would leak one realm's ids into the next realm's sync.
+  Pinned by `test/unit/core/provisioning/wildcard.spec.ts`.
+- **`IRealmProvisioner` seam:** `RealmService` takes
+  `realmProvisioners?: IRealmProvisioner[]` (order: system clients → keys →
+  wildcard; each wrapped never-fail) — `ISystemClientProvisioner` and
+  `IKeyProvisioner` extend the same contract
+  (`core/provisioning/types.ts`).
+- Authup itself declares nothing via the wildcard — product infrastructure
+  (console clients, keys) stays code-owned, template data stays
+  operator-owned. The two ownership models drift oppositely by design
+  (system = MERGE-owned reassert; template = `createOnly`, admin edits
+  survive).
+
+### Per-Realm System Clients (`admin-console`, `account-console`)
+
+Every realm auto-provisions two public OAuth2 clients (plan 079;
 `SYSTEM_CLIENT_DEFINITIONS` in `core/entities/client/system-clients.ts`,
 name constants in `@authup/core-kit`):
 
-- **`web`** (`CLIENT_WEB_NAME`) — downstream UIs embedding `client-web-kit`.
 - **`admin-console`** (`CLIENT_ADMIN_CONSOLE_NAME`) — authup's own admin
   console (`apps/client-admin-console`; its login sends `client_id=admin-console`,
   runtime-overridable via `NUXT_PUBLIC_CLIENT_ID`).
 - **`account-console`** (`CLIENT_ACCOUNT_CONSOLE_NAME`) — the account
   self-service surface served by server-core at `<publicUrl>/account`
   (plan 080; see *Account Console* below).
+
+The former third definition — `web`, a shared auto-consenting client for
+downstream RPs — was REMOVED (plan 082): it was default-on attack surface
+stamped into every realm for apps that may not exist. Downstream RPs
+register their own clients (per realm, or in every realm via a wildcard
+realm entry — see above). Legacy `web` rows survive as ordinary clients:
+still functional, no longer MERGE-refreshed (`TRUSTED_ORIGINS` changes no
+longer propagate to them), absent from new realms; deletable via the API or
+a wildcard `absent` child entry. `CLIENT_WEB_NAME` is gone and `web` is a
+plain, creatable client name again.
 
 The split exists for admission control (`accessPolicyId` per app — restrict
 the admin console without touching downstream logins; with the account
@@ -940,8 +1005,10 @@ no new endpoint — the `/authorize` verifier already resolves clients via
      after the graph sync and upserts each realm's system clients (MERGE —
      refreshes `redirectUri` when config changes).
   2. **Runtime** — `RealmService.save()` calls `ensureForRealm` when it *creates*
-     a new realm, via the injected `systemClientProvisioner` (system-level, ungated —
-     a realm creator may lack `CLIENT_CREATE`). Not called on update.
+     a new realm, via the injected `realmProvisioners` array (system clients →
+     keys → wildcard defaults; each `IRealmProvisioner` is system-level,
+     ungated — a realm creator may lack `CLIENT_CREATE` — and never-fail).
+     Not called on update.
   Idempotent. The attribute MERGE is dirty-checked to keep a steady-state boot
   free of redundant UPDATEs, but the scope binding runs unconditionally. An
   instance provisioned before the junction rows existed carries a current
@@ -962,7 +1029,7 @@ no new endpoint — the `/authorize` verifier already resolves clients via
   `accessPolicyId` (deliberately omitted from the builder so an admin-set
   policy is not wiped), and every junction row, since `ensureScopes` only
   inserts what is missing and never deletes.
-- **Guardrails:** `system`, `web`, `admin-console` and `account-console` are
+- **Guardrails:** `system`, `admin-console` and `account-console` are
   reserved client names — `ClientService.save()`
   rejects API attempts to create/rename a client onto them (`CLIENT_RESERVED_NAMES`).
   An existing `builtIn` row keeping its own name is exempt, so an admin holding
@@ -1666,7 +1733,8 @@ all serve login/consent from the IdP origin.
 
 **client-admin-console is an ordinary OAuth2 RP** — an admin console authenticating via
 auth-code + PKCE against the per-realm public `admin-console` client (plan 079;
-downstream kit apps keep riding `web`), with no privileged
+downstream kit apps register their own clients — plan 082 removed the shared
+`web` client), with no privileged
 channel into server-core. It is deliberately NOT merged into server-core
 today. The recorded long-term endpoint — deferred until after the planned
 server+worker split — is folding the admin UI into server-core as a **static
@@ -1699,8 +1767,9 @@ session cookies.
 The authenticated identity's realm MUST equal the client's realm — an identity
 cannot authorize (or redeem a code / refresh a token) against a client in
 another realm. Without this an identity with a lingering session for realm A,
-redirected to `/authorize` for realm B's `web` client (a downstream app's realm
-picker), silently minted realm-A tokens against realm B's client (confused
+redirected to `/authorize` for realm B's client (a downstream app's realm
+picker riding the then-provisioned per-realm `web` client), silently minted
+realm-A tokens against realm B's client (confused
 deputy; the artifact carried realm-A `iss`/signing-key + realm-B `aud`).
 Enforced server-side at **three** points — the kit UI (realm-mismatch card in
 `Authorize.vue`) is UX only:
@@ -1721,14 +1790,15 @@ Enforced server-side at **three** points — the kit UI (realm-mismatch card in
    `authorize()` (identity-provider callback) and in-flight pre-deploy codes.
 3. **`/token` refresh parity** — a **public** client refreshing a token whose
    `realm_id` differs from the client's realm → `invalid_grant` (kills legacy
-   cross-realm public-`web`-client refresh tokens). Confidential clients are
+   cross-realm public-client refresh tokens). Confidential clients are
    exempt — the secret proves identity, and the documented cross-realm password
    grant (UUID user + master client) relies on that exemption.
 
-Deliberate breaking change: master-realm admins can no longer ride the built-in
-`web` client into other realms' apps. A name-identified client at `/authorize`
-now also requires a realm hint (`invalid_request` otherwise — every realm has a
-`web` client, so a bare name is ambiguous). All SSR auth pages emit
+Deliberate breaking change: master-realm admins can no longer ride one
+built-in client into other realms' apps. A name-identified client at
+`/authorize` now also requires a realm hint (`invalid_request` otherwise —
+client names are only unique per realm, and every realm carries the
+same-named system clients, so a bare name is ambiguous). All SSR auth pages emit
 `Content-Security-Policy: frame-ancestors 'none'` + `X-Frame-Options: DENY`
 (clickjacking guard — the pages hydrate first-party session state, so click-
 gating is only a defense when framing is denied).
@@ -1945,8 +2015,8 @@ app (kit or non-kit) ends a lingering authup session on its own logout, so
   counts as **unverified** (no revoke; confirm page still works). Realm-key
   resolution is fail-closed too: a supplied-but-unknown realm key skips client
   resolution entirely (no name, no redirect), and a **name**-form `client_id`
-  with no realm key anywhere fails closed as well (ambiguous — every realm has
-  a `web` client; same rule as the /authorize verifier). A UUID `client_id` —
+  with no realm key anywhere fails closed as well (ambiguous — client names
+  are only unique per realm; same rule as the /authorize verifier). A UUID `client_id` —
   including the sole-`aud`-derived one — resolves globally as before.
 - **Bounded expired-hint window (plan 042 item 2):** with config
   `endSessionHintGracePeriod` > 0 (seconds past `exp`, ENV
@@ -2030,7 +2100,7 @@ postLogoutRedirectUri: <origin>/login })`. With the hint the server revokes and
 bounces straight back; without it the server's confirm page returns to
 `/login`. **It passes NO `client_id`**: omitting it lets the service resolve
 the client from the hint's sole `aud` (the client **UUID**). Since plan 047.B a
-name-form `client_id` (`web`) would also work — the service resolves it to the
+name-form `client_id` (`admin-console`) would also work — the service resolves it to the
 UUID before the `aud` cross-check — but omission stays the simplest correct
 call (no name→realm ambiguity to think about). `store.logout()` remains
 local-only — the round-trip is the chosen mechanism, **not** a
@@ -2089,7 +2159,7 @@ neutral message: no identity/policy detail, no enumeration oracle).
   and is mounted `{ optional: true, nullable }` in every validator group so
   admins can set/clear it. `buildSystemClientAttributes` deliberately omits the
   key — the provisioner MERGE would otherwise wipe an admin-set policy on
-  each per-realm system client (`web`, `admin-console`, `account-console`)
+  each per-realm system client (`admin-console`, `account-console`)
   every boot. The admin form binds it via
   `APolicyPicker` in `AClientForm`. Client caches mean a policy
   (re)assignment lags ≤60s at `/token` (`CachePrefix.CLIENT` query cache).
@@ -2247,7 +2317,7 @@ at both chokepoints:
 Unknown values in the column are inert (they can only narrow, never widen). A
 refresh rejected this way is a plain `unauthorized_client` — **not** replay
 detection, so no family revocation; restoring the grant type restores service.
-Each provisioned per-realm system client (`web`, `admin-console`,
+Each provisioned per-realm system client (`admin-console`,
 `account-console`) lists `authorization_code refresh_token`
 (refreshed by `SystemClientProvisioner`'s MERGE on startup).
 
@@ -2289,8 +2359,8 @@ The three realm-resolving grants (`password`, `authorization_code`,
   identified by its UUID). This makes the refresh leg deterministic: a
   password login via master's client refreshes against master's client again
   instead of an unscoped name lookup matching an arbitrary same-named client
-  in another realm (every realm has a built-in `web` client, so collisions
-  are guaranteed). A client name that does not exist in the resolved realm
+  in another realm (every realm carries the same-named built-in system
+  clients, so collisions are guaranteed). A client name that does not exist in the resolved realm
   fails with `invalid_client`; register the client in that realm, pass a
   matching hint, or use its UUID. On the SSR `/authorize` page the login realm is
   pinned to the **client's** realm (`codeRequest.realm_id`, seeded into the

--- a/apps/server-core/src/app/modules/config/types.ts
+++ b/apps/server-core/src/app/modules/config/types.ts
@@ -115,7 +115,7 @@ export type Config = {
 
     /**
      * Trusted first-party app origins (besides publicUrl) — used as
-     * redirect targets for the per-realm public `web` client. Does NOT
+     * redirect targets for the per-realm public system clients. Does NOT
      * drive CORS (the API reflects any origin by default; an explicit
      * CORS allowlist goes through middlewareCors), and does not affect
      * UIs using their own registered OAuth2 client. Input entries may be
@@ -123,10 +123,10 @@ export type Config = {
      * rejected) or bare hosts (host[:port]) — a bare host expands to
      * both its http and https origin during normalization, so the
      * normalized config always holds full origins (scheme://host[:port],
-     * no path); each is stored as `<origin>/**` in the web client's
+     * no path); each is stored as `<origin>/**` in the system clients'
      * redirect_uri set.
      *
-     * SECURITY: the `web` client is built_in (auto-consent + `global`
+     * SECURITY: the system clients are built_in (auto-consent + `global`
      * scope), so any origin listed here can obtain a full-permission user
      * token once a user logs in. Adding an origin grants it full login
      * capability for every realm.

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -154,8 +154,10 @@ import {
     UserRoleService,
     UserService,
 } from '../../../../core/index.ts';
+import type { IRealmProvisioner } from '../../../../core/index.ts';
 import { AuthenticationInjectionKey } from '../../authentication/index.ts';
 import { OAuth2InjectionToken } from '../../oauth2/index.ts';
+import { ProvisioningInjectionKey } from '../../provisioning/constants.ts';
 import { IdentityInjectionKey } from '../../identity/index.ts';
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import type { Config } from '../../config/index.ts';
@@ -1003,10 +1005,27 @@ export class HTTPControllerModule {
             logger,
         });
 
+        // The wildcard realm provisioner is registered by ProvisionerModule
+        // AFTER the async provisioning-source load, and the HTTP module does
+        // not depend on the provisioning module's boot order — resolve it
+        // lazily at request time. No wildcard entry declared => no-op.
+        const wildcardProvisioner : IRealmProvisioner = {
+            async ensureForRealm(realm) {
+                if (container.has(ProvisioningInjectionKey.WildcardRealmProvisioner)) {
+                    await container
+                        .resolve(ProvisioningInjectionKey.WildcardRealmProvisioner)
+                        .ensureForRealm(realm);
+                }
+            },
+        };
+
         const service = new RealmService({
             repository,
-            systemClientProvisioner,
-            keyProvisioner,
+            realmProvisioners: [
+                systemClientProvisioner,
+                keyProvisioner,
+                wildcardProvisioner,
+            ],
             logger,
         });
         const keyRepository = dataSource.getRepository(KeyEntity);

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -154,10 +154,9 @@ import {
     UserRoleService,
     UserService,
 } from '../../../../core/index.ts';
-import type { IRealmProvisioner } from '../../../../core/index.ts';
 import { AuthenticationInjectionKey } from '../../authentication/index.ts';
 import { OAuth2InjectionToken } from '../../oauth2/index.ts';
-import { ProvisioningInjectionKey } from '../../provisioning/constants.ts';
+import { LazyWildcardRealmProvisioner } from '../../provisioning/lazy-wildcard.ts';
 import { IdentityInjectionKey } from '../../identity/index.ts';
 import type { StatusResponseFeatures } from '@authup/core-http-kit';
 import type { Config } from '../../config/index.ts';
@@ -1005,26 +1004,12 @@ export class HTTPControllerModule {
             logger,
         });
 
-        // The wildcard realm provisioner is registered by ProvisionerModule
-        // AFTER the async provisioning-source load, and the HTTP module does
-        // not depend on the provisioning module's boot order — resolve it
-        // lazily at request time. No wildcard entry declared => no-op.
-        const wildcardProvisioner : IRealmProvisioner = {
-            async ensureForRealm(realm) {
-                if (container.has(ProvisioningInjectionKey.WildcardRealmProvisioner)) {
-                    await container
-                        .resolve(ProvisioningInjectionKey.WildcardRealmProvisioner)
-                        .ensureForRealm(realm);
-                }
-            },
-        };
-
         const service = new RealmService({
             repository,
             realmProvisioners: [
                 systemClientProvisioner,
                 keyProvisioner,
-                wildcardProvisioner,
+                new LazyWildcardRealmProvisioner(container),
             ],
             logger,
         });

--- a/apps/server-core/src/app/modules/provisioning/constants.ts
+++ b/apps/server-core/src/app/modules/provisioning/constants.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { TypedToken } from 'eldin';
+import type { IRealmProvisioner } from '../../../core/index.ts';
+
+export const ProvisioningInjectionKey = {
+    /**
+     * Registered by ProvisionerModule.setup iff the loaded provisioning
+     * data carries a wildcard realm entry. Resolved lazily (request time)
+     * by the realm controller factory, so the HTTP module never depends
+     * on provisioning-module boot order.
+     */
+    WildcardRealmProvisioner: new TypedToken<IRealmProvisioner>('WildcardRealmProvisioner'),
+} as const;

--- a/apps/server-core/src/app/modules/provisioning/index.ts
+++ b/apps/server-core/src/app/modules/provisioning/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './constants.ts';
+export * from './lazy-wildcard.ts';
 export * from './sources/index.ts';
 export * from './module.ts';

--- a/apps/server-core/src/app/modules/provisioning/lazy-wildcard.ts
+++ b/apps/server-core/src/app/modules/provisioning/lazy-wildcard.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Realm } from '@authup/core-kit';
+import type { IContainer } from 'eldin';
+import type { IRealmProvisioner } from '../../../core/index.ts';
+import { ProvisioningInjectionKey } from './constants.ts';
+
+/**
+ * The wildcard realm provisioner is registered by ProvisionerModule AFTER
+ * the async provisioning-source load, and the HTTP module does not depend
+ * on the provisioning module's boot order — resolve it lazily at request
+ * time. No wildcard entry declared => no-op.
+ */
+export class LazyWildcardRealmProvisioner implements IRealmProvisioner {
+    protected container: IContainer;
+
+    constructor(container: IContainer) {
+        this.container = container;
+    }
+
+    async ensureForRealm(realm: Realm): Promise<void> {
+        if (this.container.has(ProvisioningInjectionKey.WildcardRealmProvisioner)) {
+            await this.container
+                .resolve(ProvisioningInjectionKey.WildcardRealmProvisioner)
+                .ensureForRealm(realm);
+        }
+    }
+}

--- a/apps/server-core/src/app/modules/provisioning/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/module.ts
@@ -48,7 +48,14 @@ import {
     ScopeProvisioningSynchronizer,
     UserProvisioningSynchronizer,
 } from '../../../core/provisioning/synchronizer/index.ts';
+import type { RealmProvisioningRelations } from '../../../core/provisioning/entities/index.ts';
+import {
+    WildcardRealmProvisioner,
+    expandWildcardRealmEntry,
+    extractWildcardRealmEntry,
+} from '../../../core/provisioning/wildcard/index.ts';
 import type { IProvisioningSource } from '../../../core/provisioning/types.ts';
+import { ProvisioningInjectionKey } from './constants.ts';
 import {
     ClientPermissionRepositoryAdapter,
     ClientRepositoryAdapter,
@@ -105,6 +112,21 @@ export class ProvisionerModule implements IModule {
 
         const composite = new CompositeProvisioningSource(sources);
         const data = await composite.load(container);
+
+        // ---------------------------------------------------------------
+        // Wildcard realm entry (plan 082): split the `name: "*"` entry out
+        // of `data.realms` and deep-merge it UNDER every explicit realm
+        // entry (explicit wins per attribute, relation lists union) so the
+        // graph sync below covers declared realms in one pass. Realms
+        // without an explicit entry get the wildcard applied by the
+        // backfill loop; runtime-created realms via the DI-registered
+        // provisioner (RealmService hook).
+        // ---------------------------------------------------------------
+        const wildcardEntry = extractWildcardRealmEntry(data);
+        let wildcardVariants : Map<string, RealmProvisioningRelations> | undefined;
+        if (wildcardEntry) {
+            wildcardVariants = expandWildcardRealmEntry(wildcardEntry, data);
+        }
 
         const dataSource = container.resolve(DatabaseInjectionKey.DataSource);
         const realmRepository = container.resolve<Repository<Realm>>(RealmEntity);
@@ -248,10 +270,34 @@ export class ProvisionerModule implements IModule {
             logger: container.resolve(LoggerInjectionKey),
         });
 
+        // Wildcard realm provisioning (plan 082): one shared instance for
+        // the boot backfill below AND the runtime realm-create hook (the
+        // realm controller factory resolves the DI key lazily), so the two
+        // paths cannot drift. Registered only when a wildcard entry was
+        // declared.
+        let wildcardProvisioner : WildcardRealmProvisioner | undefined;
+        if (container.has(ProvisioningInjectionKey.WildcardRealmProvisioner)) {
+            container.unregister(ProvisioningInjectionKey.WildcardRealmProvisioner);
+        }
+        if (wildcardEntry) {
+            wildcardProvisioner = new WildcardRealmProvisioner({
+                relations: wildcardEntry.relations ?? {},
+                relationsByRealmName: wildcardVariants,
+                synchronizer: realmSynchronizer,
+                logger: container.resolve(LoggerInjectionKey),
+            });
+            container.register(ProvisioningInjectionKey.WildcardRealmProvisioner, { useValue: wildcardProvisioner });
+        }
+
         const realms = await realmRepository.find();
         for (const realm of realms) {
             await systemClientProvisioner.ensureForRealm(realm);
             await keyProvisioner.ensureForRealm(realm);
+            // Realms with an explicit entry were already covered by the
+            // wildcard expansion inside the graph sync above.
+            if (wildcardProvisioner && !wildcardProvisioner.hasExplicitEntry(realm)) {
+                await wildcardProvisioner.ensureForRealm(realm);
+            }
         }
 
         if (config.permissionsDefaultPolicyAssignment) {

--- a/apps/server-core/src/app/modules/provisioning/sources/composite/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/sources/composite/module.ts
@@ -5,27 +5,10 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isObject } from '@authup/kit';
 import type { RootProvisioningEntity } from '../../../../../core/provisioning/entities/root/index.ts';
+import { mergeProvisioningEntities } from '../../../../../core/provisioning/merge/index.ts';
 import type { IProvisioningSource } from '../../../../../core/provisioning/types.ts';
 import type { IContainer } from 'eldin';
-
-/**
- * Structural view of a provisioning entity used by the composite merge.
- * Covers every entity shape (realm, client, user, role, permission, scope,
- * policy): the composite-key attribute bag plus the deep-mergeable groups.
- */
-type MergeableProvisioningEntity = {
-    attributes: {
-        name?: string,
-        realmId?: string | null,
-        clientId?: string | null,
-    },
-    strategy?: unknown,
-    relations?: Record<string, unknown>,
-    children?: MergeableProvisioningEntity[],
-    extraAttributes?: Record<string, unknown>,
-};
 
 export class CompositeProvisioningSource implements IProvisioningSource {
     protected sources : IProvisioningSource[];
@@ -47,128 +30,10 @@ export class CompositeProvisioningSource implements IProvisioningSource {
     }
 
     merge(target: RootProvisioningEntity, source: RootProvisioningEntity) {
-        target.policies = this.mergeEntities(target.policies, source.policies);
-        target.permissions = this.mergeEntities(target.permissions, source.permissions);
-        target.roles = this.mergeEntities(target.roles, source.roles);
-        target.scopes = this.mergeEntities(target.scopes, source.scopes);
-        target.realms = this.mergeEntities(target.realms, source.realms);
-    }
-
-    private buildEntityKey(
-        attributes: MergeableProvisioningEntity['attributes'],
-    ): string | undefined {
-        if (!attributes.name) return undefined;
-        return `${attributes.name}:${attributes.realmId || ''}:${attributes.clientId || ''}`;
-    }
-
-    private mergeEntities<T extends MergeableProvisioningEntity>(
-        target: T[] | undefined,
-        source: T[] | undefined,
-    ): T[] | undefined {
-        if (!source) return target;
-        if (!target) return [...source];
-
-        const result = [...target];
-        source.forEach((item) => {
-            const key = this.buildEntityKey(item.attributes);
-            if (!key) {
-                result.push(item);
-                return;
-            }
-
-            const idx = result.findIndex((r) => this.buildEntityKey(r.attributes) === key);
-            if (idx !== -1) {
-                result[idx] = this.mergeEntity(result[idx], item) as T;
-            } else {
-                result.push(item);
-            }
-        });
-        return result;
-    }
-
-    /**
-     * Deep-merge two entries sharing a composite key. The later source wins
-     * per attribute, but relations are UNIONED — a later source (e.g. a
-     * mounted provisioning file) extending a built-in entry (the default
-     * source's master realm) must not silently drop the built-in relations
-     * (admin user, system client).
-     *
-     * Policy extraAttributes merge per key with the later source winning —
-     * like attributes, NOT like relations: an EA value (a names denylist,
-     * an ATTRIBUTES query tree) is policy configuration, and unioning would
-     * make shrinking a list impossible and fabricate predicates neither
-     * source authored.
-     */
-    private mergeEntity(
-        target: MergeableProvisioningEntity,
-        source: MergeableProvisioningEntity,
-    ): MergeableProvisioningEntity {
-        const output = { ...target, ...source };
-
-        output.attributes = { ...target.attributes, ...source.attributes };
-
-        if (target.strategy && !source.strategy) {
-            output.strategy = target.strategy;
-        }
-
-        if (target.relations && source.relations) {
-            output.relations = this.mergeRecord(target.relations, source.relations);
-        } else if (target.relations && !source.relations) {
-            output.relations = target.relations;
-        }
-
-        if (target.extraAttributes && source.extraAttributes) {
-            output.extraAttributes = { ...target.extraAttributes, ...source.extraAttributes };
-        } else if (target.extraAttributes && !source.extraAttributes) {
-            output.extraAttributes = target.extraAttributes;
-        }
-
-        if (target.children && source.children) {
-            output.children = this.mergeEntities(target.children, source.children);
-        } else if (target.children && !source.children) {
-            output.children = target.children;
-        }
-
-        return output;
-    }
-
-    private mergeRecord(
-        target: Record<string, unknown>,
-        source: Record<string, unknown>,
-    ): Record<string, unknown> {
-        const output : Record<string, unknown> = { ...target };
-        for (const key of Object.keys(source)) {
-            output[key] = key in target ?
-                this.mergeValue(target[key], source[key]) :
-                source[key];
-        }
-        return output;
-    }
-
-    private mergeValue(target: unknown, source: unknown): unknown {
-        if (typeof target === 'undefined') return source;
-        if (typeof source === 'undefined') return target;
-
-        if (Array.isArray(target) && Array.isArray(source)) {
-            if (this.isEntityArray(target) || this.isEntityArray(source)) {
-                return this.mergeEntities(
-                    target as MergeableProvisioningEntity[],
-                    source as MergeableProvisioningEntity[],
-                );
-            }
-            return [...new Set([...target, ...source])];
-        }
-
-        if (isObject(target) && isObject(source)) {
-            return this.mergeRecord(target, source);
-        }
-
-        return source;
-    }
-
-    private isEntityArray(value: unknown[]): value is MergeableProvisioningEntity[] {
-        return value.some(
-            (item) => isObject(item) && 'attributes' in item,
-        );
+        target.policies = mergeProvisioningEntities(target.policies, source.policies);
+        target.permissions = mergeProvisioningEntities(target.permissions, source.permissions);
+        target.roles = mergeProvisioningEntities(target.roles, source.roles);
+        target.scopes = mergeProvisioningEntities(target.scopes, source.scopes);
+        target.realms = mergeProvisioningEntities(target.realms, source.realms);
     }
 }

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -186,8 +186,8 @@ export class ClientService extends AbstractEntityService implements IClientServi
 
         const validated = await this.validator.run(data, { group });
 
-        // Reserve the system-provisioned client names (`system`, `web`) so an
-        // API caller can't create or rename a client onto them — that would
+        // Reserve the system-provisioned client names (`system`, the console
+        // clients) so an API caller can't create or rename a client onto them — that would
         // collide on unique(name, realmId) or shadow the builtIn client.
         // Provisioning and runtime hooks bypass this service, so they remain
         // free to manage the reserved clients. builtIn clients are exempt

--- a/apps/server-core/src/core/entities/client/system-clients.ts
+++ b/apps/server-core/src/core/entities/client/system-clients.ts
@@ -8,7 +8,6 @@
 import {
     CLIENT_ACCOUNT_CONSOLE_NAME,
     CLIENT_ADMIN_CONSOLE_NAME,
-    CLIENT_WEB_NAME,
     ClientAuthMethod,
     ClientTokenBindingMethod,
     ScopeName,
@@ -41,22 +40,20 @@ export const SYSTEM_CLIENT_SCOPE_NAMES: string[] = [
 /**
  * The public (PKCE) clients provisioned for every realm (plan 079):
  *
- * - `web` — downstream UIs embedding client-web-kit,
  * - `admin-console` — authup's own admin console (apps/client-admin-console),
- * - `account-console` — the account self-service surface (plan 080; the
- *   row is provisioned ahead of the surface — `web`'s `<origin>/**`
- *   patterns already cover every path it can redirect to, so an inert row
- *   adds no redirect surface).
+ * - `account-console` — the account self-service surface (plan 080; each
+ *   definition gets its own `<origin>/**` patterns from
+ *   `buildSystemClientAttributes`, so an inert row adds no redirect
+ *   surface).
+ *
+ * Downstream RPs register their own clients (per realm, or in every realm
+ * via a wildcard realm provisioning entry, plan 082) — the former shared
+ * `web` client was removed.
  *
  * `displayName` is seeded at CREATE only and never re-asserted by the
  * MERGE, so an admin may relabel a client without the next boot undoing it.
  */
 export const SYSTEM_CLIENT_DEFINITIONS: SystemClientDefinition[] = [
-    {
-        name: CLIENT_WEB_NAME,
-        displayName: 'Web',
-        scopeNames: SYSTEM_CLIENT_SCOPE_NAMES,
-    },
     {
         name: CLIENT_ADMIN_CONSOLE_NAME,
         displayName: 'Admin Console',

--- a/apps/server-core/src/core/entities/client/types.ts
+++ b/apps/server-core/src/core/entities/client/types.ts
@@ -9,10 +9,11 @@ import type { Client, Realm, Role } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { PermissionPolicyBinding } from '@authup/access';
 import type { ActorContext, EntityRepositoryFindManyResult, IEntityRepository  } from '@authup/server-kit';
+import type { IRealmProvisioner } from '../../provisioning/types.ts';
 
 /**
- * One system-provisioned public client (plan 079): `web`, `admin-console`
- * or `account-console`. `displayName` is seeded at CREATE only; the
+ * One system-provisioned public client (plan 079): `admin-console` or
+ * `account-console`. `displayName` is seeded at CREATE only; the
  * MERGE-owned attribute set is derived per definition by
  * `buildSystemClientAttributes`.
  */
@@ -23,12 +24,12 @@ export type SystemClientDefinition = {
 };
 
 /**
- * Ensures a realm has its system-provisioned public clients (`web`,
- * `admin-console`, `account-console`). Used by startup provisioning
+ * Ensures a realm has its system-provisioned public clients
+ * (`admin-console`, `account-console`). Used by startup provisioning
  * (every realm) and the runtime realm-create hook (a single realm).
  * System-level — never gated on an actor.
  */
-export interface ISystemClientProvisioner {
+export interface ISystemClientProvisioner extends IRealmProvisioner {
     ensureForRealm(realm: Realm | { id: string }): Promise<void>;
 }
 

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -16,16 +16,19 @@ import {
 import type { Realm } from '@authup/core-kit';
 import type { ActorContext, EntityRepositoryFindManyResult, Logger  } from '@authup/server-kit';
 import { AbstractEntityService } from '@authup/server-kit';
-import type { ISystemClientProvisioner } from '../client/types.ts';
-import type { IKeyProvisioner } from '../../key/types.ts';
+import type { IRealmProvisioner } from '../../provisioning/types.ts';
 import type { IRealmRepository, IRealmService } from './types.ts';
 import { decodeQuery } from '../../query/index.ts';
 import { realmSchema } from './schema.ts';
 
 export type RealmServiceContext = {
     repository: IRealmRepository;
-    systemClientProvisioner?: ISystemClientProvisioner;
-    keyProvisioner?: IKeyProvisioner;
+    /**
+     * Applied in order on realm CREATE (system clients, keys, wildcard
+     * provisioning defaults). Never-fail: a provisioner failure is logged
+     * and swallowed.
+     */
+    realmProvisioners?: IRealmProvisioner[];
     logger?: Logger;
 };
 
@@ -34,17 +37,14 @@ export class RealmService extends AbstractEntityService implements IRealmService
 
     protected validator: RealmValidator;
 
-    protected systemClientProvisioner?: ISystemClientProvisioner;
-
-    protected keyProvisioner?: IKeyProvisioner;
+    protected realmProvisioners?: IRealmProvisioner[];
 
     protected logger?: Logger;
 
     constructor(ctx: RealmServiceContext) {
         super();
         this.repository = ctx.repository;
-        this.systemClientProvisioner = ctx.systemClientProvisioner;
-        this.keyProvisioner = ctx.keyProvisioner;
+        this.realmProvisioners = ctx.realmProvisioners;
         this.logger = ctx.logger;
         this.validator = new RealmValidator();
     }
@@ -157,29 +157,26 @@ export class RealmService extends AbstractEntityService implements IRealmService
         entity = this.repository.create(validated);
         await this.repository.save(entity);
 
-        // Provision the realm's system clients (web, admin-console,
-        // account-console) via the system-level provisioner (NOT
-        // clientService.create) — it must not be gated on the actor's
-        // CLIENT_CREATE, since a realm creator may lack it. Realm creation
-        // must stay atomic from the caller's perspective: the realm is
-        // already persisted, so a provisioning failure is logged and
-        // swallowed (startup provisioning reconciles every realm's clients).
-        if (this.systemClientProvisioner) {
-            try {
-                await this.systemClientProvisioner.ensureForRealm(entity);
-            } catch (e) {
-                if (this.logger) {
-                    this.logger.warn(
-                        `Failed to provision system clients for realm ${entity.id}: ${e instanceof Error ? e.message : String(e)}`,
-                    );
+        // Provision the realm's baseline (system clients, sig + enc keys,
+        // wildcard provisioning defaults) via the system-level realm
+        // provisioners (NOT the entity services) — they must not be gated
+        // on the actor's permissions, since a realm creator may lack e.g.
+        // CLIENT_CREATE. Realm creation must stay atomic from the caller's
+        // perspective: the realm is already persisted, so a provisioner
+        // failure is logged and swallowed (startup provisioning reconciles
+        // every realm on the next boot).
+        if (this.realmProvisioners) {
+            for (const provisioner of this.realmProvisioners) {
+                try {
+                    await provisioner.ensureForRealm(entity);
+                } catch (e) {
+                    if (this.logger) {
+                        this.logger.warn(
+                            `Failed to provision realm ${entity.id}: ${e instanceof Error ? e.message : String(e)}`,
+                        );
+                    }
                 }
             }
-        }
-
-        // Mint the realm's sig + enc keys eagerly (plan 071 hybrid model) —
-        // same system-level, never-fail posture as the web client above.
-        if (this.keyProvisioner) {
-            await this.keyProvisioner.ensureForRealm(entity);
         }
 
         return {

--- a/apps/server-core/src/core/entities/realm/service.ts
+++ b/apps/server-core/src/core/entities/realm/service.ts
@@ -172,7 +172,7 @@ export class RealmService extends AbstractEntityService implements IRealmService
                 } catch (e) {
                     if (this.logger) {
                         this.logger.warn(
-                            `Failed to provision realm ${entity.id}: ${e instanceof Error ? e.message : String(e)}`,
+                            `${provisioner.constructor.name} failed for realm ${entity.id}: ${e instanceof Error ? e.message : String(e)}`,
                         );
                     }
                 }

--- a/apps/server-core/src/core/key/types.ts
+++ b/apps/server-core/src/core/key/types.ts
@@ -7,8 +7,9 @@
 
 import type { Key } from '@authup/core-kit';
 import type { JWKUse } from '@authup/specs';
+import type { IRealmProvisioner } from '../provisioning/types.ts';
 
-export interface IKeyProvisioner {
+export interface IKeyProvisioner extends IRealmProvisioner {
     /**
      * Ensure the realm holds at least one sig and one enc key row.
      * Idempotent; never throws (provisioning must not fail realm creation

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -47,9 +47,11 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
         }
 
         // A name-identified client needs a realm hint to resolve deterministically
-        // — every realm has a built-in `web` client, so `client_id=web` without a
-        // realm would bind to an arbitrary realm's client (and, post realm-gate,
-        // produce a confusing mismatch against a random realm). Require the hint.
+        // — client names are only unique per realm (every realm carries the
+        // same-named system clients, and a wildcard-provisioned client exists in
+        // every realm), so a bare name would bind to an arbitrary realm's client
+        // (and, post realm-gate, produce a confusing mismatch against a random
+        // realm). Require the hint.
         if (!isUUID(data.client_id) && !data.realm_id) {
             throw OAuth2RequestError.malformed('A realm is required to resolve a client by name.');
         }

--- a/apps/server-core/src/core/oauth2/end-session/service.ts
+++ b/apps/server-core/src/core/oauth2/end-session/service.ts
@@ -100,8 +100,9 @@ export class OAuth2EndSessionService implements IOAuth2EndSessionService {
             // Fail closed instead of dropping the realm predicate: a supplied
             // realm key that does not resolve never degrades to an unscoped
             // lookup, and a NAME-form client_id without any realm key is
-            // ambiguous (every realm has a built-in `web` client — same rule as
-            // the /authorize verifier). A UUID is globally unique and needs no
+            // ambiguous (client names are only unique per realm, and every
+            // realm carries the same-named system clients — same rule as the
+            // /authorize verifier). A UUID is globally unique and needs no
             // scope; the sole-aud-derived clientId is always a UUID.
             if (realm) {
                 client = await this.clientRepository.findOneByIdOrName(clientId, realm.id);

--- a/apps/server-core/src/core/provisioning/constants.ts
+++ b/apps/server-core/src/core/provisioning/constants.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * A realm provisioning entry declared with this name is a WILDCARD entry:
+ * its relations are ensured in every realm (existing at boot, new at
+ * creation) instead of declaring one specific realm. Literal only; partial
+ * patterns (`tenant-*`) are not supported.
+ */
+export const REALM_WILDCARD_NAME = '*';

--- a/apps/server-core/src/core/provisioning/entities/realm/index.ts
+++ b/apps/server-core/src/core/provisioning/entities/realm/index.ts
@@ -7,3 +7,4 @@
 
 export * from './types.ts';
 export * from './validator.ts';
+export * from './wildcard-validator.ts';

--- a/apps/server-core/src/core/provisioning/entities/realm/validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/realm/validator.ts
@@ -6,13 +6,19 @@
  */
 
 import { RealmValidator } from '@authup/core-kit';
+import { isObject } from '@authup/kit';
+import type { ContainerInput, ContainerRunOptions } from 'validup';
 import { Container } from 'validup';
+import { REALM_WILDCARD_NAME } from '../../constants.ts';
 import { ProvisioningStrategyValidator } from '../../strategy/index.ts';
 import { RealmProvisioningRelationsValidator } from './relations-validator.ts';
+import { RealmWildcardProvisioningValidator } from './wildcard-validator.ts';
 
 import type { RealmProvisioningEntity } from './types.ts';
 
 export class RealmProvisioningValidator extends Container<RealmProvisioningEntity> {
+    protected wildcardValidator = new RealmWildcardProvisioningValidator();
+
     protected initialize() {
         super.initialize();
 
@@ -24,5 +30,27 @@ export class RealmProvisioningValidator extends Container<RealmProvisioningEntit
 
         const relationsValidator = new RealmProvisioningRelationsValidator();
         this.mount('relations', { optional: true }, relationsValidator);
+    }
+
+    /**
+     * A realm entry named with the literal wildcard ('*') is a selector
+     * over all realms and follows its own, stricter contract — dispatch it
+     * to the wildcard validator. Anything else (including partial patterns
+     * like 'tenant-*') runs the regular realm validation, where a
+     * non-name-safe character fails the name check.
+     */
+    override async run(
+        input?: ContainerInput<RealmProvisioningEntity>,
+        options?: ContainerRunOptions<RealmProvisioningEntity>,
+    ): Promise<RealmProvisioningEntity> {
+        if (
+            isObject(input) &&
+            isObject(input.attributes) &&
+            input.attributes.name === REALM_WILDCARD_NAME
+        ) {
+            return this.wildcardValidator.run(input, options);
+        }
+
+        return super.run(input, options);
     }
 }

--- a/apps/server-core/src/core/provisioning/entities/realm/wildcard-validator.ts
+++ b/apps/server-core/src/core/provisioning/entities/realm/wildcard-validator.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { CLIENT_RESERVED_NAMES } from '@authup/core-kit';
+import { createValidator } from '@validup/zod';
+import type { ContainerInput, ContainerRunOptions, Issue } from 'validup';
+import { Container, ValidupError, defineIssueItem } from 'validup';
+import { z } from 'zod';
+import { REALM_WILDCARD_NAME } from '../../constants.ts';
+import { RealmProvisioningRelationsValidator } from './relations-validator.ts';
+import type { RealmProvisioningEntity } from './types.ts';
+
+/**
+ * Validates a WILDCARD realm entry (attributes.name === '*'). A wildcard
+ * entry is a selector over realms, not a realm declaration, so it is
+ * relations-only: `attributes` may carry nothing but the literal wildcard
+ * name, and a realm-level `strategy` is rejected (`absent` would mean
+ * "delete every realm"). Child strategies stay fully supported.
+ *
+ * Reserved client names (system / console clients) are rejected: a
+ * template stamping one into every realm would fight the system client
+ * MERGE on every boot.
+ */
+export class RealmWildcardProvisioningValidator extends Container<RealmProvisioningEntity> {
+    protected initialize() {
+        super.initialize();
+
+        this.mount('attributes', createValidator(
+            z.looseObject({ name: z.literal(REALM_WILDCARD_NAME) }).check((ctx) => {
+                const keys = Object.keys(ctx.value);
+                if (keys.length > 1) {
+                    ctx.issues.push({
+                        code: 'custom',
+                        input: ctx.value,
+                        message: 'A wildcard realm entry is relations-only and can not declare realm attributes.',
+                    });
+                }
+            }),
+        ));
+
+        this.mount('strategy', { optional: true }, createValidator(
+            z.any().check((ctx) => {
+                ctx.issues.push({
+                    code: 'custom',
+                    input: ctx.value,
+                    message: 'A wildcard realm entry can not declare a realm-level strategy.',
+                });
+            }),
+        ));
+
+        const relationsValidator = new RealmProvisioningRelationsValidator();
+        this.mount('relations', { optional: true }, relationsValidator);
+    }
+
+    override async run(
+        input?: ContainerInput<RealmProvisioningEntity>,
+        options?: ContainerRunOptions<RealmProvisioningEntity>,
+    ): Promise<RealmProvisioningEntity> {
+        const output = await super.run(input, options);
+
+        const issues : Issue[] = [];
+        const clients = output.relations?.clients ?? [];
+        clients.forEach((client, index) => {
+            const name = client.attributes?.name;
+            if (name && (CLIENT_RESERVED_NAMES as string[]).includes(name)) {
+                issues.push(defineIssueItem({
+                    path: ['relations', 'clients', index, 'attributes', 'name'],
+                    message: `The client name "${name}" is reserved for system clients and can not be declared in a wildcard realm entry.`,
+                    received: name,
+                }));
+            }
+        });
+
+        if (issues.length > 0) {
+            throw new ValidupError(issues);
+        }
+
+        return output;
+    }
+}

--- a/apps/server-core/src/core/provisioning/index.ts
+++ b/apps/server-core/src/core/provisioning/index.ts
@@ -5,7 +5,10 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './constants.ts';
 export * from './entities/index.ts';
+export * from './merge/index.ts';
 export * from './strategy/index.ts';
 export * from './synchronizer/index.ts';
 export * from './types.ts';
+export * from './wildcard/index.ts';

--- a/apps/server-core/src/core/provisioning/merge/index.ts
+++ b/apps/server-core/src/core/provisioning/merge/index.ts
@@ -5,6 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './constants.ts';
-export * from './sources/index.ts';
 export * from './module.ts';
+export * from './types.ts';

--- a/apps/server-core/src/core/provisioning/merge/module.ts
+++ b/apps/server-core/src/core/provisioning/merge/module.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isObject } from '@authup/kit';
+import type { MergeableProvisioningEntity } from './types.ts';
+
+export function buildProvisioningEntityKey(
+    attributes: MergeableProvisioningEntity['attributes'],
+): string | undefined {
+    if (!attributes.name) return undefined;
+    return `${attributes.name}:${attributes.realmId || ''}:${attributes.clientId || ''}`;
+}
+
+export function mergeProvisioningEntities<T extends MergeableProvisioningEntity>(
+    target: T[] | undefined,
+    source: T[] | undefined,
+): T[] | undefined {
+    if (!source) return target;
+    if (!target) return [...source];
+
+    const result = [...target];
+    source.forEach((item) => {
+        const key = buildProvisioningEntityKey(item.attributes);
+        if (!key) {
+            result.push(item);
+            return;
+        }
+
+        const idx = result.findIndex((r) => buildProvisioningEntityKey(r.attributes) === key);
+        if (idx !== -1) {
+            result[idx] = mergeProvisioningEntity(result[idx], item) as T;
+        } else {
+            result.push(item);
+        }
+    });
+    return result;
+}
+
+/**
+ * Deep-merge two entries sharing a composite key. The later (source) side
+ * wins per attribute, but relations are UNIONED — a later source (e.g. a
+ * mounted provisioning file) extending a built-in entry (the default
+ * source's master realm) must not silently drop the built-in relations
+ * (admin user, system client).
+ *
+ * Policy extraAttributes merge per key with the later source winning —
+ * like attributes, NOT like relations: an EA value (a names denylist,
+ * an ATTRIBUTES query tree) is policy configuration, and unioning would
+ * make shrinking a list impossible and fabricate predicates neither
+ * source authored.
+ */
+export function mergeProvisioningEntity(
+    target: MergeableProvisioningEntity,
+    source: MergeableProvisioningEntity,
+): MergeableProvisioningEntity {
+    const output = { ...target, ...source };
+
+    output.attributes = { ...target.attributes, ...source.attributes };
+
+    if (target.strategy && !source.strategy) {
+        output.strategy = target.strategy;
+    }
+
+    if (target.relations && source.relations) {
+        output.relations = mergeProvisioningRecord(target.relations, source.relations);
+    } else if (target.relations && !source.relations) {
+        output.relations = target.relations;
+    }
+
+    if (target.extraAttributes && source.extraAttributes) {
+        output.extraAttributes = { ...target.extraAttributes, ...source.extraAttributes };
+    } else if (target.extraAttributes && !source.extraAttributes) {
+        output.extraAttributes = target.extraAttributes;
+    }
+
+    if (target.children && source.children) {
+        output.children = mergeProvisioningEntities(target.children, source.children);
+    } else if (target.children && !source.children) {
+        output.children = target.children;
+    }
+
+    return output;
+}
+
+function mergeProvisioningRecord(
+    target: Record<string, unknown>,
+    source: Record<string, unknown>,
+): Record<string, unknown> {
+    const output : Record<string, unknown> = { ...target };
+    for (const key of Object.keys(source)) {
+        output[key] = key in target ?
+            mergeProvisioningValue(target[key], source[key]) :
+            source[key];
+    }
+    return output;
+}
+
+function mergeProvisioningValue(target: unknown, source: unknown): unknown {
+    if (typeof target === 'undefined') return source;
+    if (typeof source === 'undefined') return target;
+
+    if (Array.isArray(target) && Array.isArray(source)) {
+        if (isProvisioningEntityArray(target) || isProvisioningEntityArray(source)) {
+            return mergeProvisioningEntities(
+                target as MergeableProvisioningEntity[],
+                source as MergeableProvisioningEntity[],
+            );
+        }
+        return [...new Set([...target, ...source])];
+    }
+
+    if (isObject(target) && isObject(source)) {
+        return mergeProvisioningRecord(target, source);
+    }
+
+    return source;
+}
+
+function isProvisioningEntityArray(value: unknown[]): value is MergeableProvisioningEntity[] {
+    return value.some(
+        (item) => isObject(item) && 'attributes' in item,
+    );
+}

--- a/apps/server-core/src/core/provisioning/merge/types.ts
+++ b/apps/server-core/src/core/provisioning/merge/types.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Structural view of a provisioning entity used by the deep merge.
+ * Covers every entity shape (realm, client, user, role, permission, scope,
+ * policy): the composite-key attribute bag plus the deep-mergeable groups.
+ */
+export type MergeableProvisioningEntity = {
+    attributes: {
+        name?: string,
+        realmId?: string | null,
+        clientId?: string | null,
+    },
+    strategy?: unknown,
+    relations?: Record<string, unknown>,
+    children?: MergeableProvisioningEntity[],
+    extraAttributes?: Record<string, unknown>,
+};

--- a/apps/server-core/src/core/provisioning/types.ts
+++ b/apps/server-core/src/core/provisioning/types.ts
@@ -5,11 +5,22 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Realm } from '@authup/core-kit';
 import type { RootProvisioningEntity } from './entities/index.ts';
 import type { IContainer } from 'eldin';
 
 export interface IProvisioningSource {
     load(container: IContainer) : Promise<RootProvisioningEntity>;
+}
+
+/**
+ * A provisioner invoked for one realm: at startup (backfill over every
+ * existing realm) and on runtime realm creation (`RealmService.save`).
+ * Implementations must be idempotent; a failure must never fail realm
+ * creation (the caller logs and continues).
+ */
+export interface IRealmProvisioner {
+    ensureForRealm(realm: Realm): Promise<void>;
 }
 
 export interface IProvisioningSynchronizer<T> {

--- a/apps/server-core/src/core/provisioning/wildcard/index.ts
+++ b/apps/server-core/src/core/provisioning/wildcard/index.ts
@@ -5,6 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './constants.ts';
-export * from './sources/index.ts';
 export * from './module.ts';
+export * from './types.ts';

--- a/apps/server-core/src/core/provisioning/wildcard/module.ts
+++ b/apps/server-core/src/core/provisioning/wildcard/module.ts
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Realm } from '@authup/core-kit';
+import type { Logger } from '@authup/server-kit';
+import { REALM_WILDCARD_NAME } from '../constants.ts';
+import type { RealmProvisioningEntity, RealmProvisioningRelations } from '../entities/index.ts';
+import { mergeProvisioningEntity } from '../merge/index.ts';
+import type { IProvisioningSynchronizer, IRealmProvisioner } from '../types.ts';
+import type { WildcardRealmProvisionerContext } from './types.ts';
+
+function canonicalizeRealmName(name: string): string {
+    return name.trim().toLowerCase();
+}
+
+/**
+ * Split the wildcard entries (attributes.name === '*') out of
+ * `data.realms`, folding multiples (several files, several entries) into
+ * one via the composite merge rules. The folded entry is stripped to a
+ * relations-only shape: a wildcard entry is a SELECTOR over realms, so
+ * realm-level attributes and a realm-level strategy carry no meaning
+ * (validated away on the file path; discarded structurally here so
+ * programmatic sources get the same semantics).
+ */
+export function extractWildcardRealmEntry(
+    data: { realms?: RealmProvisioningEntity[] },
+): RealmProvisioningEntity | undefined {
+    if (!data.realms || data.realms.length === 0) {
+        return undefined;
+    }
+
+    const wildcards = data.realms.filter(
+        (entry) => entry.attributes.name === REALM_WILDCARD_NAME,
+    );
+    if (wildcards.length === 0) {
+        return undefined;
+    }
+
+    data.realms = data.realms.filter(
+        (entry) => entry.attributes.name !== REALM_WILDCARD_NAME,
+    );
+
+    let folded = wildcards[0];
+    for (let i = 1; i < wildcards.length; i++) {
+        folded = mergeProvisioningEntity(folded, wildcards[i]) as RealmProvisioningEntity;
+    }
+
+    return {
+        attributes: { name: REALM_WILDCARD_NAME },
+        relations: folded.relations ?? {},
+    };
+}
+
+/**
+ * Deep-merge the wildcard entry UNDER every explicit realm entry (explicit
+ * wins per attribute, relation lists union, the explicit child's strategy
+ * wins when it carries one) so the graph sync covers those realms in
+ * one pass. Returns the merged relations per canonical realm name, kept
+ * PRISTINE (cloned before the sync mutates anything) for the runtime
+ * creation hook.
+ */
+export function expandWildcardRealmEntry(
+    wildcard: RealmProvisioningEntity,
+    data: { realms?: RealmProvisioningEntity[] },
+): Map<string, RealmProvisioningRelations> {
+    const variants = new Map<string, RealmProvisioningRelations>();
+
+    if (data.realms) {
+        data.realms = data.realms.map((entry) => {
+            const merged = mergeProvisioningEntity(
+                structuredClone(wildcard),
+                entry,
+            ) as RealmProvisioningEntity;
+
+            if (entry.attributes.name) {
+                variants.set(
+                    canonicalizeRealmName(entry.attributes.name),
+                    structuredClone(merged.relations ?? {}),
+                );
+            }
+
+            return merged;
+        });
+    }
+
+    return variants;
+}
+
+/**
+ * Applies the wildcard entry's relations to ONE realm, by synthesizing a
+ * realm provisioning entity and pushing it through the regular realm
+ * synchronizer (scopes -> clients -> permissions -> roles -> users; the
+ * realm row itself is resolved by name and, carrying no strategy, is
+ * never modified). The entry is deep-cloned per application: the
+ * synchronizer mutates its input (realmId stamping, `replace` writes the
+ * resolved row id back), so a shared object would leak one realm's ids
+ * into the next realm's sync.
+ */
+export class WildcardRealmProvisioner implements IRealmProvisioner {
+    protected relations: RealmProvisioningRelations;
+
+    protected relationsByRealmName?: Map<string, RealmProvisioningRelations>;
+
+    protected synchronizer: IProvisioningSynchronizer<RealmProvisioningEntity>;
+
+    protected logger?: Logger;
+
+    constructor(ctx: WildcardRealmProvisionerContext) {
+        this.relations = ctx.relations;
+        this.relationsByRealmName = ctx.relationsByRealmName;
+        this.synchronizer = ctx.synchronizer;
+        this.logger = ctx.logger;
+    }
+
+    /**
+     * True when the loaded config also declares this realm explicitly:
+     * the startup graph sync already covers it (expansion), so the boot
+     * backfill loop skips it.
+     */
+    hasExplicitEntry(realm: Realm): boolean {
+        if (!this.relationsByRealmName || !realm.name) {
+            return false;
+        }
+        return this.relationsByRealmName.has(canonicalizeRealmName(realm.name));
+    }
+
+    async ensureForRealm(realm: Realm): Promise<void> {
+        if (!realm.name) {
+            this.logger?.warn(
+                `Skipping wildcard realm provisioning for realm ${realm.id}: the realm carries no name.`,
+            );
+            return;
+        }
+
+        const name = canonicalizeRealmName(realm.name);
+        const relations = this.relationsByRealmName?.get(name) ?? this.relations;
+
+        await this.synchronizer.synchronize(structuredClone({
+            attributes: { name },
+            relations,
+        }));
+    }
+}

--- a/apps/server-core/src/core/provisioning/wildcard/types.ts
+++ b/apps/server-core/src/core/provisioning/wildcard/types.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { Logger } from '@authup/server-kit';
+import type { RealmProvisioningEntity, RealmProvisioningRelations } from '../entities/index.ts';
+import type { IProvisioningSynchronizer } from '../types.ts';
+
+export type WildcardRealmProvisionerContext = {
+    /**
+     * The folded wildcard entry's relations, applied to realms without an
+     * explicit realm block.
+     */
+    relations: RealmProvisioningRelations,
+
+    /**
+     * Merged relations (wildcard deep-merged UNDER the explicit block) per
+     * canonical realm name, for realms the loaded config declares
+     * explicitly. Applied when such a realm is (re-)created at runtime.
+     */
+    relationsByRealmName?: Map<string, RealmProvisioningRelations>,
+
+    synchronizer: IProvisioningSynchronizer<RealmProvisioningEntity>,
+
+    logger?: Logger,
+};

--- a/apps/server-core/test/data/sources-wildcard-invalid/reserved-client.yaml
+++ b/apps/server-core/test/data/sources-wildcard-invalid/reserved-client.yaml
@@ -1,0 +1,7 @@
+realms:
+    - attributes:
+          name: "*"
+      relations:
+          clients:
+              - attributes:
+                    name: admin-console

--- a/apps/server-core/test/data/sources-wildcard/main.yaml
+++ b/apps/server-core/test/data/sources-wildcard/main.yaml
@@ -1,0 +1,12 @@
+realms:
+    - attributes:
+          # quoted on purpose: a bare * is a YAML alias token
+          name: "*"
+      relations:
+          clients:
+              - attributes:
+                    name: portal
+                    displayName: Portal
+          roles:
+              - attributes:
+                    name: template-role

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -9,8 +9,8 @@ import { randomUUID } from 'node:crypto';
 import { eq, isQuery } from '@rapiq/core';
 import { applyQuery } from '@rapiq/adapter-memory';
 import {
+    CLIENT_ADMIN_CONSOLE_NAME,
     CLIENT_RESERVED_NAMES,
-    CLIENT_WEB_NAME,
     IdentityType,
     PermissionName,
 } from '@authup/core-kit';
@@ -626,8 +626,8 @@ describe('core/entities/client/service', () => {
     });
 
     describe('guardrails', () => {
-        // Covers every reserved system-client name — incl. the plan-079
-        // additions admin-console / account-console.
+        // Covers every reserved system-client name (system plus the
+        // plan-079 console clients; `web` left the list with plan 082).
         it.each(CLIENT_RESERVED_NAMES)('should reject creating a client with the reserved name "%s"', async (name) => {
             await expect(
                 service.create(
@@ -641,8 +641,19 @@ describe('core/entities/client/service', () => {
             const entity = repository.seed(createFakeClient({ name: 'renamable' }));
 
             await expect(
-                service.update(entity.id, { name: CLIENT_WEB_NAME }, createAllowAllActor()),
+                service.update(entity.id, { name: CLIENT_ADMIN_CONSOLE_NAME }, createAllowAllActor()),
             ).rejects.toMatchObject({ code: ErrorCode.BAD_REQUEST });
+        });
+
+        // Plan 082 removed the `web` system client, so the name is a plain,
+        // creatable client name again.
+        it('should allow creating a client named "web"', async () => {
+            const result = await service.create(
+                createFakeClient({ name: 'web' }),
+                createAllowAllActor(),
+            );
+
+            expect(result.name).toBe('web');
         });
 
         it('should strip builtIn on create so API callers cannot self-assign it', async () => {

--- a/apps/server-core/test/unit/core/entities/client/system-clients.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/system-clients.spec.ts
@@ -10,7 +10,6 @@ import { Query } from '@rapiq/core';
 import {
     CLIENT_ACCOUNT_CONSOLE_NAME,
     CLIENT_ADMIN_CONSOLE_NAME,
-    CLIENT_WEB_NAME,
     ScopeName,
 } from '@authup/core-kit';
 import type { ClientScope } from '@authup/core-kit';
@@ -30,15 +29,14 @@ import {
 import { FakeScopeRepository } from '../scope/fake-repository.ts';
 import { FakeClientRepository } from './fake-repository.ts';
 
-const webDefinition = SYSTEM_CLIENT_DEFINITIONS
-    .find((definition) => definition.name === CLIENT_WEB_NAME)!;
+const adminConsoleDefinition = SYSTEM_CLIENT_DEFINITIONS
+    .find((definition) => definition.name === CLIENT_ADMIN_CONSOLE_NAME)!;
 
 describe('core/entities/client/system-clients', () => {
     const appOrigins = ['http://localhost:3000', 'https://app.example.com'];
 
-    it('should declare the web, admin-console and account-console clients', () => {
+    it('should declare the admin-console and account-console clients', () => {
         expect(SYSTEM_CLIENT_DEFINITIONS.map((definition) => definition.name)).toEqual([
-            CLIENT_WEB_NAME,
             CLIENT_ADMIN_CONSOLE_NAME,
             CLIENT_ACCOUNT_CONSOLE_NAME,
         ]);
@@ -47,9 +45,9 @@ describe('core/entities/client/system-clients', () => {
     describe('buildSystemClientAttributes', () => {
         it('should build a public built-in client with wildcard redirect uris', () => {
             const realmId = randomUUID();
-            const attributes = buildSystemClientAttributes(webDefinition, { id: realmId }, appOrigins);
+            const attributes = buildSystemClientAttributes(adminConsoleDefinition, { id: realmId }, appOrigins);
 
-            expect(attributes.name).toBe(CLIENT_WEB_NAME);
+            expect(attributes.name).toBe(CLIENT_ADMIN_CONSOLE_NAME);
             expect(attributes.realmId).toBe(realmId);
             expect(attributes.authMethod).toBe('none');
             expect(attributes.tokenBindingMethod).toBe('none');
@@ -166,7 +164,7 @@ describe('core/entities/client/system-clients', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const client = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ACCOUNT_CONSOLE_NAME,
                 realmId,
             });
 
@@ -207,7 +205,7 @@ describe('core/entities/client/system-clients', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const client = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ACCOUNT_CONSOLE_NAME,
                 realmId,
             });
             const extra = scopeRepository.seed({
@@ -235,7 +233,7 @@ describe('core/entities/client/system-clients', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const client = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ACCOUNT_CONSOLE_NAME,
                 realmId,
             });
 
@@ -248,7 +246,7 @@ describe('core/entities/client/system-clients', () => {
             repository.seed([
                 {
                     id: randomUUID(),
-                    name: CLIENT_WEB_NAME,
+                    name: CLIENT_ACCOUNT_CONSOLE_NAME,
                     realmId,
                     builtIn: true,
                     authMethod: 'none',
@@ -260,7 +258,7 @@ describe('core/entities/client/system-clients', () => {
             await provisioner.ensureForRealm({ id: realmId });
 
             const updated = await repository.findOneBy({
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ACCOUNT_CONSOLE_NAME,
                 realmId,
             });
 

--- a/apps/server-core/test/unit/core/entities/realm/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/realm/service.spec.ts
@@ -24,12 +24,12 @@ import {
 } from '@authup/server-test-kit';
 import { createFakeRealm } from '../../../../utils/domains/index.ts';
 import type { Realm } from '@authup/core-kit';
-import type { ISystemClientProvisioner } from '../../../../../src/core/entities/client/types.ts';
+import type { IRealmProvisioner } from '../../../../../src/core/provisioning/types.ts';
 
-class RecordingSystemClientProvisioner implements ISystemClientProvisioner {
+class RecordingRealmProvisioner implements IRealmProvisioner {
     public calls: string[] = [];
 
-    async ensureForRealm(realm: Realm | { id: string }): Promise<void> {
+    async ensureForRealm(realm: Realm): Promise<void> {
         this.calls.push(realm.id);
     }
 }
@@ -109,26 +109,26 @@ describe('core/entities/realm/service', () => {
             expect(found).not.toBeNull();
         });
 
-        it('should ensure a web client for the new realm when a provisioner is wired', async () => {
-            const systemClientProvisioner = new RecordingSystemClientProvisioner();
+        it('should invoke the realm provisioners for the new realm when wired', async () => {
+            const provisioner = new RecordingRealmProvisioner();
             service = new RealmService({
                 repository,
-                systemClientProvisioner,
+                realmProvisioners: [provisioner],
             });
 
             const result = await service.create(
-                { name: 'realm-with-web-client' },
+                { name: 'realm-with-provisioner' },
                 createAllowAllActor(),
             );
 
-            expect(systemClientProvisioner.calls).toEqual([result.id]);
+            expect(provisioner.calls).toEqual([result.id]);
         });
 
-        it('should not ensure a web client when updating an existing realm', async () => {
-            const systemClientProvisioner = new RecordingSystemClientProvisioner();
+        it('should not invoke the realm provisioners when updating an existing realm', async () => {
+            const provisioner = new RecordingRealmProvisioner();
             service = new RealmService({
                 repository,
-                systemClientProvisioner,
+                realmProvisioners: [provisioner],
             });
 
             const entity = repository.seed(createFakeRealm({
@@ -138,19 +138,24 @@ describe('core/entities/realm/service', () => {
 
             await service.update(entity.id, { description: 'updated description' }, createAllowAllActor());
 
-            expect(systemClientProvisioner.calls).toEqual([]);
+            expect(provisioner.calls).toEqual([]);
         });
 
-        it('should still persist the realm when web-client provisioning fails', async () => {
+        it('should still persist the realm and run later provisioners when one fails', async () => {
             // Realm creation must stay atomic from the caller's perspective:
-            // a provisioner failure is logged + swallowed, not propagated.
+            // a provisioner failure is logged + swallowed, not propagated,
+            // and must not starve the provisioners after it.
+            const provisioner = new RecordingRealmProvisioner();
             service = new RealmService({
                 repository,
-                systemClientProvisioner: {
-                    async ensureForRealm() {
-                        throw new Error('provisioning boom');
+                realmProvisioners: [
+                    {
+                        async ensureForRealm() {
+                            throw new Error('provisioning boom');
+                        },
                     },
-                },
+                    provisioner,
+                ],
             });
 
             const result = await service.create(
@@ -161,6 +166,7 @@ describe('core/entities/realm/service', () => {
             expect(result.id).toBeDefined();
             const found = await repository.findOneById(result.id);
             expect(found).not.toBeNull();
+            expect(provisioner.calls).toEqual([result.id]);
         });
     });
 

--- a/apps/server-core/test/unit/core/provisioning/wildcard.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/wildcard.spec.ts
@@ -1,0 +1,341 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { CLIENT_ADMIN_CONSOLE_NAME } from '@authup/core-kit';
+import type { Realm } from '@authup/core-kit';
+import { ValidatorGroup } from '@authup/kit';
+import type { ValidupError } from 'validup';
+import { isValidupError } from 'validup';
+import { describe, expect, it } from 'vitest';
+import { REALM_WILDCARD_NAME } from '../../../../src/core/provisioning/constants.ts';
+import type {
+    RealmProvisioningEntity,
+    RootProvisioningEntity,
+} from '../../../../src/core/provisioning/entities/index.ts';
+import { RealmProvisioningValidator } from '../../../../src/core/provisioning/entities/index.ts';
+import {
+    WildcardRealmProvisioner,
+    expandWildcardRealmEntry,
+    extractWildcardRealmEntry,
+} from '../../../../src/core/provisioning/wildcard/index.ts';
+import type { IProvisioningSynchronizer } from '../../../../src/core/provisioning/types.ts';
+
+class RecordingRealmSynchronizer implements IProvisioningSynchronizer<RealmProvisioningEntity> {
+    public inputs: RealmProvisioningEntity[] = [];
+
+    async synchronize(input: RealmProvisioningEntity): Promise<RealmProvisioningEntity> {
+        this.inputs.push(input);
+
+        // Mirror the real synchronizer's mutation behavior: realmId
+        // stamping onto child attributes, resolved-row id write-back.
+        const realmId = randomUUID();
+        for (const client of input.relations?.clients ?? []) {
+            client.attributes.realmId = realmId;
+            client.attributes.id = randomUUID();
+        }
+
+        return input;
+    }
+
+    async synchronizeMany(input: RealmProvisioningEntity[]): Promise<RealmProvisioningEntity[]> {
+        const output = [];
+        for (const item of input) {
+            output.push(await this.synchronize(item));
+        }
+        return output;
+    }
+}
+
+const buildRealm = (name: string): Realm => ({
+    id: randomUUID(),
+    name,
+} as Realm);
+
+describe('core/provisioning/wildcard', () => {
+    describe('extractWildcardRealmEntry', () => {
+        it('should return undefined when no wildcard entry exists', () => {
+            const data : RootProvisioningEntity = { realms: [{ attributes: { name: 'foo' } }] };
+
+            expect(extractWildcardRealmEntry(data)).toBeUndefined();
+            expect(data.realms).toHaveLength(1);
+        });
+
+        it('should split the wildcard entry out of the realm list', () => {
+            const data : RootProvisioningEntity = {
+                realms: [
+                    { attributes: { name: 'foo' } },
+                    {
+                        attributes: { name: REALM_WILDCARD_NAME },
+                        relations: { clients: [{ attributes: { name: 'portal' } }] },
+                    },
+                ],
+            };
+
+            const entry = extractWildcardRealmEntry(data);
+
+            expect(entry).toBeDefined();
+            expect(entry!.relations?.clients).toHaveLength(1);
+            expect(data.realms!.map((realm) => realm.attributes.name)).toEqual(['foo']);
+        });
+
+        it('should fold multiple wildcard entries via the composite merge rules', () => {
+            const data : RootProvisioningEntity = {
+                realms: [
+                    {
+                        attributes: { name: REALM_WILDCARD_NAME },
+                        relations: { clients: [{ attributes: { name: 'portal', displayName: 'Portal' } }] },
+                    },
+                    {
+                        attributes: { name: REALM_WILDCARD_NAME },
+                        relations: {
+                            clients: [{ attributes: { name: 'portal', description: 'later source' } }],
+                            roles: [{ attributes: { name: 'template-role' } }],
+                        },
+                    },
+                ],
+            };
+
+            const entry = extractWildcardRealmEntry(data);
+
+            expect(data.realms).toHaveLength(0);
+            expect(entry!.relations?.roles).toHaveLength(1);
+            expect(entry!.relations?.clients).toHaveLength(1);
+            expect(entry!.relations?.clients![0].attributes).toMatchObject({
+                name: 'portal',
+                displayName: 'Portal',
+                description: 'later source',
+            });
+        });
+
+        it('should strip realm-level attributes and strategy from the folded entry', () => {
+            const data : RootProvisioningEntity = {
+                realms: [
+                    {
+                        attributes: { name: REALM_WILDCARD_NAME, displayName: 'nope' } as RealmProvisioningEntity['attributes'],
+                        strategy: { type: 'merge' },
+                        relations: { roles: [{ attributes: { name: 'template-role' } }] },
+                    } as RealmProvisioningEntity,
+                ],
+            };
+
+            const entry = extractWildcardRealmEntry(data);
+
+            expect(entry!.attributes).toEqual({ name: REALM_WILDCARD_NAME });
+            expect(entry!.strategy).toBeUndefined();
+        });
+    });
+
+    describe('expandWildcardRealmEntry', () => {
+        const wildcard : RealmProvisioningEntity = {
+            attributes: { name: REALM_WILDCARD_NAME },
+            relations: {
+                clients: [{ attributes: { name: 'portal', displayName: 'Portal' } }],
+                roles: [{ attributes: { name: 'template-role' } }],
+            },
+        };
+
+        it('should merge the wildcard UNDER an explicit entry (explicit wins per attribute)', () => {
+            const data : RootProvisioningEntity = {
+                realms: [{
+                    attributes: { name: 'foo', displayName: 'Foo' },
+                    relations: {
+                        clients: [{
+                            attributes: { name: 'portal', displayName: 'Explicit Portal' },
+                            strategy: { type: 'merge' },
+                        }],
+                    },
+                }],
+            };
+
+            const variants = expandWildcardRealmEntry(wildcard, data);
+
+            const [merged] = data.realms!;
+            expect(merged.attributes).toMatchObject({ name: 'foo', displayName: 'Foo' });
+
+            const clients = merged.relations?.clients ?? [];
+            expect(clients).toHaveLength(1);
+            expect(clients[0].attributes.displayName).toBe('Explicit Portal');
+            expect(clients[0].strategy).toEqual({ type: 'merge' });
+
+            // relation lists union: the wildcard-only role joins the block
+            expect(merged.relations?.roles).toHaveLength(1);
+
+            expect([...variants.keys()]).toEqual(['foo']);
+            expect(variants.get('foo')!.clients![0].attributes.displayName).toBe('Explicit Portal');
+        });
+
+        it('should keep the recorded variants pristine when the expanded entries are mutated', () => {
+            const data : RootProvisioningEntity = {
+                realms: [{
+                    attributes: { name: 'foo' },
+                    relations: { clients: [{ attributes: { name: 'own-client' } }] },
+                }],
+            };
+
+            const variants = expandWildcardRealmEntry(wildcard, data);
+
+            // the graph sync mutates the expanded entries in place
+            const [merged] = data.realms!;
+            for (const client of merged.relations?.clients ?? []) {
+                client.attributes.realmId = randomUUID();
+                client.attributes.id = randomUUID();
+            }
+
+            const variant = variants.get('foo')!;
+            for (const client of variant.clients ?? []) {
+                expect(client.attributes.realmId).toBeUndefined();
+                expect(client.attributes.id).toBeUndefined();
+            }
+        });
+
+        it('should not share objects between the wildcard and the expanded entries', () => {
+            const data : RootProvisioningEntity = { realms: [{ attributes: { name: 'foo' } }] };
+
+            expandWildcardRealmEntry(wildcard, data);
+
+            const [merged] = data.realms!;
+            for (const client of merged.relations?.clients ?? []) {
+                client.attributes.realmId = randomUUID();
+            }
+
+            expect(wildcard.relations?.clients![0].attributes.realmId).toBeUndefined();
+        });
+    });
+
+    describe('WildcardRealmProvisioner', () => {
+        const relations = { clients: [{ attributes: { name: 'portal' } }] };
+
+        it('should synthesize a relations-only entry per realm', async () => {
+            const synchronizer = new RecordingRealmSynchronizer();
+            const provisioner = new WildcardRealmProvisioner({ relations, synchronizer });
+
+            await provisioner.ensureForRealm(buildRealm('foo'));
+
+            expect(synchronizer.inputs).toHaveLength(1);
+            expect(synchronizer.inputs[0].attributes).toEqual({ name: 'foo' });
+            expect(synchronizer.inputs[0].strategy).toBeUndefined();
+            expect(synchronizer.inputs[0].relations?.clients).toHaveLength(1);
+        });
+
+        // The realm synchronizer mutates its input (realmId stamping, the
+        // `replace` branch writes the resolved row id back), so a shared
+        // object would leak one realm's ids into the next realm's sync.
+        it('should deep-clone the entry per realm application', async () => {
+            const synchronizer = new RecordingRealmSynchronizer();
+            const provisioner = new WildcardRealmProvisioner({ relations, synchronizer });
+
+            await provisioner.ensureForRealm(buildRealm('foo'));
+            await provisioner.ensureForRealm(buildRealm('bar'));
+
+            const [first, second] = synchronizer.inputs;
+            expect(first.relations?.clients![0].attributes.realmId).toBeDefined();
+            expect(second.relations?.clients![0].attributes.realmId).toBeDefined();
+            expect(first.relations?.clients![0].attributes.id)
+                .not.toBe(second.relations?.clients![0].attributes.id);
+
+            // the source relations stay untouched
+            expect(relations.clients[0].attributes).toEqual({ name: 'portal' });
+        });
+
+        it('should apply the merged variant for an explicitly declared realm', async () => {
+            const synchronizer = new RecordingRealmSynchronizer();
+            const provisioner = new WildcardRealmProvisioner({
+                relations,
+                relationsByRealmName: new Map([
+                    ['foo', { clients: [{ attributes: { name: 'portal', displayName: 'Explicit Portal' } }] }],
+                ]),
+                synchronizer,
+            });
+
+            expect(provisioner.hasExplicitEntry(buildRealm('foo'))).toBe(true);
+            expect(provisioner.hasExplicitEntry(buildRealm('bar'))).toBe(false);
+
+            await provisioner.ensureForRealm(buildRealm('Foo'));
+            await provisioner.ensureForRealm(buildRealm('bar'));
+
+            expect(synchronizer.inputs[0].relations?.clients![0].attributes.displayName)
+                .toBe('Explicit Portal');
+            expect(synchronizer.inputs[1].relations?.clients![0].attributes.displayName)
+                .toBeUndefined();
+        });
+    });
+
+    describe('RealmProvisioningValidator (wildcard dispatch)', () => {
+        const validator = new RealmProvisioningValidator();
+        const run = (input: Record<string, any>) => validator.run(
+            input as RealmProvisioningEntity,
+            { group: ValidatorGroup.PROVISIONING },
+        );
+
+        // A ValidupError's top-level message is the generic
+        // "Property <path> is invalid" — the reason lives in the issues.
+        const expectIssue = async (promise: Promise<unknown>, pattern: RegExp) => {
+            await expect(promise).rejects.toSatisfy((e: unknown) => {
+                expect(isValidupError(e)).toBe(true);
+                expect(JSON.stringify((e as ValidupError).issues)).toMatch(pattern);
+                return true;
+            });
+        };
+
+        it('should accept a relations-only wildcard entry and validate its children', async () => {
+            const output = await run({
+                attributes: { name: REALM_WILDCARD_NAME },
+                relations: {
+                    clients: [{
+                        attributes: {
+                            // canonicalization must reach the output
+                            name: ' Portal ',
+                        },
+                    }],
+                },
+            });
+
+            expect(output.attributes).toEqual({ name: REALM_WILDCARD_NAME });
+            expect(output.relations?.clients![0].attributes.name).toBe('portal');
+        });
+
+        it('should reject a wildcard entry carrying realm attributes', async () => {
+            await expectIssue(run({ attributes: { name: REALM_WILDCARD_NAME, displayName: 'All Realms' } }), /relations-only/);
+        });
+
+        it('should reject a wildcard entry carrying a realm-level strategy', async () => {
+            await expectIssue(run({
+                attributes: { name: REALM_WILDCARD_NAME },
+                strategy: { type: 'absent' },
+            }), /realm-level strategy/);
+        });
+
+        it('should reject a reserved client name inside a wildcard entry', async () => {
+            await expectIssue(run({
+                attributes: { name: REALM_WILDCARD_NAME },
+                relations: { clients: [{ attributes: { name: CLIENT_ADMIN_CONSOLE_NAME } }] },
+            }), /reserved/);
+        });
+
+        // `web` left the reserved list with plan 082 — the documented
+        // legacy-row cleanup (a wildcard `absent` child named `web`) must
+        // validate.
+        it('should accept a client named "web" inside a wildcard entry', async () => {
+            const output = await run({
+                attributes: { name: REALM_WILDCARD_NAME },
+                relations: {
+                    clients: [{
+                        attributes: { name: 'web' },
+                        strategy: { type: 'absent' },
+                    }],
+                },
+            });
+
+            expect(output.relations?.clients![0].attributes.name).toBe('web');
+        });
+
+        it('should reject a partial wildcard pattern via the regular name validation', async () => {
+            await expect(run({ attributes: { name: 'tenant-*' } })).rejects.toThrow();
+        });
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/consent.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/consent.spec.ts
@@ -13,7 +13,7 @@ import {
     it,
 } from 'vitest';
 import type { Client, Realm, User } from '@authup/core-kit';
-import { CLIENT_WEB_NAME, IdentityType, ScopeName } from '@authup/core-kit';
+import { CLIENT_ADMIN_CONSOLE_NAME, IdentityType, ScopeName } from '@authup/core-kit';
 import { Client as HTTPClient } from '@authup/core-http-kit';
 import { OAuth2AuthorizationResponseType } from '@authup/specs';
 import { generateOAuth2CodeVerifier } from '../../../../../src/core';
@@ -202,16 +202,16 @@ describe('consent', () => {
     });
 
     it('writes zero rows for a built_in client', async () => {
-        const { data: webClients } = await suite.client.client.getMany({ filters: { name: CLIENT_WEB_NAME, realmId: realm.id } });
-        expect(webClients).toHaveLength(1);
-        const [webClient] = webClients;
-        expect(webClient.builtIn).toBe(true);
+        const { data: builtInClients } = await suite.client.client.getMany({ filters: { name: CLIENT_ADMIN_CONSOLE_NAME, realmId: realm.id } });
+        expect(builtInClients).toHaveLength(1);
+        const [builtInClient] = builtInClients;
+        expect(builtInClient.builtIn).toBe(true);
 
-        // the per-realm web client is public: PKCE + state are mandatory, and
-        // its redirect patterns cover the trusted dev origin
+        // the per-realm console client is public: PKCE + state are mandatory,
+        // and its redirect patterns cover the trusted dev origin
         const response = await userClient.authorize.confirm({
             response_type: OAuth2AuthorizationResponseType.CODE,
-            client_id: webClient.id,
+            client_id: builtInClient.id,
             redirect_uri: 'http://localhost:3000/login/callback',
             scope: ScopeName.GLOBAL,
             state: generateOAuth2CodeVerifier(),
@@ -219,7 +219,7 @@ describe('consent', () => {
         });
         expect(new URL(response.url).searchParams.get('code')).toBeTruthy();
 
-        const { data } = await userClient.consent.getMany({ filters: { clientId: webClient.id } });
+        const { data } = await userClient.consent.getMany({ filters: { clientId: builtInClient.id } });
         expect(data).toHaveLength(0);
     });
 

--- a/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/authorize.spec.ts
@@ -15,7 +15,6 @@ import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import {
     CLIENT_ACCOUNT_CONSOLE_NAME,
     CLIENT_ADMIN_CONSOLE_NAME,
-    CLIENT_WEB_NAME,
     REALM_MASTER_NAME,
     ScopeName,
 } from '@authup/core-kit';
@@ -103,27 +102,27 @@ describe('src/http/controllers/token', () => {
         }
     });
 
-    // Regression (#3347): the per-realm built-in `web` client declared its
-    // scopes in the `scope` column only and held no auth_client_scopes rows,
-    // so the verifier saw an empty granted set. A plain OIDC scope=openid
-    // request failed with insufficient_scope; only requests carrying `global`
-    // slipped through, via the verifier's bypass.
-    it('should authorize the built-in web client with scope=openid alone', async () => {
+    // Regression (#3347): the per-realm built-in system clients declared
+    // their scopes in the `scope` column only and held no auth_client_scopes
+    // rows, so the verifier saw an empty granted set. A plain OIDC
+    // scope=openid request failed with insufficient_scope; only requests
+    // carrying `global` slipped through, via the verifier's bypass.
+    it('should authorize a built-in system client with scope=openid alone', async () => {
         const { data: realm } = await suite.client.realm.getOne(REALM_MASTER_NAME);
-        const { data: webClients } = await suite.client.client.getMany({
+        const { data: consoleClients } = await suite.client.client.getMany({
             filters: {
-                name: CLIENT_WEB_NAME,
+                name: CLIENT_ADMIN_CONSOLE_NAME,
                 realmId: realm.id,
             },
         });
 
-        expect(webClients).toHaveLength(1);
+        expect(consoleClients).toHaveLength(1);
 
-        // the web client is public: PKCE + state are mandatory, and its
+        // the console client is public: PKCE + state are mandatory, and its
         // redirect patterns cover the trusted dev origin
         const response = await suite.client.authorize.confirm({
             response_type: OAuth2AuthorizationResponseType.CODE,
-            client_id: webClients[0].id,
+            client_id: consoleClients[0].id,
             redirect_uri: 'http://localhost:3000/login/callback',
             scope: ScopeName.OPEN_ID,
             state: generateOAuth2CodeVerifier(),
@@ -158,12 +157,16 @@ describe('src/http/controllers/token', () => {
     it('should provision the system clients for a realm created via the API', async () => {
         const { data: realm } = await suite.client.realm.create(createFakeRealm());
 
-        for (const name of [CLIENT_WEB_NAME, CLIENT_ADMIN_CONSOLE_NAME, CLIENT_ACCOUNT_CONSOLE_NAME]) {
+        for (const name of [CLIENT_ADMIN_CONSOLE_NAME, CLIENT_ACCOUNT_CONSOLE_NAME]) {
             const { data: clients } = await suite.client.client.getMany({ filters: { name, realmId: realm.id } });
 
             expect(clients, name).toHaveLength(1);
             expect(clients[0].builtIn).toBe(true);
         }
+
+        // Plan 082: the `web` system client is gone — new realms get none.
+        const { data: webClients } = await suite.client.client.getMany({ filters: { name: 'web', realmId: realm.id } });
+        expect(webClients).toHaveLength(0);
     });
 
     it('should NOT advertise implicit/hybrid response types in discovery', async () => {

--- a/apps/server-core/test/unit/modules/provisioning.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { randomUUID } from 'node:crypto';
 import { BuiltInPolicyType, SystemPolicyName } from '@authup/access';
 import type { CompositePolicy } from '@authup/access';
 import { DecisionStrategy } from '@authup/kit';
@@ -20,7 +21,6 @@ import type {
 import {
     CLIENT_ACCOUNT_CONSOLE_NAME,
     CLIENT_ADMIN_CONSOLE_NAME,
-    CLIENT_WEB_NAME,
     ClientAuthMethod,
     ClientTokenBindingMethod,
     REALM_MASTER_NAME,
@@ -58,6 +58,7 @@ import {
     PolicyRepositoryAdapter,
 } from '../../../src/app/modules/database/repositories/index.ts';
 import { DatabaseInjectionKey } from '../../../src/app/modules/database/index.ts';
+import { ProvisioningInjectionKey } from '../../../src/app/modules/provisioning/index.ts';
 import { createTestDatabaseModuleForSuite } from '../../app/index.ts';
 
 describe('app/modules/provisioning', () => {
@@ -203,19 +204,28 @@ describe('app/modules/provisioning', () => {
         expect(clientScopes.map((row) => row.scope.name).sort()).toEqual(['foo', 'realm-scope']);
     });
 
-    // Every realm carries a public `web` client whose provisioned scopes must
-    // reach the junction (#3347). `web` is also a reserved client name, so a
-    // non-built-in row predates the reservation and must not shadow the
-    // realm's login client.
-    it('should provision the web client of every realm with its scopes', async () => {
+    // Every realm carries the console system clients whose provisioned
+    // scopes must reach the junction (#3347). Their names are reserved, so
+    // a non-built-in row predates the reservation and must not shadow the
+    // realm's system client. A legacy `web` row (plan 082 removed the `web`
+    // system client) is an ordinary client now and must survive a boot
+    // untouched.
+    it('should provision the system clients of every realm and leave legacy web rows untouched', async () => {
         const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
         const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
         const clientScopeRepository = di.resolve<Repository<ClientScope>>(ClientScopeEntity);
 
-        // A legacy realm holding a confidential client on the reserved name.
-        const legacyRealm = await realmRepository.save(realmRepository.create({ name: 'takeover' }));
+        // A legacy realm holding a confidential client on a reserved name,
+        // plus a pre-plan-082 `web` row the provisioner used to own.
+        const legacyRealmName = `takeover-${randomUUID().slice(0, 8)}`;
+        const legacyRealm = await realmRepository.save(realmRepository.create({ name: legacyRealmName }));
+        // a realm with nothing seeded: pins that provisioning creates no
+        // `web` row anymore
+        const freshRealm = await realmRepository.save(
+            realmRepository.create({ name: `fresh-${randomUUID().slice(0, 8)}` }),
+        );
         await clientRepository.save(clientRepository.create({
-            name: CLIENT_WEB_NAME,
+            name: CLIENT_ADMIN_CONSOLE_NAME,
             realmId: legacyRealm.id,
             builtIn: false,
             authMethod: ClientAuthMethod.SECRET,
@@ -223,6 +233,14 @@ describe('app/modules/provisioning', () => {
             secret: 'legacy-secret',
             secretHashed: false,
             redirectUri: 'http://user-owned.example.com/**',
+        }));
+        await clientRepository.save(clientRepository.create({
+            name: 'web',
+            realmId: legacyRealm.id,
+            builtIn: true,
+            authMethod: ClientAuthMethod.NONE,
+            tokenBindingMethod: ClientTokenBindingMethod.NONE,
+            redirectUri: 'http://legacy-web.example.com/**',
         }));
 
         const provisioning = new ProvisionerModule([
@@ -240,20 +258,28 @@ describe('app/modules/provisioning', () => {
         };
 
         const masterRealm = await realmRepository.findOneBy({ name: REALM_MASTER_NAME });
-        const masterWebClient = await clientRepository.findOneBy({
-            name: CLIENT_WEB_NAME,
-            realmId: masterRealm!.id,
-        });
 
-        expect(await readScopeNames(masterWebClient!.id)).toEqual(
-            [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
-        );
+        // No realm gets a `web` system client anymore. Asserted on realms
+        // THIS run created: a reused local mysql/postgres database may
+        // legitimately hold a legacy master `web` row from a pre-plan-082
+        // run (the documented survive-untouched posture).
+        expect(await clientRepository.findBy({ name: 'web', realmId: freshRealm.id }))
+            .toHaveLength(0);
+
+        // ... and a pre-existing `web` row is not modified by boot.
+        const legacyWebClient = await clientRepository.findOneBy({
+            name: 'web',
+            realmId: legacyRealm.id,
+        });
+        expect(legacyWebClient!.builtIn).toBe(true);
+        expect(legacyWebClient!.redirectUri).toBe('http://legacy-web.example.com/**');
+        expect(await readScopeNames(legacyWebClient!.id)).toEqual([]);
 
         // `secret` is a select:false column, so read it back explicitly.
         const legacyClient = await clientRepository
             .createQueryBuilder('client')
             .addSelect('client.secret')
-            .where('client.name = :name', { name: CLIENT_WEB_NAME })
+            .where('client.name = :name', { name: CLIENT_ADMIN_CONSOLE_NAME })
             .andWhere('client.realmId = :realmId', { realmId: legacyRealm.id })
             .getOne();
 
@@ -273,7 +299,7 @@ describe('app/modules/provisioning', () => {
         // account-console system clients, scopes bound and displayName
         // seeded at create.
         for (const name of [CLIENT_ADMIN_CONSOLE_NAME, CLIENT_ACCOUNT_CONSOLE_NAME]) {
-            for (const realm of [masterRealm!, legacyRealm]) {
+            for (const realm of [masterRealm!, legacyRealm, freshRealm]) {
                 const client = await clientRepository.findOneBy({
                     name,
                     realmId: realm.id,
@@ -287,6 +313,165 @@ describe('app/modules/provisioning', () => {
                     [...SYSTEM_CLIENT_SCOPE_NAMES].sort(),
                 );
             }
+        }
+    });
+
+    // ---------------------------------------------------------------
+    // Wildcard realm entry (plan 082)
+    // ---------------------------------------------------------------
+
+    it('should load a wildcard realm entry from a provisioning file', async () => {
+        const source = new FileProvisioningSource({ cwd: 'test/data/sources-wildcard' });
+        const output = await source.load();
+
+        expect(output.realms).toHaveLength(1);
+        expect(output.realms![0].attributes).toEqual({ name: '*' });
+        expect(output.realms![0].relations?.clients).toHaveLength(1);
+        expect(output.realms![0].relations?.roles).toHaveLength(1);
+    });
+
+    it('should reject a reserved client name in a wildcard realm entry naming the file', async () => {
+        const source = new FileProvisioningSource({ cwd: 'test/data/sources-wildcard-invalid' });
+
+        await expect(source.load()).rejects.toThrow(/reserved-client\.yaml/);
+        await expect(source.load()).rejects.toThrow(/reserved/);
+    });
+
+    it('should apply a wildcard realm entry to every realm', async () => {
+        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
+        const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
+        const roleRepository = di.resolve<Repository<Role>>(RoleEntity);
+
+        // exists before boot, not declared anywhere in config (random
+        // names: local mysql/postgres runs reuse the database)
+        const preExistingName = `wc-pre-${randomUUID().slice(0, 8)}`;
+        const declaredName = `wc-declared-${randomUUID().slice(0, 8)}`;
+        const runtimeName = `wc-runtime-${randomUUID().slice(0, 8)}`;
+        const preExisting = await realmRepository.save(
+            realmRepository.create({ name: preExistingName }),
+        );
+
+        const wildcardSource = {
+            async load() {
+                return {
+                    realms: [
+                        {
+                            attributes: { name: '*' },
+                            relations: {
+                                clients: [{ attributes: { name: 'portal', displayName: 'Portal' } }],
+                                roles: [{ attributes: { name: 'template-role' } }],
+                            },
+                        },
+                        {
+                            attributes: { name: declaredName },
+                            relations: { clients: [{ attributes: { name: 'portal', displayName: 'Explicit Portal' } }] },
+                        },
+                    ],
+                };
+            },
+        };
+
+        const provisioning = new ProvisionerModule([
+            new DefaultProvisioningSource(),
+            wildcardSource,
+        ]);
+        await provisioning.setup(di);
+
+        const masterRealm = await realmRepository.findOneBy({ name: REALM_MASTER_NAME });
+        const declaredRealm = await realmRepository.findOneBy({ name: declaredName });
+
+        // fan-out: master rides the expansion into its explicit (default
+        // source) block, the pre-existing realm rides the backfill loop
+        for (const realm of [masterRealm!, preExisting]) {
+            const portal = await clientRepository.findOneBy({ name: 'portal', realmId: realm.id });
+            expect(portal, `portal in ${realm.name}`).not.toBeNull();
+            expect(portal!.displayName).toBe('Portal');
+
+            const role = await roleRepository.findOneBy({ name: 'template-role', realmId: realm.id });
+            expect(role, `template-role in ${realm.name}`).not.toBeNull();
+        }
+
+        // explicit block wins per attribute; wildcard-only relations union in
+        const declaredPortal = await clientRepository.findOneBy({
+            name: 'portal',
+            realmId: declaredRealm!.id,
+        });
+        expect(declaredPortal!.displayName).toBe('Explicit Portal');
+        expect(await roleRepository.findOneBy({
+            name: 'template-role',
+            realmId: declaredRealm!.id,
+        })).not.toBeNull();
+
+        // runtime hook: the DI-registered provisioner covers realms created
+        // after boot (RealmService invokes it on create)
+        const runtimeRealm = await realmRepository.save(
+            realmRepository.create({ name: runtimeName }),
+        );
+        const wildcardProvisioner = di.resolve(ProvisioningInjectionKey.WildcardRealmProvisioner);
+        await wildcardProvisioner.ensureForRealm(runtimeRealm);
+
+        expect(await clientRepository.findOneBy({
+            name: 'portal',
+            realmId: runtimeRealm.id,
+        })).not.toBeNull();
+
+        // createOnly (the default): a per-realm admin edit survives a boot
+        await clientRepository.update({ id: declaredPortal!.id }, { displayName: 'Admin Edited' });
+        await new ProvisionerModule([
+            new DefaultProvisioningSource(),
+            wildcardSource,
+        ]).setup(di);
+        expect((await clientRepository.findOneBy({ id: declaredPortal!.id }))!.displayName)
+            .toBe('Admin Edited');
+
+        // a merge child reasserts on every realm each boot
+        await new ProvisionerModule([
+            new DefaultProvisioningSource(),
+            {
+                async load() {
+                    return {
+                        realms: [{
+                            attributes: { name: '*' },
+                            relations: {
+                                clients: [{
+                                    attributes: { name: 'portal', displayName: 'Reasserted' },
+                                    strategy: { type: 'merge' },
+                                }],
+                            },
+                        }],
+                    };
+                },
+            },
+        ]).setup(di);
+        for (const realm of [masterRealm!, preExisting, runtimeRealm]) {
+            const portal = await clientRepository.findOneBy({ name: 'portal', realmId: realm.id });
+            expect(portal!.displayName, `portal in ${realm.name}`).toBe('Reasserted');
+        }
+
+        // an absent child sweeps the entity out of every realm
+        await new ProvisionerModule([
+            new DefaultProvisioningSource(),
+            {
+                async load() {
+                    return {
+                        realms: [{
+                            attributes: { name: '*' },
+                            relations: {
+                                clients: [{
+                                    attributes: { name: 'portal' },
+                                    strategy: { type: 'absent' },
+                                }],
+                            },
+                        }],
+                    };
+                },
+            },
+        ]).setup(di);
+        for (const realm of [masterRealm!, preExisting, declaredRealm!, runtimeRealm]) {
+            expect(
+                await clientRepository.findOneBy({ name: 'portal', realmId: realm.id }),
+                `portal in ${realm.name}`,
+            ).toBeNull();
         }
     });
 

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -134,10 +134,10 @@ export default {
      * to both its http and https origin — pass a full origin to
      * restrict to one scheme.
      * Each origin is added to the redirect-URI allowlist of the per-realm
-     * public `web` client (as `<origin>/**`).
+     * public system clients (as `<origin>/**`).
      * The origin of `publicUrl` is always trusted implicitly.
      *
-     * Security: the `web` client is built-in with global scope, so any
+     * Security: the system clients are built-in with global scope, so any
      * allowlisted origin can complete a login and obtain a full-permission
      * token — only add origins you control. In non-production, the
      * client-admin-console dev origin (http://localhost:3000) is seeded automatically.

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -190,7 +190,7 @@ realms:
           users:
               - attributes:
                     name: realm-admin
-                    password: changeme    # set per deployment!
+                    password: replace-with-a-strong-secret # set per deployment!
                 relations:
                     globalRoles:
                         - realm_admin
@@ -288,7 +288,7 @@ export default {
             relations: {
                 users: [
                     {
-                        attributes: { name: 'alice', password: 'changeme' },
+                        attributes: { name: 'alice', password: 'replace-with-a-strong-secret' },
                         relations: { globalRoles: ['project-manager'] },
                     },
                 ],
@@ -329,7 +329,7 @@ realms:
       users:
         - attributes:
             name: alice
-            password: changeme
+            password: replace-with-a-strong-secret
           relations:
             globalRoles:
               - project-manager

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -9,31 +9,45 @@ Your custom provisioning files are merged on top.
 
 ## Per-Realm System Clients
 
-Every realm automatically gets three built-in, public OAuth2 clients:
+Every realm automatically gets two built-in, public OAuth2 clients:
 
 | Name              | Used by                                                          |
 |-------------------|------------------------------------------------------------------|
-| `web`             | Your own applications embedding `@authup/client-web-kit`         |
 | `admin-console`   | Authup's admin console: selecting a realm on its login screen redirects the browser to `/authorize?client_id=admin-console&realm_id=<id>` |
 | `account-console` | Authup's [account console](./account-console.md), the self-service surface served at `<publicUrl>/account`: its sign-in redirects the browser to `/authorize?client_id=account-console&realm_id=<id>` |
 
-All three authenticate end users via the authorization-code flow with PKCE.
+Both authenticate end users via the authorization-code flow with PKCE.
 Splitting them keeps concerns separate per application: sessions and audit
 events carry the client they were issued for, and an access policy bound to
 `admin-console` restricts who may newly log in to the admin console without
-affecting logins of your own applications riding `web`. The policy gates
+affecting logins of your own applications. The policy gates
 admission (the authorization-code flow and code redemption), not tokens that
 were already issued.
+
+::: warning The `web` system client was removed
+Earlier releases additionally provisioned a shared, auto-consenting `web`
+client into every realm for applications embedding
+`@authup/client-web-kit`. That client no longer exists: register your own
+client instead: in one realm (admin console, API, or a provisioning file),
+or in every realm via a [wildcard realm entry](#realm-wildcard-name).
+
+Existing `web` rows are left untouched: they keep working, but changes to
+`publicUrl` / `trustedOrigins` no longer propagate to their redirect
+allowlists, and realms created after the upgrade do not get one. Once your
+applications have moved, delete the leftover rows via the API, or
+declaratively with a wildcard `absent` entry (see below). The name `web` is
+no longer reserved.
+:::
 
 The clients are provisioned for every existing realm on startup and for any
 realm created at runtime. Provisioning is idempotent: re-runs refresh the
 `redirectUri` allowlists but never duplicate anything.
 
-Their attributes are fixed (identical for all three, except `name`):
+Their attributes are fixed (identical for both, except `name`):
 
 | Attribute         | Value                                                              |
 |-------------------|--------------------------------------------------------------------|
-| `name`            | `web` / `admin-console` / `account-console`                        |
+| `name`            | `admin-console` / `account-console`                                |
 | `authMethod`      | `none` (public — no secret, PKCE required)                        |
 | `tokenBindingMethod` | `none`                                                         |
 | `builtIn`         | `true`                                                            |
@@ -75,7 +89,7 @@ raised. Redirect patterns in particular are configured through
 `trustedOrigins` (below), not per client.
 
 Every other attribute is left untouched and survives a restart —
-`displayName` is seeded once at creation (`Web`, `Admin Console`,
+`displayName` is seeded once at creation (`Admin Console`,
 `Account Console`) and then belongs to you. A provisioning file may
 therefore declare a system client to set `displayName`, `description`,
 `baseUrl`, `rootUrl` or `accessPolicyId`, and to assign additional roles,
@@ -88,9 +102,9 @@ realms:
       relations:
           clients:
               - attributes:
-                    name: web
+                    name: admin-console
                     builtIn: true
-                    displayName: Example Login
+                    displayName: Example Admin Console
 ```
 
 Scope assignments are additive. The built-in `global` and `openid` bindings
@@ -120,6 +134,93 @@ client-admin-console dev origin (`http://localhost:3000`) is seeded automaticall
 the realm-selection login works out of the box; in production nothing is
 seeded — set `trustedOrigins` explicitly for any UI origin other than
 `publicUrl`.
+:::
+
+## Realm Wildcard (`name: "*"`) {#realm-wildcard-name}
+
+A realm entry named with the literal `*` applies its relations to **every**
+realm: all realms existing at startup and every realm created later at
+runtime. Declare an entity once and each realm gets its own copy, with the
+target realm's id injected. Realm-level attributes and a realm-level
+`strategy` are not allowed on a wildcard entry (it selects realms, it does
+not declare one); the per-entity `strategy` vocabulary is fully available
+on its children.
+
+::: warning Quote the asterisk in YAML
+A bare `*` is a YAML alias token, so `name: *` is a parse error. Always
+write `name: "*"`.
+:::
+
+The canonical use case is a login client for your own applications in every
+realm (the replacement for the removed `web` system client), including an
+optional cleanup of leftover `web` rows:
+
+```yaml
+realms:
+    - attributes:
+          name: "*"
+      relations:
+          clients:
+              - attributes:
+                    name: portal
+                    displayName: Portal
+                    authMethod: none
+                    grantTypes: authorization_code refresh_token
+                    redirectUri: https://portal.example.com/**
+                    postLogoutRedirectUri: https://portal.example.com/**
+                    builtIn: true      # opt-in auto-consent, was web's behavior
+                relations:
+                    globalScopes:
+                        - global
+                        - openid
+              # optional: sweep the legacy web rows out of every realm
+              - attributes:
+                    name: web
+                strategy:
+                    type: absent
+```
+
+Another common template is a realm administrator in every realm:
+
+```yaml
+realms:
+    - attributes:
+          name: "*"
+      relations:
+          users:
+              - attributes:
+                    name: realm-admin
+                    password: changeme    # set per deployment!
+                relations:
+                    globalRoles:
+                        - realm_admin
+```
+
+Semantics:
+
+- **Strategies work per child, across all realms.** The default
+  `createOnly` seeds each realm once; after that the realm's own
+  administrators own the row (a later boot does not revert their edits).
+  `merge` / `replace` reassert the declared attributes in every realm on
+  every boot. `absent` removes the named entity from every realm.
+- **An explicit realm block wins.** For a realm that is also declared
+  explicitly (in any provisioning file), the wildcard entry is deep-merged
+  UNDER the explicit block with the same rules used when two files declare
+  the same entity: the explicit block wins per attribute, relation lists
+  are unioned, and an explicit child's `strategy` wins over the wildcard
+  child's.
+- **Reserved client names are rejected.** A wildcard entry declaring
+  `system`, `admin-console` or `account-console` fails validation at
+  startup: those clients are system-owned and reasserted from
+  configuration on every boot.
+- Only the literal `*` is supported; partial patterns (`tenant-*`) are
+  rejected.
+
+::: warning Template users carry template credentials
+A wildcard user with a static password puts the same credential into every
+realm. Prefer role / scope / client scaffolding in the wildcard entry, and
+create real users per realm, or at minimum rotate the seeded password
+immediately.
 :::
 
 ## File-Based Provisioning
@@ -347,6 +448,10 @@ the current contract and restores the intended decision.
 | `strategy`   | `Strategy`         | Sync strategy (optional)             |
 | `attributes` | object             | `name` (required), `description`, `displayName` |
 | `relations`  | object             | See below                            |
+
+A realm entry named `"*"` is a [wildcard](#realm-wildcard-name): its
+relations apply to every realm, and it may carry nothing besides the name
+and `relations`.
 
 **Realm relations** (all optional):
 

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -5,7 +5,31 @@ Entries are grouped by release, newest first. Routine changes (features, fixes) 
 [changelog](https://github.com/authup/authup/blob/master/CHANGELOG.md); anything listed here
 either requires operator action or deliberately changes behavior.
 
-## Next release (after v1.0.0-beta.51)
+## Next release (after v1.0.0-beta.58)
+
+### The per-realm `web` client was removed
+
+The shared `web` system client is no longer provisioned. Authup's own
+consoles were moved off it earlier (`admin-console` / `account-console`);
+it existed purely for downstream applications and was default-on attack
+surface (auto-consent + `global` scope in every realm).
+
+**Existing `web` rows are not touched**: logins against them keep working.
+Two behavior changes require action:
+
+1. `PUBLIC_URL` / `TRUSTED_ORIGINS` changes no longer propagate to the
+   leftover rows; their `redirectUri` / `postLogoutRedirectUri` are
+   frozen as-is.
+2. Realms created after the upgrade get no `web` client, so a
+   `client_id=web` login breaks there.
+
+Register a client of your own instead. To keep the every-realm semantics,
+declare it once via a [wildcard realm entry](./provisioning.md#realm-wildcard-name)
+(`realms[].name: "*"`), which also offers a declarative `absent` cleanup for
+the leftover `web` rows. `CLIENT_WEB_NAME` was removed from
+`@authup/core-kit`, and `web` is a regular, creatable client name again.
+
+## v1.0.0-beta.52 (was: next release after v1.0.0-beta.51)
 
 ### Login redirect allowlist — set `TRUSTED_ORIGINS`
 

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -25,7 +25,7 @@ Two behavior changes require action:
 
 Register a client of your own instead. To keep the every-realm semantics,
 declare it once via a [wildcard realm entry](./provisioning.md#realm-wildcard-name)
-(`realms[].name: "*"`), which also offers a declarative `absent` cleanup for
+(`realms[].attributes.name: "*"`), which also offers a declarative `absent` cleanup for
 the leftover `web` rows. `CLIENT_WEB_NAME` was removed from
 `@authup/core-kit`, and `web` is a regular, creatable client name again.
 

--- a/packages/core-kit/src/domains/client/constants.ts
+++ b/packages/core-kit/src/domains/client/constants.ts
@@ -11,13 +11,6 @@
 export const CLIENT_SYSTEM_NAME = 'system';
 
 /**
- * The public OAuth2 client provisioned for every realm for downstream
- * UIs embedding client-web-kit. Authup's own surfaces use the dedicated
- * admin-console / account-console clients instead.
- */
-export const CLIENT_WEB_NAME = 'web';
-
-/**
  * The public OAuth2 client provisioned for every realm for authup's own
  * admin console (apps/client-admin-console).
  */
@@ -55,7 +48,6 @@ export const CLIENT_CERTIFICATE_URI_PREFIX = 'urn:authup:client:';
  */
 export const CLIENT_RESERVED_NAMES = [
     CLIENT_SYSTEM_NAME,
-    CLIENT_WEB_NAME,
     CLIENT_ADMIN_CONSOLE_NAME,
     CLIENT_ACCOUNT_CONSOLE_NAME,
 ];


### PR DESCRIPTION
Implements plan 082 in two stages, ordered within this one PR (the removal builds on the replacement mechanism).

## Stage 1 — wildcard realm provisioning (`realms[].name: "*"`)

A realm provisioning entry named with the literal `*` is a selector over realms: its relations (clients / roles / scopes / permissions / users) are ensured in **every** realm — all realms existing at boot, and every realm created later at runtime. Per-child `strategy` keeps the full vocabulary: `createOnly` (default; seed once, realm admins own the row), `merge` / `replace` (reassert per boot on every realm), `absent` (sweep the named entity out of every realm).

- **Relations-only:** realm-level attributes and a realm-level `strategy` are rejected (`strategy: absent` on a wildcard would mean "delete every realm"). Dispatched by `RealmProvisioningValidator.run` to a dedicated `RealmWildcardProvisioningValidator`; partial patterns (`tenant-*`) fail the regular name check. Reserved client names (`system`, the console clients) are rejected inside a wildcard entry at config load.
- **Composition = expansion:** the folded wildcard entry is deep-merged UNDER every explicit realm block using the composite-source merge rules (explicit wins per attribute, relation lists union, the explicit child's strategy wins), so declared realms are covered by the graph sync in one pass. A sequential "run defaults after explicit blocks" was rejected as unsound: `createOnly` is first-writer-wins while `merge` is last-writer-wins, so no ordering satisfies "explicit wins" for both.
- **Fan-out:** realms without an explicit block get the entry via the startup backfill loop; runtime-created realms via the DI-registered `WildcardRealmProvisioner` (one shared instance for both paths). Application deep-clones the entry per realm: the realm synchronizer mutates its input (realmId stamping, `replace` id write-back), so a shared object would leak one realm's ids into the next realm's sync (pinned by test).
- **`IRealmProvisioner` seam:** `RealmService` now takes `realmProvisioners?: IRealmProvisioner[]` (system clients → keys → wildcard, each never-fail); `ISystemClientProvisioner` / `IKeyProvisioner` extend the contract. The realm controller factory resolves the wildcard provisioner lazily at request time, so the HTTP module keeps no boot-order dependency on the provisioning module.
- The composite source's private deep-merge helpers moved to `core/provisioning/merge/` and are shared by the composite source and the wildcard expansion.
- YAML note (documented): a bare `*` is a YAML alias token — `name: "*"` must be quoted.

This is also the mechanism for #2927: a wildcard user with `globalRoles: [realm_admin]` gives every existing and future realm its own admin (recipe in the provisioning docs). Closes #2927.

## Stage 2 — remove the `web` system client

`SYSTEM_CLIENT_DEFINITIONS` shrinks to `admin-console` + `account-console`. `CLIENT_WEB_NAME` and its `CLIENT_RESERVED_NAMES` entry are removed from `@authup/core-kit` (hard removal, pre-1.0 posture), so `web` becomes a plain, creatable client name again — which is also what lets a wildcard `absent` child sweep leftover rows declaratively.

**Breaking change / migration** (also in `docs/src/guide/deployment/upgrading.md`):

- Existing `web` rows survive untouched: still functional, but `PUBLIC_URL` / `TRUSTED_ORIGINS` changes no longer propagate to them, and new realms get no `web` client.
- Replacement: register your own client, e.g. once for every realm via the wildcard entry (worked example incl. the optional legacy-`web` cleanup in the provisioning docs).

## Verification

- Full server-core suite (172 files / 1838 tests), monorepo `npm run test` (18 projects), `check:types`, ESLint: green.
- Provisioning + wildcard specs additionally green against MySQL and PostgreSQL (the spec was made robust against reused local databases, where a legacy master `web` row legitimately survives).
- Launcher smoke (`test:smoke`): boots server-core + admin console, clean SIGTERM shutdown.
- New coverage: `test/unit/core/provisioning/wildcard.spec.ts` (extraction/folding, expansion + pristine variants, clone-per-realm incl. `replace`, validator matrix incl. the `web`-now-allowed pin), wildcard cases in `test/unit/modules/provisioning.spec.ts` (boot fan-out, explicit-wins, runtime hook via DI, createOnly-respects-admin-edit, merge reassert, absent sweep, file fixtures incl. reserved-name rejection with file path), legacy-`web`-untouched + no-`web`-on-fresh-realm pins, HTTP realm-creation assertion.

Out-of-repo follow-ups (tracked in plan 082): helm `web` references (helm#3 vehicle), hub/portal migration off `client_id=web` before upgrading, close #2927 with the recipe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wildcard realm provisioning for applying clients, roles, and other settings to current and future realms.
  * Added validation and merge behavior for wildcard provisioning entries.
  * New realms now receive only the built-in admin and account console clients.

* **Changes**
  * Removed automatic provisioning of the shared `web` client for new realms.
  * Existing `web` clients remain unchanged and can be replaced with custom clients.

* **Documentation**
  * Added provisioning, OAuth, logout, configuration, and upgrade guidance for these changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->