### PR TITLE
feat!: namespace store cookies per client

### DIFF
--- a/apps/client-account-console/src/main.ts
+++ b/apps/client-account-console/src/main.ts
@@ -14,6 +14,7 @@ import {
     loadAuthorizationRequest,
     syncTranslatorLocaleFromManager,
 } from '@authup/client-web-kit';
+import { CLIENT_ACCOUNT_CONSOLE_NAME } from '@authup/core-kit';
 import { matchLocale } from '@authup/i18n';
 import { omitRecord } from '@authup/kit';
 import { OAuth2ErrorCode } from '@authup/specs';
@@ -199,6 +200,11 @@ const localeHandles = installLocale(app, {
 install(app, {
     baseURL: config.apiUrl,
     pinia,
+    // This console is served from the IdP origin, so without a namespace it
+    // shares one cookie set with the hosted auth pages: it would adopt
+    // whatever login came before it, and its own tokens would be readable by
+    // the next surface on the origin (plan 087).
+    cookiePrefix: CLIENT_ACCOUNT_CONSOLE_NAME,
     translatorLocale: matchLocale(localeHandles.resolved.value),
 });
 

--- a/apps/client-account-console/src/pages/index.vue
+++ b/apps/client-account-console/src/pages/index.vue
@@ -44,6 +44,7 @@ import {
 import { useRoute, useRouter } from 'vue-router';
 import { injectAccountConsoleConfig } from '../di';
 import { saveAccountConsoleRef, useAccountConsoleRef } from '../ref';
+import { readSsoRealmId } from '../sso-session';
 import { useAccountToasts } from './utils';
 
 export default defineComponent({
@@ -191,8 +192,14 @@ export default defineComponent({
         const handleRealmSelect = (realm: Realm) => kick(realm.id);
 
         // A `?realmId=` hint (deep link from a realm-specific app) skips the
-        // realm chooser. Suppressed while an error param is present so a
-        // denial cannot loop back into the flow without a user action.
+        // realm chooser, and so does an existing IdP session: this console
+        // holds its own cookie namespace (plan 087), so a visitor arriving
+        // from another application reads UNAUTHENTICATED here even though the
+        // IdP knows them. Their realm names what to authorize against, and
+        // the hosted page then issues without asking for credentials again.
+        //
+        // Suppressed while an error param is present so a denial cannot loop
+        // back into the flow without a user action.
         const kicked = ref(false);
         watchEffect(() => {
             if (kicked.value ||
@@ -204,9 +211,10 @@ export default defineComponent({
             const hint = typeof route.query.realmId === 'string' ?
                 route.query.realmId :
                 undefined;
-            if (hint) {
+            const realmKey = hint || readSsoRealmId();
+            if (realmKey) {
                 kicked.value = true;
-                Promise.resolve().then(() => kick(hint));
+                Promise.resolve().then(() => kick(realmKey));
             }
         });
 

--- a/apps/client-account-console/src/sso-session.ts
+++ b/apps/client-account-console/src/sso-session.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/* global document */
+
+import { CookieName } from '@authup/core-http-kit';
+
+/**
+ * Read the realm of the IdP's own SSO session, if one exists.
+ *
+ * This console keeps its tokens under its own cookie namespace (plan 087),
+ * so it cannot see, and must not use, the session the hosted auth pages hold
+ * on the same origin. But it still needs that session's REALM: a visitor
+ * arriving from another application has no tokens here yet, and without a
+ * realm the shell would show a realm chooser to somebody who is plainly
+ * signed in on the IdP.
+ *
+ * So this reads exactly one value out of the bare tier, to name the realm to
+ * authorize against. The tokens beside it are deliberately not read: the
+ * whole point of the namespace is that this console obtains its own.
+ */
+export function readSsoRealmId() : string | undefined {
+    if (typeof document === 'undefined') {
+        return undefined;
+    }
+
+    // The bare tier is what the hosted auth pages write, so the name carries
+    // no prefix. Reading it through `CookieName` keeps it tied to the kit's
+    // vocabulary rather than a literal that could drift.
+    const pattern = new RegExp(`(?:^|;\\s*)${CookieName.REALM}=([^;]+)`);
+    const match = document.cookie.match(pattern);
+    const raw = match?.[1];
+    if (!raw) {
+        return undefined;
+    }
+
+    // The value is a JSON `{ id, name }` written by the store. Both the
+    // percent-decoding and the parse are attacker-adjacent (any same-origin
+    // script can write a cookie), so a malformed value must degrade to "no
+    // SSO session" rather than throw out of a render.
+    try {
+        const parsed = JSON.parse(decodeURIComponent(raw));
+
+        if (
+            parsed &&
+            typeof parsed === 'object' &&
+            typeof parsed.id === 'string' &&
+            parsed.id.length > 0
+        ) {
+            return parsed.id;
+        }
+    } catch {
+        // ignore: a bad cookie means the chooser, never a broken page.
+    }
+
+    return undefined;
+}

--- a/apps/client-account-console/test/unit/sso-session.spec.ts
+++ b/apps/client-account-console/test/unit/sso-session.spec.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+// @vitest-environment happy-dom
+
+import { CookieName } from '@authup/core-http-kit';
+import {
+    afterEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { readSsoRealmId } from '../../src/sso-session';
+
+function setCookie(name: string, value: string) {
+    document.cookie = `${name}=${value}; path=/`;
+}
+
+afterEach(() => {
+    for (const entry of document.cookie.split(';')) {
+        const key = entry.split('=')[0]?.trim();
+        if (key) {
+            document.cookie = `${key}=; path=/; max-age=0`;
+        }
+    }
+});
+
+describe('src/sso-session', () => {
+    it('reads the realm id from the bare tier', () => {
+        setCookie(
+            CookieName.REALM,
+            encodeURIComponent(JSON.stringify({ id: 'realm-1', name: 'master' })),
+        );
+
+        expect(readSsoRealmId()).toEqual('realm-1');
+    });
+
+    it('returns undefined without an SSO session', () => {
+        expect(readSsoRealmId()).toBeUndefined();
+    });
+
+    it('ignores this console\'s own namespaced realm cookie', () => {
+        // The namespaced set is read by the store itself. If this reached for
+        // it too, the console would kick against its own stale realm instead
+        // of the realm the IdP session is actually in.
+        setCookie(
+            `account-console.${CookieName.REALM}`,
+            encodeURIComponent(JSON.stringify({ id: 'realm-mine', name: 'mine' })),
+        );
+
+        expect(readSsoRealmId()).toBeUndefined();
+    });
+
+    it.each([
+        ['not json at all', 'nonsense'],
+        ['a malformed percent escape', '%E0%A4%A'],
+        ['json without an id', encodeURIComponent(JSON.stringify({ name: 'master' }))],
+        ['a non-string id', encodeURIComponent(JSON.stringify({ id: 42 }))],
+        ['an empty id', encodeURIComponent(JSON.stringify({ id: '' }))],
+        ['a json primitive', encodeURIComponent(JSON.stringify('realm-1'))],
+    ])('degrades to undefined for %s', (_label, value) => {
+        // Any same-origin script can write this cookie, so a bad value has to
+        // mean "no SSO session", never an exception out of a render.
+        setCookie(CookieName.REALM, value);
+
+        expect(readSsoRealmId()).toBeUndefined();
+    });
+});

--- a/apps/client-admin-console/nuxt.config.ts
+++ b/apps/client-admin-console/nuxt.config.ts
@@ -109,6 +109,12 @@ export default defineNuxtConfig({
             {
                 apiURLRuntimeKey: 'apiUrl',
                 cookieDomainRuntimeKey: 'cookieDomain',
+                // Namespace this console's store cookies (plan 087). Its own
+                // origin would not need it, but cookies ignore the port, so
+                // in the default dev setup `localhost:3000` shares a jar with
+                // server-core on `:3001` and the two consoles would otherwise
+                // overwrite each other's session.
+                cookiePrefix: CLIENT_ADMIN_CONSOLE_NAME,
             } satisfies ModuleOptions,
         ],
         [

--- a/packages/client-web-kit/src/core/store/install.ts
+++ b/packages/client-web-kit/src/core/store/install.ts
@@ -75,6 +75,19 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
     const cookiePath = options.cookiePath || COOKIE_PATH;
 
     /**
+     * Namespace a store cookie under the configured application.
+     *
+     * `.` rather than `:` because RFC 6265 defines a cookie name as an RFC
+     * 2616 token, whose separator set includes `:`. Browsers accept it,
+     * proxies and cookie libraries do not uniformly.
+     */
+    const cookieName = (name: string) => (
+        options.cookiePrefix ? `${options.cookiePrefix}.${name}` : name
+    );
+
+    const cookieNames = Object.values(CookieName).map(cookieName);
+
+    /**
      * Drop the copies written before the path was pinned.
      *
      * Those sit on the browser's default-path for the writing document
@@ -93,6 +106,10 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
      * redundant: `/account` serves the console too, and a copy written from
      * `/account/password` sits on exactly `/account`, matching it. Only the
      * store's own names are touched, and never on the pinned path.
+     *
+     * With a `cookiePrefix` set, only THIS application's names are cleared.
+     * The bare tier belongs to the hosted auth pages, so clearing it would
+     * sign the visitor out of the IdP as a side effect of loading an app.
      */
     const dropShadowingCookies = () => {
         const pathname = typeof window === 'undefined' ?
@@ -114,7 +131,7 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
                 continue;
             }
 
-            for (const key of Object.values(CookieName)) {
+            for (const key of cookieNames) {
                 cookieUnset(key, { path });
             }
         }
@@ -141,7 +158,7 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
 
         let value : any;
         for (const key of keys) {
-            value = cookieGet(key);
+            value = cookieGet(cookieName(key));
             if (!value) {
                 continue;
             }
@@ -201,12 +218,12 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.ACCESS_TOKEN_EXPIRE_DATE, input, {
+                cookieSet(cookieName(CookieName.ACCESS_TOKEN_EXPIRE_DATE), input, {
                     maxAge: maxAgeFn(),
                     path: cookiePath,
                 });
             } else {
-                cookieUnset(CookieName.ACCESS_TOKEN_EXPIRE_DATE, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.ACCESS_TOKEN_EXPIRE_DATE), { path: cookiePath });
             }
         },
     );
@@ -216,12 +233,12 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         (input) => {
             if (input) {
                 const maxAge = maxAgeFn();
-                cookieSet(CookieName.ACCESS_TOKEN, input, {
+                cookieSet(cookieName(CookieName.ACCESS_TOKEN), input, {
                     maxAge,
                     path: cookiePath,
                 });
             } else {
-                cookieUnset(CookieName.ACCESS_TOKEN, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.ACCESS_TOKEN), { path: cookiePath });
             }
         },
     );
@@ -230,9 +247,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REFRESH_TOKEN_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REFRESH_TOKEN, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.REFRESH_TOKEN), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REFRESH_TOKEN, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.REFRESH_TOKEN), { path: cookiePath });
             }
         },
     );
@@ -241,9 +258,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.ID_TOKEN_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.ID_TOKEN, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.ID_TOKEN), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.ID_TOKEN, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.ID_TOKEN), { path: cookiePath });
             }
         },
     );
@@ -252,9 +269,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.USER_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.USER, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.USER), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.USER, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.USER), { path: cookiePath });
             }
         },
     );
@@ -263,9 +280,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REALM_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REALM, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.REALM), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REALM, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.REALM), { path: cookiePath });
             }
         },
     );
@@ -274,9 +291,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REALM_MANAGEMENT_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REALM_MANAGEMENT, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.REALM_MANAGEMENT), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REALM_MANAGEMENT, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.REALM_MANAGEMENT), { path: cookiePath });
             }
         },
     );

--- a/packages/client-web-kit/src/core/store/types.ts
+++ b/packages/client-web-kit/src/core/store/types.ts
@@ -71,5 +71,32 @@ export type StoreInstallOptions = {
      * reads any path through an iframe.
      */
     cookiePath?: string,
+    /**
+     * Namespace the store cookies under an application, as
+     * `<prefix>.<name>` (`account-console.access_token`).
+     *
+     * Cookies are per ORIGIN, not per application, and the hosted auth pages
+     * live on the same origin as anything server-core serves. Without a
+     * prefix every surface there shares one session: an application adopts
+     * whatever login came before it, and its own tokens are readable by the
+     * next one. Locally it is broader still, since cookies ignore the port,
+     * so an app on `localhost:3000` shares the jar with the IdP on `:3001`.
+     *
+     * The prefix is what makes the tiers distinguishable. BARE names belong
+     * to the IdP's own SSO session, owned by the hosted auth pages; a
+     * PREFIXED set belongs to one application. Every relying party embedding
+     * the kit should set it to its OAuth2 client name. The auth pages must
+     * not: they are the IdP surface rather than a client, and their session
+     * is what the `prompt=none` / `select_account` ladder reads.
+     *
+     * Use the client NAME, which an application knows before it has any
+     * session, never the client id, which it cannot know until it has one.
+     * Names are unique per realm, so two realms' same-named clients still
+     * collide on one origin and switching realms replaces the session. That
+     * matches the single-cookie-set behaviour this replaces.
+     *
+     * Unset keeps the bare names, so an existing consumer is unchanged.
+     */
+    cookiePrefix?: string,
     pinia?: Pinia
 };

--- a/packages/client-web-kit/src/module.ts
+++ b/packages/client-web-kit/src/module.ts
@@ -65,6 +65,7 @@ export function install(app: App, options: Options): void {
         cookieGet: options.cookieGet,
         cookieUnset: options.cookieUnset,
         cookiePath: options.cookiePath,
+        cookiePrefix: options.cookiePrefix,
     });
 
     installHTTPClientAuthenticationHook(app, {

--- a/packages/client-web-kit/src/types.ts
+++ b/packages/client-web-kit/src/types.ts
@@ -116,6 +116,13 @@ export type Options = {
      * See the store install option of the same name.
      */
     cookiePath?: string,
+    /**
+     * Namespace the store cookies under this application's OAuth2 client
+     * name, as `<prefix>.<name>`. See the store install option of the same
+     * name: bare names are the IdP's own SSO session, a prefixed set belongs
+     * to one application.
+     */
+    cookiePrefix?: string,
 
     pinia?: Pinia,
     isServer?: boolean,

--- a/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
@@ -47,7 +47,7 @@ type CookieUnsetCall = {
     options: CookieOptions
 };
 
-function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
+function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string, cookiePrefix?: string) {
     const jar = new Map<string, unknown>(Object.entries(seed));
     const setCalls : CookieSetCall[] = [];
     const unsetCalls : CookieUnsetCall[] = [];
@@ -67,6 +67,7 @@ function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
 
     installStore(app, {
         cookiePath,
+        cookiePrefix,
         httpClient,
         pinia,
         cookieGet: (key) => jar.get(key),
@@ -91,6 +92,7 @@ function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
         httpClient, 
         setCalls, 
         unsetCalls,
+        jar,
     };
 }
 
@@ -297,6 +299,108 @@ describe('core/store/install-cookies path', () => {
         expect(unsetCalls).not.toHaveLength(0);
         for (const call of [...setCalls, ...unsetCalls]) {
             expect(call.options.path).toEqual('/auth');
+        }
+    });
+});
+
+describe('core/store/install-cookies (per-client namespace)', () => {
+    const PREFIX = 'account-console';
+    const name = (key: string) => `${PREFIX}.${key}`;
+
+    it('hydrates from the namespaced cookies', () => {
+        const { store } = buildApp({
+            [name(CookieName.ACCESS_TOKEN)]: 'mine-at',
+            [name(CookieName.ACCESS_TOKEN_EXPIRE_DATE)]: '2099-01-01T00:00:00.000Z',
+            [name(CookieName.REFRESH_TOKEN)]: 'mine-rt',
+            [name(CookieName.REALM)]: { id: 'realm-1', name: 'master' },
+        }, undefined, PREFIX);
+
+        expect(store.accessToken).toEqual('mine-at');
+        expect(store.refreshToken).toEqual('mine-rt');
+        expect(store.realm).toMatchObject({ id: 'realm-1' });
+    });
+
+    it('does NOT adopt the bare tier', () => {
+        // The bare names are the IdP's own SSO session, written by the hosted
+        // auth pages on the same origin. A namespaced app must ignore them:
+        // adopting them is the whole defect this replaces.
+        const { store } = buildApp({
+            [CookieName.ACCESS_TOKEN]: 'sso-at',
+            [CookieName.REFRESH_TOKEN]: 'sso-rt',
+            [CookieName.USER]: { id: 'someone-else', name: 'other' },
+        }, undefined, PREFIX);
+
+        expect(store.accessToken).toBeNull();
+        expect(store.refreshToken).toBeNull();
+        expect(store.user).toBeNull();
+        expect(store.loggedIn).toBe(false);
+    });
+
+    it('writes only namespaced cookies, leaving the bare tier untouched', async () => {
+        const {
+            store, 
+            setCalls, 
+            jar, 
+        } = buildApp({ [CookieName.ACCESS_TOKEN]: 'sso-at' }, undefined, PREFIX);
+
+        await store.login({ name: 'admin', password: 'start123' });
+
+        expect(setCalls).not.toHaveLength(0);
+        for (const call of setCalls) {
+            expect(call.key.startsWith(`${PREFIX}.`)).toBe(true);
+        }
+
+        // the reverse leak: this app's tokens are not readable under the bare
+        // names, so the next surface on the origin cannot pick them up
+        expect(jar.get(CookieName.ACCESS_TOKEN)).toEqual('sso-at');
+        expect(jar.get(name(CookieName.ACCESS_TOKEN))).toEqual('at-1');
+    });
+
+    it('keeps the pinned hydration order under a prefix', () => {
+        // The expire date must still hydrate before the access token, or the
+        // write-back echo re-persists the token as a session cookie.
+        const { setCalls } = buildApp({
+            [name(CookieName.ACCESS_TOKEN)]: 'mine-at',
+            [name(CookieName.ACCESS_TOKEN_EXPIRE_DATE)]: '2099-01-01T00:00:00.000Z',
+        }, undefined, PREFIX);
+
+        const echo = setCalls.find((call) => call.key === name(CookieName.ACCESS_TOKEN));
+        expect(echo!.options.maxAge).toBeTypeOf('number');
+        expect(echo!.options.maxAge!).toBeGreaterThan(0);
+    });
+
+    it('clears only its own names when dropping shadowing copies', () => {
+        // The clear only runs for a path with segments, so the document has
+        // to sit below the root for this to exercise anything.
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            writable: true,
+            value: { pathname: '/account/password' },
+        });
+
+        try {
+            const { unsetCalls } = buildApp({}, undefined, PREFIX);
+
+            expect(unsetCalls).not.toHaveLength(0);
+
+            // Every clear targets this app's namespace. Clearing the bare
+            // tier would sign the visitor out of the IdP as a side effect of
+            // loading this app.
+            for (const call of unsetCalls) {
+                expect(call.key.startsWith(`${PREFIX}.`)).toBe(true);
+            }
+
+            // and it does reach its own names on a shadowing path
+            expect(unsetCalls.some(
+                (call) => call.key === name(CookieName.ACCESS_TOKEN) &&
+                    call.options.path === '/account',
+            )).toBe(true);
+        } finally {
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                writable: true,
+                value: { pathname: '/' },
+            });
         }
     });
 });

--- a/packages/client-web-nuxt/src/module.ts
+++ b/packages/client-web-nuxt/src/module.ts
@@ -39,6 +39,7 @@ export default defineNuxtModule<ModuleOptions>({
 
             cookieDomain: options.cookieDomain,
             cookieDomainRuntimeKey: options.cookieDomainRuntimeKey,
+            cookiePrefix: options.cookiePrefix,
 
             homeRoute: options.homeRoute,
             loginRoute: options.loginRoute,

--- a/packages/client-web-nuxt/src/runtime/plugins/kit.ts
+++ b/packages/client-web-nuxt/src/runtime/plugins/kit.ts
@@ -91,6 +91,7 @@ export default defineNuxtPlugin({
         install(ctx.vueApp, {
             pinia: ctx.$pinia as Pinia,
             baseURL,
+            cookiePrefix: (runtimeConfig.public.authup as RuntimeOptions).cookiePrefix,
             cookieSet: (key, value, options) => {
                 const app = tryUseNuxtApp();
                 if (app) {

--- a/packages/client-web-nuxt/src/runtime/types.ts
+++ b/packages/client-web-nuxt/src/runtime/types.ts
@@ -35,6 +35,17 @@ export type RuntimeOptions = {
     cookieDomainRuntimeKey?: string,
 
     /**
+     * Namespace the store cookies under this application's OAuth2 client
+     * name, as `<prefix>.<name>`.
+     *
+     * Set it whenever the app can share an origin (or a host, since cookies
+     * ignore the port) with the authup IdP or another kit app. Bare names
+     * belong to the IdP's own SSO session; a prefixed set belongs to one
+     * application.
+     */
+    cookiePrefix?: string,
+
+    /**
      * Path of the home route
      * Default: /
      */


### PR DESCRIPTION
> **Stacked on #3400.** Base is `feat/account-console-session-binding`. GitHub retargets this to `master` once that lands.

## Problem

Cookies are per **origin**, not per application, and the hosted auth pages share their origin with everything else server-core serves. So every surface there used one set of tokens under bare names (`access_token`, `refresh_token`, …).

Two consequences, in both directions:

- The account console **adopts** whatever login came before it, so the `account-console` client's `accessPolicyId` is never evaluated for a visitor arriving with a lingering session.
- Its own tokens are **readable** by the next surface on the origin, including the admin console or any trusted-origin app sharing the domain.

Locally it is broader still: cookies ignore the port, so an app on `localhost:3000` shares the jar with the IdP on `:3001`.

An earlier revision of #3400 answered this by *detecting* a foreign session (a `client_name` claim, a store ref, a gate that re-minted through a silent `prompt=none` flow). That was a check layered on top of a sharing problem. This removes the sharing, so the question cannot arise, and it closes the reverse leak the detection approach never addressed.

## Change

The store takes a `cookiePrefix` and writes `<prefix>.<name>`. The prefix alone distinguishes two tiers:

- **Bare names are the IdP's own SSO session**, owned by the hosted auth pages. They are not a client, they are the IdP surface, and their session is what the `prompt=none` / `select_account` ladder reads. `apps/client-auth-console` is therefore unchanged.
- **A prefixed set belongs to one application.** Both consoles set it to their OAuth2 client name; any RP embedding the kit should too.

Threaded through `@authup/client-web-kit`'s install options and `@authup/client-web-nuxt`'s module options.

## Two decisions worth stating

**`.` and not `:`.** RFC 6265 defines a cookie name as an RFC 2616 `token`, whose separator set includes `:`. Browsers accept it; proxies, WAFs and cookie libraries do not uniformly.

**Client name, not client id.** The name is what an application knows *before* it has a session; the id it cannot know until it has one, which is exactly when it needs to read a cookie. Names are unique per realm, so two realms' same-named clients still collide on one origin and switching realms replaces the session — which is what the single cookie set already did, so this preserves the behaviour rather than regressing it.

## Load-bearing details

- **Clearing shadowed copies follows the prefix and leaves the bare tier alone.** Clearing it would sign the visitor out of the IdP as a side effect of loading an application. Pinned by a test that fails if the implementation reverts to the unprefixed name list (verified by reintroducing the bug).
- **The admin console gets a prefix too**, despite its own origin, because the default dev setup shares a host with server-core.
- **The account console reads one value out of the bare tier: the realm.** A visitor arriving from another application now has no tokens here and would otherwise see a realm chooser while plainly signed in on the IdP. The tokens beside it are deliberately not read.

## Breaking change

Cookies written by an application configured with a `cookiePrefix` use `<prefix>.<name>`. Existing bare cookies are **not** migrated — they cannot be attributed to an application, since they were written by the hosted login and possibly overwritten by a console — so each prefixed application signs out once on upgrade. A consumer reading `CookieName` values off the document directly must add the same prefix. Inside this repo `CookieName` has exactly one consumer (`core/store/install.ts`), but it is exported from `@authup/core-http-kit`'s public surface, so **hub and portal should be checked before release notes.**

## Verification

- Build 24/24 projects; ESLint clean.
- client-web-kit 29 files / 206 tests, account console 3 files / 23 tests, server-core 180/180 unaffected.
- New tests: hydration from the namespaced names; the bare tier is **not** adopted; writes never touch the bare tier and this app's tokens are not readable under bare names; the pinned expire-date-before-token hydration order survives the prefix; shadow-clearing touches only this namespace. Plus a spec for the realm reader covering malformed, non-string, empty and non-object payloads, since any same-origin script can write that cookie.
