### PR TITLE
feat: session token visibility (admin user tab + account console)

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -3039,9 +3039,19 @@ cases in `user.spec.ts`. When adding a per-row gate to a new
 `getMany`, wire `applyRealmScopeSelect` into its adapter with every column the
 gate reads.
 
-**UI:** three surfaces backed by the kit `<ASessions>` collection: the top-level admin pages `apps/client-admin-console/pages/sessions/` (list of every session the actor's realm reach permits, subject names via the gated `include=user,client` — the session schema's `relations.allowed` is `['realm', 'user', 'client']`, each include gated by the #3295 relations read gate on the target's read permission — plus a `/sessions/:id` detail page rendering the session's `auth_session_tokens` inventory through the kit `<ASessionTokens>` collection over `GET /session-tokens?filter[sessionId]=…&include=client`), `apps/client-account-console/src/pages/sessions.vue` (the actor's **own**
-sessions, `filter: { userId }`), and `apps/client-admin-console/pages/users/[id]/sessions.vue` (a `<VCTable>`
-page for an admin viewing a user's sessions). The account console page
+**UI:** three surfaces backed by the kit `<ASessions>` collection: the top-level admin pages `apps/client-admin-console/pages/sessions/` (list of every session the actor's realm reach permits, subject names via the gated `include=user,client` — the session schema's `relations.allowed` is `['realm', 'user', 'client']`, each include gated by the #3295 relations read gate on the target's read permission — plus a `/sessions/:id` detail page rendering the session's `auth_session_tokens` inventory through the kit `<ASessionTokens>` collection over `GET /session-tokens?filter[sessionId]=…`), `apps/client-account-console/src/pages/sessions.vue` (the actor's **own**
+sessions, `filter: { userId }`, each session card expandable into its own
+`<ASessionTokens>` inventory — application, kind, created/expires, status;
+deliberately no per-token ip/user-agent, since server-side renderer refreshes
+stamp values like `node` that would read as an unknown device to an end
+user), and `apps/client-admin-console/pages/users/[id]/sessions.vue` (a `<VCTable>`
+page for an admin viewing a user's sessions; each row links to the
+`/sessions/:id` detail page). **Session-token reads carry a client SUMMARY
+unconditionally** (id / name / displayName, joined by the repository adapter —
+the consent-list shape): `client` is deliberately absent from the session-token
+schema's `relations.allowed`, so a raw `?include=client` cannot force the
+full-column join, while a self-service reader without `CLIENT_READ` still gets
+application names for its own token rows. The account console page
 carries a **"log out other devices"** button
 (`authupApp` `SESSION_REVOKE_OTHERS*` keys) that confirms via `useAlertDialog`
 then calls `client.session.deleteMany()` (`DELETE /sessions` — revoke-all-but-

--- a/apps/client-account-console/src/pages/sessions.vue
+++ b/apps/client-account-console/src/pages/sessions.vue
@@ -6,16 +6,19 @@
   -->
 <script lang="ts">
 import { defineQuery } from '@rapiq/core';
-import type { Session } from '@authup/core-kit';
+import type { Session, SessionToken } from '@authup/core-kit';
 import {
     TranslatorTranslationActionKey,
     TranslatorTranslationAppKey,
+    TranslatorTranslationCommonKey,
     TranslatorTranslationEntityKey,
+    TranslatorTranslationFieldKey,
     TranslatorTranslationNamespace,
 } from '@authup/i18n';
 import {
     AEntityDelete,
     APagination,
+    ASessionTokens,
     ASessions,
     injectHTTPClient,
     injectStore,
@@ -30,10 +33,17 @@ import { useAlertDialog } from '@vuecs/overlays';
 import { computed, defineComponent, ref } from 'vue';
 import { useAccountToasts } from './utils';
 
+// One line on purpose: Tailwind's scanner must see the arbitrary-value
+// candidate unbroken to generate the utility.
+const TOKEN_GRID_CLASSES = 'sm:grid sm:items-center sm:gap-x-3 sm:grid-cols-[minmax(0,1fr)_4.75rem_8.75rem_8.75rem_5.5rem]';
+
+const TOKEN_ROW_CLASSES = `py-1.5 text-sm ${TOKEN_GRID_CLASSES}`;
+
 export default defineComponent({
     components: {
         AEntityDelete,
         APagination,
+        ASessionTokens,
         ASessions,
         VCButton,
         VCIcon,
@@ -62,6 +72,16 @@ export default defineComponent({
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_OTHERS_CONFIRM_DESCRIPTION },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_CURRENT },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.LOGOUT },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.DETAILS },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_TOKEN_STATUS_ACTIVE },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_TOKEN_STATUS_CONSUMED },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_TOKEN_STATUS_REVOKED },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_TOKEN_STATUS_EXPIRED },
+            { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.CREATED_AT },
+            { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.EXPIRES_AT },
+            { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.KIND },
+            { namespace: TranslatorTranslationNamespace.FIELD, key: TranslatorTranslationFieldKey.STATUS },
+            { namespace: TranslatorTranslationNamespace.COMMON, key: TranslatorTranslationCommonKey.APPLICATION },
             { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.ABORT },
         ]);
 
@@ -109,6 +129,55 @@ export default defineComponent({
             }
         };
 
+        const expanded = ref<Record<string, boolean>>({});
+        const toggleTokens = (id: string) => {
+            expanded.value[id] = !expanded.value[id];
+        };
+
+        const buildTokensQuery = (id: string) => defineQuery<SessionToken>({
+            filters: { sessionId: id },
+            sort: { createdAt: 'DESC' },
+        });
+
+        const tokenState = (row: SessionToken): 'revoked' | 'consumed' | 'expired' | 'active' => {
+            if (row.revokedAt) {
+                return 'revoked';
+            }
+            if (row.consumedAt) {
+                return 'consumed';
+            }
+            if (row.expiresAt && Date.parse(row.expiresAt) < Date.now()) {
+                return 'expired';
+            }
+
+            return 'active';
+        };
+
+        const tokenStatus = (row: SessionToken): string => {
+            switch (tokenState(row)) {
+                case 'revoked':
+                    return translations.sessionTokenStatusRevoked;
+                case 'consumed':
+                    return translations.sessionTokenStatusConsumed;
+                case 'expired':
+                    return translations.sessionTokenStatusExpired;
+                default:
+                    return translations.sessionTokenStatusActive;
+            }
+        };
+
+        const tokenStatusClass = (row: SessionToken): string => {
+            switch (tokenState(row)) {
+                case 'revoked':
+                    return 'bg-error-600/10 text-error-600';
+                case 'consumed':
+                case 'expired':
+                    return 'bg-fg-muted/10 text-fg-muted';
+                default:
+                    return 'bg-success-600/10 text-success-600';
+            }
+        };
+
         return {
             userId,
             sessionId,
@@ -116,6 +185,13 @@ export default defineComponent({
             translations,
             revoking,
             revokeOthers,
+            expanded,
+            toggleTokens,
+            buildTokensQuery,
+            tokenStatus,
+            tokenStatusClass,
+            tokenGridClasses: TOKEN_GRID_CLASSES,
+            tokenRowClasses: TOKEN_ROW_CLASSES,
         };
     },
 });
@@ -159,43 +235,142 @@ export default defineComponent({
                     <div
                         v-for="row in props.data"
                         :key="row.id"
-                        class="rounded border border-border p-3 flex items-center gap-3"
+                        class="rounded border border-border"
                     >
-                        <VCIcon
-                            name="fa6-solid:desktop"
-                            class="text-fg-muted"
-                        />
-                        <div class="flex-1 min-w-0">
-                            <div
-                                class="truncate"
-                                :title="row.userAgent || undefined"
-                            >
-                                <template v-if="row.userAgent">
-                                    {{ row.userAgent }}
-                                </template>
-                                <span v-else>&ndash;</span>
+                        <div class="p-3 flex items-center gap-3">
+                            <VCIcon
+                                name="fa6-solid:desktop"
+                                class="text-fg-muted"
+                            />
+                            <div class="flex-1 min-w-0">
+                                <div
+                                    class="truncate"
+                                    :title="row.userAgent || undefined"
+                                >
+                                    <template v-if="row.userAgent">
+                                        {{ row.userAgent }}
+                                    </template>
+                                    <span v-else>&ndash;</span>
+                                </div>
+                                <small class="text-fg-muted flex flex-wrap gap-2">
+                                    <span v-if="row.ipAddress">{{ row.ipAddress }}</span>
+                                    <VCTimeago
+                                        v-if="row.seenAt"
+                                        :datetime="row.seenAt"
+                                    />
+                                </small>
                             </div>
-                            <small class="text-fg-muted flex flex-wrap gap-2">
-                                <span v-if="row.ipAddress">{{ row.ipAddress }}</span>
-                                <VCTimeago
-                                    v-if="row.seenAt"
-                                    :datetime="row.seenAt"
-                                />
-                            </small>
+                            <span
+                                v-if="row.id === sessionId"
+                                class="inline-flex items-center rounded-full bg-primary-600/10 px-2 py-0.5 text-xs font-medium text-primary-600"
+                            >
+                                {{ translations.sessionCurrent }}
+                            </span>
+                            <VCButton
+                                size="sm"
+                                color="primary"
+                                variant="outline"
+                                :aria-label="translations.details"
+                                :title="translations.details"
+                                @click="toggleTokens(row.id)"
+                            >
+                                <template #leading>
+                                    <VCIcon :name="expanded[row.id] ? 'fa6-solid:chevron-up' : 'fa6-solid:chevron-down'" />
+                                </template>
+                            </VCButton>
+                            <AEntityDelete
+                                v-if="row.id !== sessionId"
+                                :entity-id="row.id"
+                                entity-type="session"
+                                :with-text="false"
+                                @deleted="props.deleted"
+                            />
                         </div>
-                        <span
-                            v-if="row.id === sessionId"
-                            class="inline-flex items-center rounded-full bg-primary-600/10 px-2 py-0.5 text-xs font-medium text-primary-600"
+                        <div
+                            v-if="expanded[row.id]"
+                            class="border-t border-border p-3"
                         >
-                            {{ translations.sessionCurrent }}
-                        </span>
-                        <AEntityDelete
-                            v-else
-                            :entity-id="row.id"
-                            entity-type="session"
-                            :with-text="false"
-                            @deleted="props.deleted"
-                        />
+                            <ASessionTokens
+                                :query="buildTokensQuery(row.id)"
+                                :body="{ tag: 'div' }"
+                                :footer="true"
+                            >
+                                <template #footer="tokenProps">
+                                    <APagination
+                                        :busy="tokenProps.busy"
+                                        :meta="tokenProps.meta"
+                                        :load="tokenProps.load"
+                                    />
+                                </template>
+                                <template #body="tokenProps">
+                                    <div
+                                        class="hidden border-b border-border pb-1.5 text-[0.65rem] font-semibold uppercase
+                                            tracking-wider text-fg-muted"
+                                        :class="tokenGridClasses"
+                                    >
+                                        <span>{{ translations.application }}</span>
+                                        <span class="text-center">{{ translations.kind }}</span>
+                                        <span>{{ translations.createdAt }}</span>
+                                        <span>{{ translations.expiresAt }}</span>
+                                        <span class="text-right">{{ translations.status }}</span>
+                                    </div>
+                                    <div class="flex flex-col divide-y divide-border">
+                                        <div
+                                            v-for="token in tokenProps.data"
+                                            :key="token.id"
+                                            :class="tokenRowClasses"
+                                        >
+                                            <div class="flex items-center gap-2 sm:contents">
+                                                <span
+                                                    class="flex-1 min-w-0 truncate sm:col-start-1 sm:row-start-1 sm:flex-none"
+                                                    :class="token.client ? 'font-medium' : 'text-fg-muted'"
+                                                >
+                                                    <template v-if="token.client">
+                                                        {{ token.client.displayName ?? token.client.name }}
+                                                    </template>
+                                                    <template v-else>
+                                                        &ndash;
+                                                    </template>
+                                                </span>
+                                                <span
+                                                    class="rounded bg-bg-muted px-1.5 py-0.5 font-mono text-xs text-fg-muted
+                                                        sm:col-start-2 sm:row-start-1 sm:w-full sm:text-center"
+                                                >
+                                                    {{ token.kind }}
+                                                </span>
+                                                <span
+                                                    class="inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium
+                                                        sm:col-start-5 sm:row-start-1 sm:justify-self-end"
+                                                    :class="tokenStatusClass(token)"
+                                                >
+                                                    {{ tokenStatus(token) }}
+                                                </span>
+                                            </div>
+                                            <div class="mt-0.5 flex flex-wrap items-center gap-x-1.5 text-xs text-fg-muted sm:contents">
+                                                <span class="sm:col-start-3 sm:row-start-1 sm:text-sm">
+                                                    <span class="sm:hidden">{{ translations.createdAt }}: </span>
+                                                    <VCTimeago :datetime="token.createdAt" />
+                                                </span>
+                                                <span
+                                                    class="sm:hidden"
+                                                    aria-hidden="true"
+                                                >&middot;</span>
+                                                <span class="sm:col-start-4 sm:row-start-1 sm:text-sm">
+                                                    <span class="sm:hidden">{{ translations.expiresAt }}: </span>
+                                                    <VCTimeago
+                                                        v-if="token.expiresAt"
+                                                        :datetime="token.expiresAt"
+                                                    />
+                                                    <template v-else>
+                                                        &ndash;
+                                                    </template>
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </template>
+                            </ASessionTokens>
+                        </div>
                     </div>
                 </div>
             </template>

--- a/apps/client-admin-console/pages/sessions/[id]/index.vue
+++ b/apps/client-admin-console/pages/sessions/[id]/index.vue
@@ -131,7 +131,6 @@ export default defineComponent({
 
         const tokensQuery = defineQuery<SessionToken>({
             filters: { sessionId: route.params.id as string },
-            relations: ['client'],
             sort: { createdAt: 'DESC' },
         });
 

--- a/apps/client-admin-console/pages/sessions/index/index.vue
+++ b/apps/client-admin-console/pages/sessions/index/index.vue
@@ -23,6 +23,7 @@ import { storeToRefs } from 'pinia';
 import type { TableColumn } from '@vuecs/table';
 import type { FormOption } from '@vuecs/forms';
 import { VCFormSelect } from '@vuecs/forms';
+import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
 import { VCLink } from '@vuecs/link';
 import { computed, ref } from 'vue';
@@ -35,6 +36,7 @@ export default defineNuxtComponent({
         AEntityDelete,
         APagination,
         ASessions,
+        VCButton,
         VCFormSelect,
         VCIcon,
         VCLink,
@@ -160,6 +162,7 @@ export default defineNuxtComponent({
             subjectKind,
             subjectKindOptions,
             applySubjectKind,
+            VCLink,
         };
     },
 });
@@ -255,13 +258,19 @@ export default defineNuxtComponent({
                     <VCTimeago :datetime="row.expiresAt" />
                 </template>
                 <template #cell-options="{ row }">
-                    <VCLink
+                    <VCButton
+                        :as="VCLink"
                         :to="`/sessions/${row.id}`"
                         :aria-label="translations.details"
                         :title="translations.details"
+                        size="sm"
+                        color="primary"
+                        variant="outline"
                     >
-                        <VCIcon name="fa6-solid:bars" />
-                    </VCLink>
+                        <template #leading>
+                            <VCIcon name="fa6-solid:bars" />
+                        </template>
+                    </VCButton>
                     <span
                         v-if="row.id === sessionId"
                         class="ms-2 inline-flex items-center rounded-full bg-primary-600/10 px-2 py-0.5 text-xs font-medium text-primary-600"

--- a/apps/client-admin-console/pages/users/[id]/sessions.vue
+++ b/apps/client-admin-console/pages/users/[id]/sessions.vue
@@ -20,6 +20,7 @@ import {
 import type { TableColumn } from '@vuecs/table';
 import { VCButton } from '@vuecs/button';
 import { VCIcon } from '@vuecs/icon';
+import { VCLink } from '@vuecs/link';
 import { useAlertDialog } from '@vuecs/overlays';
 import type { PropType } from 'vue';
 import { computed, ref } from 'vue';
@@ -60,6 +61,7 @@ export default defineNuxtComponent({
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_TITLE },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.SESSION_REVOKE_ALL_CONFIRM_DESCRIPTION },
             { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.LOGOUT },
+            { namespace: TranslatorTranslationNamespace.APP, key: TranslatorTranslationAppKey.DETAILS },
             { namespace: TranslatorTranslationNamespace.ACTION, key: TranslatorTranslationActionKey.ABORT },
         ]);
 
@@ -149,6 +151,7 @@ export default defineNuxtComponent({
             translations,
             revoking,
             revokeAll,
+            VCLink,
         };
     },
 });
@@ -205,6 +208,20 @@ export default defineNuxtComponent({
                     <VCTimeago :datetime="row.expiresAt" />
                 </template>
                 <template #cell-options="{ row }">
+                    <VCButton
+                        :as="VCLink"
+                        :to="`/sessions/${row.id}`"
+                        :aria-label="translations.details"
+                        :title="translations.details"
+                        size="sm"
+                        color="primary"
+                        variant="outline"
+                        class="me-1"
+                    >
+                        <template #leading>
+                            <VCIcon name="fa6-solid:bars" />
+                        </template>
+                    </VCButton>
                     <AEntityDelete
                         :entity-id="row.id"
                         entity-type="session"

--- a/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
@@ -134,12 +134,30 @@ export class SessionTokenRepositoryAdapter implements ISessionTokenRepository {
         ]);
     }
 
+    /**
+     * Always expose only a client SUMMARY (id / name / displayName) on the
+     * read paths — the consent-list shape. `client` is deliberately absent
+     * from the schema's relations allow-list, so a raw `?include=client`
+     * cannot force the full-column join (redirect patterns, grant types,
+     * secret storage flags, accessPolicyId), while a self-service reader
+     * without CLIENT_READ still gets the application name per token row.
+     */
+    protected joinClientSummary(qb: SelectQueryBuilder<SessionTokenEntity>) {
+        qb.leftJoin('sessionToken.client', 'client');
+        qb.addSelect([
+            'client.id',
+            'client.name',
+            'client.displayName',
+        ]);
+    }
+
     async findMany(query: IQuery): Promise<EntityRepositoryFindManyResult<SessionToken>> {
         const qb = this.repository.createQueryBuilder('sessionToken');
 
         const { pagination } = applyQuery(qb, query);
 
         this.joinSessionForGate(qb);
+        this.joinClientSummary(qb);
 
         const [entities, total] = await qb.getManyAndCount();
 
@@ -157,6 +175,7 @@ export class SessionTokenRepositoryAdapter implements ISessionTokenRepository {
             .where('sessionToken.id = :id', { id });
 
         this.joinSessionForGate(qb);
+        this.joinClientSummary(qb);
 
         return qb.getOne();
     }

--- a/apps/server-core/src/core/entities/session-token/schema.ts
+++ b/apps/server-core/src/core/entities/session-token/schema.ts
@@ -10,10 +10,7 @@ import type { SessionToken } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
 import { createRelationsReadGate } from '../../query/relations.ts';
 
-const schemaMapping = {
-    session: EntityType.SESSION,
-    client: EntityType.CLIENT,
-};
+const schemaMapping = { session: EntityType.SESSION };
 
 /**
  * The token inventory as a query surface.
@@ -57,7 +54,11 @@ export const sessionTokenSchema = defineSchema<SessionToken>({
             'kind',
         ],
     },
-    relations: { allowed: ['session', 'client'], validate: createRelationsReadGate(schemaMapping) },
+    // `client` is deliberately absent: the repository always joins a client
+    // SUMMARY (id / name / displayName — the consent-list shape), so a raw
+    // `?include=client` cannot force the full-column join and a self-service
+    // reader still gets application names without CLIENT_READ.
+    relations: { allowed: ['session'], validate: createRelationsReadGate(schemaMapping) },
     sort: { allowed: ['createdAt', 'expiresAt'] },
     pagination: { maxLimit: 50 },
     schemaMapping,

--- a/apps/server-core/test/unit/http/controllers/entities/session-token.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/session-token.spec.ts
@@ -143,6 +143,58 @@ describe('src/http/controllers/session-token', () => {
         expect(clientIds.has(secondApp.id)).toBe(true);
     });
 
+    it('serves a client summary that include=client cannot widen', async () => {
+        const { sessionId, firstApp } = await buildTwoAppSession();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/session-tokens?filter[sessionId]=${sessionId}&include=client`,
+            { headers: admin },
+        );
+        expect(response.status).toEqual(200);
+
+        const body = await response.json();
+        const row = body.data.find((entry: any) => entry.clientId === firstApp.id);
+
+        expect(row.client).toBeDefined();
+        expect(row.client.name).toEqual(firstApp.name);
+
+        // Summary only (the consent-list shape): the full client row must
+        // never ride a token read, whatever the reader includes.
+        expect(row.client.redirectUri).toBeUndefined();
+        expect(row.client.grantTypes).toBeUndefined();
+        expect(row.client.secret).toBeUndefined();
+        expect(row.client.accessPolicyId).toBeUndefined();
+    });
+
+    it('serves the client summary to a non-privileged reader', async () => {
+        // The account console renders application names off this: a reader
+        // without CLIENT_READ cannot include the client relation, so the
+        // summary has to ride the row unconditionally.
+        const {
+            sessionId, 
+            firstApp, 
+            firstGrant, 
+        } = await buildTwoAppSession();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/session-tokens?filter[sessionId]=${sessionId}`,
+            { headers: { Authorization: `Bearer ${firstGrant.access_token}` } },
+        );
+        expect(response.status).toEqual(200);
+
+        const body = await response.json();
+        const row = body.data.find((entry: any) => entry.clientId === firstApp.id);
+
+        expect(row.client).toBeDefined();
+        expect(row.client.name).toEqual(firstApp.name);
+        expect(row.client.redirectUri).toBeUndefined();
+        expect(row.client.secret).toBeUndefined();
+    });
+
     it('finds every session an application served', async () => {
         const { sessionId, secondApp } = await buildTwoAppSession();
 

--- a/packages/client-web-theme/assets/css/styles/generics.css
+++ b/packages/client-web-theme/assets/css/styles/generics.css
@@ -13,9 +13,11 @@
     height: 250px !important;
 }
 
-.flex {
-    display: flex;
-}
+/*
+ * No `.flex` rule here: Tailwind generates it in `@layer utilities`, and an
+ * unlayered duplicate would beat every layered utility that changes `display`
+ * on a `.flex` element (`sm:contents`, `sm:hidden`, ...).
+ */
 
 .justify-space-between {
     justify-content: space-between;


### PR DESCRIPTION
## Summary

Session-token visibility everywhere it was missing, plus two fixes found on the way.

- **Admin console `/sessions`**: the per-row details action was a bare link with no button classes and rendered unstyled; it now uses the standard outline button pattern like every other index page.
- **Admin console user detail, Sessions tab**: each session row links to the `/sessions/:id` detail page, which renders the session's token inventory.
- **server-core `/session-tokens`**: reads now always join a client SUMMARY (`id`, `name`, `displayName`; the consent-list shape). `client` left the schema's relations allow-list, so `?include=client` can no longer force the full-column join (redirect patterns, grant types, secret storage flags, accessPolicyId) for anyone, while a self-service reader without `CLIENT_READ` still sees application names on its own token rows.
- **Account console `/account/sessions`**: each session card expands into its own token table (application, kind, created/expires, status; column-header grid on desktop, two-line stack on narrow screens). Deliberately no per-token ip/user-agent: server-side renderer refreshes stamp values like `node`, which would read as an unknown device to an end user.
- **client-web-theme**: removed an unlayered legacy `.flex { display: flex }` from `generics.css`. It duplicated Tailwind's own utility, but as an unlayered rule it beat every layered utility changing `display` on a `.flex` element, so responsive patterns like `sm:contents` or `sm:hidden` silently never applied in any console.

## Tests

- New HTTP specs pin the client summary: it rides every read (non-privileged reader included) and `include=client` cannot widen it beyond the summary shape.
- Full server-core suite green (186 files, 2064 tests). Consoles rebuilt and type-checked; all three surfaces verified in a running stack at desktop and mobile widths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expandable session-token details in the account console, including application, type, creation, expiration, and status information.
  * Added session detail links to admin session and user session views.
  * Improved session-token results with concise client summaries.

* **Bug Fixes**
  * Restricted session-token client data to safe summary fields.
  * Preserved responsive layout behavior for display utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->