### PR TITLE
fix: send the authorization code in the identity-provider token exchange

### DIFF
--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -371,9 +371,13 @@ export class IdentityProviderController {
 
         const { code } = useRequestQuery(event);
 
+        if (typeof code !== 'string' || code.length === 0) {
+            throw new BadRequestError('The authorization code is missing.');
+        }
+
         const authenticator = this.buildProviderAuthenticator(entity, { clientId: data.codeRequest?.client_id });
 
-        const user = await authenticator.authenticate(code);
+        const user = await authenticator.authenticate({ code });
 
         const realm = await this.realmRepository.resolve(entity.realmId, true);
 

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
@@ -130,4 +130,27 @@ describe('identity-provider login flow', () => {
 
         expect(response.status).toEqual(302);
     });
+
+    it('rejects a callback carrying no authorization code', async () => {
+        // a fresh state — the previous one was consumed above
+        const state = await authorizeOut();
+
+        tokenRequestBody = undefined;
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+
+        expect(response.status).toEqual(400);
+
+        // the provider must not be contacted at all — a code-less exchange
+        // has nothing to redeem
+        expect(tokenRequestBody).toBeUndefined();
+    });
 });

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { IdentityProvider, Realm } from '@authup/core-kit';
+import {
+    createFakeOAuth2IdentityProvider,
+    createFakeRealm,
+    httpRequest,
+} from '../../../../../utils';
+import { createTestApplication } from '../../../../../app';
+
+const USER_AGENT = 'login-spec-agent';
+
+const encode = (input: Record<string, any>) => Buffer.from(JSON.stringify(input)).toString('base64url');
+
+describe('identity-provider login flow', () => {
+    const suite = createTestApplication();
+
+    let idpServer: Server;
+    let idpURL: string;
+
+    let realm: Realm;
+    let provider: IdentityProvider;
+
+    let tokenRequestBody: URLSearchParams | undefined;
+
+    beforeAll(async () => {
+        // A minimal external IdP. Unlike a permissive stub, its token
+        // endpoint enforces the one thing RFC 6749 §4.1.3 makes
+        // mandatory: the `code` parameter. A stub that answers every
+        // request with a token cannot catch a client that never sends
+        // the code at all.
+        idpServer = createServer((req, res) => {
+            if (req.url && req.url.startsWith('/token')) {
+                let raw = '';
+                req.on('data', (chunk) => {
+                    raw += chunk;
+                });
+                req.on('end', () => {
+                    tokenRequestBody = new URLSearchParams(raw);
+
+                    res.setHeader('content-type', 'application/json');
+
+                    if (!tokenRequestBody.get('code')) {
+                        res.statusCode = 400;
+                        res.end(JSON.stringify({ error: 'invalid_request' }));
+                        return;
+                    }
+
+                    const accessToken = `${encode({ alg: 'none', typ: 'JWT' })}.${encode({
+                        sub: 'external-user-1',
+                        email: 'external@example.com',
+                    })}.x`;
+                    res.end(JSON.stringify({ access_token: accessToken, token_type: 'Bearer' }));
+                });
+                return;
+            }
+
+            res.statusCode = 404;
+            res.end();
+        });
+        await new Promise<void>((resolve) => {
+            idpServer.listen(0, '127.0.0.1', resolve);
+        });
+        idpURL = `http://127.0.0.1:${(idpServer.address() as AddressInfo).port}`;
+
+        await suite.setup();
+
+        realm = (await suite.client.realm.create(createFakeRealm())).data;
+        provider = (await suite.client.identityProvider.create(createFakeOAuth2IdentityProvider({
+            realmId: realm.id,
+            tokenUrl: `${idpURL}/token`,
+            authorizeUrl: `${idpURL}/authorize`,
+        }))).data;
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+        await new Promise<void>((resolve, reject) => {
+            idpServer.close((err) => (err ? reject(err) : resolve()));
+        });
+    });
+
+    async function authorizeOut(): Promise<string> {
+        const response = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        expect(response.status).toEqual(302);
+
+        const location = response.headers.get('location');
+        expect(location).toBeTruthy();
+
+        const state = new URL(location as string).searchParams.get('state');
+        expect(state).toBeTruthy();
+
+        return state as string;
+    }
+
+    it('sends the authorization code to the provider token endpoint', async () => {
+        const state = await authorizeOut();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code-1`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+
+        expect(tokenRequestBody).toBeDefined();
+        expect(tokenRequestBody?.get('grant_type')).toEqual('authorization_code');
+        expect(tokenRequestBody?.get('code')).toEqual('external-code-1');
+
+        expect(response.status).toEqual(302);
+    });
+});


### PR DESCRIPTION
## Problem

Federated login through an external OAuth2/OIDC identity provider has been broken since a55da4190 (#2767). Every attempt fails at the provider's token endpoint.

That commit changed the authenticator payload from a bare string to `{ code, code_verifier? }` and updated `IdentityProviderOAuth2Authenticator`, but not the caller in `IdentityProviderController.authorizeIn`, which kept passing the raw string. `useRequestQuery()` is loosely typed, so the compiler never saw it.

hapic builds the token request as `create({ grant_type, ...parameters })`. Spreading a *string* produces indexed keys, so the outgoing body was:

```
0=d&1=b&2=1&…&grant_type=authorization_code&redirect_uri=…&client_id=…&client_secret=…
```

with no `code` at all. The provider answers `invalid_request`, surfacing to the user as a 400.

Reproduced against a live authup provider: replaying that exact request shape returns `invalid_request`, while the same request carrying a `code` returns `invalid_grant` — confirming client credentials and `redirect_uri` were never the problem.

## Fix

Pass `{ code }`, mirroring what the later account-linking path at line 577 already does, and reject a missing code with a clear `BadRequestError` instead of letting an empty value reach the provider as an opaque failure.

## Why no test caught it

`link.spec.ts` covers `completeLink`, not `authorizeIn`, and its fake provider returns a token for *any* request — so it cannot detect a client that omits the code. The new `login.spec.ts` drives the login callback and its fake provider enforces `code` the way a real token endpoint does. It fails on the previous code with `expected null to deeply equal 'external-code-1'`.

## Verification

- New spec red before the change, green after
- Full `apps/server-core` suite: 191 files, 2133 tests passing
- End-to-end against a real authup-to-authup federation: `/authorize-out` → remote code issued → callback returns 302 (was 400) → local user created and linked → code redeemed at `/token` for a full access/refresh/id token set with `amr: ["ext"]`

## Follow-ups (not in this PR)

- The local user is named after the remote `sub` (a UUID) with a null email, because only the access token is decoded and `userInfoUrl` is never called. Filed separately.
- Upstream network/HTTP failures log only `"400  (POST …)"`; hapic keeps the real reason on `cause` and the provider's error body names the actual OAuth2 code. Logging either would have made this a one-minute diagnosis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identity-provider login validation by rejecting callbacks without a valid authorization code.
  * Ensured authorization codes are correctly passed during authentication.

* **Tests**
  * Added coverage for the OAuth2 authorization-code login flow, including token exchange and redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->