### PR TITLE
fix: repair the account console session and the userinfo email claim

### DIFF
--- a/apps/server-core/src/adapters/http/controllers/workflows/userinfo/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/userinfo/module.ts
@@ -51,6 +51,17 @@ export class UserInfoController {
             id = actor.identity.data.id;
         }
 
-        return this.service.getOne(id, actor, useRequestQuery(event));
+        // `email` is a standard OIDC claim, but the column is `select: false`
+        // (opt-in projection), so the default field set leaves it out and the
+        // claims document arrives without it. This endpoint only ever serves
+        // the CALLER'S OWN record, so the claim rides on top of the defaults.
+        // A caller stating its own `fields` keeps full control: the opt-in
+        // stays opt-in wherever the projection is explicit.
+        const query = useRequestQuery(event);
+
+        return this.service.getOne(id, actor, {
+            ...query,
+            fields: query.fields || '+email',
+        });
     }
 }

--- a/apps/server-core/test/unit/http/controllers/workflows/userinfo.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/userinfo.spec.ts
@@ -37,6 +37,24 @@ describe('src/http/controllers/workflows/userinfo', () => {
         expect(response.meta).toBeUndefined();
     });
 
+    // `email` is a standard OIDC claim, but the column is select:false, so it
+    // is absent from the default field set. Without it the account console
+    // renders an empty email box and submits a null over the user's address.
+    it('should carry the email claim', async () => {
+        const response = await suite.client.userInfo.get<Record<string, any>>();
+
+        expect(response.email).toBeDefined();
+    });
+
+    it('should leave an explicit projection untouched', async () => {
+        const response = await httpRequest(suite, 'GET', '/userinfo?fields=name', { headers: { Authorization: `Basic ${Buffer.from('admin:start123').toString('base64')}` } });
+        const body = await response.json();
+
+        expect(response.status).toEqual(200);
+        expect(body.name).toEqual('admin');
+        expect(body.email).toBeUndefined();
+    });
+
     it('should reject an unauthenticated request', async () => {
         const response = await httpRequest(suite, 'GET', '/userinfo');
 

--- a/apps/server-core/test/unit/http/controllers/workflows/userinfo.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/userinfo.spec.ts
@@ -11,7 +11,7 @@ import {
     expect,
     it,
 } from 'vitest';
-import { REALM_MASTER_NAME } from '@authup/core-kit';
+import { REALM_MASTER_NAME, buildUserFakeEmail } from '@authup/core-kit';
 import { httpRequest } from '../../../../utils';
 import { createTestApplication } from '../../../../app';
 
@@ -43,7 +43,9 @@ describe('src/http/controllers/workflows/userinfo', () => {
     it('should carry the email claim', async () => {
         const response = await suite.client.userInfo.get<Record<string, any>>();
 
-        expect(response.email).toBeDefined();
+        // the seeded address, not merely a present key: `toBeDefined()` also
+        // passes for the null the form used to submit back over it
+        expect(response.email).toEqual(buildUserFakeEmail('admin'));
     });
 
     it('should leave an explicit projection untouched', async () => {

--- a/packages/client-web-kit/src/core/store/constants.ts
+++ b/packages/client-web-kit/src/core/store/constants.ts
@@ -8,6 +8,12 @@
 export const STORE_ID = 'authup';
 
 /**
+ * Path store cookies default to: the only one every surface on an origin is
+ * guaranteed to read back. Narrow it per host via `cookiePath`.
+ */
+export const COOKIE_PATH = '/';
+
+/**
  * The store's auth phase, derived from state PRESENCE
  * (access/refresh token / realm / user) plus an in-flight interaction
  * marker.

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -10,7 +10,7 @@ import {
     PermissionMemoryProvider,
     PolicyEngine,
 } from '@authup/access';
-import { OAuth2Error } from '@authup/specs';
+import { OAuth2Error, OAuth2SubKind } from '@authup/specs';
 import type { IClient } from '@authup/core-http-kit';
 import { computed, ref } from 'vue';
 import type {
@@ -343,6 +343,22 @@ export function createStore(context: StoreCreateContext) {
 
     const fetchUserInfo = async (token: string) : Promise<User> => client.userInfo.get<User>(`Bearer ${token}`);
 
+    /**
+     * Whether the currently held user IS the subject of the introspected
+     * token. A user that came from anywhere but this token (cookie
+     * hydration, a raw seed) is only as trustworthy as the pairing, and the
+     * two can drift apart (a sibling login on the same origin, an id from a
+     * previous provisioning run). Revalidation re-fetches on a mismatch
+     * instead of carrying the stale identity for the app's lifetime: it is
+     * what the UI renders and what its forms write against.
+     */
+    const isTokenSubject = (
+        value: User | null,
+        introspection: OAuth2TokenIntrospectionResponse,
+    ) : boolean => !!value &&
+        introspection.sub_kind === OAuth2SubKind.USER &&
+        introspection.sub === value.id;
+
     type SessionCommitContext = {
         // tokenGeneration captured when staging started
         generation: number,
@@ -536,7 +552,9 @@ export function createStore(context: StoreCreateContext) {
         }
 
         const introspection = await fetchTokenIntrospection(token);
-        const userInfo = user.value ? undefined : await fetchUserInfo(token);
+        const userInfo = isTokenSubject(user.value, introspection) ?
+            undefined :
+            await fetchUserInfo(token);
 
         commitSession({
             generation,

--- a/packages/client-web-kit/src/core/store/install.ts
+++ b/packages/client-web-kit/src/core/store/install.ts
@@ -86,8 +86,15 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
      * next refresh replays into family revocation. So they are cleared once,
      * before reading, and the browser falls back to the pinned session (or to
      * signed out, if that one already lapsed).
+     *
+     * Cleared is every path a cookie could sit on and still reach this
+     * document, which by the RFC 6265 5.2.4 path-match is each `/`-boundary
+     * prefix of the current path PLUS that path itself. The last part is not
+     * redundant: `/account` serves the console too, and a copy written from
+     * `/account/password` sits on exactly `/account`, matching it. Only the
+     * store's own names are touched, and never on the pinned path.
      */
-    const dropDefaultPathCookies = () => {
+    const dropShadowingCookies = () => {
         const pathname = typeof window === 'undefined' ?
             undefined :
             window.location?.pathname;
@@ -96,14 +103,20 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
             return;
         }
 
-        const index = pathname.lastIndexOf('/');
-        const defaultPath = index <= 0 ? '/' : pathname.slice(0, index);
-        if (defaultPath === cookiePath) {
-            return;
-        }
+        let path = '';
+        for (const segment of pathname.split('/')) {
+            if (!segment) {
+                continue;
+            }
 
-        for (const key of Object.values(CookieName)) {
-            cookieUnset(key, { path: defaultPath });
+            path += `/${segment}`;
+            if (path === cookiePath) {
+                continue;
+            }
+
+            for (const key of Object.values(CookieName)) {
+                cookieUnset(key, { path });
+            }
         }
     };
 
@@ -268,7 +281,7 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         },
     );
 
-    dropDefaultPathCookies();
+    dropShadowingCookies();
     readCookies();
 
     provideStoreFactory(storeFactory, app);

--- a/packages/client-web-kit/src/core/store/install.ts
+++ b/packages/client-web-kit/src/core/store/install.ts
@@ -15,7 +15,7 @@ import type {
     CookieSetFn, 
     CookieUnsetFn,
 } from '../../types';
-import { STORE_ID } from './constants';
+import { COOKIE_PATH, STORE_ID } from './constants';
 import { createStore } from './create';
 import { StoreDispatcherEventName, createStoreDispatcher, provideStoreDispatcher } from './dispatcher';
 import { hasStoreFactory, provideStoreFactory } from './singleton';
@@ -66,6 +66,46 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         const cookies = useCookies();
         cookieUnset = cookies.remove;
     }
+
+    // Written explicitly, because a cookie stored without a `Path` takes the
+    // browser's default-path: the directory of the writing document. The
+    // account console at `/account` and the hosted auth pages at `/` are one
+    // origin sharing one session under one set of cookie names, so the
+    // implicit paths gave them two shadowing sets that expire independently.
+    const cookiePath = options.cookiePath || COOKIE_PATH;
+
+    /**
+     * Drop the copies written before the path was pinned.
+     *
+     * Those sit on the browser's default-path for the writing document
+     * (RFC 6265 5.1.4): `/account` for the account console. A pinned write
+     * does not overwrite them, and they WIN the read, because
+     * `document.cookie` lists the longer path first and the parser keeps the
+     * first match. Hydration would then persist what they hold back onto the
+     * pinned path, replacing a live refresh token with a stale one, which the
+     * next refresh replays into family revocation. So they are cleared once,
+     * before reading, and the browser falls back to the pinned session (or to
+     * signed out, if that one already lapsed).
+     */
+    const dropDefaultPathCookies = () => {
+        const pathname = typeof window === 'undefined' ?
+            undefined :
+            window.location?.pathname;
+
+        if (typeof pathname !== 'string') {
+            return;
+        }
+
+        const index = pathname.lastIndexOf('/');
+        const defaultPath = index <= 0 ? '/' : pathname.slice(0, index);
+        if (defaultPath === cookiePath) {
+            return;
+        }
+
+        for (const key of Object.values(CookieName)) {
+            cookieUnset(key, { path: defaultPath });
+        }
+    };
 
     const readCookies = () => {
         if (store.cookiesRead) {
@@ -148,9 +188,12 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.ACCESS_TOKEN_EXPIRE_DATE, input, { maxAge: maxAgeFn() });
+                cookieSet(CookieName.ACCESS_TOKEN_EXPIRE_DATE, input, {
+                    maxAge: maxAgeFn(),
+                    path: cookiePath,
+                });
             } else {
-                cookieUnset(CookieName.ACCESS_TOKEN_EXPIRE_DATE, {});
+                cookieUnset(CookieName.ACCESS_TOKEN_EXPIRE_DATE, { path: cookiePath });
             }
         },
     );
@@ -160,9 +203,12 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         (input) => {
             if (input) {
                 const maxAge = maxAgeFn();
-                cookieSet(CookieName.ACCESS_TOKEN, input, { maxAge });
+                cookieSet(CookieName.ACCESS_TOKEN, input, {
+                    maxAge,
+                    path: cookiePath,
+                });
             } else {
-                cookieUnset(CookieName.ACCESS_TOKEN, {});
+                cookieUnset(CookieName.ACCESS_TOKEN, { path: cookiePath });
             }
         },
     );
@@ -171,9 +217,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REFRESH_TOKEN_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REFRESH_TOKEN, input, {});
+                cookieSet(CookieName.REFRESH_TOKEN, input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REFRESH_TOKEN, {});
+                cookieUnset(CookieName.REFRESH_TOKEN, { path: cookiePath });
             }
         },
     );
@@ -182,9 +228,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.ID_TOKEN_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.ID_TOKEN, input, {});
+                cookieSet(CookieName.ID_TOKEN, input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.ID_TOKEN, {});
+                cookieUnset(CookieName.ID_TOKEN, { path: cookiePath });
             }
         },
     );
@@ -193,9 +239,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.USER_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.USER, input, {});
+                cookieSet(CookieName.USER, input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.USER, {});
+                cookieUnset(CookieName.USER, { path: cookiePath });
             }
         },
     );
@@ -204,9 +250,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REALM_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REALM, input, {});
+                cookieSet(CookieName.REALM, input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REALM, {});
+                cookieUnset(CookieName.REALM, { path: cookiePath });
             }
         },
     );
@@ -215,13 +261,14 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REALM_MANAGEMENT_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REALM_MANAGEMENT, input, {});
+                cookieSet(CookieName.REALM_MANAGEMENT, input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REALM_MANAGEMENT, {});
+                cookieUnset(CookieName.REALM_MANAGEMENT, { path: cookiePath });
             }
         },
     );
 
+    dropDefaultPathCookies();
     readCookies();
 
     provideStoreFactory(storeFactory, app);

--- a/packages/client-web-kit/src/core/store/types.ts
+++ b/packages/client-web-kit/src/core/store/types.ts
@@ -57,5 +57,19 @@ export type StoreInstallOptions = {
     cookieSet?: CookieSetFn,
     cookieUnset?: CookieUnsetFn,
     cookieGet?: CookieGetFn,
+    /**
+     * Path the store cookies are written (and cleared) with, defaulting to
+     * the root. It is the app's own mount point, not the API's: the cookies
+     * are read back in JavaScript to rehydrate the store and are never sent
+     * to the API as credentials, and a cookie can only be written for the
+     * writing document's origin regardless.
+     *
+     * Every authup surface on one origin must pass the SAME value. They share
+     * cookie names, so two paths mean two shadowing sets that expire
+     * independently and can pair a `user` from one login with a token from
+     * another. Note the path is hygiene, not isolation: same-origin code
+     * reads any path through an iframe.
+     */
+    cookiePath?: string,
     pinia?: Pinia
 };

--- a/packages/client-web-kit/src/module.ts
+++ b/packages/client-web-kit/src/module.ts
@@ -64,6 +64,7 @@ export function install(app: App, options: Options): void {
         cookieSet: options.cookieSet,
         cookieGet: options.cookieGet,
         cookieUnset: options.cookieUnset,
+        cookiePath: options.cookiePath,
     });
 
     installHTTPClientAuthenticationHook(app, {

--- a/packages/client-web-kit/src/types.ts
+++ b/packages/client-web-kit/src/types.ts
@@ -111,6 +111,11 @@ export type Options = {
     cookieSet?: CookieSetFn,
     cookieUnset?: CookieUnsetFn,
     cookieGet?: CookieGetFn,
+    /**
+     * Path the store cookies are written with: the app's own mount point.
+     * See the store install option of the same name.
+     */
+    cookiePath?: string,
 
     pinia?: Pinia,
     isServer?: boolean,

--- a/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
@@ -8,7 +8,12 @@
 import { CookieName } from '@authup/core-http-kit';
 import { createFakeClient } from '@authup/core-http-kit/testing';
 import { createPinia } from 'pinia';
-import { describe, expect, it } from 'vitest';
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
 import { createApp, h } from 'vue';
 import type { CookieOptions } from '../../../../src/types';
 import { injectStore, installStore } from '../../../../src/core/store';
@@ -37,10 +42,15 @@ type CookieSetCall = {
     options: CookieOptions
 };
 
-function buildApp(seed: Record<string, unknown> = {}) {
+type CookieUnsetCall = {
+    key: string,
+    options: CookieOptions
+};
+
+function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
     const jar = new Map<string, unknown>(Object.entries(seed));
     const setCalls : CookieSetCall[] = [];
-    const unsetCalls : string[] = [];
+    const unsetCalls : CookieUnsetCall[] = [];
 
     const httpClient = createFakeClient({
         handlers: {
@@ -56,6 +66,7 @@ function buildApp(seed: Record<string, unknown> = {}) {
     app.use(pinia);
 
     installStore(app, {
+        cookiePath,
         httpClient,
         pinia,
         cookieGet: (key) => jar.get(key),
@@ -67,8 +78,8 @@ function buildApp(seed: Record<string, unknown> = {}) {
             });
             jar.set(key, value);
         },
-        cookieUnset: (key) => {
-            unsetCalls.push(key);
+        cookieUnset: (key, options) => {
+            unsetCalls.push({ key, options });
             jar.delete(key);
         },
     });
@@ -162,7 +173,7 @@ describe('core/store/install-cookies', () => {
 
         await store.logout();
 
-        expect(unsetCalls).toEqual([
+        expect(unsetCalls.map((call) => call.key)).toEqual([
             CookieName.ACCESS_TOKEN,
             CookieName.ACCESS_TOKEN_EXPIRE_DATE,
             CookieName.REFRESH_TOKEN,
@@ -172,5 +183,100 @@ describe('core/store/install-cookies', () => {
             CookieName.REALM_MANAGEMENT,
         ]);
         expect(setCalls).toHaveLength(0);
+    });
+});
+
+describe('core/store/install-cookies path', () => {
+    const setPathname = (pathname: string) => {
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            writable: true,
+            value: { pathname },
+        });
+    };
+
+    afterEach(() => {
+        setPathname('/');
+    });
+
+    // A cookie stored without an explicit `Path` inherits the browser's
+    // default-path, the directory of the writing document. The account
+    // console at `/account` and the hosted auth pages at `/` are one origin
+    // sharing one session under one set of cookie names, so the implicit
+    // paths gave them two shadowing sets that expire independently: a `user`
+    // from one login then pairs up with an `access_token` from another and
+    // the store renders an identity that is not the token's subject.
+    it('writes and clears every cookie at the default root path', async () => {
+        const {
+            store,
+            setCalls,
+            unsetCalls,
+        } = buildApp();
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+        });
+
+        expect(setCalls).not.toHaveLength(0);
+        for (const call of setCalls) {
+            expect(call.options.path).toEqual('/');
+        }
+
+        await store.logout();
+
+        expect(unsetCalls).not.toHaveLength(0);
+        for (const call of unsetCalls) {
+            expect(call.options.path).toEqual('/');
+        }
+    });
+
+    // Copies written before the path was pinned sit on the browser's
+    // default-path and WIN the read, so hydration would persist their
+    // contents onto the pinned path: a stale refresh token replacing a live
+    // one, replayed into family revocation on the next refresh.
+    it('clears the pre-pinning copies on the document default-path', () => {
+        setPathname('/account/password');
+
+        const { unsetCalls } = buildApp();
+
+        const dropped = unsetCalls.filter((call) => call.options.path === '/account');
+        expect(dropped.map((call) => call.key).sort())
+            .toEqual(Object.values(CookieName).sort());
+    });
+
+    it('clears nothing extra when the document sits on the cookie path', () => {
+        setPathname('/account');
+
+        const { unsetCalls } = buildApp();
+
+        expect(unsetCalls).toHaveLength(0);
+    });
+
+    it('writes and clears every cookie at a host-declared path', async () => {
+        setPathname('/auth/account/');
+
+        const {
+            store,
+            setCalls,
+            unsetCalls,
+        } = buildApp({}, '/auth');
+
+        // ignore the install-time migration drops
+        setCalls.length = 0;
+        unsetCalls.length = 0;
+
+        await store.login({
+            name: 'admin',
+            password: 'start123',
+        });
+
+        await store.logout();
+
+        expect(setCalls).not.toHaveLength(0);
+        expect(unsetCalls).not.toHaveLength(0);
+        for (const call of [...setCalls, ...unsetCalls]) {
+            expect(call.options.path).toEqual('/auth');
+        }
     });
 });

--- a/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
@@ -235,18 +235,38 @@ describe('core/store/install-cookies path', () => {
     // default-path and WIN the read, so hydration would persist their
     // contents onto the pinned path: a stale refresh token replacing a live
     // one, replayed into family revocation on the next refresh.
-    it('clears the pre-pinning copies on the document default-path', () => {
+    it('clears the pre-pinning copies that can reach the document', () => {
         setPathname('/account/password');
 
         const { unsetCalls } = buildApp();
 
-        const dropped = unsetCalls.filter((call) => call.options.path === '/account');
-        expect(dropped.map((call) => call.key).sort())
-            .toEqual(Object.values(CookieName).sort());
+        const paths = new Set(unsetCalls.map((call) => call.options.path));
+        expect(paths).toEqual(new Set(['/account', '/account/password']));
+
+        for (const path of paths) {
+            expect(unsetCalls
+                .filter((call) => call.options.path === path)
+                .map((call) => call.key)
+                .sort())
+                .toEqual(Object.values(CookieName).sort());
+        }
     });
 
-    it('clears nothing extra when the document sits on the cookie path', () => {
+    // `/account` serves the console as well, and a copy written from
+    // `/account/password` sits on exactly `/account` — which path-matches it.
+    // Clearing only the document's default-path (`/` here) would leave it to
+    // win hydration.
+    it('clears the mount path itself on a trailing-slash-less route', () => {
         setPathname('/account');
+
+        const { unsetCalls } = buildApp();
+
+        const paths = new Set(unsetCalls.map((call) => call.options.path));
+        expect(paths).toEqual(new Set(['/account']));
+    });
+
+    it('clears nothing when the document sits on the cookie path', () => {
+        setPathname('/');
 
         const { unsetCalls } = buildApp();
 

--- a/packages/client-web-kit/test/unit/core/store/revalidate.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/revalidate.spec.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient } from '@authup/core-http-kit/testing';
+import type { FakeClient } from '@authup/core-http-kit/testing';
+import { describe, expect, it } from 'vitest';
+import type { User } from '@authup/core-kit';
+import { createStore, createStoreDispatcher } from '../../../../src/core/store';
+
+const TOKEN_SUBJECT = 'user-1';
+
+function buildStore() {
+    const httpClient = createFakeClient({
+        handlers: {
+            'POST /token/introspect': () => ({
+                exp: 9999999999,
+                sub: TOKEN_SUBJECT,
+                sub_kind: 'user',
+                session_id: 'sess-1',
+                realm_id: 'realm-1',
+                realm_name: 'master',
+                permissions: [],
+            }),
+            'GET /userinfo': () => ({
+                id: TOKEN_SUBJECT,
+                name: 'admin',
+                realmId: 'realm-1',
+            }),
+        },
+    });
+
+    const store = createStore({
+        httpClient,
+        dispatcher: createStoreDispatcher(),
+    });
+
+    return { store, httpClient };
+}
+
+function countUserInfoRequests(httpClient: FakeClient) : number {
+    return httpClient.requests.filter(
+        (request) => request.method === 'GET' &&
+            new URL(request.url, 'http://localhost').pathname === '/userinfo',
+    ).length;
+}
+
+describe('core/store/revalidate', () => {
+    it('keeps a seeded user that is the token subject', async () => {
+        const { store, httpClient } = buildStore();
+
+        store.setAccessToken('at-1');
+        store.setUser({
+            id: TOKEN_SUBJECT,
+            name: 'admin',
+        } as User);
+
+        await store.resolve();
+
+        expect(countUserInfoRequests(httpClient)).toEqual(0);
+        expect(store.user.value).toMatchObject({ id: TOKEN_SUBJECT });
+    });
+
+    // A seeded user (cookie hydration, raw seeding) is only as trustworthy as
+    // its pairing with the token, and the two drift apart: a sibling login on
+    // the same origin, an id left over from a previous provisioning run. It is
+    // what the UI renders and what its forms write against, so a mismatch must
+    // re-resolve instead of being carried for the app's lifetime.
+    it('replaces a seeded user that is not the token subject', async () => {
+        const { store, httpClient } = buildStore();
+
+        store.setAccessToken('at-1');
+        store.setUser({
+            id: 'someone-else',
+            name: 'stale',
+        } as User);
+
+        await store.resolve();
+
+        expect(countUserInfoRequests(httpClient)).toEqual(1);
+        expect(store.user.value).toMatchObject({
+            id: TOKEN_SUBJECT,
+            name: 'admin',
+        });
+    });
+
+    it('resolves the user when none is present', async () => {
+        const { store, httpClient } = buildStore();
+
+        store.setAccessToken('at-1');
+
+        await store.resolve();
+
+        expect(countUserInfoRequests(httpClient)).toEqual(1);
+        expect(store.user.value).toMatchObject({ id: TOKEN_SUBJECT });
+    });
+});


### PR DESCRIPTION
Clicking **Update** on the account console General tab answered `EntityNotFoundError`. Two independent defects were behind it, plus a third the first one masked.

## 1. Store cookies had no `Path`

A cookie stored without a `Path` takes the browser's default-path: the directory of the writing document. The account console at `/account` and the hosted auth pages at `/` are one origin sharing one session under one set of cookie names, so they wrote two sets. Observed in a browser after a single login:

```
access_token  path=/          user  path=/          <- written by /authorize
access_token  path=/account   user  path=/account   <- written by /account
```

They expire on different schedules (`access_token` carries a maxAge, `user` / `refresh_token` / `id_token` are session cookies), so a `user` surviving from one login pairs with an `access_token` from another. The page then rendered one identity while the bearer belonged to another, and the update posted to `/users/<stale id>` with the realm taken from the token. The realm-scoped lookup in `UserService.save()` missed:

```
404 POST /users/5d9776ec-…   body: {…,"realmId":"fca23761-… (master)"}
{"name":"EntityNotFoundError","code":"entity_not_found","issues":[]}
```

Every write and clear now carries an explicit `cookiePath`, defaulting to the root. It is the app's own mount point, not the API's: these cookies are read back in JavaScript to rehydrate the store and are never sent to the API as credentials, and a cookie can only be written for the writing document's origin regardless. Every surface on one origin must pass the same value. Hosts mounted below the root of a shared domain can narrow it.

Note the path is hygiene, not isolation: same-origin code can read any path through an iframe. The boundary is the origin.

### Migration

Copies written before the pin are cleared once at install, at the document's default-path. This is not cosmetic. They are not overwritten by the pinned writes and they **win the read** (`document.cookie` lists the longer path first, and `cookie.parse` keeps the first match), so hydration persists their contents back onto the pinned path. Measured on the fix without this step:

```
refresh_token@/account = stale-rt     <- survives, wins the read
refresh_token@/        = stale-rt     <- the LIVE root token overwritten with it
```

The next refresh replays that token, and replay detection revokes the family, killing the live session. Only the store's own cookie names are cleared; unrelated cookies on that path are untouched.

## 2. A held user was never checked against the token

`revalidate()` skipped the userinfo fetch whenever a user was already present, so a user from anywhere but the current token was trusted for the app's lifetime, while the realm was refreshed from introspection every time. The fetch is now skipped only when the held user IS the introspected subject.

This is what heals the identity in the case above; without it the console kept rendering the stale user.

## 3. `/userinfo` never carried the email claim

`user.email` is a `select: false` column, opt-in through the field projection and absent from the default set, and the endpoint forwarded the request query untouched. So the form rendered an empty email box and submitted `null`:

```
400 POST /users/87e8da49-…   {…,"email":null,…}
{"name":"ValidupError","message":"Property email is invalid"}
```

Reproducible from any clean login, on the account console General tab and the admin console settings page alike. The endpoint serves the caller's own record, so the claim now rides on top of the defaults; a caller stating its own `fields` keeps full control.

## Verification

Driven through a real browser against a server-core instance:

- fresh login: one cookie set at `/`, email prefilled, untouched Update returns 202
- browser carrying pre-fix `/account` cookies: stale copies dropped, live root refresh token intact, correct identity rendered
- both original failures reproduced first, byte for byte, then confirmed gone

`packages/client-web-kit` 193/193. `apps/server-core` 172/172 files, 1853/1853 tests.

## Notes for review

- `cookiePath` is not passed by any host in this repo yet; the root default is correct for every current topology. It exists for a deployment mounted below the root of a shared domain.
- The migration clear has no expiry and runs on every install. It can be dropped in a future major.
- Adjacent, not addressed: `realm_management` is hydrated from its cookie and never re-checked against the token, the same shape as defect 2.
- The admin console was not exercised end to end. Its cookie behaviour is unchanged (Nuxt's `useCookie` already defaulted to `path: '/'`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - User information responses now include the email claim by default.
  - Applications can configure the cookie path used for authentication sessions, including deployments under paths such as `/auth`.
- **Bug Fixes**
  - Improved cleanup of cookies created on previous paths.
  - Authentication sessions now refresh user details when the stored user does not match the active token.
  - Explicit user information field selections continue to be honored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->