### PR TITLE
fix: repair the embedded vite SSR integration

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -588,6 +588,18 @@ not by client-admin-console:
   console shares (Nuxt's `__NUXT__` model; each console is its own
   document, so the shapes never coexist — the account console injects its
   runtime config under the same name).
+- **Template splicing goes through `replaceTemplateMarker`** (never a bare
+  `String.prototype.replace` with a string replacement). A string
+  replacement expands `$&`, `` $` ``, `$'` and `$$` **in the replacement
+  value**, and the value spliced into `<!--app-html-->` carries the SSR
+  hydration payload, which reflects raw query parameters. `?token=$'`
+  therefore used to splice the template's own tail into the payload,
+  leaving an inline script that was no longer valid JavaScript, so
+  `window.__AUTHUP__` was never assigned and the page died with "No
+  hydration data set." (not XSS: the injected span is template-derived).
+  `serializeInlineScriptJSON` cannot defend against this, because the
+  expansion happens after the value has been built. The same rule covers
+  the account console's `<!--account-config-->` splice.
 - **Serving seam (plan 083)**: the Vue app ships as
   `@authup/client-auth-console` (a server-core runtime dependency),
   resolved via `resolveAuthConsolePackagePath`/`-DistPath`
@@ -605,6 +617,23 @@ not by client-admin-console:
   to replace the hosted auth UI (the Keycloak login-theme analog). A
   missing bundle 500s with an actionable message (build
   `apps/client-auth-console` first).
+- **JIT dev mode caveats.** `ssr.noExternal: true` is scoped to
+  `command === 'build'` in the auth console's `vite.config.ts`: it is what
+  makes the published `dist/server/server.js` self-contained, but applying
+  it in dev inlines `vue/server-renderer`, which resolves to its CJS build
+  under the node condition and cannot be evaluated by the SSR module
+  runner (`exports is not defined` through `ssrLoadModule` and the ssr
+  environment runner alike). The key is omitted rather than set to
+  `false`, which rolldown rejects. The app's `resolve.alias` list must
+  also cover every `@authup/*` package it pulls in transitively, so dev
+  resolution reaches package source instead of a possibly unbuilt dist
+  (and so the bundle agrees with the root tsconfig paths `vue-tsc`
+  checks). Note the gate itself, `isCodeTransformation(JUST_IN_TIME)`, is
+  only true under ts-node/tsx, and no server-core script runs that way —
+  so the branch is currently unreachable in practice and its breakage
+  went unnoticed for a long time. The vite dev server is created once in
+  `registerAssetsMiddleware` and closed by `HTTPMiddlewareModule.teardown`
+  (it owns a file watcher plus an HMR websocket).
 - **Feature flags** ride the hydration payload (`data.features`,
   `StatusResponseFeatures` shape) — pages render the form when the
   workflow is enabled, otherwise a localized "disabled" notice (no 404:
@@ -1112,7 +1141,8 @@ adapters/http/controllers/workflows/
 adapters/http/ui/                   — one folder per served console + shared serving helpers
   shared/html.ts                    — readUIClientPreferences (locale/color-mode cookies), stampHtmlAttributes,
                                       applyUIPageHeaders (content-type + CSP frame-ancestors + XFO + referrer),
-                                      rebaseAssetURLs(html, basePath, viteBase), serializeInlineScriptJSON
+                                      rebaseAssetURLs(html, basePath, viteBase), serializeInlineScriptJSON,
+                                      replaceTemplateMarker (the ONLY way to splice a value into a page template)
   auth-console/module.ts            — renderAuthConsolePage(event, {url, payload}) SSR render plumbing (JIT vs package dist)
   auth-console/resolve.ts           — resolveAuthConsolePackagePath/-DistPath (locter locateUp resolution of @authup/client-auth-console)
   auth-console/serve.ts             — serveWorkflowPage (workflow GET payload assembly + open-redirect guard)

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -597,9 +597,13 @@ not by client-admin-console:
   leaving an inline script that was no longer valid JavaScript, so
   `window.__AUTHUP__` was never assigned and the page died with "No
   hydration data set." (not XSS: the injected span is template-derived).
-  `serializeInlineScriptJSON` cannot defend against this, because the
-  expansion happens after the value has been built. The same rule covers
-  the account console's `<!--account-config-->` splice.
+  No escaping helper can defend against this, because the expansion
+  happens after the value has been built: the auth console payload is
+  serialized inside the bundle (`serializePayload` in
+  `apps/client-auth-console/src/window.ts`), the account console config by
+  `serializeInlineScriptJSON`, and both produce a string that
+  `String.prototype.replace` then re-interprets. The same rule covers the
+  account console's `<!--account-config-->` splice.
 - **Serving seam (plan 083)**: the Vue app ships as
   `@authup/client-auth-console` (a server-core runtime dependency),
   resolved via `resolveAuthConsolePackagePath`/`-DistPath`
@@ -629,9 +633,9 @@ not by client-admin-console:
   resolution reaches package source instead of a possibly unbuilt dist
   (and so the bundle agrees with the root tsconfig paths `vue-tsc`
   checks). Note the gate itself, `isCodeTransformation(JUST_IN_TIME)`, is
-  only true under ts-node/tsx, and no server-core script runs that way —
-  so the branch is currently unreachable in practice and its breakage
-  went unnoticed for a long time. The vite dev server is created once in
+  only true under ts-node/tsx, and no server-core script runs that way.
+  The branch is therefore unreachable in practice, which is why its
+  breakage went unnoticed. The vite dev server is created once in
   `registerAssetsMiddleware` and closed by `HTTPMiddlewareModule.teardown`
   (it owns a file watcher plus an HMR websocket).
 - **Feature flags** ride the hydration payload (`data.features`,

--- a/apps/client-auth-console/index.html
+++ b/apps/client-auth-console/index.html
@@ -15,7 +15,6 @@
 </head>
 <body>
     <div id="app"><!--app-html--></div>
-    <!--app-payload-->
     <script type="module" src="/src/client.ts"></script>
 </body>
 </html>

--- a/apps/client-auth-console/vite.config.ts
+++ b/apps/client-auth-console/vite.config.ts
@@ -16,7 +16,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const packagesRoot = path.resolve(__dirname, '..', '..', 'packages');
 const repositoryRoot = path.resolve(__dirname, '..', '..');
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
     base: '/public/',
     plugins: [
         vuePlugin(),
@@ -58,7 +58,11 @@ export default defineConfig({
     ],
     resolve: {
         alias: {
+            '@authup/access': path.join(packagesRoot, 'access', 'src'),
             '@authup/core-kit': path.join(packagesRoot, 'core-kit', 'src'),
+            '@authup/core-realtime-kit': path.join(packagesRoot, 'core-realtime-kit', 'src'),
+            '@authup/errors': path.join(packagesRoot, 'errors', 'src'),
+            '@authup/i18n': path.join(packagesRoot, 'i18n', 'src'),
             '@authup/core-http-kit': path.join(packagesRoot, 'core-http-kit', 'src'),
             '@authup/kit': path.join(packagesRoot, 'kit', 'src'),
             '@authup/client-web-kit': path.join(packagesRoot, 'client-web-kit', 'src'),
@@ -67,5 +71,10 @@ export default defineConfig({
             '@authup/specs': path.join(packagesRoot, 'specs', 'src'),
         },
     },
-    ssr: { noExternal: true },
-});
+    // Bundle every dependency into the SSR build so the published
+    // dist/server/server.js is self-contained for server-core to read.
+    // Dev must NOT inline them: vue/server-renderer resolves to its CJS
+    // build under the node condition, which the SSR module runner cannot
+    // evaluate ("exports is not defined").
+    ...(command === 'build' ? { ssr: { noExternal: true } } : {}),
+}));

--- a/apps/server-core/src/adapters/http/middleware/built-in/assets.ts
+++ b/apps/server-core/src/adapters/http/middleware/built-in/assets.ts
@@ -21,7 +21,12 @@ import { resolveAuthConsoleDistPath, resolveAuthConsolePackagePath } from '../..
 
 export const VITE_SERVER_STORE_KEY = Symbol('ViteServer');
 
-export async function registerAssetsMiddleware(router: App) {
+/**
+ * Returns the vite dev server it created (JIT mode only), so the caller can
+ * close it on teardown. It owns a file watcher and an HMR websocket, which
+ * outlive the http listener otherwise.
+ */
+export async function registerAssetsMiddleware(router: App) : Promise<ViteDevServer | undefined> {
     // Static assets of the account console SPA (its fixed vite base is
     // /account/). Served in dev mode too — the bundle is prebuilt, not
     // vite-transformed. A missing bundle only disables the mount; the page
@@ -59,7 +64,7 @@ export async function registerAssetsMiddleware(router: App) {
                 },
             ));
         }
-        return;
+        return undefined;
     }
 
     // JIT (dev) mode serves the auth console straight from the package
@@ -94,4 +99,6 @@ export async function registerAssetsMiddleware(router: App) {
         event.store[VITE_SERVER_STORE_KEY] = server;
         return event.next();
     }));
+
+    return server;
 }

--- a/apps/server-core/src/adapters/http/ui/account-console/module.ts
+++ b/apps/server-core/src/adapters/http/ui/account-console/module.ts
@@ -17,6 +17,7 @@ import {
     applyUIPageHeaders,
     readUIClientPreferences,
     rebaseAssetURLs,
+    replaceTemplateMarker,
     serializeInlineScriptJSON,
     stampHtmlAttributes,
 } from '../shared/index.ts';
@@ -97,7 +98,8 @@ export async function serveAccountConsolePage(
         features: options.features,
     };
 
-    let body = html.replace(
+    let body = replaceTemplateMarker(
+        html,
         CONFIG_MARKER,
         `<script>window.__AUTHUP__ = ${serializeInlineScriptJSON(config)};</script>`,
     );

--- a/apps/server-core/src/adapters/http/ui/auth-console/module.ts
+++ b/apps/server-core/src/adapters/http/ui/auth-console/module.ts
@@ -20,6 +20,7 @@ import {
     applyUIPageHeaders,
     readUIClientPreferences,
     rebaseAssetURLs,
+    replaceTemplateMarker,
     stampHtmlAttributes,
 } from '../shared/index.ts';
 import { resolveAuthConsoleDistPath, resolveAuthConsolePackagePath } from './resolve.ts';
@@ -45,6 +46,7 @@ export async function renderAuthConsolePage(event: IAppEvent, ctx: AuthConsoleRe
     let html : string;
     let manifest : Record<string, any>;
     let render : RenderFunction;
+    let vite : ViteDevServer | undefined;
 
     if (isJIT) {
         const packagePath = resolveAuthConsolePackagePath();
@@ -54,13 +56,16 @@ export async function renderAuthConsolePage(event: IAppEvent, ctx: AuthConsoleRe
             );
         }
 
-        const vite = event.store[VITE_SERVER_STORE_KEY] as ViteDevServer;
+        vite = event.store[VITE_SERVER_STORE_KEY] as ViteDevServer;
 
         html = await fs.promises.readFile(
             path.join(packagePath, 'index.html'),
             'utf-8',
         );
-        html = await vite.transformIndexHtml('/', html);
+        // Pass the rendered route, not a fixed '/': the URL reaches every
+        // transformIndexHtml hook as its context and decides the filename a
+        // plugin resolves inline-module sourcemaps against.
+        html = await vite.transformIndexHtml(ctx.url, html);
         manifest = {};
         render = (await vite.ssrLoadModule('/src/server.ts')).render as RenderFunction;
     } else {
@@ -86,16 +91,29 @@ export async function renderAuthConsolePage(event: IAppEvent, ctx: AuthConsoleRe
 
     const httpClientFactory = event.store[UI_HTTP_CLIENT_FACTORY_STORE_KEY] as (() => IClient) | undefined;
 
-    const [appHtml, preloadLinks] = await render({
-        url: ctx.url,
-        manifest,
-        payload: ctx.payload,
-        httpClient: httpClientFactory ? httpClientFactory() : undefined,
-    });
+    let appHtml : string;
+    let preloadLinks : string;
 
-    let body = html
-        .replace('<!--preload-links-->', preloadLinks)
-        .replace('<!--app-html-->', appHtml);
+    try {
+        [appHtml, preloadLinks] = await render({
+            url: ctx.url,
+            manifest,
+            payload: ctx.payload,
+            httpClient: httpClientFactory ? httpClientFactory() : undefined,
+        });
+    } catch (e) {
+        // Map the bundled frames back onto the source files before the error
+        // reaches the logger. Only the dev server can do this, so a production
+        // render rethrows untouched.
+        if (vite && e instanceof Error) {
+            vite.ssrFixStacktrace(e);
+        }
+
+        throw e;
+    }
+
+    let body = replaceTemplateMarker(html, '<!--preload-links-->', preloadLinks);
+    body = replaceTemplateMarker(body, '<!--app-html-->', appHtml);
 
     body = stampHtmlAttributes(body, preferences);
 

--- a/apps/server-core/src/adapters/http/ui/auth-console/module.ts
+++ b/apps/server-core/src/adapters/http/ui/auth-console/module.ts
@@ -62,9 +62,9 @@ export async function renderAuthConsolePage(event: IAppEvent, ctx: AuthConsoleRe
             path.join(packagePath, 'index.html'),
             'utf-8',
         );
-        // Pass the rendered route, not a fixed '/': the URL reaches every
-        // transformIndexHtml hook as its context and decides the filename a
-        // plugin resolves inline-module sourcemaps against.
+        // The URL reaches every transformIndexHtml hook as its context.
+        // Pass the rendered route rather than a fixed '/', as vite's own SSR
+        // guide does.
         html = await vite.transformIndexHtml(ctx.url, html);
         manifest = {};
         render = (await vite.ssrLoadModule('/src/server.ts')).render as RenderFunction;

--- a/apps/server-core/src/adapters/http/ui/shared/html.ts
+++ b/apps/server-core/src/adapters/http/ui/shared/html.ts
@@ -44,7 +44,23 @@ export function stampHtmlAttributes(html: string, preferences: UIClientPreferenc
         htmlAttrs += ` class="${preferences.colorMode}"`;
     }
 
-    return html.replace(/<html\b[^>]*>/i, `<html ${htmlAttrs}>`);
+    return html.replace(/<html\b[^>]*>/i, () => `<html ${htmlAttrs}>`);
+}
+
+/**
+ * Replace a template marker (`<!--app-html-->`, `<!--account-config-->`, ...)
+ * with a rendered value.
+ *
+ * The replacement is passed as a FUNCTION on purpose. A string replacement
+ * expands the `$&`, `` $` ``, `$'` and `$$` patterns, so a `$'` anywhere in
+ * the value splices the template's own text back into the page. The values
+ * spliced here carry raw request input (the SSR hydration payload reflects
+ * query parameters), which made `?token=$'` return a page whose inline
+ * payload script was no longer valid JavaScript. Escaping cannot prevent
+ * this: the expansion happens after the value was built.
+ */
+export function replaceTemplateMarker(html: string, marker: string, value: string) : string {
+    return html.replace(marker, () => value);
 }
 
 /**
@@ -78,7 +94,7 @@ export function rebaseAssetURLs(html: string, basePath: string, viteBase: string
 
     return html.replace(
         new RegExp(`(src|href)="${viteBase.replace(/[.*+?^${}()|[\]\\/]/g, '\\$&')}`, 'g'),
-        `$1="${basePath}${viteBase}`,
+        (_match, attribute) => `${attribute}="${basePath}${viteBase}`,
     );
 }
 

--- a/apps/server-core/src/app/modules/http/module.ts
+++ b/apps/server-core/src/app/modules/http/module.ts
@@ -165,6 +165,8 @@ export class HTTPModule implements IModule {
 
         container.unregister(MetricsInjectionKey);
 
+        await this.middleware.teardown();
+
         if (!this.instance) return;
 
         container.unregister(HTTPInjectionKey.Server);

--- a/apps/server-core/src/app/modules/http/modules/middleware.ts
+++ b/apps/server-core/src/app/modules/http/modules/middleware.ts
@@ -8,6 +8,7 @@
 import type { App } from 'routup';
 import path from 'node:path';
 import type { IContainer } from 'eldin';
+import type { ViteDevServer } from 'vite';
 import type { Repository } from 'typeorm';
 import type { Realm } from '@authup/core-kit';
 import {
@@ -39,6 +40,8 @@ import {
 } from '../../database/index.ts';
 
 export class HTTPMiddlewareModule {
+    protected viteServer : ViteDevServer | undefined;
+
     async mountBefore(router: App, container: IContainer): Promise<void> {
         // @routup/prometheus must be installed before any other plugin or
         // route so that its onion middleware can observe the full request
@@ -86,7 +89,21 @@ export class HTTPMiddlewareModule {
     }
 
     async mountAssets(router: App): Promise<void> {
-        await registerAssetsMiddleware(router);
+        this.viteServer = await registerAssetsMiddleware(router);
+    }
+
+    /**
+     * Release what the mounted middlewares own beyond the http listener. Only
+     * the JIT vite dev server qualifies: it keeps a file watcher and an HMR
+     * websocket alive, which would survive every setup/teardown cycle.
+     */
+    async teardown(): Promise<void> {
+        if (!this.viteServer) {
+            return;
+        }
+
+        await this.viteServer.close();
+        this.viteServer = undefined;
     }
 
     async mountUIHttpClient(router: App, container: IContainer): Promise<void> {

--- a/apps/server-core/test/unit/adapters/http/ui/shared/html.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/shared/html.spec.ts
@@ -71,6 +71,14 @@ describe('rebaseAssetURLs', () => {
             .toBe('<script type="module" crossorigin src="/auth/account/assets/index-jkl.js"></script>');
     });
 
+    it('does not expand replacement patterns carried by the base path', () => {
+        // basePath is publicUrl's pathname, which may legally contain a `$`.
+        const input = '<script src="/public/assets/a.js"></script>';
+
+        expect(rebaseAssetURLs(input, '/a$&b', '/public/'))
+            .toBe('<script src="/a$&b/public/assets/a.js"></script>');
+    });
+
     it('treats regex metacharacters in the vite base literally', () => {
         const input = '<script src="/public.v2/assets/a.js"></script><script src="/publicXv2/assets/b.js"></script>';
 

--- a/apps/server-core/test/unit/adapters/http/ui/shared/html.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/shared/html.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { rebaseAssetURLs } from '../../../../../../src/adapters/http/ui/shared/html.ts';
+import { rebaseAssetURLs, replaceTemplateMarker } from '../../../../../../src/adapters/http/ui/shared/html.ts';
 
 const HTML = `<!doctype html>
 <html lang="en">
@@ -21,6 +21,26 @@ const HTML = `<!doctype html>
     <script>window.__PAYLOAD__ = {"config":{"baseURL":"https://example.com/auth"},"data":{"redirect":"/authorize?response_type=code"}}</script>
 </body>
 </html>`;
+
+describe('replaceTemplateMarker', () => {
+    const TEMPLATE = '<body><div id="app"><!--app-html--></div><script src="/public/x.js"></script></body>';
+
+    it.each(['$\'', '$`', '$&', '$$'])('does not expand the %s replacement pattern', (pattern) => {
+        const value = `<p>${pattern}</p>`;
+
+        expect(replaceTemplateMarker(TEMPLATE, '<!--app-html-->', value))
+            .toBe(`<body><div id="app">${value}</div><script src="/public/x.js"></script></body>`);
+    });
+
+    it('replaces only the first occurrence', () => {
+        expect(replaceTemplateMarker('<a><!--m--></a><b><!--m--></b>', '<!--m-->', 'x'))
+            .toBe('<a>x</a><b><!--m--></b>');
+    });
+
+    it('leaves the template untouched when the marker is absent', () => {
+        expect(replaceTemplateMarker(TEMPLATE, '<!--missing-->', 'x')).toBe(TEMPLATE);
+    });
+});
 
 describe('rebaseAssetURLs', () => {
     it('prefixes script, stylesheet and preload references with the base path', () => {

--- a/apps/server-core/test/unit/http/controllers/workflows/ui-pages.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/ui-pages.spec.ts
@@ -164,6 +164,39 @@ describe('src/http/controllers/workflows (SSR pages)', () => {
         expect(payload.data.token).toEqual(token);
     });
 
+    it.each([
+        ['$\'', 'token'],
+        ['$`', 'token'],
+        ['$&', 'token'],
+        ['$$', 'token'],
+    ])('should not expand the %s replacement pattern carried by %s', async (value, parameter) => {
+        const query = new URLSearchParams({ [parameter]: value });
+
+        const response = await httpRequest(suite, 'GET', `/password-reset?${query.toString()}`);
+        expect(response.status).toEqual(200);
+
+        const body = await response.text();
+
+        // A string replacement would expand the pattern and splice the
+        // template's own text into the payload, leaving invalid JavaScript
+        // that never assigns window.__AUTHUP__.
+        const payload = extractHydrationPayload(body);
+        expect(payload.data.token).toEqual(value);
+
+        expect(body.match(/<div id="app">/g)).toHaveLength(1);
+    });
+
+    it('should not expand a replacement pattern carried by the redirect parameter', async () => {
+        const redirect = '/authorize?state=$\'';
+        const query = new URLSearchParams({ redirect });
+
+        const response = await httpRequest(suite, 'GET', `/register?${query.toString()}`);
+        expect(response.status).toEqual(200);
+
+        const payload = extractHydrationPayload(await response.text());
+        expect(payload.data.redirect).toEqual(redirect);
+    });
+
     it('should pass a relative redirect through to the page', async () => {
         const redirect = '/authorize?client_id=web&response_type=code';
         const query = new URLSearchParams({ redirect });


### PR DESCRIPTION
Four fixes to how server-core renders and serves the console apps. Found while assessing whether vite's Environment API is worth adopting (it is not, see the note at the end).

## 1. Replacement patterns spliced the page template

`renderAuthConsolePage` filled `<!--app-html-->` / `<!--preload-links-->` with **string** replacements, so `$&`, `` $` ``, `$'` and `$$` inside the value were expanded by `String.prototype.replace`.

The SSR hydration payload reflects raw query parameters, so the value is attacker-influenced. Reproduced against the production branch, unauthenticated:

```
GET /activate?token=$'
```

The template's own tail gets spliced into the payload JSON, the inline script stops being valid JavaScript, `window.__AUTHUP__` is never assigned, and the page dies with "No hydration data set.". Reachable via `token` on the token-aware pages and via `redirect` on all five workflow pages (`sanitizeRelativeRedirect` passes `/$'` unchanged).

This is not XSS. The injected span comes from the template itself, so no attacker-controlled markup is introduced. It is a remotely triggerable broken auth page.

Escaping cannot fix it, because the expansion happens after the value has been built. Every marker splice now goes through `replaceTemplateMarker()`, which passes a function replacer; `stampHtmlAttributes` and `rebaseAssetURLs` moved off string replacements too. The account console's config splice had the same shape (operator-controlled input only).

## 2. The just-in-time dev SSR path never worked

`ssr: { noExternal: true }` applied in dev as well as in builds, and `vue/server-renderer` resolves to its CJS build under the node condition, which the SSR module runner cannot evaluate. Both `ssrLoadModule()` and the ssr environment runner failed identically with `exports is not defined`, so server-core's JIT branch could not render a single page.

`noExternal` is now scoped to `command === 'build'`, where it is what makes the published `dist/server/server.js` self-contained. The key is omitted rather than set to `false`, since rolldown rejects `false` as a `noExternal` value. The four `@authup/*` packages the app pulls in transitively are now aliased like the other seven, which dev resolution needs and which aligns the bundle with the root tsconfig paths `vue-tsc` checks against.

Verified by execution: the path goes from `exports is not defined` to a 2745 character render of `/register`.

## 3. Dead `<!--app-payload-->` marker

Nothing replaced it, so the comment shipped verbatim in every response.

## 4. Dev SSR render plumbing

- `transformIndexHtml` received a hardcoded `'/'` instead of the rendered route.
- A failing render threw the bundled stack straight at the logger. It now goes through `ssrFixStacktrace` first, which only the dev server can do, so production rethrows untouched.
- The vite dev server was created at boot and never closed, leaking a file watcher and an HMR websocket per setup/teardown cycle. `registerAssetsMiddleware` returns it and `HTTPMiddlewareModule.teardown()` closes it.

## Verification

- `npm run build`: 24 projects green. `dist/client/index.html`, `dist/client/.vite/ssr-manifest.json` and `dist/server/server.js` all still emitted, so the three paths server-core reads are unchanged.
- `npm run test -w apps/server-core`: 1821 passed. One unrelated failure in `client-secret-projection.spec.ts` (permission-name uniqueness collision under parallel sqlite); passes 10/10 in isolation.
- `npm run check:types -w apps/server-core` and eslint: clean.
- 10 new tests. Reverting the fix in section 1 fails 9 of them.

## Deliberately not in this PR

- **The JIT branch is repaired but still unreachable.** `isCodeTransformation(JUST_IN_TIME)` is only true under ts-node/tsx and no server-core script runs that way, which is why the breakage went unnoticed. Adding a TS runner means verifying the whole boot path, since typeorm entity loading keys off the same gate. Filing separately.
- **The payload still renders inside `#app`.** Moving it to where the marker was requires the auth console to stop concatenating while server-core starts injecting, which changes the published render contract's semantics. With mismatched versions that breaks hydration outright, so it belongs with #3376.
- **The Environment API does not apply here.** `root` and `base` are root-level only in vite 8.2.0 and the dev HTML middleware is hardcoded to `environments.client`, so two apps at `/public/` and `/account/` still need two `createServer` calls. `ssrLoadModule` is also not deprecated; it *is* the ssr environment runner internally.