### PR TITLE
fix!: redirect-pattern matching, plus fixes from the beta.58 release audit

### DIFF
--- a/apps/authup/test/smoke/run.mjs
+++ b/apps/authup/test/smoke/run.mjs
@@ -121,6 +121,36 @@ async function probe(url) {
     }
 }
 
+/**
+ * Assert that server-core can actually resolve and serve a console package.
+ *
+ * The `locateUpSync` walk that finds `@authup/client-auth-console` and
+ * `@authup/client-account-console` exists specifically for the published
+ * install layout, which only the packed scenario reproduces. Nothing else
+ * exercises it: a resolution regression, or a tarball shipped without its
+ * bundle (`npm pack` does not run `prepublishOnly`), degrades silently
+ * because boot still succeeds and only the console routes break.
+ */
+async function assertConsoleServed(name, url, marker) {
+    let response;
+    try {
+        response = await fetch(url, { redirect: 'follow' });
+    } catch (e) {
+        throw fail(`${name}: ${url} could not be reached (${e.message}).`);
+    }
+
+    if (response.status !== 200) {
+        throw fail(`${name}: ${url} answered ${response.status}, expected 200. The console package is probably unresolved or unbuilt.`);
+    }
+
+    const body = await response.text();
+    if (!body.includes(marker)) {
+        throw fail(`${name}: ${url} answered 200 but the body does not contain ${marker}, so the console shell was not rendered.`);
+    }
+
+    log(`${name}: ${url} served the console shell.`);
+}
+
 async function waitUntilReady(name, url, child) {
     const startedAt = Date.now();
 
@@ -208,6 +238,24 @@ async function executeScenario(name, cliExec, cliArgs, cwd) {
     try {
         await waitUntilReady(`${name}/server-core`, SERVER_URL, child);
         await waitUntilReady(`${name}/client-admin-console`, WEB_URL, child);
+
+        // Both consoles are RUNTIME dependencies of server-core, resolved out
+        // of node_modules and served from their built dist. Probing the root
+        // URLs alone leaves that resolution untested.
+        await assertConsoleServed(
+            `${name}/client-auth-console`,
+            `${SERVER_URL}/logout`,
+            'window.__AUTHUP__',
+        );
+        // window.__AUTHUP__ rather than the shell markup: it only appears if
+        // the `<!--account-config-->` marker was found and replaced, which is
+        // that console's entire runtime contract. Without it the SPA silently
+        // degrades to deriving its API URL from the origin.
+        await assertConsoleServed(
+            `${name}/client-account-console`,
+            `${SERVER_URL}/account`,
+            'window.__AUTHUP__',
+        );
 
         log(`${name}: sending SIGTERM.`);
         child.kill('SIGTERM');

--- a/apps/authup/test/smoke/run.mjs
+++ b/apps/authup/test/smoke/run.mjs
@@ -131,16 +131,22 @@ async function probe(url) {
  * bundle (`npm pack` does not run `prepublishOnly`), degrades silently
  * because boot still succeeds and only the console routes break.
  */
-async function assertConsoleServed(name, url, marker) {
+async function assertConsoleServed(name, route, marker) {
+    // SERVER_URL carries a trailing slash, so build the target with `new URL`
+    // rather than interpolating (`${SERVER_URL}/logout` requests `//logout`).
+    const url = new URL(route, SERVER_URL).href;
+
     let response;
     try {
-        response = await fetch(url, { redirect: 'follow' });
+        // Not `follow`: a redirect to some other page that happens to contain
+        // the marker would hide a broken console route.
+        response = await fetch(url, { redirect: 'manual' });
     } catch (e) {
         throw fail(`${name}: ${url} could not be reached (${e.message}).`);
     }
 
     if (response.status !== 200) {
-        throw fail(`${name}: ${url} answered ${response.status}, expected 200. The console package is probably unresolved or unbuilt.`);
+        throw fail(`${name}: ${url} answered ${response.status}, expected 200 without a redirect. The console package is probably unresolved or unbuilt.`);
     }
 
     const body = await response.text();
@@ -244,7 +250,7 @@ async function executeScenario(name, cliExec, cliArgs, cwd) {
         // URLs alone leaves that resolution untested.
         await assertConsoleServed(
             `${name}/client-auth-console`,
-            `${SERVER_URL}/logout`,
+            'logout',
             'window.__AUTHUP__',
         );
         // window.__AUTHUP__ rather than the shell markup: it only appears if
@@ -253,7 +259,7 @@ async function executeScenario(name, cliExec, cliArgs, cwd) {
         // degrades to deriving its API URL from the origin.
         await assertConsoleServed(
             `${name}/client-account-console`,
-            `${SERVER_URL}/account`,
+            'account',
             'window.__AUTHUP__',
         );
 

--- a/apps/client-account-console/vite.config.ts
+++ b/apps/client-account-console/vite.config.ts
@@ -43,6 +43,11 @@ export default defineConfig({
         }),
     ],
     resolve: {
+        // Single copy of the state/runtime singletons. The kit is bundled from
+        // source, so without this its `pinia` resolves from
+        // packages/client-web-kit/node_modules while the app's resolves here,
+        // and the two `Symbol('pinia')` values never meet.
+        dedupe: ['pinia', 'vue'],
         alias: {
             '@authup/access': path.join(packagesRoot, 'access', 'src'),
             '@authup/core-kit': path.join(packagesRoot, 'core-kit', 'src'),

--- a/apps/client-admin-console/pages/settings/[[...path]].vue
+++ b/apps/client-admin-console/pages/settings/[[...path]].vue
@@ -13,13 +13,17 @@ import { LayoutKey } from '../../config/layout';
 // Self-service moved to the account console, served by server-core on the
 // IdP origin. This stub keeps the sidebar entry and old bookmarks working
 // by mapping each retired settings path onto its account console route.
-const PATH_MAP : Record<string, string> = {
-    '': '/',
-    password: '/password',
-    mfa: '/authenticators',
-    sessions: '/sessions',
-    applications: '/applications',
-};
+// A Map rather than an object literal: the key comes from the URL, and a
+// plain record is read through Object.prototype, so `/settings/constructor`
+// would resolve to a function instead of undefined and never reach the
+// fallback below.
+const PATH_MAP = new Map<string, string>([
+    ['', '/'],
+    ['password', '/password'],
+    ['mfa', '/authenticators'],
+    ['sessions', '/sessions'],
+    ['applications', '/applications'],
+]);
 
 export default defineComponent({
     async setup() {
@@ -30,7 +34,7 @@ export default defineComponent({
         const key = Array.isArray(segments) ? segments.join('/') : (segments ?? '');
 
         await navigateTo(
-            useAccountConsoleURL(PATH_MAP[key] ?? '/'),
+            useAccountConsoleURL(PATH_MAP.get(key) ?? '/'),
             { external: true, redirectCode: 302 },
         );
     },

--- a/apps/client-auth-console/vite.config.ts
+++ b/apps/client-auth-console/vite.config.ts
@@ -57,6 +57,17 @@ export default defineConfig(({ command }) => ({
         }),
     ],
     resolve: {
+        // The kit is bundled from source (see the aliases below), so `pinia`
+        // and `vue` resolve from packages/client-web-kit/node_modules for kit
+        // modules and from this app for app modules. Two copies of pinia mean
+        // two `Symbol('pinia')` values, so `app.use(pinia)` provides under one
+        // and the kit's `injectStore()` injects the other. It only appears to
+        // work because installing the store calls the factory with an explicit
+        // instance, which sets `activePinia` inside the kit's copy - a MODULE
+        // GLOBAL. Every SSR request builds its own pinia, so under concurrent
+        // renders that global points at whichever request installed last and a
+        // kit component can read another request's session.
+        dedupe: ['pinia', 'vue'],
         alias: {
             '@authup/access': path.join(packagesRoot, 'access', 'src'),
             '@authup/core-kit': path.join(packagesRoot, 'core-kit', 'src'),

--- a/apps/server-core/src/adapters/http/ui/account-console/ref.ts
+++ b/apps/server-core/src/adapters/http/ui/account-console/ref.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isSimpleMatch } from '@authup/kit';
+import { isSimpleURLMatch } from '@authup/kit';
 
 /**
  * Upper bound on an accepted `ref`, matching the cap
@@ -26,9 +26,11 @@ export const ACCOUNT_CONSOLE_REF_MAX_LENGTH = 2000;
  * host (`admin.example.com@evil.test`) and a scheme downgrade.
  *
  * The value is canonicalized through `URL` before matching, so a host
- * differing only in case still matches (`isSimpleMatch` is case-sensitive,
- * while a host is not). The canonical form is what gets returned, and it is
- * what the page embeds.
+ * differing only in case still matches (the matcher is case-sensitive, while
+ * a host is not). The canonical form is what gets returned, and it is what
+ * the page embeds. `isSimpleURLMatch` canonicalizes as well, which is what
+ * keeps a wildcard in a trusted origin from escaping the authority; doing it
+ * here too is what lets this function RETURN the canonical form.
  *
  * Returns undefined for anything that does not pass. The caller drops it
  * silently, the way `sanitizeRelativeRedirect` drops a bad workflow
@@ -60,7 +62,7 @@ export function resolveAccountConsoleRef(
 
     const candidate = `${url.origin}${url.pathname}${url.search}${url.hash}`;
 
-    if (!isSimpleMatch(candidate, trustedOrigins.map((origin) => `${origin}/**`))) {
+    if (!isSimpleURLMatch(candidate, trustedOrigins.map((origin) => `${origin}/**`))) {
         return undefined;
     }
 

--- a/apps/server-core/src/adapters/http/ui/console-packages/module.ts
+++ b/apps/server-core/src/adapters/http/ui/console-packages/module.ts
@@ -14,6 +14,9 @@ import {
     setAccountConsolePackagePath,
 } from '../account-console/index.ts';
 import { resolveAuthConsoleDistPath, setAuthConsolePackagePath } from '../auth-console/index.ts';
+// Type position only (see AUTH_CONSOLE_CONTRACT_VERSION_IN_SYNC below), so
+// the runtime stays a dist-file read and the layering rule holds.
+import type { CONTRACT_VERSION as AuthConsoleContractVersion } from '@authup/client-auth-console';
 import type { ConsolePackageOptions } from './types.ts';
 
 /**
@@ -24,6 +27,21 @@ import type { ConsolePackageOptions } from './types.ts';
  * change breaks a package built against the previous shape.
  */
 export const AUTH_CONSOLE_CONTRACT_VERSION = 1;
+
+/**
+ * Compile-time link to the value this constant mirrors.
+ *
+ * The runtime assert below only fires for a SUBSTITUTED package, so a bump
+ * on one side and not the other would otherwise go unnoticed until a
+ * substituted console failed at boot in someone else's deployment. The
+ * annotation costs nothing at runtime (types are erased) and fails this
+ * package's build the moment the two drift.
+ */
+type AuthConsoleContractVersionInSync =    typeof AuthConsoleContractVersion extends typeof AUTH_CONSOLE_CONTRACT_VERSION ?
+    true :
+    never;
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const AUTH_CONSOLE_CONTRACT_VERSION_IN_SYNC : AuthConsoleContractVersionInSync = true;
 
 /**
  * The marker the account console's index.html must carry. It is that

--- a/apps/server-core/src/adapters/http/ui/theme/assets.ts
+++ b/apps/server-core/src/adapters/http/ui/theme/assets.ts
@@ -38,7 +38,7 @@ const REQUEST_PATH_PATTERN = /^[a-z0-9][a-z0-9._/-]*$/i;
  */
 export function createThemeAssetsHandler(provider: IThemeProvider) : Handler {
     return defineCoreHandler(async (event) => {
-        const assetsPath = provider.getAssetsPath();
+        const assetsPath = await provider.getAssetsPath();
         if (!assetsPath) {
             event.response.status = 404;
 

--- a/apps/server-core/src/adapters/http/ui/theme/contract/constants.ts
+++ b/apps/server-core/src/adapters/http/ui/theme/contract/constants.ts
@@ -56,20 +56,68 @@ export const THEME_MANIFEST_VERSION = 1;
  * `@authup/client-web-kit-theme`, so nothing could bind the two and it
  * would rot in both directions: a newly added CSS token would fail
  * validation for a legitimate override, and a removed one would stay
- * accepted. The grammar cannot rot, and it is the same validation an
- * untrusted (per-realm) token source would need unchanged.
+ * accepted. The grammar cannot rot.
+ *
+ * It is NOT sufficient for an untrusted (per-realm) token source, and a
+ * later rung must not adopt it unchanged. Values are guarded by a denylist
+ * of CSS functions, and a denylist over a language that keeps gaining
+ * functions leaks by construction: `image-set()` and `src()` already had
+ * to be added after `url()`. Filesystem input is operator trust, equal to
+ * the process, so a denylist is proportionate here. Untrusted input needs
+ * an allowlist of accepted value SHAPES (a colour, a length, a keyword)
+ * per token, which is a different validator.
  */
 export const THEME_TOKEN_NAME_PATTERN = /^--[a-z][a-z0-9-]*$/;
 
 export const THEME_TOKEN_VALUE_MAX_LENGTH = 256;
 
 /**
+ * Every CSS function that can load a remote resource.
+ *
+ * Blocking `url(` alone does not close the request-emitting-sink hole:
+ * `image-set()`, `image()`, `src()` and `cross-fade()` all take a bare
+ * string URL, and a token like `--authup-auth-logo-image` is substituted
+ * straight into an image-accepting property. `element()` and `paint()`
+ * cannot fetch, but they render document content into a paint sink and
+ * have no business in an operator token either.
+ *
+ * A denylist over function names is still a denylist, so this list is the
+ * floor rather than the argument: the values it guards are operator
+ * authored, and an operator can already ship arbitrary CSS through
+ * `theme.css`. It exists so a value cannot QUIETLY do something the
+ * grammar advertises as impossible. A per-realm (untrusted) token source
+ * must not reuse it as-is; see the note on the name pattern below.
+ */
+const THEME_TOKEN_VALUE_FORBIDDEN_FUNCTIONS = [
+    'url',
+    'expression',
+    'image',
+    'image-set',
+    'src',
+    'cross-fade',
+    'element',
+    'paint',
+];
+
+/**
  * Keeps a token value from closing the declaration block, opening a tag,
  * starting a new at-rule or comment, or turning the server-emitted token
- * block into a request-emitting sink (`url(`). Layer 2 (`theme.css`) may
- * of course use `url()`; that asymmetry is deliberate and documented.
+ * block into a request-emitting sink. Layer 2 (`theme.css`) may of course
+ * use `url()`; that asymmetry is deliberate and documented.
+ *
+ * `{` is forbidden alongside `}`: it opens a block inside the declaration,
+ * which swallows the rule that follows. One stray brace in a light token
+ * silently absorbs the whole `.dark` rule, so dark mode stops applying
+ * with no error anywhere.
+ *
+ * Vendor prefixes are covered (`-webkit-image-set(`), and so is whitespace
+ * before the paren; escapes cannot be used to smuggle a name past this
+ * because `\` is forbidden outright.
  */
-export const THEME_TOKEN_VALUE_FORBIDDEN_PATTERN = /[}<>;@\\]|\/\*|url\s*\(|expression\s*\(/i;
+export const THEME_TOKEN_VALUE_FORBIDDEN_PATTERN = new RegExp(
+    `[{}<>;@\\\\]|\\/\\*|(?:^|[^a-z0-9-])(?:-[a-z]+-)?(?:${THEME_TOKEN_VALUE_FORBIDDEN_FUNCTIONS.join('|')})\\s*\\(`,
+    'i',
+);
 
 /**
  * Every asset kind a theme may contain, and the content type it is pinned

--- a/apps/server-core/src/adapters/http/ui/theme/module.ts
+++ b/apps/server-core/src/adapters/http/ui/theme/module.ts
@@ -102,7 +102,9 @@ export class ThemeProvider implements IThemeProvider {
         return this.manifest;
     }
 
-    getAssetsPath() : string | undefined {
+    async getAssetsPath() : Promise<string | undefined> {
+        await this.revalidate();
+
         return this.assetsPath;
     }
 
@@ -217,6 +219,13 @@ export class ThemeProvider implements IThemeProvider {
             return;
         }
         this.revalidatedAt = now;
+
+        // Re-resolved with the manifest, not captured at boot: a directory
+        // that carried no `assets/` when the process started would otherwise
+        // 404 every asset forever, even though the manifest hot-reloads and
+        // can start referencing them. One stat, on the interval that already
+        // pays for two.
+        this.assetsPath = await this.resolveAssetsPath();
 
         await this.revalidateManifest();
         this.revalidateFragment();

--- a/apps/server-core/src/adapters/http/ui/theme/types.ts
+++ b/apps/server-core/src/adapters/http/ui/theme/types.ts
@@ -46,7 +46,7 @@ export interface IThemeProvider {
      * The realpathed `<root>/assets` directory, or undefined when absent.
      * Every served path is re-checked against this value.
      */
-    getAssetsPath() : string | undefined;
+    getAssetsPath() : Promise<string | undefined>;
 
     /**
      * The markup injected before `</head>`, memoized per base path.

--- a/apps/server-core/src/app/modules/config/origins.ts
+++ b/apps/server-core/src/app/modules/config/origins.ts
@@ -6,6 +6,7 @@
  */
 
 import { URL } from 'node:url';
+import { patternHasGlobstarInAuthority } from '@authup/kit';
 import type { Config } from './types.ts';
 
 const SCHEME_REGEX = /^[a-z][a-z0-9+.-]*:\/\//i;
@@ -27,6 +28,15 @@ const ALLOWED_PROTOCOLS = ['http:', 'https:'];
  * Throws on values that don't parse as a URL/host or use another scheme.
  */
 export function expandToOrigins(value: string): string[] {
+    // `new URL()` accepts `*` and `**` as a hostname, and every trusted origin
+    // becomes an `<origin>/**` redirect pattern for the system clients. A `**`
+    // there matches the rest of the value outright, so a single typo would
+    // turn the redirect allowlist of every realm's console clients into
+    // allow-any-origin. A single `*` is a supported host wildcard.
+    if (patternHasGlobstarInAuthority(value)) {
+        throw new Error(`A trusted origin must not use ** in the host, it would match every origin. Use a single * for a host wildcard, got: ${value}`);
+    }
+
     if (SCHEME_REGEX.test(value)) {
         const url = new URL(value);
         if (!ALLOWED_PROTOCOLS.includes(url.protocol)) {

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -7,7 +7,7 @@
 
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { ScopeName, isClientPublic } from '@authup/core-kit';
-import { isSimpleMatch, isUUID } from '@authup/kit';
+import { isSimpleURLMatch, isUUID } from '@authup/kit';
 import {
     OAuth2ClientError,
     OAuth2GrantError,
@@ -117,7 +117,12 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
         if (data.redirect_uri) {
             const redirectUris = client.redirectUri.split(',');
 
-            if (!isSimpleMatch(data.redirect_uri, redirectUris)) {
+            // isSimpleURLMatch, never isSimpleMatch: the raw matcher treats `/`
+            // as its only boundary, so a `*` in a registered pattern's host
+            // absorbs a `?`, `#` or `\` and the pattern's remaining host
+            // literal lands in the query of a foreign origin. The code would
+            // then be issued to that origin.
+            if (!isSimpleURLMatch(data.redirect_uri, redirectUris)) {
                 throw OAuth2GrantError.redirectUriMismatch();
             }
         }

--- a/apps/server-core/src/core/oauth2/end-session/service.ts
+++ b/apps/server-core/src/core/oauth2/end-session/service.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { isSimpleMatch, isUUID } from '@authup/kit';
+import { isSimpleURLMatch, isUUID } from '@authup/kit';
 import type { Client, IdentityType } from '@authup/core-kit';
 import { EventName, EventRefType, EventScope } from '@authup/core-kit';
 import type { OAuth2TokenPayload } from '@authup/specs';
@@ -226,6 +226,10 @@ export class OAuth2EndSessionService implements IOAuth2EndSessionService {
             return false;
         }
 
-        return isSimpleMatch(candidate, registered.split(','));
+        // isSimpleURLMatch, never isSimpleMatch: matched against the raw
+        // string, a `*` in a registered pattern's host absorbs a `?`, `#` or
+        // `\`, which would turn this endpoint into a server-issued open
+        // redirect carrying `state`.
+        return isSimpleURLMatch(candidate, registered.split(','));
     }
 }

--- a/apps/server-core/src/core/provisioning/merge/module.ts
+++ b/apps/server-core/src/core/provisioning/merge/module.ts
@@ -6,7 +6,7 @@
  */
 
 import { isObject } from '@authup/kit';
-import type { MergeableProvisioningEntity } from './types.ts';
+import type { MergeProvisioningOptions, MergeableProvisioningEntity } from './types.ts';
 
 export function buildProvisioningEntityKey(
     attributes: MergeableProvisioningEntity['attributes'],
@@ -18,6 +18,7 @@ export function buildProvisioningEntityKey(
 export function mergeProvisioningEntities<T extends MergeableProvisioningEntity>(
     target: T[] | undefined,
     source: T[] | undefined,
+    options: MergeProvisioningOptions = {},
 ): T[] | undefined {
     if (!source) return target;
     if (!target) return [...source];
@@ -32,7 +33,7 @@ export function mergeProvisioningEntities<T extends MergeableProvisioningEntity>
 
         const idx = result.findIndex((r) => buildProvisioningEntityKey(r.attributes) === key);
         if (idx !== -1) {
-            result[idx] = mergeProvisioningEntity(result[idx], item) as T;
+            result[idx] = mergeProvisioningEntity(result[idx], item, options) as T;
         } else {
             result.push(item);
         }
@@ -56,17 +57,23 @@ export function mergeProvisioningEntities<T extends MergeableProvisioningEntity>
 export function mergeProvisioningEntity(
     target: MergeableProvisioningEntity,
     source: MergeableProvisioningEntity,
+    options: MergeProvisioningOptions = {},
 ): MergeableProvisioningEntity {
     const output = { ...target, ...source };
 
     output.attributes = { ...target.attributes, ...source.attributes };
 
+    const inheritStrategy = options.inheritStrategy ?? true;
     if (target.strategy && !source.strategy) {
-        output.strategy = target.strategy;
+        if (inheritStrategy) {
+            output.strategy = target.strategy;
+        } else {
+            delete output.strategy;
+        }
     }
 
     if (target.relations && source.relations) {
-        output.relations = mergeProvisioningRecord(target.relations, source.relations);
+        output.relations = mergeProvisioningRecord(target.relations, source.relations, options);
     } else if (target.relations && !source.relations) {
         output.relations = target.relations;
     }
@@ -78,7 +85,7 @@ export function mergeProvisioningEntity(
     }
 
     if (target.children && source.children) {
-        output.children = mergeProvisioningEntities(target.children, source.children);
+        output.children = mergeProvisioningEntities(target.children, source.children, options);
     } else if (target.children && !source.children) {
         output.children = target.children;
     }
@@ -89,17 +96,22 @@ export function mergeProvisioningEntity(
 function mergeProvisioningRecord(
     target: Record<string, unknown>,
     source: Record<string, unknown>,
+    options: MergeProvisioningOptions = {},
 ): Record<string, unknown> {
     const output : Record<string, unknown> = { ...target };
     for (const key of Object.keys(source)) {
         output[key] = key in target ?
-            mergeProvisioningValue(target[key], source[key]) :
+            mergeProvisioningValue(target[key], source[key], options) :
             source[key];
     }
     return output;
 }
 
-function mergeProvisioningValue(target: unknown, source: unknown): unknown {
+function mergeProvisioningValue(
+    target: unknown,
+    source: unknown,
+    options: MergeProvisioningOptions = {},
+): unknown {
     if (typeof target === 'undefined') return source;
     if (typeof source === 'undefined') return target;
 
@@ -108,13 +120,14 @@ function mergeProvisioningValue(target: unknown, source: unknown): unknown {
             return mergeProvisioningEntities(
                 target as MergeableProvisioningEntity[],
                 source as MergeableProvisioningEntity[],
+                options,
             );
         }
         return [...new Set([...target, ...source])];
     }
 
     if (isObject(target) && isObject(source)) {
-        return mergeProvisioningRecord(target, source);
+        return mergeProvisioningRecord(target, source, options);
     }
 
     return source;

--- a/apps/server-core/src/core/provisioning/merge/types.ts
+++ b/apps/server-core/src/core/provisioning/merge/types.ts
@@ -10,6 +10,24 @@
  * Covers every entity shape (realm, client, user, role, permission, scope,
  * policy): the composite-key attribute bag plus the deep-mergeable groups.
  */
+export type MergeProvisioningOptions = {
+    /**
+     * May a source entry that declares no `strategy` inherit the target's?
+     *
+     * True for the composite source, where target/source are "earlier file"
+     * and "later file" and inheriting an unspecified strategy is the
+     * documented rule.
+     *
+     * False for the wildcard expansion, where the precedence is INVERTED:
+     * the target is the wildcard (low precedence) and the source is an
+     * explicit realm block (high precedence). Inheriting there would let a
+     * wildcard child supply the lifecycle of an entity the operator declared
+     * explicitly, and `absent` is part of that vocabulary, so a wildcard
+     * sweep would delete the very row the explicit block declares.
+     */
+    inheritStrategy?: boolean,
+};
+
 export type MergeableProvisioningEntity = {
     attributes: {
         name?: string,

--- a/apps/server-core/src/core/provisioning/wildcard/module.ts
+++ b/apps/server-core/src/core/provisioning/wildcard/module.ts
@@ -71,9 +71,17 @@ export function expandWildcardRealmEntry(
 
     if (data.realms) {
         data.realms = data.realms.map((entry) => {
+            // inheritStrategy: false — the precedence here is inverted
+            // relative to the composite source. The wildcard is the low
+            // precedence side, so it must not supply the lifecycle of an
+            // entity the operator declared explicitly: a wildcard child
+            // carrying `absent` would otherwise delete the very row the
+            // explicit realm block declares. A child that declares no
+            // strategy falls back to the normal default instead.
             const merged = mergeProvisioningEntity(
                 structuredClone(wildcard),
                 entry,
+                { inheritStrategy: false },
             ) as RealmProvisioningEntity;
 
             if (entry.attributes.name) {

--- a/apps/server-core/test/unit/adapters/http/ui/theme-provider.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/theme-provider.spec.ts
@@ -15,6 +15,7 @@ import {
     it, 
 } from 'vitest';
 import { ThemeProvider } from '../../../../../src/adapters/http/ui/theme/index.ts';
+import { THEME_MANIFEST_REVALIDATE_INTERVAL } from '../../../../../src/adapters/http/ui/theme/constants.ts';
 
 const roots : string[] = [];
 
@@ -62,7 +63,7 @@ describe('adapters/http/ui/theme (ThemeProvider)', () => {
         await provider.load();
 
         expect(await provider.getManifest()).toBeUndefined();
-        expect(provider.getAssetsPath()).toBeDefined();
+        expect(await provider.getAssetsPath()).toBeDefined();
     });
 
     it('should ignore an assets path that is not a directory', async () => {
@@ -71,7 +72,7 @@ describe('adapters/http/ui/theme (ThemeProvider)', () => {
         const provider = new ThemeProvider({ directoryPath: root });
         await provider.load();
 
-        expect(provider.getAssetsPath()).toBeUndefined();
+        expect(await provider.getAssetsPath()).toBeUndefined();
     });
 
     it('should fail the boot when the manifest is a directory', async () => {
@@ -89,7 +90,29 @@ describe('adapters/http/ui/theme (ThemeProvider)', () => {
         const provider = new ThemeProvider({ directoryPath: root });
         await provider.load();
 
-        expect(provider.getAssetsPath()).toBeUndefined();
+        expect(await provider.getAssetsPath()).toBeUndefined();
+    });
+
+    it('should pick up an assets directory created after the boot', async () => {
+        // Captured once at boot, an operator adding assets/ later (or a
+        // ConfigMap gaining it) would 404 every asset until the pod restarts,
+        // even though the manifest itself hot-reloads and can start
+        // referencing them.
+        const root = createDirectory({ 'theme.json': JSON.stringify({ version: 1 }) });
+
+        const provider = new ThemeProvider({ directoryPath: root });
+        await provider.load();
+
+        expect(await provider.getAssetsPath()).toBeUndefined();
+
+        fs.mkdirSync(path.join(root, 'assets'), { recursive: true });
+
+        // The resolution rides the same debounce as the manifest reload.
+        await new Promise((resolve) => {
+            setTimeout(resolve, THEME_MANIFEST_REVALIDATE_INTERVAL + 50);
+        });
+
+        expect(await provider.getAssetsPath()).toBeDefined();
     });
 
     describe('head fragment', () => {

--- a/apps/server-core/test/unit/adapters/http/ui/theme.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/ui/theme.spec.ts
@@ -21,7 +21,7 @@ function createProvider(manifest: ThemeManifest | undefined) : IThemeProvider {
     return {
         load: async () => { /* noop */ },
         getManifest: async () => manifest,
-        getAssetsPath: () => undefined,
+        getAssetsPath: async () => undefined,
         getHead: async (basePath: string) => (manifest ? buildThemeHead(manifest, basePath) : ''),
     };
 }
@@ -73,6 +73,20 @@ describe('adapters/http/ui/theme', () => {
             ['expression(alert(1))', 'legacy dynamic expression'],
             ['red/*comment', 'opens a comment'],
             ['@import "x"', 'starts an at-rule'],
+            // A `{` opens a block inside the declaration and swallows the rule
+            // that follows, so one stray brace in a light token silently
+            // absorbs the whole `.dark` rule and dark mode stops applying.
+            ['red{', 'opens a block that swallows the next rule'],
+            // Blocking url( alone does not close the request-sink hole: these
+            // all take a bare string URL, and a logo token is substituted
+            // straight into an image-accepting property.
+            ['image-set("https://evil.example.com/x.png" 1x)', 'fetches via image-set'],
+            ['-webkit-image-set("https://evil.example.com/x.png" 1x)', 'fetches via a vendor prefix'],
+            ['image("https://evil.example.com/x.png")', 'fetches via image'],
+            ['src("https://evil.example.com/x.png")', 'fetches via src'],
+            ['cross-fade(image-set("https://evil.example.com/x.png" 1x), none)', 'fetches via cross-fade'],
+            ['element(#x)', 'renders document content into a paint sink'],
+            ['paint(evil)', 'renders a paint worklet'],
         ])('should reject the token value %s (%s)', async (value) => {
             await expect(parseThemeManifest(
                 { version: 1, tokens: { '--authup-auth-accent': value } },
@@ -90,10 +104,16 @@ describe('adapters/http/ui/theme', () => {
                     '--authup-auth-card-box-shadow': '0 1px 2px rgba(0,0,0,.1)',
                     '--radius-md': '2px',
                     '--text-6xl': '3.75rem',
+                    // the function denylist must key on whole names, so a
+                    // value merely CONTAINING one stays valid
+                    '--authup-auth-backdrop': 'linear-gradient(to right, #fff, #000)',
+                    '--authup-surface-card': 'color-mix(in oklab, var(--a), var(--b) 40%)',
+                    '--authup-auth-card-padding': 'clamp(1rem, 2vw, 3rem)',
+                    '--authup-brand-image-token': 'var(--brand-image)',
                 },
             }, 'theme.json');
 
-            expect(Object.keys(manifest.tokens ?? {})).toHaveLength(6);
+            expect(Object.keys(manifest.tokens ?? {})).toHaveLength(10);
         });
 
         it.each([

--- a/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code-request/verifier/module.spec.ts
@@ -322,5 +322,56 @@ describe('OAuth2AuthorizationCodeRequestVerifier', () => {
                 ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_REDIRECT_URI_MISMATCH }));
             }
         });
+
+        it('should reject a redirect whose authority terminator a host wildcard would absorb', async () => {
+            // The matcher's only boundary is `/`, but a URL authority also ends
+            // at `?`, `#` and `\`. Matched against the raw string, the wildcard
+            // absorbs one of those and `.example.com` lands in the query or
+            // fragment of a foreign origin, so the code would be issued to
+            // https://evil.test. Canonicalizing the candidate first is what
+            // stops it, which is why the verifier must not call isSimpleMatch.
+            const client = clientRepository.seed({
+                authMethod: 'secret',
+                tokenBindingMethod: 'none',
+                redirectUri: 'https://*.example.com/**',
+            });
+
+            const candidates = [
+                'https://evil.test?.example.com/callback',
+                'https://evil.test#.example.com/callback',
+                'https://evil.test\\.example.com/callback',
+                'https://user@evil.test#.example.com/callback',
+                'https://evil.test:8443#.example.com/callback',
+            ];
+
+            for (const redirectUri of candidates) {
+                await expect(
+                    verifier.verify({
+                        client_id: client.id,
+                        response_type: OAuth2AuthorizationResponseType.CODE,
+                        redirect_uri: redirectUri,
+                    }),
+                ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_REDIRECT_URI_MISMATCH }));
+            }
+        });
+
+        it('should reject a redirect that walks out of a path scoped pattern', async () => {
+            // The authorized string has to be the string the browser navigates
+            // to: `new URL(...)` collapses the dot segments, so without
+            // canonicalization the target ends up outside the allowed prefix.
+            const client = clientRepository.seed({
+                authMethod: 'secret',
+                tokenBindingMethod: 'none',
+                redirectUri: 'https://app.example.com/tenant-a/**',
+            });
+
+            await expect(
+                verifier.verify({
+                    client_id: client.id,
+                    response_type: OAuth2AuthorizationResponseType.CODE,
+                    redirect_uri: 'https://app.example.com/tenant-a/../tenant-b/callback',
+                }),
+            ).rejects.toThrow(expect.objectContaining({ code: ErrorCode.OAUTH_REDIRECT_URI_MISMATCH }));
+        });
     });
 });

--- a/apps/server-core/test/unit/core/provisioning/wildcard.spec.ts
+++ b/apps/server-core/test/unit/core/provisioning/wildcard.spec.ts
@@ -169,6 +169,91 @@ describe('core/provisioning/wildcard', () => {
             expect(variants.get('foo')!.clients![0].attributes.displayName).toBe('Explicit Portal');
         });
 
+        it('should not let a wildcard child supply the strategy of an explicitly declared one', () => {
+            // The documented sweep recipe: retire a client everywhere via a
+            // wildcard `absent` child. A realm that declares the same client
+            // explicitly must keep it — inheriting the wildcard's strategy
+            // would DELETE the row the explicit block declares, silently and
+            // on every boot.
+            const sweep : RealmProvisioningEntity = {
+                attributes: { name: REALM_WILDCARD_NAME },
+                relations: {
+                    clients: [{
+                        attributes: { name: 'portal' },
+                        strategy: { type: 'absent' },
+                    }],
+                },
+            };
+
+            const data : RootProvisioningEntity = {
+                realms: [{
+                    attributes: { name: 'keeps-it' },
+                    relations: { clients: [{ attributes: { name: 'portal', displayName: 'Kept' } }] },
+                }],
+            };
+
+            expandWildcardRealmEntry(sweep, data);
+
+            const [merged] = data.realms!;
+            const clients = merged.relations?.clients ?? [];
+
+            expect(clients).toHaveLength(1);
+            expect(clients[0].attributes.displayName).toBe('Kept');
+            expect(clients[0].strategy).toBeUndefined();
+        });
+
+        it('should still let an explicit child declare its own strategy over the wildcard', () => {
+            const sweep : RealmProvisioningEntity = {
+                attributes: { name: REALM_WILDCARD_NAME },
+                relations: {
+                    clients: [{
+                        attributes: { name: 'portal' },
+                        strategy: { type: 'absent' },
+                    }],
+                },
+            };
+
+            const data : RootProvisioningEntity = {
+                realms: [{
+                    attributes: { name: 'keeps-it' },
+                    relations: {
+                        clients: [{
+                            attributes: { name: 'portal' },
+                            strategy: { type: 'merge' },
+                        }],
+                    },
+                }],
+            };
+
+            expandWildcardRealmEntry(sweep, data);
+
+            const clients = data.realms![0].relations?.clients ?? [];
+
+            expect(clients[0].strategy).toEqual({ type: 'merge' });
+        });
+
+        it('should apply the wildcard strategy to a realm that does not declare the entity', () => {
+            // The sweep must still reach every realm that did NOT opt out.
+            const sweep : RealmProvisioningEntity = {
+                attributes: { name: REALM_WILDCARD_NAME },
+                relations: {
+                    clients: [{
+                        attributes: { name: 'portal' },
+                        strategy: { type: 'absent' },
+                    }],
+                },
+            };
+
+            const data : RootProvisioningEntity = { realms: [{ attributes: { name: 'untouched' } }] };
+
+            expandWildcardRealmEntry(sweep, data);
+
+            const clients = data.realms![0].relations?.clients ?? [];
+
+            expect(clients).toHaveLength(1);
+            expect(clients[0].strategy).toEqual({ type: 'absent' });
+        });
+
         it('should keep the recorded variants pristine when the expanded entries are mutated', () => {
             const data : RootProvisioningEntity = {
                 realms: [{

--- a/apps/server-core/test/unit/http/controllers/workflows/docs-authorize-url.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/docs-authorize-url.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createFakeClient as createFakeHTTPClient } from '@authup/core-http-kit/testing';
+import {
+    afterAll, 
+    beforeAll, 
+    describe, 
+    expect, 
+    it,
+} from 'vitest';
+import { HTTPInjectionKey } from '../../../../../src/app';
+import { createTestApplication } from '../../../../app';
+import type { TestHTTPApplication } from '../../../../app';
+import { httpRequest } from '../../../../utils';
+
+/**
+ * The theming guide tells an operator to open one specific /authorize URL to
+ * see their colours applied. Every parameter in it is load-bearing (a
+ * name-form client_id needs a realm hint, and a public client needs state and
+ * PKCE), so a copy-pasted URL that the verifier rejects renders an error card
+ * and the guide's "the submit button should be red" can never be observed.
+ *
+ * Pinned here because the failure is silent: the page still returns 200.
+ */
+describe('http/controllers/workflows/docs-authorize-url', () => {
+    const suite : TestHTTPApplication = createTestApplication();
+
+    beforeAll(async () => {
+        suite.container.register(
+            HTTPInjectionKey.UIHttpClient,
+            { useFactory: () => createFakeHTTPClient({ handlers: { 'GET /identity-providers': () => ({ data: [], meta: { total: 0 } }) } }) },
+            { lifetime: 'transient' },
+        );
+
+        await suite.setup();
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    it('should render the authorize page for the URL the theming guide documents', async () => {
+        const response = await httpRequest(
+            suite,
+            'GET',
+            '/authorize?response_type=code&client_id=admin-console&realm_id=master&scope=openid&state=devstate&code_challenge=devchallenge&redirect_uri=http%3A%2F%2Flocalhost%3A3001%2F',
+        );
+
+        expect(response.status).toEqual(200);
+
+        const body = await response.text();
+
+        // The payload is inlined as raw JSON in a <script>, so the error is
+        // NOT html-escaped. Asserting on an escaped form would pass for every
+        // possible response.
+        expect(body).toContain('window.__AUTHUP__');
+        expect(body).not.toContain('"error":');
+    });
+
+    it('should reject the shape the guide used to document', async () => {
+        // A rejected request still answers 200 and still renders a document,
+        // which is why the assertion has to look inside the payload.
+        const response = await httpRequest(
+            suite,
+            'GET',
+            '/authorize?response_type=code&client_id=admin-console',
+        );
+
+        const body = await response.text();
+
+        expect(body).toContain('"error":');
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/workflows/ui-pages-theme.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/ui-pages-theme.spec.ts
@@ -97,7 +97,7 @@ function createThemeDirectory() : { themePath: string, outsidePath: string } {
 }
 
 describe('http/controllers/workflows/ui-pages-theme', () => {
-    const { themePath } = createThemeDirectory();
+    const { themePath, outsidePath } = createThemeDirectory();
 
     const suite : TestHTTPApplication = createTestApplication({
         config: (config) => {
@@ -274,9 +274,33 @@ describe('http/controllers/workflows/ui-pages-theme', () => {
             // Following symlinks is mandatory (a ConfigMap volume is a
             // symlink farm), so containment is enforced by realpath, not by
             // refusing links.
+            //
+            // The link is (re)created inside the CURRENT revision on purpose.
+            // The fixture puts it in the first revision, which the swap test
+            // above deletes, so asserting a 404 without this would only prove
+            // the file is missing and would pass with the containment check
+            // removed.
+            const revision = fs.readlinkSync(path.join(themePath, '..data'));
+            const assetsPath = path.join(themePath, revision, 'assets');
+            const linkPath = path.join(assetsPath, 'escape.css');
+            fs.rmSync(linkPath, { force: true });
+            fs.symlinkSync(outsidePath, linkPath);
+
+            // Control: the link resolves and its target is readable through
+            // the mount, so a 404 can only come from containment. Without it
+            // this test cannot tell "refused" from "not there".
+            expect(fs.readFileSync(linkPath, 'utf-8')).toContain('leaked');
+
             const response = await httpRequest(suite, 'GET', '/theme/escape.css');
 
             expect(response.status).toEqual(404);
+
+            // Control: a legitimate asset in that same directory IS a symlink
+            // too and must still be served, so the 404 above is containment
+            // and not a blanket refusal to follow links.
+            const legitimate = await httpRequest(suite, 'GET', '/theme/theme.css');
+
+            expect(legitimate.status).toEqual(200);
         });
 
         it('should reject an extension outside the allowlist', async () => {

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -205,10 +205,15 @@ Semantics:
   every boot. `absent` removes the named entity from every realm.
 - **An explicit realm block wins.** For a realm that is also declared
   explicitly (in any provisioning file), the wildcard entry is deep-merged
-  UNDER the explicit block with the same rules used when two files declare
-  the same entity: the explicit block wins per attribute, relation lists
-  are unioned, and an explicit child's `strategy` wins over the wildcard
-  child's.
+  UNDER the explicit block: the explicit block wins per attribute and
+  relation lists are unioned.
+
+  A declared entity also owns its own lifecycle. When both sides declare the
+  same entity, the explicit child's `strategy` applies, and if it declares
+  none it falls back to the default (`createOnly`) rather than inheriting the
+  wildcard child's. This is what makes the sweep below safe to combine with an
+  explicit declaration: a wildcard `absent` child removes the entity from
+  every realm that does *not* declare it, and leaves the realms that do.
 - **Reserved client names are rejected.** A wildcard entry declaring
   `system`, `admin-console` or `account-console` fails validation at
   startup: those clients are system-owned and reasserted from

--- a/docs/src/guide/deployment/theming.md
+++ b/docs/src/guide/deployment/theming.md
@@ -127,7 +127,7 @@ that `/authorize` rejects an incomplete request by rendering an error card
 (with a `200`, so the page still loads), and every parameter below is
 required:
 
-```
+```text
 http://localhost:3001/authorize?response_type=code&client_id=admin-console&realm_id=master&scope=openid&state=devstate&code_challenge=devchallenge&redirect_uri=http%3A%2F%2Flocalhost%3A3001%2F
 ```
 

--- a/docs/src/guide/deployment/theming.md
+++ b/docs/src/guide/deployment/theming.md
@@ -119,10 +119,28 @@ docker run --rm -p 3001:3001 \
   authup/authup
 ```
 
-Open `http://localhost:3001/authorize?response_type=code&client_id=admin-console`.
-The submit button should be red. Check the startup log if not: authup prints
-the resolved theme directory, whether the manifest loaded, and every file it
-will serve.
+The quickest check is `http://localhost:3001/logout`. It is served by the
+same console and carries the same theme, and it takes no parameters.
+
+To see the accent on the login form itself, open the hosted login page. Note
+that `/authorize` rejects an incomplete request by rendering an error card
+(with a `200`, so the page still loads), and every parameter below is
+required:
+
+```
+http://localhost:3001/authorize?response_type=code&client_id=admin-console&realm_id=master&scope=openid&state=devstate&code_challenge=devchallenge&redirect_uri=http%3A%2F%2Flocalhost%3A3001%2F
+```
+
+The submit button should be red. `realm_id` is needed because a client
+identified by name is only unique per realm and every realm carries the
+same-named system clients; `state` (at least 5 characters) and
+`code_challenge` are required because `admin-console` is a public client; and
+`redirect_uri` has to match one of its registered patterns, which are derived
+from `PUBLIC_URL` and `TRUSTED_ORIGINS`.
+
+Check the startup log if the colour does not appear: authup prints the
+resolved theme directory, whether the manifest loaded, and every file it will
+serve.
 
 **4. Add the surfaces.** Colours split into an accent (above) and the surface
 ramp everything else derives from. Add to `tokens`, and mirror the

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -20,15 +20,19 @@ authorized is the string the browser navigates to. **No action is required**,
 and no legitimate redirect stops matching. Three side effects are worth
 knowing:
 
-1. A pattern is now matched against the normalized URL, so a host differing
-   only in case, an explicit default port (`:443` on https) and `.`/`..`
-   segments resolve before comparison. A path-scoped pattern can no longer be
-   walked out of with `..`.
+1. Both the request and the stored pattern are normalized before comparison,
+   so a host differing only in case, an explicit default port (`:443` on
+   https) and `.`/`..` segments resolve on either side. A path-scoped pattern
+   can no longer be walked out of with `..`, and a pattern that was written
+   non-canonically (`https://APP.example.com/**`, `https://app.example.com:443/**`)
+   now matches the requests it always looked like it should.
 2. `**` is no longer accepted inside the host of a pattern. It matches the
    rest of the value outright, so `https://**.example.com/**` read as "any
-   subdomain" but accepted every origin. A single `*` is unchanged and still
-   means "one host label". A stored pattern is not rewritten; only new writes
-   are rejected.
+   subdomain" but accepted every origin. A single `*` is unchanged: it matches
+   any run of characters that does not cross a `/`, so it spans dots and
+   `https://*.example.com/**` covers `https://a.b.example.com/cb` as well as
+   `https://a.example.com/cb`. A stored pattern is not rewritten; only new
+   writes are rejected.
 3. `TRUSTED_ORIGINS` rejects the same shape at startup, with a message naming
    the offending value.
 

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -7,6 +7,62 @@ either requires operator action or deliberately changes behavior.
 
 ## Next release (after v1.0.0-beta.58)
 
+### Security fix: redirect patterns with a host wildcard
+
+A `redirectUri` / `postLogoutRedirectUri` pattern carrying a `*` in its host
+(`https://*.example.com/**`) matched more than its host. The matcher treats
+`/` as its only boundary, while a URL authority also ends at `?`, `#` and
+`\`, so `https://evil.test?.example.com/cb` matched the pattern above and an
+authorization code was issued to `evil.test`.
+
+The candidate is now canonicalized before matching, so the string that gets
+authorized is the string the browser navigates to. **No action is required**,
+and no legitimate redirect stops matching. Three side effects are worth
+knowing:
+
+1. A pattern is now matched against the normalized URL, so a host differing
+   only in case, an explicit default port (`:443` on https) and `.`/`..`
+   segments resolve before comparison. A path-scoped pattern can no longer be
+   walked out of with `..`.
+2. `**` is no longer accepted inside the host of a pattern. It matches the
+   rest of the value outright, so `https://**.example.com/**` read as "any
+   subdomain" but accepted every origin. A single `*` is unchanged and still
+   means "one host label". A stored pattern is not rewritten; only new writes
+   are rejected.
+3. `TRUSTED_ORIGINS` rejects the same shape at startup, with a message naming
+   the offending value.
+
+### `client/web` was renamed to `client/admin-console`
+
+The rename of the admin console app (`@authup/client-web` →
+`@authup/client-admin-console`) reaches the operator surface. There is **no
+backwards alias**, and an unknown selector is now a hard error instead of a
+silent success:
+
+- **Docker**: `docker run authup/authup client/web start` →
+  `client/admin-console start`. The entrypoint used to exit `0` on an unknown
+  service, so this previously looked like a healthy container that started
+  nothing. It now exits `1`.
+- **Launcher config**: a `client.web` section in `authup.conf` is no longer
+  read. Rename it to `client.admin-console`, otherwise every key in it
+  (`port`, `host`, `apiUrl`, `cookieDomain`) silently falls back to its
+  default.
+- **CLI**: `authup start client/web` → `authup start client/admin-console`.
+- **Binary**: `authup-ui` → `authup-admin-console`.
+
+### `admin-console` and `account-console` are reserved client names
+
+Both names are now provisioned as system clients in every realm. If a client
+of either name already exists, **it is taken over** rather than left alone:
+the provisioner overwrites `name`, `realmId`, `authMethod`,
+`tokenBindingMethod`, `builtIn`, `active`, `grantTypes`, `scope`,
+`redirectUri` and `postLogoutRedirectUri`, which makes it a public
+(secret-less) auto-consenting client.
+
+Rename any existing client on those names **before** upgrading. Attributes
+outside that list (`displayName`, `description`, `accessPolicyId`, junction
+rows) are preserved.
+
 ### The per-realm `web` client was removed
 
 The shared `web` system client is no longer provisioned. Authup's own

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,7 +38,15 @@ case "${SERVICE}" in
         export NUXT_PORT=3000
         exec npm run "${COMMAND}" --workspace=apps/client-admin-console
         ;;
-    *) echo "Unknown service: ${SERVICE}";;
+    # Must exit non-zero: the container would otherwise terminate
+    # SUCCESSFULLY having started nothing, which reads as a healthy run. The
+    # client/web -> client/admin-console rename makes this reachable for any
+    # deployment still passing the old name.
+    *)
+        echo "Unknown service: ${SERVICE}" >&2
+        echo "Expected one of: server/core, client/admin-console" >&2
+        exit 1
+        ;;
 esac
 
 

--- a/packages/client-web-kit-theme/assets/css/styles/account.css
+++ b/packages/client-web-kit-theme/assets/css/styles/account.css
@@ -81,27 +81,7 @@
         font-weight: 600;
     }
 
-    /*
-     * The return link to the referring application, leading the tab strip.
-     * A trailing rule separates it from the tabs: it leaves the console
-     * rather than selecting a section, so it must not read as a
-     * permanently-inactive tab. Muted so the active tab stays dominant.
-     */
-    .a-account-shell-nav-link--back {
-        color: var(--authup-account-surface-color-muted);
-        gap: 0.375rem;
-        margin-right: 0.25rem;
-        padding-right: 0.75rem;
-        border-right: 1px solid var(--authup-account-surface-border-color);
-        border-radius: 0;
-    }
-
-    .a-account-shell-nav-link--back:hover {
-        color: var(--authup-account-surface-color);
-        background: none;
-    }
-
-.a-account-shell-nav {
+    .a-account-shell-nav {
         display: flex;
         flex-wrap: wrap;
         gap: 0.35rem;
@@ -126,6 +106,31 @@
     .a-account-shell-nav-link--active:hover {
         color: var(--authup-account-nav-active-color);
         background: var(--authup-account-nav-active-background);
+    }
+
+    /*
+     * The return link to the referring application, leading the tab strip.
+     * A trailing rule separates it from the tabs: it leaves the console
+     * rather than selecting a section, so it must not read as a
+     * permanently-inactive tab. Muted so the active tab stays dominant.
+     *
+     * Declared AFTER the base link rule on purpose. Both carry the same
+     * specificity and sit in the same layer, so source order decides, and
+     * placed before it the base rule silently won for every property they
+     * share (including the hover background this rule exists to remove).
+     */
+    .a-account-shell-nav-link--back {
+        color: var(--authup-account-surface-color-muted);
+        gap: 0.375rem;
+        margin-right: 0.25rem;
+        padding-right: 0.75rem;
+        border-right: 1px solid var(--authup-account-surface-border-color);
+        border-radius: 0;
+    }
+
+    .a-account-shell-nav-link--back:hover {
+        color: var(--authup-account-surface-color);
+        background: none;
     }
 
     .a-account-shell-body {

--- a/packages/client-web-kit-theme/assets/css/styles/tokens.css
+++ b/packages/client-web-kit-theme/assets/css/styles/tokens.css
@@ -45,7 +45,7 @@
         /*
          * auth chrome (.a-auth-shell / .a-auth-gadget / .a-auth-back-link
          * and the realm chooser) — the shared logged-out surfaces rendered
-         * by client-web's auth layout and the embedded SSR auth pages.
+         * by the admin console's auth layout and the embedded SSR auth pages.
          */
         --authup-auth-accent:                   var(--vc-color-primary-500);
         --authup-auth-accent-alt:               #cc8181;

--- a/packages/client-web-kit/src/components/utility/AAuthApp.vue
+++ b/packages/client-web-kit/src/components/utility/AAuthApp.vue
@@ -9,7 +9,7 @@ import { VCToastProvider, VCToaster } from '@vuecs/overlays';
 import { defineComponent } from 'vue';
 import AAuthGadgets from './AAuthGadgets.vue';
 
-// Shared shell for the logged-out auth surfaces (client-web's auth layout
+// Shared shell for the logged-out auth surfaces (the admin console's auth layout
 // + the embedded SSR app root):
 //
 //   - <VCToastProvider> wraps the root so any descendant <VCToaster> (or

--- a/packages/client-web-kit/src/components/utility/AAuthGadgets.vue
+++ b/packages/client-web-kit/src/components/utility/AAuthGadgets.vue
@@ -9,7 +9,7 @@ import { defineComponent } from 'vue';
 import AColorModeSwitcher from './AColorModeSwitcher.vue';
 import { ALanguageSwitcherDropdown } from './ALanguageSwitcherDropdown';
 
-// Top-right control cluster shared by every auth surface (client-web's
+// Top-right control cluster shared by every auth surface (the admin console's
 // auth layout + the embedded SSR app + the account console): color mode
 // and language, plus a slot for host-specific gadgets (the account
 // console appends its user chip + sign-out here so the page has ONE top

--- a/packages/client-web-kit/src/components/utility/AAuthShell.vue
+++ b/packages/client-web-kit/src/components/utility/AAuthShell.vue
@@ -10,7 +10,7 @@ import { defineComponent } from 'vue';
 export default defineComponent({
     props: {
         // Compact authup mark in the card header. The full hero artwork
-        // stays an app concern (client-web's login entry); the shell only
+        // stays an app concern (the admin console's login entry); the shell only
         // carries the small brand identity for backend-served auth pages.
         logo: {
             type: Boolean,

--- a/packages/client-web-kit/src/components/utility/AColorModeSwitcher.vue
+++ b/packages/client-web-kit/src/components/utility/AColorModeSwitcher.vue
@@ -14,7 +14,7 @@ import {
 import { useTranslations } from '../../core';
 
 // Presentational on purpose: color-mode *storage* is framework-specific
-// (client-web uses @vuecs/nuxt's cookie-backed useColorMode()), so the
+// (the admin console uses @vuecs/nuxt's cookie-backed useColorMode()), so the
 // component only owns the icon, the localized aria-labels and the toggle
 // event — bind it with `v-model:dark="isDark"`.
 export default defineComponent({

--- a/packages/client-web-kit/src/components/utility/ALanguageSwitcherDropdown.ts
+++ b/packages/client-web-kit/src/components/utility/ALanguageSwitcherDropdown.ts
@@ -32,7 +32,7 @@ const ALanguageSwitcherDropdown = defineComponent({
         },
     },
     // Deliberately NOT `async`: an async setup() turns the component into
-    // a Suspense-dependent subtree. Nuxt (client-web) provides a root
+    // a Suspense-dependent subtree. Nuxt (the admin console) provides a root
     // Suspense, but the embedded server-core SSR app does not — there the
     // component would server-render yet never hydrate (dropdown dead).
     setup(props) {

--- a/packages/client-web-kit/src/components/utility/entity/AEntityDelete.ts
+++ b/packages/client-web-kit/src/components/utility/entity/AEntityDelete.ts
@@ -123,7 +123,7 @@ const AEntityDelete = defineComponent({
         // in consumers/tests that skip @vuecs/overlays. `useAlertDialog()` only
         // calls inject() (no lifecycle hooks), so this one-time conditional
         // resolution in setup is safe. When enabled it injects the app-level
-        // manager (host: <VCAlertDialogProvider> in the client-web default
+        // manager (host: <VCAlertDialogProvider> in the admin console default
         // layout) and resolves true (Delete) / false (Abort / Escape); on the
         // server it resolves false without enqueuing, but onClick is client-only.
         const confirmDialog = props.withPrompt ? useAlertDialog() : undefined;

--- a/packages/client-web-kit/src/components/utility/toggle-button/AToggleButton.vue
+++ b/packages/client-web-kit/src/components/utility/toggle-button/AToggleButton.vue
@@ -78,7 +78,7 @@ export default defineComponent({
         // doesn't require `app.use(installOverlays)`. `useAlertDialog()` only
         // calls inject() (no lifecycle hooks), so this one-time conditional
         // resolution in setup is safe. Host: <VCAlertDialogProvider> in the
-        // client-web default layout.
+        // admin console default layout.
         const confirmDialog = props.withPrompt ? useAlertDialog() : undefined;
 
         const handleClick = async (e: Event) => {

--- a/packages/core-kit/src/domains/client/validator.ts
+++ b/packages/core-kit/src/domains/client/validator.ts
@@ -8,10 +8,51 @@
 import { createValidator } from '@validup/zod';
 import { Container } from 'validup';
 import { z } from 'zod';
-import { ValidatorGroup } from '@authup/kit';
+import { ValidatorGroup, patternHasGlobstarInAuthority } from '@authup/kit';
 import type { Client } from './entity';
 import { isClientNameValid } from './helpers';
 import { ClientAuthMethod, ClientTokenBindingMethod } from './constants';
+
+/**
+ * Schema for a comma separated list of redirect patterns.
+ *
+ * Each element must be a URL, and none may place a `**` in its authority.
+ * `**` matches the rest of the value outright, so `https://**.example.com/**`
+ * reads as "any subdomain of example.com" but accepts every origin, which
+ * would make the allowlist meaningless. A single `*` stays supported: the
+ * matcher canonicalizes the candidate first, so a host wildcard cannot reach
+ * past the authority.
+ */
+function buildRedirectPatternSchema(name: string) {
+    return z
+        .string()
+        .check((ctx) => {
+            const validator = z.url();
+            const urls = ctx.value.split(',');
+            for (const url of urls) {
+                try {
+                    validator.parse(url);
+                } catch (e) {
+                    ctx.issues.push({
+                        input: url,
+                        code: 'custom',
+                        message: e instanceof Error ? e.message : `The ${name} is not valid.`,
+                    });
+
+                    continue;
+                }
+
+                if (patternHasGlobstarInAuthority(url)) {
+                    ctx.issues.push({
+                        input: url,
+                        code: 'custom',
+                        message: `The ${name} must not use ** in the host, it would match every origin. Use a single * for a host wildcard.`,
+                    });
+                }
+            }
+        })
+        .nullable();
+}
 
 export class ClientValidator extends Container<Client> {
     protected override initialize() {
@@ -110,51 +151,13 @@ export class ClientValidator extends Container<Client> {
         this.mount(
             'redirectUri',
             { optional: true },
-            createValidator(
-                z
-                    .string()
-                    .check((ctx) => {
-                        const validator = z.url();
-                        const urls = ctx.value.split(',');
-                        for (const url of urls) {
-                            try {
-                                validator.parse(url);
-                            } catch (e) {
-                                ctx.issues.push({
-                                    input: url,
-                                    code: 'custom',
-                                    message: e instanceof Error ? e.message : 'The redirectUri is not valid.',
-                                });
-                            }
-                        }
-                    })
-                    .nullable(),
-            ),
+            createValidator(buildRedirectPatternSchema('redirectUri')),
         );
 
         this.mount(
             'postLogoutRedirectUri',
             { optional: true },
-            createValidator(
-                z
-                    .string()
-                    .check((ctx) => {
-                        const validator = z.url();
-                        const urls = ctx.value.split(',');
-                        for (const url of urls) {
-                            try {
-                                validator.parse(url);
-                            } catch (e) {
-                                ctx.issues.push({
-                                    input: url,
-                                    code: 'custom',
-                                    message: e instanceof Error ? e.message : 'The postLogoutRedirectUri is not valid.',
-                                });
-                            }
-                        }
-                    })
-                    .nullable(),
-            ),
+            createValidator(buildRedirectPatternSchema('postLogoutRedirectUri')),
         );
 
         this.mount(

--- a/packages/kit/src/index.ts
+++ b/packages/kit/src/index.ts
@@ -15,6 +15,7 @@ export * from './generate-name';
 export * from './generate-secret';
 export * from './has-own-property';
 export * from './is-simple-match';
+export * from './is-simple-url-match';
 export * from './nanoid';
 export * from './slugify';
 export * from './object';

--- a/packages/kit/src/is-simple-url-match.ts
+++ b/packages/kit/src/is-simple-url-match.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { isSimpleMatch } from './is-simple-match';
+
+/**
+ * Reduce a URL to the form a browser would navigate to.
+ *
+ * Only http(s) is canonicalized. A custom-scheme redirect (`myapp://cb`, the
+ * native-app pattern of RFC 8252) has no origin, so reconstructing it would
+ * corrupt it.
+ *
+ * Returns every form the value may legitimately be compared as, or undefined
+ * when the value is not an http(s) URL.
+ */
+function canonicalizeHttpURL(url: URL) : string[] {
+    // `origin` is assembled from parsed components, so it can never carry an
+    // authority terminator, userinfo, a non-canonical host case or a default
+    // port. Appending the remaining components to it guarantees a `/` directly
+    // behind the authority, which is the one boundary the matcher understands.
+    const canonical = `${url.origin}${url.pathname}${url.search}${url.hash}`;
+
+    // A bare origin serializes with the root path (`https://x` -> `https://x/`),
+    // so a pattern registered without the trailing slash would stop matching.
+    // Offering the origin as a second form keeps that working, and is safe for
+    // the same reason: an origin ends at the authority, so no wildcard in the
+    // pattern can reach past it.
+    if (url.pathname === '/' && !url.search && !url.hash) {
+        return [canonical, url.origin];
+    }
+
+    return [canonical];
+}
+
+/**
+ * Match a URL against a glob pattern, or against any pattern of a list.
+ *
+ * The wildcard vocabulary is `isSimpleMatch`'s (`*` stays inside a path
+ * segment, `**` matches the rest), but the value is canonicalized first, so
+ * the string that gets authorized is the string the browser navigates to.
+ *
+ * That is what makes a wildcard in the pattern's authority safe.
+ * `isSimpleMatch` knows exactly one boundary, `/`, while a URL authority is
+ * also terminated by `?`, `#` and `\`. Against the raw string a `*` in the
+ * host absorbs one of those and the pattern's remaining host literal lands in
+ * the query or fragment of a foreign origin, so
+ * `https://evil.test?.example.com/cb` matches `https://*.example.com/**` and
+ * an authorization code is delivered to the attacker. Canonicalizing first
+ * puts a `/` behind the authority and the wildcard can no longer cross it.
+ *
+ * Case, default port, userinfo and `..` segments are resolved by the same
+ * step, so a path-scoped pattern can no longer be walked out of either.
+ *
+ * Use this for every trust decision over a URL. `isSimpleMatch` on a raw URL
+ * string is not safe when the pattern may carry a wildcard in its authority.
+ */
+export function isSimpleURLMatch(
+    value: string,
+    pattern: string | string[],
+) : boolean {
+    let url : URL;
+    try {
+        url = new URL(value);
+    } catch {
+        // Nothing a browser could navigate to, so nothing to authorize.
+        return false;
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        // Custom scheme: no origin to canonicalize against, matched verbatim
+        // as before. A wildcard in the authority of such a pattern is rejected
+        // at write time by `patternHasGlobstarInAuthority`.
+        return isSimpleMatch(value, pattern);
+    }
+
+    const candidates = canonicalizeHttpURL(url);
+    for (const candidate of candidates) {
+        if (isSimpleMatch(candidate, pattern)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Does the pattern place a `**` in its authority?
+ *
+ * A single `*` there is a supported host wildcard and is safe once the value
+ * is canonicalized. `**` is not: it matches the rest of the value outright,
+ * discarding everything the pattern says after it, so
+ * `https://**.example.com/**` reads as "any subdomain of example.com" but
+ * accepts every https origin. There is no safe reading of it, so it is
+ * rejected where patterns are written rather than given a meaning at match
+ * time.
+ */
+export function patternHasGlobstarInAuthority(pattern: string) : boolean {
+    const separator = pattern.indexOf('://');
+
+    const start = separator === -1 ? 0 : separator + '://'.length;
+    const end = pattern.indexOf('/', start);
+    const authority = end === -1 ? pattern.slice(start) : pattern.slice(start, end);
+
+    return authority.includes('**');
+}

--- a/packages/kit/src/is-simple-url-match.ts
+++ b/packages/kit/src/is-simple-url-match.ts
@@ -37,6 +37,36 @@ function canonicalizeHttpURL(url: URL) : string[] {
 }
 
 /**
+ * Reduce a pattern to the same canonical form as the candidate.
+ *
+ * Both sides have to be normalized or the comparison is asymmetric: a stored
+ * `https://app.example.com:443/**` or `https://APP.example.com/**` would stop
+ * matching the moment the candidate is canonicalized, which would log users
+ * out of a working deployment.
+ *
+ * Wildcards survive it. `*` is a legal host and path character, so `URL`
+ * leaves `*` and `**` untouched wherever they appear and only normalizes what
+ * should be normalized (host case, default port, userinfo, dot segments).
+ *
+ * A pattern that is not an http(s) URL is returned untouched, so custom
+ * schemes and any non-URL pattern keep comparing verbatim.
+ */
+function canonicalizePattern(pattern: string) : string {
+    let url : URL;
+    try {
+        url = new URL(pattern);
+    } catch {
+        return pattern;
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        return pattern;
+    }
+
+    return `${url.origin}${url.pathname}${url.search}${url.hash}`;
+}
+
+/**
  * Match a URL against a glob pattern, or against any pattern of a list.
  *
  * The wildcard vocabulary is `isSimpleMatch`'s (`*` stays inside a path
@@ -53,7 +83,9 @@ function canonicalizeHttpURL(url: URL) : string[] {
  * puts a `/` behind the authority and the wildcard can no longer cross it.
  *
  * Case, default port, userinfo and `..` segments are resolved by the same
- * step, so a path-scoped pattern can no longer be walked out of either.
+ * step, so a path-scoped pattern can no longer be walked out of either. The
+ * pattern is normalized the same way, since normalizing only one side would
+ * stop a stored `https://APP.example.com/**` from matching anything.
  *
  * Use this for every trust decision over a URL. `isSimpleMatch` on a raw URL
  * string is not safe when the pattern may carry a wildcard in its authority.
@@ -62,6 +94,8 @@ export function isSimpleURLMatch(
     value: string,
     pattern: string | string[],
 ) : boolean {
+    const patterns = Array.isArray(pattern) ? pattern : [pattern];
+
     let url : URL;
     try {
         url = new URL(value);
@@ -72,15 +106,19 @@ export function isSimpleURLMatch(
 
     if (url.protocol !== 'http:' && url.protocol !== 'https:') {
         // Custom scheme: no origin to canonicalize against, matched verbatim
-        // as before. A wildcard in the authority of such a pattern is rejected
-        // at write time by `patternHasGlobstarInAuthority`.
-        return isSimpleMatch(value, pattern);
+        // as before. A `**` in the authority of such a pattern is rejected at
+        // write time by `patternHasGlobstarInAuthority`.
+        return isSimpleMatch(value, patterns);
     }
 
     const candidates = canonicalizeHttpURL(url);
-    for (const candidate of candidates) {
-        if (isSimpleMatch(candidate, pattern)) {
-            return true;
+    for (const item of patterns) {
+        const canonicalPattern = canonicalizePattern(item);
+
+        for (const candidate of candidates) {
+            if (isSimpleMatch(candidate, canonicalPattern)) {
+                return true;
+            }
         }
     }
 
@@ -102,8 +140,13 @@ export function patternHasGlobstarInAuthority(pattern: string) : boolean {
     const separator = pattern.indexOf('://');
 
     const start = separator === -1 ? 0 : separator + '://'.length;
-    const end = pattern.indexOf('/', start);
-    const authority = end === -1 ? pattern.slice(start) : pattern.slice(start, end);
 
-    return authority.includes('**');
+    // The authority ends at the FIRST of these, not at `/` alone. Scanning
+    // only for `/` swallows the query and fragment, so an origin-scoped
+    // `https://app.example.com?next=**` would be rejected for a `**` that is
+    // nowhere near the host.
+    const offset = pattern.slice(start).search(/[/?#\\]/);
+    const end = offset === -1 ? pattern.length : start + offset;
+
+    return pattern.slice(start, end).includes('**');
 }

--- a/packages/kit/test/unit/is-simple-url-match.spec.ts
+++ b/packages/kit/test/unit/is-simple-url-match.spec.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isSimpleMatch, isSimpleURLMatch, patternHasGlobstarInAuthority } from '../../src';
+
+describe('is-simple-url-match', () => {
+    // isSimpleMatch knows exactly one boundary, `/`, but a URL authority also
+    // ends at `?`, `#` and `\`. Matched against the raw string, a `*` in the
+    // host absorbs one of those and the pattern's remaining host literal ends
+    // up in the query or fragment of a foreign origin, so the authorization
+    // code is delivered to the attacker. Each of these matched before the
+    // value was canonicalized.
+    it('should not let a host wildcard absorb an authority terminator', () => {
+        const pattern = 'https://*.example.com/**';
+
+        expect(isSimpleURLMatch('https://evil.test?.example.com/cb', pattern)).toBeFalsy();
+        expect(isSimpleURLMatch('https://evil.test#.example.com/cb', pattern)).toBeFalsy();
+        expect(isSimpleURLMatch('https://evil.test\\.example.com/cb', pattern)).toBeFalsy();
+        expect(isSimpleURLMatch('https://user@evil.test#.example.com/cb', pattern)).toBeFalsy();
+        expect(isSimpleURLMatch('https://evil.test:8443#.example.com/cb', pattern)).toBeFalsy();
+
+        // the raw matcher is what these get past, which is why the consumers
+        // must not call it directly on a URL
+        expect(isSimpleMatch('https://evil.test?.example.com/cb', pattern)).toBeTruthy();
+    });
+
+    it('should not match a foreign origin', () => {
+        expect(isSimpleURLMatch('https://a.example.com.evil.test/cb', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('https://a.example.com@evil.test/cb', 'https://*.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('https://evil.test', 'https://app.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('http://app.example.com/cb', 'https://app.example.com/**')).toBeFalsy();
+    });
+
+    // The authorized string has to be the string the browser navigates to, or
+    // a path-scoped pattern can be walked out of via dot segments.
+    it('should resolve dot segments before matching', () => {
+        expect(isSimpleURLMatch(
+            'https://app.example.com/tenant-a/../tenant-b/cb',
+            'https://app.example.com/tenant-a/**',
+        )).toBeFalsy();
+
+        expect(isSimpleURLMatch(
+            'https://app.example.com/tenant-a/./cb',
+            'https://app.example.com/tenant-a/**',
+        )).toBeTruthy();
+    });
+
+    it('should match a legitimate redirect', () => {
+        expect(isSimpleURLMatch('https://app.example.com/cb', 'https://app.example.com/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com/a/b/c', 'https://app.example.com/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com/cb', 'https://app.example.com/*')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com/cb', 'https://app.example.com/cb')).toBeTruthy();
+        expect(isSimpleURLMatch('http://localhost:3000/login/callback', 'http://localhost:3000/**')).toBeTruthy();
+    });
+
+    // A bare origin serializes with the root path, so a pattern registered
+    // without the trailing slash would stop matching if the canonical form
+    // were the only candidate.
+    it('should match a bare origin against a pattern carrying no trailing slash', () => {
+        expect(isSimpleURLMatch('https://app.example.com', 'https://app.example.com')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com/', 'https://app.example.com')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com', 'https://app.example.com/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com', 'https://app.example.com/*')).toBeTruthy();
+    });
+
+    it('should keep supporting a host wildcard', () => {
+        const pattern = 'https://*.example.com/**';
+
+        expect(isSimpleURLMatch('https://a.example.com/cb', pattern)).toBeTruthy();
+        expect(isSimpleURLMatch('https://a.b.example.com/cb', pattern)).toBeTruthy();
+        expect(isSimpleURLMatch('https://a.example.com', pattern)).toBeTruthy();
+    });
+
+    // Canonicalization is what makes these equivalent, and they are: the
+    // browser navigates to the same origin either way.
+    it('should normalize host case, the default port and userinfo', () => {
+        expect(isSimpleURLMatch('https://APP.example.com/cb', 'https://app.example.com/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com:443/cb', 'https://app.example.com/**')).toBeTruthy();
+        expect(isSimpleURLMatch('http://app.example.com:80/cb', 'http://app.example.com/**')).toBeTruthy();
+    });
+
+    it('should match a custom scheme verbatim', () => {
+        expect(isSimpleURLMatch('myapp://callback', 'myapp://callback')).toBeTruthy();
+        expect(isSimpleURLMatch('myapp://callback/x', 'myapp://callback/**')).toBeTruthy();
+        expect(isSimpleURLMatch('myapp://other', 'myapp://callback')).toBeFalsy();
+    });
+
+    it('should reject a value that is not a URL', () => {
+        expect(isSimpleURLMatch('/relative/path', 'https://app.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('//evil.test', 'https://app.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('', 'https://app.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('not a url', '**')).toBeFalsy();
+    });
+
+    it('should accept a list of patterns', () => {
+        const patterns = ['https://a.example.com/**', 'https://b.example.com/**'];
+
+        expect(isSimpleURLMatch('https://b.example.com/cb', patterns)).toBeTruthy();
+        expect(isSimpleURLMatch('https://c.example.com/cb', patterns)).toBeFalsy();
+        expect(isSimpleURLMatch('https://a.example.com/cb', [])).toBeFalsy();
+    });
+
+    // Every pair a wildcard-free pattern accepted before must still be
+    // accepted: those are the overwhelming majority of configured patterns,
+    // and this change must not log anyone out of a working deployment.
+    it('should not narrow what a wildcard-free pattern accepts', () => {
+        const hosts = ['app.example.com', 'localhost:3000', 'a.b.example.com'];
+        const patternPaths = ['/**', '/*', '/cb', ''];
+        const valuePaths = ['', '/', '/cb', '/auth/callback', '/a/b/c', '/cb?x=1', '/cb#f'];
+
+        const regressions: string[] = [];
+        for (const host of hosts) {
+            for (const patternPath of patternPaths) {
+                const pattern = `https://${host}${patternPath}`;
+                for (const valuePath of valuePaths) {
+                    const value = `https://${host}${valuePath}`;
+                    if (isSimpleMatch(value, pattern) && !isSimpleURLMatch(value, pattern)) {
+                        regressions.push(`${value} ~ ${pattern}`);
+                    }
+                }
+            }
+        }
+
+        expect(regressions).toEqual([]);
+    });
+
+    describe('patternHasGlobstarInAuthority', () => {
+        // `**` matches the rest of the value outright, discarding whatever the
+        // pattern says after it, so a `**` in the authority accepts every
+        // origin. There is no safe reading of it.
+        it('should detect a globstar in the authority', () => {
+            expect(patternHasGlobstarInAuthority('https://**.example.com/**')).toBeTruthy();
+            expect(patternHasGlobstarInAuthority('https://**')).toBeTruthy();
+            expect(patternHasGlobstarInAuthority('**')).toBeTruthy();
+            expect(patternHasGlobstarInAuthority('https://**:3000/cb')).toBeTruthy();
+        });
+
+        it('should allow a single wildcard and a globstar in the path', () => {
+            expect(patternHasGlobstarInAuthority('https://*.example.com/**')).toBeFalsy();
+            expect(patternHasGlobstarInAuthority('https://app.example.com/**')).toBeFalsy();
+            expect(patternHasGlobstarInAuthority('https://app.example.com/**/cb')).toBeFalsy();
+            expect(patternHasGlobstarInAuthority('http://localhost:3000/**')).toBeFalsy();
+            expect(patternHasGlobstarInAuthority('myapp://cb/**')).toBeFalsy();
+        });
+    });
+});

--- a/packages/kit/test/unit/is-simple-url-match.spec.ts
+++ b/packages/kit/test/unit/is-simple-url-match.spec.ts
@@ -84,6 +84,27 @@ describe('is-simple-url-match', () => {
         expect(isSimpleURLMatch('http://app.example.com:80/cb', 'http://app.example.com/**')).toBeTruthy();
     });
 
+    // Normalizing only the candidate would make the comparison asymmetric and
+    // silently stop a stored pattern from ever matching, which on upgrade
+    // reads as "login broke".
+    it('should normalize the pattern as well as the value', () => {
+        expect(isSimpleURLMatch('https://app.example.com:443/cb', 'https://app.example.com:443/**')).toBeTruthy();
+        expect(isSimpleURLMatch('http://app.example.com:80/cb', 'http://app.example.com:80/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://APP.example.com/cb', 'https://APP.example.com/**')).toBeTruthy();
+
+        // and the two sides meet in the middle
+        expect(isSimpleURLMatch('https://app.example.com/cb', 'https://APP.example.com/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com/cb', 'https://app.example.com:443/**')).toBeTruthy();
+        expect(isSimpleURLMatch('https://app.example.com/cb', 'https://user@app.example.com/**')).toBeTruthy();
+    });
+
+    it('should keep normalizing the pattern from narrowing a match', () => {
+        // a normalized pattern must not start matching a foreign origin
+        expect(isSimpleURLMatch('https://evil.test/cb', 'https://APP.example.com/**')).toBeFalsy();
+        expect(isSimpleURLMatch('https://app.example.com.evil.test/cb', 'https://app.example.com:443/**')).toBeFalsy();
+        expect(isSimpleURLMatch('http://app.example.com/cb', 'https://app.example.com:443/**')).toBeFalsy();
+    });
+
     it('should match a custom scheme verbatim', () => {
         expect(isSimpleURLMatch('myapp://callback', 'myapp://callback')).toBeTruthy();
         expect(isSimpleURLMatch('myapp://callback/x', 'myapp://callback/**')).toBeTruthy();
@@ -109,7 +130,17 @@ describe('is-simple-url-match', () => {
     // accepted: those are the overwhelming majority of configured patterns,
     // and this change must not log anyone out of a working deployment.
     it('should not narrow what a wildcard-free pattern accepts', () => {
-        const hosts = ['app.example.com', 'localhost:3000', 'a.b.example.com'];
+        // The pattern hosts deliberately include NON-canonical spellings. A
+        // sweep over already-canonical patterns cannot see the asymmetry that
+        // normalizing only the candidate introduces, which is exactly how a
+        // stored `:443` or mixed-case pattern silently stopped matching.
+        const hosts = [
+            'app.example.com',
+            'localhost:3000',
+            'a.b.example.com',
+            'app.example.com:443',
+            'APP.example.com',
+        ];
         const patternPaths = ['/**', '/*', '/cb', ''];
         const valuePaths = ['', '/', '/cb', '/auth/callback', '/a/b/c', '/cb?x=1', '/cb#f'];
 
@@ -146,6 +177,14 @@ describe('is-simple-url-match', () => {
             expect(patternHasGlobstarInAuthority('https://app.example.com/**/cb')).toBeFalsy();
             expect(patternHasGlobstarInAuthority('http://localhost:3000/**')).toBeFalsy();
             expect(patternHasGlobstarInAuthority('myapp://cb/**')).toBeFalsy();
+        });
+
+        it('should end the authority at a query or fragment, not only at a slash', () => {
+            // scanning to `/` alone swallows the query and fragment, so a `**`
+            // nowhere near the host would reject an origin-scoped pattern
+            expect(patternHasGlobstarInAuthority('https://app.example.com?next=**')).toBeFalsy();
+            expect(patternHasGlobstarInAuthority('https://app.example.com#**')).toBeFalsy();
+            expect(patternHasGlobstarInAuthority('https://app.example.com\\**')).toBeFalsy();
         });
     });
 });


### PR DESCRIPTION
Fixes found while reviewing `v1.0.0-beta.58..master`. The first one should
land before the release.

## Auth-code exfiltration via a host wildcard

`isSimpleMatch` treats `/` as its only boundary, but a URL authority also ends
at `?`, `#` and `\`. A `*` in the host of a registered pattern absorbs one of
those, so the pattern's remaining host literal lands in the query or fragment
of a foreign origin:

```
pattern https://*.example.com/**          before   after
  https://evil.test?.example.com/cb       match  → no
  https://evil.test#.example.com/cb       match  → no
  https://evil.test\.example.com/cb       match  → no
  https://user@evil.test#.example.com/cb  match  → no
  https://evil.test/.example.com/cb       no       no    (control: `/` blocks)
```

Running the delivery code from `AuthorizeController.confirm` on those inputs
puts the code in the query string on `evil.test`:

```
https://evil.test/?state=x&code=SECRET_CODE#.example.com/cb
https://evil.test/.example.com/cb?state=x&code=SECRET_CODE
```

The per-realm console clients are public, `builtIn` (auto-consent, no screen)
and `global` scoped, and the attacker chooses the PKCE challenge, so one click
by a signed-in admin yields a full-permission token. `isValidPostLogoutRedirect`
has the same shape (it parses the URL for a protocol check, then matches the
raw string), giving a server-issued open redirect carrying `state`.

Reachable via config: `new URL('https://*.example.com').origin` returns the
wildcard verbatim, so `expandToOrigins` → `trustedOrigins` →
`buildSystemClientAttributes` writes `https://*.example.com/**` into
`redirectUri` **and** `postLogoutRedirectUri` in every realm.

Introduced by #3396, which is what made host wildcards work at all (all four
variants matched nothing before) and which also documented them as safe.

**The fix is the pattern already in this repo.** `resolveAccountConsoleRef`
canonicalizes through `URL` before matching, which is why the account console
is the one unaffected consumer. That is now `isSimpleURLMatch` in
`@authup/kit`, and all three consumers use it, so the string that gets
authorized is the string the browser navigates to. Case, the default port,
userinfo and dot segments resolve in the same step, which also closes
path-scoped patterns being walked out of with `..`.

Both sides are normalized, not just the candidate. Normalizing one side makes
the comparison asymmetric, and a stored `https://app.example.com:443/**` or
`https://APP.example.com/**` would stop matching, which on upgrade reads as
"login broke". Wildcards survive the step untouched, and two pre-existing
mismatches resolve as a side effect.

Verified with three independent implementations (the shipped two-pointer, a
recursive reference, and a regex compiler) agreeing over **1,863,225 pairs**,
plus a matrix of real URL shapes. A regression sweep over every value/pattern
pair a wildcard-free pattern accepts — including non-canonical pattern hosts —
confirms nothing legitimate stops matching, and it fails if the normalization
is removed.

> **Breaking:** `**` is no longer accepted inside the host of a pattern or a
> `TRUSTED_ORIGINS` entry. It matches the rest of the value outright, so
> `https://**.example.com/**` read as "any subdomain" but accepted every
> origin. A single `*` is unchanged. Stored patterns are not rewritten; new
> writes are rejected and an offending `TRUSTED_ORIGINS` value fails the boot.

## Two pinia copies in the published SSR bundle

Both consoles bundle the kit from source, so `pinia` resolved from
`packages/client-web-kit/node_modules` for kit modules and from the app for
app modules. `dist/server/server.js` carried two complete pinia modules, and
`Symbol('pinia')` is per copy.

It worked only through a module global: installing the store calls the factory
with an explicit instance, and pinia's `useStore` calls `setActivePinia()` on
its own copy. The auth console builds a fresh app and pinia **per SSR
request**, so under concurrent renders that global points at whichever request
installed last and a kit component calling `injectStore()` can read another
request's session.

Fixed with `resolve.dedupe` rather than a root override: the root slot is held
at `@vue/devtools-api` 7.x by vitepress, so an override would drag docs tooling
onto 8.x to fix a bundling problem. Verified on the rebuilt bundle
(`Symbol("pinia")` 2 → 1).

## Wildcard provisioning could delete an explicitly declared entity

A child declared by both a wildcard entry and an explicit realm block
inherited the *wildcard's* strategy when the explicit child declared none.
`absent` is in that vocabulary, so the documented sweep recipe deleted the row
the explicit block declares, on every boot. The inheritance is correct for the
composite source; the wildcard expansion inverts the precedence, so it opts
out.

## Theme token grammar

`url(` was blocked while `image-set()`, `image()`, `src()` and `cross-fade()`
were not, and all take a bare string URL into a token substituted straight
into an image property. `{` was allowed and silently swallowed the `.dark`
rule. Both fixed, and the claim that this grammar is reusable for an untrusted
per-realm source is dropped: a denylist over CSS functions leaks by
construction, which is what happened here.

## Tests that did not assert what they claimed

- The symlink containment test asserted a 404 for a file an earlier test had
  already deleted. It passed with the containment check removed. Now
  self-contained, with a control proving the target is readable through the
  mount. Verified by disabling the check: it fails, serving the leaked file.
- The packed smoke run never requested a console page, so the `locateUpSync`
  walk that only the published layout exercises was untested, and a tarball
  with no bundle went green. It now asserts both consoles serve.

## Smaller items

`entrypoint.sh` exited **0** on an unknown service (so a container that started
nothing succeeded — reachable for anything still passing `client/web`); the
`/settings` stub read its path map through `Object.prototype`; the contract
version was a hand-copied literal with no link to the package's own (now a
type-level link that fails the build on drift); the account nav back-link
modifier was declared before the base rule that overrode it.

`upgrading.md` gained the three breaking changes it was missing, and the
theming quick start printed an `/authorize` URL the verifier rejects (it still
answers 200, so the reader saw an error card with no indication why).

## Verification

`server-core` 1995 tests, `client-web-kit` 201, `kit` 48, `core-kit` 19,
`authup` 30 — all passing. Type check and lint clean. Both console apps build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Reliability**
  - Strengthened redirect URL validation and blocked unsafe wildcard patterns.
  - Improved theme asset validation to prevent unsafe CSS and file access.
  - Unknown startup services now fail clearly with supported options.

- **Bug Fixes**
  - Improved canonical URL matching for OAuth and logout redirects.
  - Ensured newly available theme assets are detected without restarting.
  - Preserved explicit provisioning settings over wildcard defaults.
  - Corrected account navigation styling.

- **Documentation**
  - Added upgrade guidance, provisioning behavior details, and improved theming smoke-test instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
