### PR TITLE
docs: record the hub schema-drift probe in the reference mapping

### DIFF
--- a/.agents/references/privateaim-hub.md
+++ b/.agents/references/privateaim-hub.md
@@ -62,3 +62,10 @@ the "upstream candidates" below are improvements hub should adopt back**, tracke
 - Aggregation/statistics endpoints (counts over time, per-action) — both expose only
   list+filter; Authentik-style dashboards would need new query surfaces.
 - Notification rules over the event stream (authup: rejected in plan 062; hub: n/a).
+
+## Migration hygiene (drift gate, 2026-08-10)
+
+| hub | authup | difference |
+|---|---|---|
+| `.github/workflows/main.yml` migration round-trip (run / revert xN / re-run, per server app x dialect) | `tests-migrations` job | hub HAS the empty round-trip but NO drift gate and no populated round-trip on top of it. |
+| `apps/server-core/.../1784000000000-RegistryFkSetNullAndRenameAnalysis` (`RENAME TABLE analysis TO analyses`, "constraint names intact") | `1785871780234-AlignSchemaWithEntityMetadata` (the repair for the same failure class) | The carried-over names are the bug: typeorm derives `IDX_/FK_<hash>` from table+column, so a table rename changes every derived name. hub server-core drifts 14 statements per dialect (4 indexes + 3 FKs on `analyses` under `analysis`-derived hashes); messenger/storage/telemetry probed clean. Filed as PrivateAIM/hub#1823 with the authup fix as the template (`assertSchemaMatchesMetadata` gate from typeorm-extension >= 4.0.0-beta.3 — hub is already on beta.3 — plus `scripts/{assert-schema-drift,verify-latest-migration}.mjs`). |


### PR DESCRIPTION
Adds the migration-hygiene row to the PrivateAIM/hub reference file: the drift probe run on 2026-08-10 (server-core drifts 14 statements per dialect from the analysis -> analyses rename; messenger/storage/telemetry clean), filed upstream as PrivateAIM/hub#1823 with the gate shipped in #3352 as the template. Docs only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added migration hygiene guidance covering schema drift checks and naming consistency.
  * Documented known migration and schema-metadata issues for improved maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->