### PR TITLE
feat(server-core): revoke sessions by the application that used them

### DIFF
--- a/apps/server-core/src/adapters/http/controllers/entities/session/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/session/module.ts
@@ -27,6 +27,28 @@ import {
 import { ForceLoggedInMiddleware } from '../../../middleware/index.ts';
 import { buildActorContext, useRequestSessionId } from '../../../request/index.ts';
 
+/**
+ * Read the `usedClientId` request parameter: the "every session that served
+ * application X" target, accepting a single id or a comma list.
+ *
+ * It is deliberately not a rapiq filter. `filter[clientId]` matches the
+ * session's own column, which names only the client that FIRST authorized on
+ * the row, and inferring intent from a user-supplied condition tree (what
+ * does a negated or OR-nested value mean?) is not something a bulk delete
+ * should be doing.
+ */
+function useRequestUsedClientIds(event: IAppEvent) : string[] | undefined {
+    const raw = useRequestQuery(event)?.usedClientId;
+
+    const values = (Array.isArray(raw) ? raw : [raw])
+        .filter((value): value is string => typeof value === 'string')
+        .flatMap((value) => value.split(','))
+        .map((value) => value.trim())
+        .filter((value) => value.length > 0);
+
+    return values.length > 0 ? values : undefined;
+}
+
 export type SessionControllerContext = {
     service: ISessionService,
 };
@@ -48,7 +70,7 @@ export class SessionController {
         const {
             data,
             meta,
-        } = await this.service.getMany(useRequestQuery(event), actor);
+        } = await this.service.getMany(useRequestQuery(event), actor, { clientIds: useRequestUsedClientIds(event) });
 
         return {
             data,
@@ -86,6 +108,7 @@ export class SessionController {
         const result = await this.service.deleteMany(actor, {
             query: useRequestQuery(event),
             currentSessionId: useRequestSessionId(event),
+            clientIds: useRequestUsedClientIds(event),
         });
 
         event.response.status = 202;

--- a/apps/server-core/src/app/modules/authentication/repositories/session.ts
+++ b/apps/server-core/src/app/modules/authentication/repositories/session.ts
@@ -9,7 +9,8 @@ import type { Session } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { EntityRepositoryFindManyResult, ICache } from '@authup/server-kit';
 import { buildCacheKey } from '@authup/server-kit';
-import type { Repository } from 'typeorm';
+import type { Repository, SelectQueryBuilder } from 'typeorm';
+import { Brackets } from 'typeorm';
 import { applyQuery, redactFieldConditions } from '../../database/repositories/query.ts';
 import type {
     ISessionRepository,
@@ -55,6 +56,43 @@ export class SessionRepository implements ISessionRepository {
 
     // -----------------------------------------------------
 
+    /**
+     * Restrict to sessions that served one of the given clients.
+     *
+     * Two reaches, OR-ed inside one bracket so the whole thing stays a single
+     * AND-ed term and cannot widen the surrounding WHERE: the session's own
+     * `client_id` (write-once, so it names the client that FIRST authorized
+     * on the row) and an EXISTS over `auth_session_tokens`, which carries the
+     * per-application attribution for every client the session went on to
+     * serve. The session column alone would miss every later application, and
+     * the EXISTS alone would miss a session whose tokens have since been
+     * swept, so both are needed.
+     *
+     * Raw column names rather than property paths: this is a correlated
+     * subquery against a table with no query surface of its own.
+     *
+     * The bind parameter stays named `usedClientIds` rather than matching the
+     * option. It shares a builder with the conditions rapiq generates from the
+     * client's own query, and a name that reads like a column is exactly the
+     * one at risk of colliding there, which TypeORM would resolve by silently
+     * overwriting a binding.
+     */
+    protected applyClientIds(qb: SelectQueryBuilder<Session>, ids?: string[]) {
+        if (!ids || ids.length === 0) {
+            return;
+        }
+
+        qb.andWhere(new Brackets((where) => {
+            where.where('session.client_id IN (:...usedClientIds)', { usedClientIds: ids })
+                .orWhere(
+                    'EXISTS (SELECT 1 FROM auth_session_tokens ust' +
+                    ' WHERE ust.session_id = session.id' +
+                    ' AND ust.client_id IN (:...usedClientIds))',
+                    { usedClientIds: ids },
+                );
+        }));
+    }
+
     async findMany(
         query: IQuery,
         options: SessionFindManyOptions = {},
@@ -72,6 +110,8 @@ export class SessionRepository implements ISessionRepository {
                 ownerSubKind: options.owner.subKind,
             });
         }
+
+        this.applyClientIds(qb, options.clientIds);
 
         const [entities, total] = await qb.getManyAndCount();
 
@@ -93,7 +133,7 @@ export class SessionRepository implements ISessionRepository {
             .getMany();
     }
 
-    async findAllByQuery(query: IQuery): Promise<Session[]> {
+    async findAllByQuery(query: IQuery, options: SessionFindManyOptions = {}): Promise<Session[]> {
         const qb = this.repository.createQueryBuilder('session');
 
         // NOTE: `parameters: ['filters']` — a bulk revoke must reach every
@@ -103,6 +143,8 @@ export class SessionRepository implements ISessionRepository {
         applyQuery(qb, query);
 
         applyRealmScopeSelect(qb, 'session', ['sub', 'subKind']);
+
+        this.applyClientIds(qb, options.clientIds);
 
         return qb.getMany();
     }

--- a/apps/server-core/src/core/authentication/session/types.ts
+++ b/apps/server-core/src/core/authentication/session/types.ts
@@ -34,6 +34,14 @@ export type SessionFindManyOptions = {
      * mandatory WHERE that a rapiq query filter cannot override.
      */
     owner?: SessionOwner,
+    /**
+     * Restrict to sessions that issued a token for one of these clients.
+     * Applied as a mandatory WHERE alongside `owner`: the session's own
+     * `client_id` (the client that first authorized on it) OR an EXISTS over
+     * `auth_session_tokens`, which is where per-application attribution
+     * actually lives. An empty array is treated as absent.
+     */
+    clientIds?: string[],
 };
 
 export interface ISessionRepository {
@@ -49,7 +57,7 @@ export interface ISessionRepository {
      * the admin "force-logout" path; per-session authorization is enforced by
      * the caller (`SessionService`).
      */
-    findAllByQuery(query: IQuery): Promise<Session[]>;
+    findAllByQuery(query: IQuery, options?: SessionFindManyOptions): Promise<Session[]>;
 
     save(session: Partial<Session>): Promise<Session>;
 

--- a/apps/server-core/src/core/entities/session/service.ts
+++ b/apps/server-core/src/core/entities/session/service.ts
@@ -24,7 +24,12 @@ import { AbstractEntityService } from '@authup/server-kit';
 import type { ActorContext, EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { ISessionRepository } from '../../authentication/index.ts';
 import { SESSION_FILTER_KEYS } from '../../authentication/index.ts';
-import type { ISessionService, SessionDeleteManyOptions, SessionDeleteManyResult } from './types.ts';
+import type {
+    ISessionService,
+    SessionDeleteManyOptions,
+    SessionDeleteManyResult,
+    SessionGetManyOptions,
+} from './types.ts';
 import { appendQueryConditions, decodeQuery } from '../../query/index.ts';
 import { sessionSchema } from './schema.ts';
 
@@ -49,6 +54,7 @@ export class SessionService extends AbstractEntityService implements ISessionSer
     async getMany(
         query: Record<string, any>,
         actor: ActorContext,
+        options: SessionGetManyOptions = {},
     ): Promise<EntityRepositoryFindManyResult<Session>> {
         const parsed = await decodeQuery(query, { schema: sessionSchema, actor });
 
@@ -69,6 +75,7 @@ export class SessionService extends AbstractEntityService implements ISessionSer
                     sub: actor.identity!.data.id,
                     subKind: actor.identity!.type,
                 },
+                clientIds: options.clientIds,
             });
         }
 
@@ -92,10 +99,13 @@ export class SessionService extends AbstractEntityService implements ISessionSer
                 );
             }
 
-            return this.repository.findMany(scoped);
+            return this.repository.findMany(scoped, { clientIds: options.clientIds });
         }
 
-        const { data: entities, meta } = await this.repository.findMany(parsed);
+        const { data: entities, meta } = await this.repository.findMany(
+            parsed,
+            { clientIds: options.clientIds },
+        );
 
         const data: Session[] = [];
         let { total } = meta;
@@ -181,8 +191,16 @@ export class SessionService extends AbstractEntityService implements ISessionSer
             throw new AuthupError({ code: ErrorCode.IDENTITY_UNAUTHORIZED, message: 'Authentication required.' });
         }
 
-        if (this.hasTargetFilter(options.query)) {
-            return this.deleteManyByQuery(actor, options.query!);
+        // A `usedClientId` parameter targets just as precisely as a filter
+        // does, so it selects the admin path on its own. Without this the
+        // call would fall through to self-service and silently revoke the
+        // caller's own devices instead of the named application's sessions.
+        const clientIds = options.clientIds && options.clientIds.length > 0 ?
+            options.clientIds :
+            undefined;
+
+        if (clientIds || this.hasTargetFilter(options.query)) {
+            return this.deleteManyByQuery(actor, options.query ?? {}, clientIds);
         }
 
         return this.deleteManyForSelf(actor, options.currentSessionId);
@@ -261,6 +279,7 @@ export class SessionService extends AbstractEntityService implements ISessionSer
     protected async deleteManyByQuery(
         actor: ActorContext,
         query: Record<string, any>,
+        clientIds?: string[],
     ): Promise<SessionDeleteManyResult> {
         // Gate: an actor without SESSION_DELETE cannot force-logout anyone → 403.
         await actor.permissionEvaluator.preEvaluate({ name: PermissionName.SESSION_DELETE });
@@ -271,6 +290,7 @@ export class SessionService extends AbstractEntityService implements ISessionSer
                 parameters: ['filters'], 
                 actor, 
             }),
+            { clientIds },
         );
 
         let count = 0;

--- a/apps/server-core/src/core/entities/session/types.ts
+++ b/apps/server-core/src/core/entities/session/types.ts
@@ -12,6 +12,16 @@ export type SessionDeleteManyResult = {
     count: number,
 };
 
+export type SessionGetManyOptions = {
+    /**
+     * Restrict to sessions that issued a token for one of these clients
+     * (`?usedClientId=`). The read counterpart of the same option on
+     * `SessionDeleteManyOptions`, so an operator can list what a revoke
+     * would reach before running it.
+     */
+    clientIds?: string[],
+};
+
 export type SessionDeleteManyOptions = {
     /**
      * The parsed request query. When it carries a recognized target filter
@@ -24,6 +34,23 @@ export type SessionDeleteManyOptions = {
      * self-service path so "log out my other devices" keeps this device.
      */
     currentSessionId?: string,
+    /**
+     * Restrict to sessions that ISSUED A TOKEN for one of these clients
+     * (`?usedClientId=`). This is the "revoke application X everywhere"
+     * target, and it reaches every session the client actually served,
+     * which `filter[clientId]` cannot: that column names only the client
+     * that FIRST authorized on the row, while one browser session serves
+     * several applications.
+     *
+     * Deliberately a request parameter rather than a rapiq filter. Reading
+     * intent out of a user-supplied condition tree would have to decide
+     * what a negated or OR-nested `clientId` means, and on a bulk delete a
+     * wrong answer is a mass deletion. A scalar parameter has one meaning.
+     *
+     * Its presence alone selects the admin bulk-revoke path (SESSION_DELETE
+     * plus the per-session realm match), exactly like a target filter.
+     */
+    clientIds?: string[],
 };
 
 export interface ISessionService {
@@ -32,7 +59,11 @@ export interface ISessionService {
      * sessions (self-service); an actor with `SESSION_READ` sees every session
      * its realm reach permits.
      */
-    getMany(query: Record<string, any>, actor: ActorContext): Promise<EntityRepositoryFindManyResult<Session>>;
+    getMany(
+        query: Record<string, any>,
+        actor: ActorContext,
+        options?: SessionGetManyOptions,
+    ): Promise<EntityRepositoryFindManyResult<Session>>;
 
     /**
      * Read a single session by id. Own sessions need no permission.

--- a/apps/server-core/test/unit/http/controllers/workflows/token/session-token-attribution.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/session-token-attribution.spec.ts
@@ -314,6 +314,73 @@ describe('src/http/controllers/token (session-token client attribution)', () => 
         expect(sessions.data.filter((s) => s.sub === user.id)).toHaveLength(1);
     });
 
+    it('revokes by usedClientId a session the application served but did not create', async () => {
+        // The capability `filter[clientId]` cannot provide. Session.clientId is
+        // write-once, so a second application riding the same browser session
+        // is invisible to it, and an operator revoking that application after a
+        // compromise would match nothing.
+        const firstSecret = generateOAuth2CodeVerifier();
+        const firstApp = await createConfidentialClient(firstSecret);
+        const secondSecret = generateOAuth2CodeVerifier();
+        const secondApp = await createConfidentialClient(secondSecret);
+
+        const password = 'attribution-used-client-password';
+        const { data: user } = await suite.client.user.create(createFakeUser({ password }));
+        const login = await suite.client.token.createWithPassword({
+            username: user.name,
+            password,
+        });
+
+        const bearer = new HTTPClient({ baseURL: suite.baseURL });
+        bearer.setAuthorizationHeader({ type: 'Bearer', token: login.access_token });
+        const sessionId = decodeJwtPayload(login.access_token).session_id!;
+
+        await authorizeAndExchange(bearer, firstApp, firstSecret);
+        await authorizeAndExchange(bearer, secondApp, secondSecret);
+
+        const admin = { Authorization: `Basic ${Buffer.from('admin:start123').toString('base64')}` };
+
+        // The session column names only the first application, so the plain
+        // filter cannot reach it for the second.
+        const byColumn = await httpRequest(
+            suite,
+            'GET',
+            `/sessions?filter[clientId]=${secondApp.id}`,
+            { headers: admin },
+        );
+        expect(byColumn.status).toEqual(200);
+        expect((await byColumn.json()).data.map((s: any) => s.id)).not.toContain(sessionId);
+
+        // usedClientId reaches it, because the token rows carry the real
+        // per-application attribution.
+        const byUsage = await httpRequest(
+            suite,
+            'GET',
+            `/sessions?usedClientId=${secondApp.id}`,
+            { headers: admin },
+        );
+        expect(byUsage.status).toEqual(200);
+        expect((await byUsage.json()).data.map((s: any) => s.id)).toContain(sessionId);
+
+        // and the revoke reaches it too
+        const revoked = await httpRequest(
+            suite,
+            'DELETE',
+            `/sessions?usedClientId=${secondApp.id}`,
+            { headers: admin },
+        );
+        expect(revoked.status).toEqual(202);
+        expect((await revoked.json()).count).toBeGreaterThanOrEqual(1);
+
+        const remaining = await httpRequest(
+            suite,
+            'GET',
+            `/sessions?filter[sub]=${user.id}`,
+            { headers: admin },
+        );
+        expect((await remaining.json()).data.map((s: any) => s.id)).not.toContain(sessionId);
+    });
+
     it('derives the mfa-login completion attribution from the pending session', async () => {
         const password = 'attribution-mfa-password';
 


### PR DESCRIPTION
> **Stacked on #3400.** Base is `feat/account-console-session-binding`, because this builds on the `auth_session_tokens.client_id` column added there. Review or merge #3400 first; GitHub will retarget this to `master` automatically once it lands.

## Problem

Sessions can only be found by `auth_sessions.client_id`, and #3400 makes that column write-once, so it names the client that **first** authorized on the row. One browser session serves several applications, so an operator revoking application X after a compromise misses every session X served but did not create.

Concretely, with the admin console opened first and the account console second, `DELETE /sessions?filter[clientId]=<account-console>` matches nothing. Before #3400 the column was last-writer-wins, so it matched — differently partial, but partial either way. Neither answers "every session this application served".

## Change

`GET` and `DELETE /sessions` accept `?usedClientId=<id>`, a single id or a comma list. A session matches when **either**

- its own `client_id` names one of them (the client that first authorized), **or**
- an `EXISTS` over `auth_session_tokens.client_id` finds a token issued for one of them.

Both reaches are needed. The column alone misses every later application; the `EXISTS` alone misses a session whose token rows have since been swept by the cleanup component.

## Why a request parameter and not a rapiq filter

Inferring this from a user-supplied condition tree means deciding what a negated or OR-nested `clientId` means. On a bulk delete a wrong answer is a mass deletion, so the safe move is a parameter with exactly one meaning. It composes as a mandatory AND-ed bracket next to the existing `owner` constraint, so no client-supplied filter can widen it.

Its presence selects the admin bulk-revoke path on its own. Without that it would fall through to self-service and silently revoke the caller's own devices instead of the named application's sessions. That means it carries the same `SESSION_DELETE` gate and per-session realm match as any target filter — filter breadth still cannot escalate, so a `realm_admin` reaches only its own realm's sessions.

`filter[clientId]` is untouched and still matches the session column.

## Verification

- server-core 180/180 files, full suite green. `check:types` clean, ESLint clean.
- New test in `session-token-attribution.spec.ts` pins the actual capability gap: with two applications on one browser session, `filter[clientId]=<second app>` does **not** return the session, `usedClientId=<second app>` does, and the revoke removes it.

## Follow-up left open

The account console's Applications page revokes *consent*, which is prompt-level: it stops the next silent issue and leaves live tokens working. It could now offer a real "sign out of this application everywhere" by calling this endpoint. Not done here, and note the page lists consent rows, which `authorization/module.ts:57` skips for `builtIn` clients, so neither console appears there.
