### PR TITLE
fix(kit): match single-* wildcard against a whole segment

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1009,6 +1009,18 @@ no new endpoint — the `/authorize` verifier already resolves clients via
   (plan 078 "relocatable by choice") registers its origin via
   `TRUSTED_ORIGINS`, never by editing the client row. `displayName` is seeded
   at CREATE only (never re-asserted), so admins can relabel.
+- **Pattern semantics** (`isSimpleMatch`, `@authup/kit`): `*` matches a run
+  of characters (empty included) that does not cross a `/`, `**` matches the
+  rest of the value, and a pattern ending in `/*` or `/**` also matches the
+  value stopping in front of that separator (so `<origin>/**` covers the bare
+  origin). The `/` boundary is what keeps a host wildcard inside the host:
+  `https://*.example.com/**` covers every subdomain but not
+  `https://a.example.com.evil.test/cb`, `https://a.example.com@evil.test/cb`
+  or a differing port. Matching is case sensitive, so a caller comparing URLs
+  canonicalizes first (`resolveAccountConsoleRef`). Before #3394 the single-`*`
+  branch advanced one character instead of consuming the run, which made a
+  host wildcard inert AND matched any value carrying no further `/` against
+  any pattern holding a `*`.
 - **Scopes** (`SYSTEM_CLIENT_SCOPE_NAMES` = `global` + `openid`, per
   definition) are bound as
   `auth_client_scopes` rows. That junction is the only source `/authorize`

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1011,16 +1011,26 @@ no new endpoint — the `/authorize` verifier already resolves clients via
   at CREATE only (never re-asserted), so admins can relabel.
 - **Pattern semantics** (`isSimpleMatch`, `@authup/kit`): `*` matches a run
   of characters (empty included) that does not cross a `/`, `**` matches the
-  rest of the value, and a pattern ending in `/*` or `/**` also matches the
-  value stopping in front of that separator (so `<origin>/**` covers the bare
-  origin). The `/` boundary is what keeps a host wildcard inside the host:
+  rest of the value, and once the value is exhausted a separator in front of
+  a wildcard is optional (so `<origin>/**` covers the bare origin). The `/`
+  boundary is what keeps a host wildcard inside the host:
   `https://*.example.com/**` covers every subdomain but not
   `https://a.example.com.evil.test/cb`, `https://a.example.com@evil.test/cb`
   or a differing port. Matching is case sensitive, so a caller comparing URLs
-  canonicalizes first (`resolveAccountConsoleRef`). Before #3394 the single-`*`
-  branch advanced one character instead of consuming the run, which made a
-  host wildcard inert AND matched any value carrying no further `/` against
-  any pattern holding a `*`.
+  canonicalizes first (`resolveAccountConsoleRef`). The matcher walks value
+  and pattern on separate indices with ONE backtrack point (the last `*`),
+  which bounds it at O(value x pattern) and keeps it regex-free, so no
+  pattern can be turned into a ReDoS. A property test pins it against a
+  recursive reference over every value/pattern pair up to length 4
+  (`packages/kit/test/unit/is-simple-match.spec.ts`) — keep that test when
+  touching the walk, since the backtracking is far easier to break than to
+  review. Before #3394 the single-`*` branch advanced ONE character instead
+  of consuming the run: a host wildcard was inert, and worse, the
+  no-separator-left early return made every path-less value match every
+  pattern sharing its literal prefix, so a client holding a single `*` in
+  `redirectUri` accepted `https://attacker.test` as a redirect target. The
+  provisioned `<origin>/**` patterns were never affected (their only
+  wildcard is a `**`, which returns early).
 - **Scopes** (`SYSTEM_CLIENT_SCOPE_NAMES` = `global` + `openid`, per
   definition) are bound as
   `auth_client_scopes` rows. That junction is the only source `/authorize`

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -278,5 +278,45 @@ describe('OAuth2AuthorizationCodeRequestVerifier', () => {
             });
             expect(result.redirectUriVerified).toBe(true);
         });
+
+        it('should accept a redirect matching a registered host wildcard', async () => {
+            const client = clientRepository.seed({
+                authMethod: 'secret',
+                tokenBindingMethod: 'none',
+                redirectUri: 'https://*.example.com/**',
+            });
+            const result = await verifier.verify({
+                client_id: client.id,
+                response_type: OAuth2AuthorizationResponseType.CODE,
+                redirect_uri: 'https://app.example.com/callback',
+            });
+            expect(result.redirectUriVerified).toBe(true);
+        });
+
+        it('should reject a redirect a registered host wildcard does not cover', async () => {
+            // the wildcard never crosses a `/`, so it stays inside the host
+            const client = clientRepository.seed({
+                authMethod: 'secret',
+                tokenBindingMethod: 'none',
+                redirectUri: 'https://*.example.com/**',
+            });
+
+            const candidates = [
+                'https://app.example.com.evil.test/callback',
+                'https://app.example.com@evil.test/callback',
+                'https://app.example.com:8443/callback',
+                'http://app.example.com/callback',
+            ];
+
+            for (const redirectUri of candidates) {
+                await expect(
+                    verifier.verify({
+                        client_id: client.id,
+                        response_type: OAuth2AuthorizationResponseType.CODE,
+                        redirect_uri: redirectUri,
+                    }),
+                ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_REDIRECT_URI_MISMATCH }));
+            }
+        });
     });
 });

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -306,6 +306,10 @@ describe('OAuth2AuthorizationCodeRequestVerifier', () => {
                 'https://app.example.com@evil.test/callback',
                 'https://app.example.com:8443/callback',
                 'http://app.example.com/callback',
+                // a path-less URI used to satisfy every pattern sharing its
+                // literal prefix, which let any origin collect the code
+                'https://attacker.test',
+                'https://attacker.test?code=1',
             ];
 
             for (const redirectUri of candidates) {

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -166,10 +166,16 @@ export default {
      * Each origin is added to the redirect-URI allowlist of the per-realm
      * public system clients (as `<origin>/**`).
      * The origin of `publicUrl` is always trusted implicitly.
+     * A host may carry a `*` (e.g. https://*.example.com), which matches
+     * any host ending in `.example.com`. The wildcard never crosses a `/`,
+     * so it cannot reach past the host, and a non-default port has to be
+     * written out (https://*.example.com:8443).
      *
      * Security: the system clients are built-in with global scope, so any
      * allowlisted origin can complete a login and obtain a full-permission
-     * token — only add origins you control. In non-production, the
+     * token — only add origins you control. A wildcard host trusts every
+     * subdomain, so use one only where you control the whole domain.
+     * In non-production, the
      * client-admin-console dev origin (http://localhost:3000) is seeded automatically.
      * env: TRUSTED_ORIGINS (comma-separated)
      * default: []

--- a/packages/kit/src/is-simple-match.ts
+++ b/packages/kit/src/is-simple-match.ts
@@ -5,10 +5,50 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+/**
+ * Check if the remaining pattern can match an empty value.
+ *
+ * That is the case for a run of wildcards, optionally preceded by the
+ * separator in front of the first one, so `https://example.com` matches
+ * `https://example.com/**`.
+ */
+function matchesEmpty(pattern: string, index: number) : boolean {
+    let i = index;
+
+    if (pattern[i] === '/' && pattern[i + 1] === '*') {
+        i++;
+    }
+
+    while (i < pattern.length) {
+        if (pattern[i] !== '*') {
+            return false;
+        }
+
+        if (pattern[i + 1] === '*') {
+            return true;
+        }
+
+        i++;
+    }
+
+    return true;
+}
+
+/**
+ * Match a value against a glob pattern, or against any pattern of a list.
+ *
+ * `*` matches a run of characters (the empty run included) that does not
+ * cross a `/`, `**` matches the rest of the value, separators included.
+ * A pattern ending in `/*` or `/**` also matches the value that stops in
+ * front of that separator.
+ *
+ * The comparison is case sensitive, so a caller matching URLs has to
+ * canonicalize the value first.
+ */
 export function isSimpleMatch(
     value: string,
     pattern: string | string[],
-) {
+) : boolean {
     if (Array.isArray(pattern)) {
         for (const element of pattern) {
             if (isSimpleMatch(value, element)) {
@@ -18,41 +58,44 @@ export function isSimpleMatch(
 
         return false;
     }
+
     if (value === pattern) {
         return true;
     }
 
-    const maxLength = Math.max(value.length, pattern.length);
+    let valueIndex = 0;
+    let patternIndex = 0;
+    let globValueIndex = -1;
+    let globPatternIndex = -1;
 
-    for (let i = 0; i < maxLength; i++) {
-        if (value[i] === pattern[i]) {
-            continue;
-        }
-
-        if (pattern[i] === '*') {
-            if (pattern[i + 1] === '*') {
+    while (valueIndex < value.length) {
+        if (pattern[patternIndex] === '*') {
+            if (pattern[patternIndex + 1] === '*') {
                 return true;
             }
 
-            let sI : number = -1;
-            for (let j = i; j < value.length; j++) {
-                if (value[j] === '/') {
-                    sI = j + 1;
-                    break;
-                }
-            }
-
-            if (sI === -1) {
-                return true;
-            }
+            globPatternIndex = patternIndex;
+            globValueIndex = valueIndex;
+            patternIndex++;
 
             continue;
         }
 
-        return !value[i] &&
-            pattern[i] === '/' &&
-            pattern[i + 1] === '*';
+        if (pattern[patternIndex] === value[valueIndex]) {
+            patternIndex++;
+            valueIndex++;
+
+            continue;
+        }
+
+        if (globPatternIndex === -1 || value[globValueIndex] === '/') {
+            return false;
+        }
+
+        globValueIndex++;
+        valueIndex = globValueIndex;
+        patternIndex = globPatternIndex + 1;
     }
 
-    return false;
+    return matchesEmpty(pattern, patternIndex);
 }

--- a/packages/kit/src/is-simple-match.ts
+++ b/packages/kit/src/is-simple-match.ts
@@ -8,18 +8,20 @@
 /**
  * Check if the remaining pattern can match an empty value.
  *
- * That is the case for a run of wildcards, optionally preceded by the
- * separator in front of the first one, so `https://example.com` matches
- * `https://example.com/**`.
+ * Wildcards match the empty run, and a separator in front of a wildcard is
+ * optional once the value is exhausted, so `https://example.com` matches
+ * `https://example.com/**`. Anything else has to be present in the value.
  */
 function matchesEmpty(pattern: string, index: number) : boolean {
     let i = index;
 
-    if (pattern[i] === '/' && pattern[i + 1] === '*') {
-        i++;
-    }
-
     while (i < pattern.length) {
+        if (pattern[i] === '/' && pattern[i + 1] === '*') {
+            i++;
+
+            continue;
+        }
+
         if (pattern[i] !== '*') {
             return false;
         }
@@ -39,8 +41,8 @@ function matchesEmpty(pattern: string, index: number) : boolean {
  *
  * `*` matches a run of characters (the empty run included) that does not
  * cross a `/`, `**` matches the rest of the value, separators included.
- * A pattern ending in `/*` or `/**` also matches the value that stops in
- * front of that separator.
+ * Once the value is exhausted, a separator in front of a wildcard is
+ * optional, so `https://example.com` matches `https://example.com/**`.
  *
  * The comparison is case sensitive, so a caller matching URLs has to
  * canonicalize the value first.

--- a/packages/kit/test/unit/is-simple-match.spec.ts
+++ b/packages/kit/test/unit/is-simple-match.spec.ts
@@ -52,6 +52,22 @@ describe('is-simple-match', () => {
         expect(isSimpleMatch('https://admin.example.com', 'https://*.example.com')).toBeTruthy();
     });
 
+    it('should treat a separator in front of a wildcard as optional', () => {
+        expect(isSimpleMatch('test', 'test/*/**')).toBeTruthy();
+        expect(isSimpleMatch('test', 'test*/**')).toBeTruthy();
+        expect(isSimpleMatch('test', 'test/*bar')).toBeFalsy();
+        expect(isSimpleMatch('test', 'test//**')).toBeFalsy();
+    });
+
+    it('should not match an unrelated origin carrying no path', () => {
+        // the wildcard used to swallow the rest of a value that held no
+        // further separator, so every path-less URI matched every pattern
+        // whose literal prefix it shared
+        expect(isSimpleMatch('https://attacker.test', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleMatch('https://attacker.test?code=1', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleMatch('https://attacker.test', 'https://app.example.com/*')).toBeFalsy();
+    });
+
     it('should not match host wildcard of another origin', () => {
         expect(isSimpleMatch('https://a.example.com', 'https://*.example.com.evil.test/**')).toBeFalsy();
         expect(isSimpleMatch('https://a.example.com.evil.test/cb', 'https://*.example.com/**')).toBeFalsy();
@@ -59,5 +75,79 @@ describe('is-simple-match', () => {
         expect(isSimpleMatch('https://a.example.com:8080/cb', 'https://*.example.com/**')).toBeFalsy();
         expect(isSimpleMatch('http://a.example.com/cb', 'https://*.example.com/**')).toBeFalsy();
         expect(isSimpleMatch('https://example.com/cb', 'https://*.example.com/**')).toBeFalsy();
+    });
+
+    it('should agree with the reference matcher on every short value/pattern pair', () => {
+        // isSimpleMatch walks both sides on separate indices and backtracks
+        // into the last wildcard, which is a lot easier to get subtly wrong
+        // than to review. The reference below is the same contract written
+        // as a plain recursive search: exponential, but obviously correct.
+        // Both are exercised over every string of length <= 4 built from the
+        // alphabet below, so a regression on either side shows up as a
+        // disagreement rather than as an untested corner.
+        const reference = (value: string, pattern: string) : boolean => {
+            const match = (valueIndex: number, patternIndex: number) : boolean => {
+                if (patternIndex >= pattern.length) {
+                    return valueIndex >= value.length;
+                }
+
+                if (pattern[patternIndex] === '*' && pattern[patternIndex + 1] === '*') {
+                    return true;
+                }
+
+                if (pattern[patternIndex] === '*') {
+                    for (let i = valueIndex; ; i++) {
+                        if (match(i, patternIndex + 1)) {
+                            return true;
+                        }
+
+                        if (i >= value.length || value[i] === '/') {
+                            return false;
+                        }
+                    }
+                }
+
+                if (
+                    valueIndex >= value.length &&
+                    pattern[patternIndex] === '/' &&
+                    pattern[patternIndex + 1] === '*'
+                ) {
+                    return match(valueIndex, patternIndex + 1);
+                }
+
+                if (valueIndex < value.length && pattern[patternIndex] === value[valueIndex]) {
+                    return match(valueIndex + 1, patternIndex + 1);
+                }
+
+                return false;
+            };
+
+            return match(0, 0);
+        };
+
+        const alphabet = ['a', 'b', '/', '*'];
+        const corpus: string[] = [];
+        const build = (prefix: string, depth: number) => {
+            corpus.push(prefix);
+            if (depth === 0) {
+                return;
+            }
+
+            for (const character of alphabet) {
+                build(prefix + character, depth - 1);
+            }
+        };
+        build('', 4);
+
+        const divergences: string[] = [];
+        for (const value of corpus) {
+            for (const pattern of corpus) {
+                if (isSimpleMatch(value, pattern) !== reference(value, pattern)) {
+                    divergences.push(`${JSON.stringify(value)} ~ ${JSON.stringify(pattern)}`);
+                }
+            }
+        }
+
+        expect(divergences).toEqual([]);
     });
 });

--- a/packages/kit/test/unit/is-simple-match.spec.ts
+++ b/packages/kit/test/unit/is-simple-match.spec.ts
@@ -34,4 +34,30 @@ describe('is-simple-match', () => {
     it('should not match with glob star', () => {
         expect(isSimpleMatch('baz', 'test/**')).toBeFalsy();
     });
+
+    it('should match single glob followed by a literal', () => {
+        expect(isSimpleMatch('test/foo/bar', 'test/*/bar')).toBeTruthy();
+        expect(isSimpleMatch('test//bar', 'test/*/bar')).toBeTruthy();
+    });
+
+    it('should not match single glob across a path separator', () => {
+        expect(isSimpleMatch('test/foo/baz/bar', 'test/*/bar')).toBeFalsy();
+        expect(isSimpleMatch('https://admin.example.com/a/b', 'https://*.example.com/*')).toBeFalsy();
+    });
+
+    it('should match host wildcard', () => {
+        expect(isSimpleMatch('https://admin.example.com/cb', 'https://*.example.com/**')).toBeTruthy();
+        expect(isSimpleMatch('https://admin.example.com', 'https://*.example.com/**')).toBeTruthy();
+        expect(isSimpleMatch('https://a.b.example.com/cb', 'https://*.example.com/**')).toBeTruthy();
+        expect(isSimpleMatch('https://admin.example.com', 'https://*.example.com')).toBeTruthy();
+    });
+
+    it('should not match host wildcard of another origin', () => {
+        expect(isSimpleMatch('https://a.example.com', 'https://*.example.com.evil.test/**')).toBeFalsy();
+        expect(isSimpleMatch('https://a.example.com.evil.test/cb', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleMatch('https://a.example.com@evil.test/cb', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleMatch('https://a.example.com:8080/cb', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleMatch('http://a.example.com/cb', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleMatch('https://example.com/cb', 'https://*.example.com/**')).toBeFalsy();
+    });
 });


### PR DESCRIPTION
Fixes the `isSimpleMatch` single-`*` branch reported in #3394.

## The defect

The matcher walked value and pattern on **one** index, so a `*` advanced a
single character instead of consuming the run it stands for. That has two
consequences, and the second one is the serious half.

**1. The wildcard is inert (as reported).** `https://admin.example.com/cb` never
matched `https://*.example.com/**`, so a host wildcard in `TRUSTED_ORIGINS` was
accepted at boot, stamped into every system client, and then matched nothing.

**2. The wildcard also over-matches.** When no `/` remained in the value, the
`sI === -1` branch returned `true` outright, whatever the rest of the pattern
said. So **any path-less value matched any pattern sharing its literal prefix**:

```
true   https://attacker.test        ~  https://*.example.com/**
true   https://attacker.test?code=1 ~  https://*.example.com/**
true   https://attacker.test        ~  https://app.example.com/*
```

A client carrying a single `*` anywhere in `redirectUri` therefore accepted an
arbitrary attacker origin as its redirect target, which hands over the
authorization code. The same branch backs `postLogoutRedirectUri` and the
account console `ref` check. The provisioned `<origin>/**` patterns are **not**
affected, since their only wildcard is a `**`, which returns before that branch.
Reaching it requires an operator-written single `*`, which the same bug made
look non-functional for ordinary URIs.

## The fix

`isSimpleMatch` now walks value and pattern on separate indices and backtracks
into the last `*`, refusing to extend it past a `/`. The contract, now stated in
the JSDoc:

- `*` matches a run of characters (the empty run included) that does not cross a `/`
- `**` matches the rest of the value, separators included
- once the value is exhausted, a separator in front of a wildcard is optional,
  so `<origin>/**` keeps matching the bare origin

The `/` boundary is what keeps a host wildcard inside the host, so
`https://*.example.com/**` covers subdomains but rejects a suffix-extended host
(`a.example.com.evil.test`), a userinfo-prefixed host (`a.example.com@evil.test`),
a differing port and a scheme downgrade.

Fixing the matcher was preferred over rejecting host wildcards in
`expandToOrigins`, since the latter leaves consequence 2 in place for every
hand-written client `redirectUri`.

## Verification

A two-pointer matcher with backtracking is easy to get subtly wrong, so it was
checked against a recursive reference written from the contract above:

- every value/pattern pair over `a b / *` up to length 5, 1,863,225 pairs: **0 divergences**
- 500,000 random pairs up to length 14 over `a b / * . : @ ?`: **0 divergences**
- 1,008 URL-shaped pairs (hosts x paths x patterns): **0 divergences**

The first run of that comparison is what produced the second commit: the
empty-tail check was skipping only the first separator, so `test/*/**` did not
match `test` although `test/**` did. Every divergence found was in the
under-permissive direction, none in the over-matching one.

The reference is kept as a property test over every pair up to length 4
(116,281 pairs, 26ms), so the walk cannot regress silently.

Pathological inputs (2,000-character value against a 500-wildcard pattern)
resolve in tens of microseconds. There is one backtrack point and no regex, so
there is no ReDoS surface.

## Behaviour delta

Measured old vs new over realistic stored patterns. Widened, 6 cases, all of the
intended kind:

```
+ https://app.example.com/callback   ~  https://*.example.com/**
+ https://admin.example.com/callback ~  https://*.example.com/**
+ https://a.b.example.com/callback   ~  https://*.example.com/**   (and 3 more)
```

Narrowed, 8 cases, in two families: the security fixes
(`https://app.example.com.evil.test` and `...@evil.test` no longer match
`https://*.example.com/**`), and patterns that used to match values of the wrong
shape entirely (`https://app.example.com/callback` matching
`https://app.example.com/*/callback`). Nothing provisioned by authup changes.

## Tests

- `packages/kit/test/unit/is-simple-match.spec.ts`: host wildcards, the `/`
  boundary, the path-less bypass above, the optional-separator rule, and the
  property test. All five pre-existing cases are unchanged and still pass.
- `apps/server-core/.../code-request/verifier/module.spec.ts`: the same at the
  OAuth2 redirect allowlist itself.

Each was watched failing against the old matcher before the fix landed.

## Adjacent, not fixed here

`client.redirectUri.split(',')` (and the `postLogoutRedirectUri` equivalent) does
not trim, so `a/**, b/**` yields a pattern with a leading space that can never
match. It is a separate behaviour change on the same security surface, so it is
kept out of this PR.

closes #3394
