### PR TITLE
test(server-core): stop parallel workers from sharing one test database

### DIFF
--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -13,6 +13,18 @@
   so its own `import 'reflect-metadata'` does not reach test-file
   contexts. Any spec importing `src/core` transitively loads x509 (via the
   client-certificate module), so this must stay — do not remove it.
+- **Per-worker sqlite isolation (server-core, issue #3405)**: spec files run
+  in parallel vitest workers, so a shared database file made the suite flake
+  on a different spec each run. The global setup provisions a template
+  database at `writable/test.sql`; `createTestDatabaseModuleForSuite` gives
+  every worker its own copy (`writable/test-<poolId>.sql`, keyed by
+  `VITEST_POOL_ID`), created on first use in that worker and swept by the
+  next global setup. Files that reuse a pool slot share its copy
+  sequentially, so a spec must never rely on state written by another spec
+  file. The MySQL/Postgres runs have no per-worker copy (one shared server
+  database), so `test/vitest.config.ts` turns `fileParallelism` off for
+  them instead; expect those runs to take several times the sqlite
+  wall-clock.
 
 ## Running Tests
 

--- a/apps/server-core/test/app/database.ts
+++ b/apps/server-core/test/app/database.ts
@@ -14,7 +14,20 @@ import { ConfigInjectionKey, DatabaseModule } from '../../src';
 import type { IContainer } from 'eldin';
 import { PACKAGE_PATH } from '../../src/path.ts';
 
-async function resolveDataSourceOptions(container: IContainer) {
+const DATABASE_DIRECTORY_PATH = path.join(PACKAGE_PATH, 'writable');
+const TEMPLATE_DATABASE_PATH = path.join(DATABASE_DIRECTORY_PATH, 'test.sql');
+const WORKER_DATABASE_REGEX = /^test-\d+\.sql$/;
+
+// Spec files run in parallel worker processes, so every worker gets its own
+// copy of the provisioned template database. VITEST_POOL_ID is stable per
+// pool slot: two concurrently-running files never share it, while files that
+// reuse a slot sequentially share the copy (the pre-existing single-file
+// semantics, minus the cross-worker races).
+function buildWorkerDatabasePath(): string {
+    return path.join(DATABASE_DIRECTORY_PATH, `test-${process.env.VITEST_POOL_ID || '0'}.sql`);
+}
+
+async function resolveDataSourceOptions(container: IContainer, database: string) {
     const config = container.resolve(ConfigInjectionKey);
 
     if (config.env !== EnvironmentName.TEST) {
@@ -27,7 +40,7 @@ async function resolveDataSourceOptions(container: IContainer) {
     } else {
         config.db = {
             type: 'better-sqlite3',
-            database: path.join(PACKAGE_PATH, 'writable', 'test.sql'),
+            database,
         };
     }
 
@@ -36,22 +49,29 @@ async function resolveDataSourceOptions(container: IContainer) {
 
 export function createTestDatabaseModuleForSetup(): DatabaseModule {
     return new DatabaseModule({
-        prepareBuild: resolveDataSourceOptions,
+        prepareBuild: (container) => resolveDataSourceOptions(container, TEMPLATE_DATABASE_PATH),
         async setup(_container, options) {
-            if (typeof options.database === 'string') {
+            if (options.type === 'better-sqlite3' && typeof options.database === 'string') {
                 fs.rmSync(options.database, { force: true });
                 fs.mkdirSync(path.dirname(options.database), { recursive: true });
+
+                const entries = fs.readdirSync(DATABASE_DIRECTORY_PATH);
+                for (const entry of entries) {
+                    if (WORKER_DATABASE_REGEX.test(entry)) {
+                        fs.rmSync(path.join(DATABASE_DIRECTORY_PATH, entry), { force: true });
+                    }
+                }
             } else {
                 await dropDatabase({
                     options,
-                    ifExist: true, 
+                    ifExist: true,
                 });
             }
 
             await createDatabase({
                 options,
                 synchronize: false,
-                ifNotExist: true, 
+                ifNotExist: true,
             });
         },
         async migrate(_container, dataSource) {
@@ -73,10 +93,27 @@ export function createTestDatabaseModuleForSuite(): DatabaseModule {
                 process.env.DB_DATABASE = connection.database;
             }
 
-            await resolveDataSourceOptions(container);
+            await resolveDataSourceOptions(container, buildWorkerDatabasePath());
         },
-        async setup() {
-            // do nothing — DB already exists from global setup
+        async setup(_container, options) {
+            if (options.type !== 'better-sqlite3' || typeof options.database !== 'string') {
+                return;
+            }
+
+            if (fs.existsSync(options.database)) {
+                return;
+            }
+
+            if (!fs.existsSync(TEMPLATE_DATABASE_PATH)) {
+                throw new Error(
+                    `The provisioned template database is missing (${TEMPLATE_DATABASE_PATH}). ` +
+                    'Run the suite via "npm run test --workspace=apps/server-core" ' +
+                    '(or "npx vitest run --config test/vitest.config.ts") so the global setup creates it.',
+                );
+            }
+
+            fs.mkdirSync(path.dirname(options.database), { recursive: true });
+            fs.copyFileSync(TEMPLATE_DATABASE_PATH, options.database);
         },
         async migrate(_container, dataSource) {
             await dataSource.synchronize();

--- a/apps/server-core/test/vitest.config.ts
+++ b/apps/server-core/test/vitest.config.ts
@@ -8,6 +8,17 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+// The sqlite run isolates parallel workers via per-worker copies of the
+// provisioned template database (see test/app/database.ts). The
+// mysql/postgres runs have no equivalent (every worker shares the one
+// server database), so their spec files must not run concurrently:
+// concurrent files corrupt each other's rows and the suite fails on a
+// different spec each run (#3405).
+const databaseType = process.env.DB_TYPE;
+const usesSharedServerDatabase = !!databaseType &&
+    databaseType !== 'better-sqlite3' &&
+    databaseType !== 'sqlite';
+
 export default defineConfig({
     test: {
         globalSetup: ['test/setup'],
@@ -17,6 +28,7 @@ export default defineConfig({
         // import time. Production entry points already import it first.
         setupFiles: ['reflect-metadata'],
         include: ['test/unit/**/*.spec.ts'],
+        fileParallelism: !usesSharedServerDatabase,
     },
     plugins: [swc.vite()],
 });


### PR DESCRIPTION
## Problem

Closes #3405.

Every spec file pointed at the same `writable/test.sql`, while vitest runs spec files in parallel workers by default. Concurrent files corrupted each other's rows (provisioned realms, the admin user, system clients), so the suite failed intermittently on a different spec each run and always passed in isolation.

The issue assumed the MySQL/Postgres runs were unaffected. They are not: `test:mysql` with 13 local workers reproduced the issue's headline failure (`SystemClientProvisioner.ensureForRealm` hitting the `auth_clients.realm_id` FK because a concurrent spec deleted the realm) against the one shared `app` database. CI has simply been running with fewer cores.

## Fix

- **sqlite (issue option 1):** the global setup provisions `writable/test.sql` as a template only. `createTestDatabaseModuleForSuite` gives every worker its own copy (`writable/test-<poolId>.sql`, keyed by `VITEST_POOL_ID`), created on first use and swept by the next global setup. Files that reuse a pool slot share its copy sequentially, which matches the previous single-file semantics minus the cross-worker races. A missing template (running vitest without the global setup) now fails with an actionable message instead of half-working against a stale file.
- **mysql/postgres (issue option 2, scoped):** a server database has no cheap per-worker copy, so `test/vitest.config.ts` turns `fileParallelism` off when `DB_TYPE` names one. The default sqlite run keeps full parallelism.
- Both test database modules now discriminate the sqlite branch on `options.type` instead of `typeof options.database` (a mysql/postgres database name is a string too). That makes the previously unreachable `dropDatabase` branch live, so `test:mysql` / `test:psql` start from a dropped database instead of a stale one (the dirty local `app` databases that have confused several past sessions).

## Verification

- sqlite: 3 consecutive full-suite runs green (181 files, 2023 tests, ~22s wall-clock, unchanged).
- mysql, parallel, before the serialization: reproduced the wildcard-realm FK failure.
- mysql, serial (local compose): full suite green in 184s.
- postgres (local compose): scoped run green, exercising the drop + provision path on that dialect.
- `npm run check:types -w apps/server-core` green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for isolating SQLite test databases across parallel workers.

* **Tests**
  * Improved SQLite test isolation by creating separate databases for each worker.
  * Preserved appropriate cleanup and setup behavior for different database types.
  * Enabled parallel SQLite test execution while preventing unsafe parallelism for shared MySQL and PostgreSQL databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
- CI on this PR: all checks green. The serialized `tests-server-core` jobs took 7m04s (mysql) and 6m41s (postgres) against a ~4m baseline on master, both including the ~2.5m checkout/install/build preamble: the test step roughly doubled, on 4-core runners that only ever ran 3-4 workers.
