### PR TITLE
feat!: namespace store cookies per client (parked)

### DIFF
--- a/apps/client-account-console/src/main.ts
+++ b/apps/client-account-console/src/main.ts
@@ -14,6 +14,7 @@ import {
     loadAuthorizationRequest,
     syncTranslatorLocaleFromManager,
 } from '@authup/client-web-kit';
+import { CLIENT_ACCOUNT_CONSOLE_NAME } from '@authup/core-kit';
 import { matchLocale } from '@authup/i18n';
 import { omitRecord } from '@authup/kit';
 import { OAuth2ErrorCode } from '@authup/specs';
@@ -199,6 +200,11 @@ const localeHandles = installLocale(app, {
 install(app, {
     baseURL: config.apiUrl,
     pinia,
+    // This console is served from the IdP origin, so without a namespace it
+    // shares one cookie set with the hosted auth pages: it would adopt
+    // whatever login came before it, and its own tokens would be readable by
+    // the next surface on the origin (plan 087).
+    cookiePrefix: CLIENT_ACCOUNT_CONSOLE_NAME,
     translatorLocale: matchLocale(localeHandles.resolved.value),
 });
 

--- a/apps/client-account-console/src/pages/index.vue
+++ b/apps/client-account-console/src/pages/index.vue
@@ -193,6 +193,11 @@ export default defineComponent({
         // A `?realmId=` hint (deep link from a realm-specific app) skips the
         // realm chooser. Suppressed while an error param is present so a
         // denial cannot loop back into the flow without a user action.
+        //
+        // NOTE: with its own cookie namespace this console no longer adopts
+        // the IdP session, so a visitor arriving from another application
+        // picks a realm once. Seeding that from the IdP session needs a
+        // carrier the store does not currently write (see plan 087).
         const kicked = ref(false);
         watchEffect(() => {
             if (kicked.value ||

--- a/apps/client-admin-console/nuxt.config.ts
+++ b/apps/client-admin-console/nuxt.config.ts
@@ -109,6 +109,12 @@ export default defineNuxtConfig({
             {
                 apiURLRuntimeKey: 'apiUrl',
                 cookieDomainRuntimeKey: 'cookieDomain',
+                // Namespace this console's store cookies (plan 087). Its own
+                // origin would not need it, but cookies ignore the port, so
+                // in the default dev setup `localhost:3000` shares a jar with
+                // server-core on `:3001` and the two consoles would otherwise
+                // overwrite each other's session.
+                cookiePrefix: CLIENT_ADMIN_CONSOLE_NAME,
             } satisfies ModuleOptions,
         ],
         [

--- a/packages/client-web-kit/src/core/store/install.ts
+++ b/packages/client-web-kit/src/core/store/install.ts
@@ -75,6 +75,19 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
     const cookiePath = options.cookiePath || COOKIE_PATH;
 
     /**
+     * Namespace a store cookie under the configured application.
+     *
+     * `.` rather than `:` because RFC 6265 defines a cookie name as an RFC
+     * 2616 token, whose separator set includes `:`. Browsers accept it,
+     * proxies and cookie libraries do not uniformly.
+     */
+    const cookieName = (name: string) => (
+        options.cookiePrefix ? `${options.cookiePrefix}.${name}` : name
+    );
+
+    const cookieNames = Object.values(CookieName).map(cookieName);
+
+    /**
      * Drop the copies written before the path was pinned.
      *
      * Those sit on the browser's default-path for the writing document
@@ -93,6 +106,10 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
      * redundant: `/account` serves the console too, and a copy written from
      * `/account/password` sits on exactly `/account`, matching it. Only the
      * store's own names are touched, and never on the pinned path.
+     *
+     * With a `cookiePrefix` set, only THIS application's names are cleared.
+     * The bare tier belongs to the hosted auth pages, so clearing it would
+     * sign the visitor out of the IdP as a side effect of loading an app.
      */
     const dropShadowingCookies = () => {
         const pathname = typeof window === 'undefined' ?
@@ -114,7 +131,7 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
                 continue;
             }
 
-            for (const key of Object.values(CookieName)) {
+            for (const key of cookieNames) {
                 cookieUnset(key, { path });
             }
         }
@@ -141,7 +158,7 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
 
         let value : any;
         for (const key of keys) {
-            value = cookieGet(key);
+            value = cookieGet(cookieName(key));
             if (!value) {
                 continue;
             }
@@ -201,12 +218,12 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.ACCESS_TOKEN_EXPIRE_DATE_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.ACCESS_TOKEN_EXPIRE_DATE, input, {
+                cookieSet(cookieName(CookieName.ACCESS_TOKEN_EXPIRE_DATE), input, {
                     maxAge: maxAgeFn(),
                     path: cookiePath,
                 });
             } else {
-                cookieUnset(CookieName.ACCESS_TOKEN_EXPIRE_DATE, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.ACCESS_TOKEN_EXPIRE_DATE), { path: cookiePath });
             }
         },
     );
@@ -216,12 +233,12 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         (input) => {
             if (input) {
                 const maxAge = maxAgeFn();
-                cookieSet(CookieName.ACCESS_TOKEN, input, {
+                cookieSet(cookieName(CookieName.ACCESS_TOKEN), input, {
                     maxAge,
                     path: cookiePath,
                 });
             } else {
-                cookieUnset(CookieName.ACCESS_TOKEN, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.ACCESS_TOKEN), { path: cookiePath });
             }
         },
     );
@@ -230,9 +247,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REFRESH_TOKEN_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REFRESH_TOKEN, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.REFRESH_TOKEN), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REFRESH_TOKEN, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.REFRESH_TOKEN), { path: cookiePath });
             }
         },
     );
@@ -241,9 +258,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.ID_TOKEN_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.ID_TOKEN, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.ID_TOKEN), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.ID_TOKEN, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.ID_TOKEN), { path: cookiePath });
             }
         },
     );
@@ -252,9 +269,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.USER_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.USER, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.USER), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.USER, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.USER), { path: cookiePath });
             }
         },
     );
@@ -263,9 +280,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REALM_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REALM, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.REALM), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REALM, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.REALM), { path: cookiePath });
             }
         },
     );
@@ -274,9 +291,9 @@ export function installStore(app: App, options: StoreInstallOptions = {}) {
         StoreDispatcherEventName.REALM_MANAGEMENT_UPDATED,
         (input) => {
             if (input) {
-                cookieSet(CookieName.REALM_MANAGEMENT, input, { path: cookiePath });
+                cookieSet(cookieName(CookieName.REALM_MANAGEMENT), input, { path: cookiePath });
             } else {
-                cookieUnset(CookieName.REALM_MANAGEMENT, { path: cookiePath });
+                cookieUnset(cookieName(CookieName.REALM_MANAGEMENT), { path: cookiePath });
             }
         },
     );

--- a/packages/client-web-kit/src/core/store/types.ts
+++ b/packages/client-web-kit/src/core/store/types.ts
@@ -71,5 +71,32 @@ export type StoreInstallOptions = {
      * reads any path through an iframe.
      */
     cookiePath?: string,
+    /**
+     * Namespace the store cookies under an application, as
+     * `<prefix>.<name>` (`account-console.access_token`).
+     *
+     * Cookies are per ORIGIN, not per application, and the hosted auth pages
+     * live on the same origin as anything server-core serves. Without a
+     * prefix every surface there shares one session: an application adopts
+     * whatever login came before it, and its own tokens are readable by the
+     * next one. Locally it is broader still, since cookies ignore the port,
+     * so an app on `localhost:3000` shares the jar with the IdP on `:3001`.
+     *
+     * The prefix is what makes the tiers distinguishable. BARE names belong
+     * to the IdP's own SSO session, owned by the hosted auth pages; a
+     * PREFIXED set belongs to one application. Every relying party embedding
+     * the kit should set it to its OAuth2 client name. The auth pages must
+     * not: they are the IdP surface rather than a client, and their session
+     * is what the `prompt=none` / `select_account` ladder reads.
+     *
+     * Use the client NAME, which an application knows before it has any
+     * session, never the client id, which it cannot know until it has one.
+     * Names are unique per realm, so two realms' same-named clients still
+     * collide on one origin and switching realms replaces the session. That
+     * matches the single-cookie-set behaviour this replaces.
+     *
+     * Unset keeps the bare names, so an existing consumer is unchanged.
+     */
+    cookiePrefix?: string,
     pinia?: Pinia
 };

--- a/packages/client-web-kit/src/module.ts
+++ b/packages/client-web-kit/src/module.ts
@@ -65,6 +65,7 @@ export function install(app: App, options: Options): void {
         cookieGet: options.cookieGet,
         cookieUnset: options.cookieUnset,
         cookiePath: options.cookiePath,
+        cookiePrefix: options.cookiePrefix,
     });
 
     installHTTPClientAuthenticationHook(app, {

--- a/packages/client-web-kit/src/types.ts
+++ b/packages/client-web-kit/src/types.ts
@@ -116,6 +116,13 @@ export type Options = {
      * See the store install option of the same name.
      */
     cookiePath?: string,
+    /**
+     * Namespace the store cookies under this application's OAuth2 client
+     * name, as `<prefix>.<name>`. See the store install option of the same
+     * name: bare names are the IdP's own SSO session, a prefixed set belongs
+     * to one application.
+     */
+    cookiePrefix?: string,
 
     pinia?: Pinia,
     isServer?: boolean,

--- a/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
@@ -47,7 +47,7 @@ type CookieUnsetCall = {
     options: CookieOptions
 };
 
-function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
+function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string, cookiePrefix?: string) {
     const jar = new Map<string, unknown>(Object.entries(seed));
     const setCalls : CookieSetCall[] = [];
     const unsetCalls : CookieUnsetCall[] = [];
@@ -67,6 +67,7 @@ function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
 
     installStore(app, {
         cookiePath,
+        cookiePrefix,
         httpClient,
         pinia,
         cookieGet: (key) => jar.get(key),
@@ -91,6 +92,7 @@ function buildApp(seed: Record<string, unknown> = {}, cookiePath?: string) {
         httpClient, 
         setCalls, 
         unsetCalls,
+        jar,
     };
 }
 
@@ -297,6 +299,108 @@ describe('core/store/install-cookies path', () => {
         expect(unsetCalls).not.toHaveLength(0);
         for (const call of [...setCalls, ...unsetCalls]) {
             expect(call.options.path).toEqual('/auth');
+        }
+    });
+});
+
+describe('core/store/install-cookies (per-client namespace)', () => {
+    const PREFIX = 'account-console';
+    const name = (key: string) => `${PREFIX}.${key}`;
+
+    it('hydrates from the namespaced cookies', () => {
+        const { store } = buildApp({
+            [name(CookieName.ACCESS_TOKEN)]: 'mine-at',
+            [name(CookieName.ACCESS_TOKEN_EXPIRE_DATE)]: '2099-01-01T00:00:00.000Z',
+            [name(CookieName.REFRESH_TOKEN)]: 'mine-rt',
+            [name(CookieName.REALM)]: { id: 'realm-1', name: 'master' },
+        }, undefined, PREFIX);
+
+        expect(store.accessToken).toEqual('mine-at');
+        expect(store.refreshToken).toEqual('mine-rt');
+        expect(store.realm).toMatchObject({ id: 'realm-1' });
+    });
+
+    it('does NOT adopt the bare tier', () => {
+        // The bare names are the IdP's own SSO session, written by the hosted
+        // auth pages on the same origin. A namespaced app must ignore them:
+        // adopting them is the whole defect this replaces.
+        const { store } = buildApp({
+            [CookieName.ACCESS_TOKEN]: 'sso-at',
+            [CookieName.REFRESH_TOKEN]: 'sso-rt',
+            [CookieName.USER]: { id: 'someone-else', name: 'other' },
+        }, undefined, PREFIX);
+
+        expect(store.accessToken).toBeNull();
+        expect(store.refreshToken).toBeNull();
+        expect(store.user).toBeNull();
+        expect(store.loggedIn).toBe(false);
+    });
+
+    it('writes only namespaced cookies, leaving the bare tier untouched', async () => {
+        const {
+            store, 
+            setCalls, 
+            jar, 
+        } = buildApp({ [CookieName.ACCESS_TOKEN]: 'sso-at' }, undefined, PREFIX);
+
+        await store.login({ name: 'admin', password: 'start123' });
+
+        expect(setCalls).not.toHaveLength(0);
+        for (const call of setCalls) {
+            expect(call.key.startsWith(`${PREFIX}.`)).toBe(true);
+        }
+
+        // the reverse leak: this app's tokens are not readable under the bare
+        // names, so the next surface on the origin cannot pick them up
+        expect(jar.get(CookieName.ACCESS_TOKEN)).toEqual('sso-at');
+        expect(jar.get(name(CookieName.ACCESS_TOKEN))).toEqual('at-1');
+    });
+
+    it('keeps the pinned hydration order under a prefix', () => {
+        // The expire date must still hydrate before the access token, or the
+        // write-back echo re-persists the token as a session cookie.
+        const { setCalls } = buildApp({
+            [name(CookieName.ACCESS_TOKEN)]: 'mine-at',
+            [name(CookieName.ACCESS_TOKEN_EXPIRE_DATE)]: '2099-01-01T00:00:00.000Z',
+        }, undefined, PREFIX);
+
+        const echo = setCalls.find((call) => call.key === name(CookieName.ACCESS_TOKEN));
+        expect(echo!.options.maxAge).toBeTypeOf('number');
+        expect(echo!.options.maxAge!).toBeGreaterThan(0);
+    });
+
+    it('clears only its own names when dropping shadowing copies', () => {
+        // The clear only runs for a path with segments, so the document has
+        // to sit below the root for this to exercise anything.
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            writable: true,
+            value: { pathname: '/account/password' },
+        });
+
+        try {
+            const { unsetCalls } = buildApp({}, undefined, PREFIX);
+
+            expect(unsetCalls).not.toHaveLength(0);
+
+            // Every clear targets this app's namespace. Clearing the bare
+            // tier would sign the visitor out of the IdP as a side effect of
+            // loading this app.
+            for (const call of unsetCalls) {
+                expect(call.key.startsWith(`${PREFIX}.`)).toBe(true);
+            }
+
+            // and it does reach its own names on a shadowing path
+            expect(unsetCalls.some(
+                (call) => call.key === name(CookieName.ACCESS_TOKEN) &&
+                    call.options.path === '/account',
+            )).toBe(true);
+        } finally {
+            Object.defineProperty(window, 'location', {
+                configurable: true,
+                writable: true,
+                value: { pathname: '/' },
+            });
         }
     });
 });

--- a/packages/client-web-nuxt/src/module.ts
+++ b/packages/client-web-nuxt/src/module.ts
@@ -39,6 +39,7 @@ export default defineNuxtModule<ModuleOptions>({
 
             cookieDomain: options.cookieDomain,
             cookieDomainRuntimeKey: options.cookieDomainRuntimeKey,
+            cookiePrefix: options.cookiePrefix,
 
             homeRoute: options.homeRoute,
             loginRoute: options.loginRoute,

--- a/packages/client-web-nuxt/src/runtime/plugins/kit.ts
+++ b/packages/client-web-nuxt/src/runtime/plugins/kit.ts
@@ -91,6 +91,7 @@ export default defineNuxtPlugin({
         install(ctx.vueApp, {
             pinia: ctx.$pinia as Pinia,
             baseURL,
+            cookiePrefix: (runtimeConfig.public.authup as RuntimeOptions).cookiePrefix,
             cookieSet: (key, value, options) => {
                 const app = tryUseNuxtApp();
                 if (app) {

--- a/packages/client-web-nuxt/src/runtime/types.ts
+++ b/packages/client-web-nuxt/src/runtime/types.ts
@@ -35,6 +35,17 @@ export type RuntimeOptions = {
     cookieDomainRuntimeKey?: string,
 
     /**
+     * Namespace the store cookies under this application's OAuth2 client
+     * name, as `<prefix>.<name>`.
+     *
+     * Set it whenever the app can share an origin (or a host, since cookies
+     * ignore the port) with the authup IdP or another kit app. Bare names
+     * belong to the IdP's own SSO session; a prefixed set belongs to one
+     * application.
+     */
+    cookiePrefix?: string,
+
+    /**
      * Path of the home route
      * Default: /
      */


### PR DESCRIPTION
> **Parked draft.** Held pending the console credential decision in plan 088. If the consoles move to an opaque session identifier, namespacing JWT cookies is largely moot, so this should not be built on until that is settled.

The server-side half of the original stack was split out and is mergeable on its own as #3404.

## What this does

Cookies are per **origin**, and the hosted auth pages share theirs with everything server-core serves, so every surface used one set of tokens: the account console adopted whatever login came before it, and its own tokens were readable by the next surface. Locally it is broader still, since cookies ignore the port.

The store takes a `cookiePrefix` and writes `<prefix>.<name>`. Bare names are the IdP's own SSO session (owned by the hosted auth pages, which are the IdP surface rather than a client); a prefixed set belongs to one application.

`.` and not `:` because RFC 6265 defines a cookie name as an RFC 2616 `token`, whose separator set includes `:`. The prefix is the client **name**, which an app knows before it has a session, never the id, which it cannot know until it has one.

Shadow-clearing follows the prefix and deliberately leaves the bare tier alone: clearing it would sign the visitor out of the IdP as a side effect of loading an app. Pinned by a test verified to fail if the implementation reverts.

## Why it is parked

**Header size.** Namespacing fixes sharing by making the IdP origin carry two cookie sets instead of one, so header weight roughly doubles there: three JWTs plus a `user` blob per set, on every request including assets. Roughly 3-8 KB against nginx's default 8 KB buffer. An opaque session identifier collapses that to about 40 bytes and also makes the credential `HttpOnly`, which no amount of namespacing achieves.

**Realm continuity.** With its own namespace the account console no longer adopts the IdP session, so a visitor arriving from another application picks a realm once. An earlier revision read the realm from the bare tier; that could not work, because nothing writes that cookie (`setRealm` is called only by cleanup and hydration, while introspection writes `realm.value` directly by design). It was removed rather than carried along.