### PR TITLE
build: emit the auth console SSR build from one vite build

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -41,7 +41,20 @@
   resolve against the inherited root `baseUrl`, so `../../packages/...`
   silently resolves outside the repo, never matches, and the check degrades to
   the last-built dist declarations (where vue-tsc-emitted component prop
-  unions can differ from source).
+  unions can differ from source). The corollary is that each Vite console
+  app's `resolve.alias` map must list **every** `@authup/*` package it pulls
+  in, transitive ones included: an unaliased package is bundled from its
+  built dist while `vue-tsc` checks the source, so the two silently disagree
+  until a rebuild.
+- The auth console emits both halves of its SSR output from one
+  `vite build`, declared as `environments: { client, ssr }` plus
+  `builder: {}` rather than two invocations with CLI flags. The output
+  paths are load-bearing (server-core reads `dist/client/index.html`,
+  `dist/client/.vite/ssr-manifest.json` and `dist/server/server.js`), so
+  the SSR `entryFileNames` is pinned instead of derived from the entry
+  name. Keep `sharedPlugins` off: `NuxtIconBundle` accumulates scanned
+  icons in a closure, so one shared instance would leak the client scan
+  into the ssr build.
 
 ## Testing
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -52,9 +52,11 @@
   paths are load-bearing (server-core reads `dist/client/index.html`,
   `dist/client/.vite/ssr-manifest.json` and `dist/server/server.js`), so
   the SSR `entryFileNames` is pinned instead of derived from the entry
-  name. Keep `sharedPlugins` off: `NuxtIconBundle` accumulates scanned
-  icons in a closure, so one shared instance would leak the client scan
-  into the ssr build.
+  name. Leave `builder.sharedPlugins` at its default (off): plugin
+  instances hold `configResolved`-scoped state, and the environments
+  resolve differently enough (`consumer`, `build.ssr`, outDir) that
+  sharing one instance across both is not something the plugin set is
+  written for.
 
 ## Testing
 

--- a/apps/client-account-console/package.json
+++ b/apps/client-account-console/package.json
@@ -17,7 +17,6 @@
         "build:js": "vite build",
         "build": "npm run build:types && npm run build:js",
         "dev": "vite",
-        "dev:build": "vite build --watch",
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
         "prepublishOnly": "npm run build"
     },

--- a/apps/client-account-console/package.json
+++ b/apps/client-account-console/package.json
@@ -17,6 +17,7 @@
         "build:js": "vite build",
         "build": "npm run build:types && npm run build:js",
         "dev": "vite",
+        "dev:build": "vite build --watch",
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
         "prepublishOnly": "npm run build"
     },

--- a/apps/client-account-console/vite.config.ts
+++ b/apps/client-account-console/vite.config.ts
@@ -44,8 +44,12 @@ export default defineConfig({
     ],
     resolve: {
         alias: {
+            '@authup/access': path.join(packagesRoot, 'access', 'src'),
             '@authup/core-kit': path.join(packagesRoot, 'core-kit', 'src'),
             '@authup/core-http-kit': path.join(packagesRoot, 'core-http-kit', 'src'),
+            '@authup/core-realtime-kit': path.join(packagesRoot, 'core-realtime-kit', 'src'),
+            '@authup/errors': path.join(packagesRoot, 'errors', 'src'),
+            '@authup/i18n': path.join(packagesRoot, 'i18n', 'src'),
             '@authup/kit': path.join(packagesRoot, 'kit', 'src'),
             '@authup/client-web-kit': path.join(packagesRoot, 'client-web-kit', 'src'),
             '@authup/client-web-kit-theme': path.join(packagesRoot, 'client-web-kit-theme', 'src'),

--- a/apps/client-auth-console/package.json
+++ b/apps/client-auth-console/package.json
@@ -16,9 +16,7 @@
     },
     "scripts": {
         "build:types": "vue-tsc --noEmit -p tsconfig.json",
-        "build:client": "vite build --ssrManifest .vite/ssr-manifest.json --outDir dist/client",
-        "build:server": "vite build --ssr src/server.ts --outDir dist/server",
-        "build:js": "npm run build:server && npm run build:client",
+        "build:js": "vite build",
         "build": "npm run build:types && npm run build:js",
         "prepublishOnly": "npm run build"
     },

--- a/apps/client-auth-console/vite.config.ts
+++ b/apps/client-auth-console/vite.config.ts
@@ -102,8 +102,9 @@ export default defineConfig(({ command }) => ({
         },
     },
     // Opt into builder.buildApp(). Plugin instances stay per-environment
-    // (sharedPlugins defaults to false): NuxtIconBundle accumulates scanned
-    // icons in a closure, so one shared instance would leak the client
-    // scan into the ssr build.
+    // (sharedPlugins defaults to false): plugins hold configResolved-scoped
+    // state, and the two environments resolve differently enough (consumer,
+    // build.ssr, outDir) that sharing one instance is not what this plugin
+    // set is written for.
     builder: {},
 }));

--- a/apps/client-auth-console/vite.config.ts
+++ b/apps/client-auth-console/vite.config.ts
@@ -77,4 +77,33 @@ export default defineConfig(({ command }) => ({
     // build under the node condition, which the SSR module runner cannot
     // evaluate ("exports is not defined").
     ...(command === 'build' ? { ssr: { noExternal: true } } : {}),
+    // Both halves of the build are declared here rather than passed as CLI
+    // flags, so one `vite build` emits them via builder.buildApp(). The
+    // three paths server-core reads are pinned by these values:
+    // dist/client/index.html, dist/client/.vite/ssr-manifest.json and
+    // dist/server/server.js.
+    environments: {
+        client: {
+            build: {
+                outDir: 'dist/client',
+                ssrManifest: '.vite/ssr-manifest.json',
+            },
+        },
+        ssr: {
+            input: 'src/server.ts',
+            build: {
+                outDir: 'dist/server',
+                rollupOptions: {
+                    // The CLI form derived this from the entry name. Pin it,
+                    // because server-core reads that exact filename.
+                    output: { entryFileNames: 'server.js' },
+                },
+            },
+        },
+    },
+    // Opt into builder.buildApp(). Plugin instances stay per-environment
+    // (sharedPlugins defaults to false): NuxtIconBundle accumulates scanned
+    // icons in a closure, so one shared instance would leak the client
+    // scan into the ssr build.
+    builder: {},
 }));


### PR DESCRIPTION
Rebased onto master now that #3380 has landed. Build tooling only, no runtime source changes.

## One `vite build` for the auth console

The client and ssr halves were two invocations carrying their output paths as CLI flags:

```
build:client  vite build --ssrManifest .vite/ssr-manifest.json --outDir dist/client
build:server  vite build --ssr src/server.ts --outDir dist/server
build:js      npm run build:server && npm run build:client
```

They are now declared as `environments: { client, ssr }` with `builder: {}`, so `build:js` is just `vite build`. The layout server-core depends on lives next to the rest of the config instead of in package.json flags.

The SSR entry filename used to be derived from the entry name. It is pinned via `entryFileNames`, because server-core reads `dist/server/server.js` by that exact path.

`builder.sharedPlugins` stays at its default (off): plugin instances hold `configResolved`-scoped state, and the two environments resolve differently enough (`consumer`, `build.ssr`, outDir) that sharing one instance is not what this plugin set is written for.

### Output equivalence, measured against master's actual build

Built both ways from the same tree (master's `vite.config.ts` + package.json for the old form, this branch's for the new):

- Identical 59-file set.
- `dist/client/index.html` and `dist/client/.vite/ssr-manifest.json` byte-identical.
- `dist/server/server.js` is the same byte length and carries the same 54 icons (compared as parsed sets), but differs in one respect: the two icon collections are serialized `fa6-brands, fa6-solid` under the old form and `fa6-solid, fa6-brands` under the new one.

That delta **is** caused by this change, via the build-order flip (the old scripts built ssr first, `buildApp()` builds client first). It is not build nondeterminism: each config reproduces its own hash exactly across repeated runs.

```
OLD-config run 1/2: f9514b48...  (identical to each other)
NEW-config run 1/2: 86d80d95...  (identical to each other)
```

It is benign, because the collections are handed to `addIcon` and registration order carries no meaning.

## Account console

Aliases the four `@authup/*` packages it pulls in transitively (`access`, `core-realtime-kit`, `errors`, `i18n`), matching what #3380 did for the auth console. Without them the bundle compiles those packages from their built dist while `vue-tsc` checks the source the root tsconfig paths point at, so the two can disagree until a rebuild.

An earlier revision of this PR also added a `dev:build` (`vite build --watch`) script. **It was removed after auditing**, because it cannot work: `serveAccountConsolePage` latches `index.html` for the process lifetime outside the `JUST_IN_TIME` branch, and that branch is unreachable from every server-core script (#3382). Assets are content-hashed and each watch rebuild empties `outDir`, so the latched HTML would point at a deleted file and the `fallthrough: false` `/account/assets` mount would answer 404 until a restart. Making it work means invalidating those caches, which is a runtime change and belongs with #3382.

## Verification

- `npm run build`: 24 projects green on the rebased base.
- `npm run test -w apps/server-core`: 172 files, 1851 tests, all passing. Includes the specs pinning the dist layout (`assets.spec.ts`, `ui-pages-icons.spec.ts`, `account-pages.spec.ts`, `html.spec.ts`).
- eslint clean on both configs.

## Deliberately not done

A shared alias/icon-glob module for the two vite configs plus `nuxt.config.ts`. It would prevent the drift this PR fixes by hand, but it means inventing a root-level build-config file that three apps import across workspace boundaries. Aligning the lists and writing the rule into `.agents/conventions.md` is the cheaper guard; a test asserting the configs match the root tsconfig paths would be the next step if drift recurs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build Improvements**
  - Improved the account and authentication console build process for more reliable client and server-rendered output.
  - Standardized build artifacts and generated server-rendering support files for smoother deployment.
  - Improved package resolution to help ensure required functionality is included consistently across console builds.

- **Documentation**
  - Updated development guidance for console build and package-alias configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->