### PR TITLE
fix: answer invalid_grant when a session is revoked mid-rotation

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -3002,12 +3002,12 @@ old jti`) then AT (`refreshTokenId = new RT jti`). On consume-failure →
 `sessionId` is present (M2M client-credentials writes only an access row —
 it mints no RT).
 
-**Nothing holds the session between resolving it and issuing.** A concurrent
-request may delete the `auth_sessions` row after `findOneById` and before an
-issuer writes its inventory row: the replay reaction on this same family (two
-requests presenting one token, the loser calling `revokeFamily` while the winner
-is still issuing), an explicit logout, `DELETE /sessions/:id`, an admin
-force-logout, or the sweeper. The insert then violates
+**Nothing holds a token row's parents between resolving them and issuing.** A
+concurrent request may delete the `auth_sessions` row after `findOneById` and
+before an issuer writes its inventory row: the replay reaction on this same
+family (two requests presenting one token, the loser calling `revokeFamily`
+while the winner is still issuing), an explicit logout, `DELETE /sessions/:id`,
+an admin force-logout, or the sweeper. The insert then violates
 `FK_auth_session_tokens_session_id`. Refusing is correct, but the refusal has to
 be an OAuth2 answer: the presented token is already consumed and
 cache-blocklisted, so the client has nothing to retry with, and a 500 reads as
@@ -3015,16 +3015,30 @@ retryable to most OAuth2 clients while hiding a benign-and-expected race among
 real faults (issue #3435). So `SessionTokenRepositoryAdapter.create` translates a
 foreign-key rejection (`isForeignKeyConstraintDatabaseError` in
 `adapters/database/errors/driver.ts`, the sibling of the consent-insert
-uniqueness check) into `SessionTokenSessionMissingError`
+uniqueness check) into `SessionTokenRelationMissingError`
 (`core/oauth2/session-token/error.ts`, declared on the `create` port), and the
 refresh grant wraps both issuer calls and re-raises it as `invalid_grant`. Only
 that one condition is translated; every other failure is rethrown untouched, so
-a signing or cache fault still surfaces as one. The window is deliberately not
-narrowed: a pre-issue re-read closes nothing (the delete can still land one
-statement later) and the client-facing outcome is identical either way. The
-other mint sites (password / authorize / identity / client-credentials / MFA
-completion) create their session in the same request, so they keep the error's
-own code, a plain 400, rather than an OAuth2 grant error.
+a signing or cache fault still surfaces as one.
+
+**The error names no relation, deliberately.** `client_id` is the row's second
+foreign key, so a client deleted in the same window lands on the same path. It
+cannot be told apart portably: postgres reports the failing constraint as a
+field on the error, mysql only inside the message text, and sqlite says
+`FOREIGN KEY constraint failed` and nothing else, so a per-relation verdict
+would be unimplementable on the dialect the test suite runs on. It would also
+change no caller. Both parents are `ON DELETE CASCADE` onto
+`auth_session_tokens`, so whichever went missing has already deleted the
+presented token's own row, and `invalid_grant` is the right answer either way
+(a later refresh would fail its `findOneById` lookup with `refresh token is
+unknown` regardless).
+
+**The window is deliberately not narrowed.** A pre-issue re-read closes nothing
+(the delete can still land one statement later) and the client-facing outcome is
+identical either way. The other mint sites (password / authorize / identity /
+client-credentials / MFA completion) create their session in the same request,
+so they keep the error's own code, a plain 400, rather than an OAuth2 grant
+error.
 
 **Device identity and issuance provenance are separate fields.** The session
 says which device it belongs to, the `auth_session_tokens` row says where each

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -3002,6 +3002,30 @@ old jti`) then AT (`refreshTokenId = new RT jti`). On consume-failure →
 `sessionId` is present (M2M client-credentials writes only an access row —
 it mints no RT).
 
+**Nothing holds the session between resolving it and issuing.** A concurrent
+request may delete the `auth_sessions` row after `findOneById` and before an
+issuer writes its inventory row: the replay reaction on this same family (two
+requests presenting one token, the loser calling `revokeFamily` while the winner
+is still issuing), an explicit logout, `DELETE /sessions/:id`, an admin
+force-logout, or the sweeper. The insert then violates
+`FK_auth_session_tokens_session_id`. Refusing is correct, but the refusal has to
+be an OAuth2 answer: the presented token is already consumed and
+cache-blocklisted, so the client has nothing to retry with, and a 500 reads as
+retryable to most OAuth2 clients while hiding a benign-and-expected race among
+real faults (issue #3435). So `SessionTokenRepositoryAdapter.create` translates a
+foreign-key rejection (`isForeignKeyConstraintDatabaseError` in
+`adapters/database/errors/driver.ts`, the sibling of the consent-insert
+uniqueness check) into `SessionTokenSessionMissingError`
+(`core/oauth2/session-token/error.ts`, declared on the `create` port), and the
+refresh grant wraps both issuer calls and re-raises it as `invalid_grant`. Only
+that one condition is translated; every other failure is rethrown untouched, so
+a signing or cache fault still surfaces as one. The window is deliberately not
+narrowed: a pre-issue re-read closes nothing (the delete can still land one
+statement later) and the client-facing outcome is identical either way. The
+other mint sites (password / authorize / identity / client-credentials / MFA
+completion) create their session in the same request, so they keep the error's
+own code, a plain 400, rather than an OAuth2 grant error.
+
 **Device identity and issuance provenance are separate fields.** The session
 says which device it belongs to, the `auth_session_tokens` row says where each
 token was issued from. Conflating them into one mutable column is what produced

--- a/apps/server-core/src/adapters/database/errors/driver.ts
+++ b/apps/server-core/src/adapters/database/errors/driver.ts
@@ -52,3 +52,25 @@ export function isUniqueConstraintDatabaseError(input: unknown): boolean {
     const code = getDatabaseDriverErrorCode(input);
     return typeof code === 'string' && UNIQUE_CONSTRAINT_ERROR_CODES.includes(code);
 }
+
+const FOREIGN_KEY_CONSTRAINT_ERROR_CODES = [
+    'ER_NO_REFERENCED_ROW', // mysql: insert/update references a missing parent
+    'ER_NO_REFERENCED_ROW_2', // mysql: same, reported with the constraint name
+    'ER_ROW_IS_REFERENCED', // mysql: delete/update of a still-referenced parent
+    'ER_ROW_IS_REFERENCED_2', // mysql: same, reported with the constraint name
+    '23503', // postgres: foreign_key_violation, both directions
+    'SQLITE_CONSTRAINT_FOREIGNKEY', // sqlite (better-sqlite3), both directions
+];
+
+/**
+ * True when the error is a foreign-key violation from any supported driver.
+ *
+ * Postgres and sqlite report one code for both directions, so the mysql
+ * counterparts of both are listed too and the helper stays direction-agnostic.
+ * The direction follows from the statement instead: an INSERT can only ever
+ * fail because the row it references is gone.
+ */
+export function isForeignKeyConstraintDatabaseError(input: unknown): boolean {
+    const code = getDatabaseDriverErrorCode(input);
+    return typeof code === 'string' && FOREIGN_KEY_CONSTRAINT_ERROR_CODES.includes(code);
+}

--- a/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
@@ -13,7 +13,7 @@ import { In, LessThan } from 'typeorm';
 import { applyQuery, redactFieldConditions } from '../../../database/repositories/query.ts';
 import { SessionTokenEntity } from '../../../../../adapters/database/domains/index.ts';
 import { isForeignKeyConstraintDatabaseError } from '../../../../../adapters/database/errors/index.ts';
-import { SessionTokenSessionMissingError } from '../../../../../core/index.ts';
+import { SessionTokenRelationMissingError } from '../../../../../core/index.ts';
 import type {
     ISessionTokenRepository,
     SessionTokenCreateInput,
@@ -45,15 +45,16 @@ export class SessionTokenRepositoryAdapter implements ISessionTokenRepository {
         try {
             await this.repository.insert(entity);
         } catch (e) {
-            // The only foreign key an insert can violate here is `session_id`
-            // (`client_id` is written from an already-resolved client, and both
-            // parents cascade). So a rejection means the session was deleted
-            // between the caller resolving it and this write: a concurrent
-            // replay reaction, logout, force-logout or sweep. Name that
-            // condition instead of letting a driver error escape as an
-            // unhandled internal error (issue #3435).
+            // A rejection means one of the two parents was deleted between the
+            // caller resolving it and this write: the session (a concurrent
+            // replay reaction, logout, force-logout or sweep) or the client the
+            // token is attributed to. Both cascade onto this table, so either
+            // way the token rows are already gone and the caller's answer is the
+            // same, which is why the error names neither. Report that condition
+            // instead of letting a driver error escape as an unhandled internal
+            // error (issue #3435).
             if (isForeignKeyConstraintDatabaseError(e)) {
-                throw new SessionTokenSessionMissingError();
+                throw new SessionTokenRelationMissingError();
             }
 
             throw e;

--- a/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
@@ -12,6 +12,8 @@ import type { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
 import { In, LessThan } from 'typeorm';
 import { applyQuery, redactFieldConditions } from '../../../database/repositories/query.ts';
 import { SessionTokenEntity } from '../../../../../adapters/database/domains/index.ts';
+import { isForeignKeyConstraintDatabaseError } from '../../../../../adapters/database/errors/index.ts';
+import { SessionTokenSessionMissingError } from '../../../../../core/index.ts';
 import type {
     ISessionTokenRepository,
     SessionTokenCreateInput,
@@ -40,7 +42,22 @@ export class SessionTokenRepositoryAdapter implements ISessionTokenRepository {
             expiresAt: input.expiresAt,
         });
 
-        await this.repository.insert(entity);
+        try {
+            await this.repository.insert(entity);
+        } catch (e) {
+            // The only foreign key an insert can violate here is `session_id`
+            // (`client_id` is written from an already-resolved client, and both
+            // parents cascade). So a rejection means the session was deleted
+            // between the caller resolving it and this write: a concurrent
+            // replay reaction, logout, force-logout or sweep. Name that
+            // condition instead of letting a driver error escape as an
+            // unhandled internal error (issue #3435).
+            if (isForeignKeyConstraintDatabaseError(e)) {
+                throw new SessionTokenSessionMissingError();
+            }
+
+            throw e;
+        }
 
         // insert() does not hydrate @CreateDateColumn back onto the in-memory
         // entity (the DB fills created_at via its DEFAULT). Stamp it so the

--- a/apps/server-core/src/core/oauth2/grant-types/refresh-token.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/refresh-token.ts
@@ -12,6 +12,7 @@ import type { Logger } from '@authup/server-kit';
 import type { IEventService } from '../../entities/index.ts';
 import type { IAuthFlowMetrics } from '../../metrics/index.ts';
 import { buildOAuth2BearerTokenResponse } from '../response/index.ts';
+import { isSessionTokenSessionMissingError } from '../session-token/index.ts';
 import type { ISessionTokenRepository } from '../session-token/index.ts';
 import type { IOAuth2TokenIssuer, IOAuth2TokenRepository, IOAuth2TokenVerifier } from '../token/index.ts';
 import { OAuth2BaseGrant } from './base.ts';
@@ -133,30 +134,54 @@ export class OAuth2RefreshTokenGrant extends OAuth2BaseGrant<string | OAuth2Toke
         // expiresAt, so "last active" stays accurate.
         await this.sessionManager.refresh(session);
 
-        const [refreshToken, refreshTokenPayload] = await this.refreshTokenIssuer.issue({
-            ...payload,
-            ...(options.confirmation ? { cnf: options.confirmation } : {}),
-            user_agent: options.userAgent ?? session.userAgent,
-            remote_address: options.ipAddress ?? session.ipAddress,
-            exp: this.refreshTokenIssuer.buildExp(),
-            parent_id: payload.jti,
-        });
+        // The session was resolved above, but nothing holds it. A concurrent
+        // request can revoke it (a replay reaction on this same family, an
+        // explicit logout, an admin force-logout, the sweeper) before the
+        // issuers write their inventory rows, and the write is then rejected by
+        // the session foreign key. Refusing the request is correct, since it
+        // must not receive tokens for a session that no longer exists, but it
+        // has to read as `invalid_grant` rather than as an internal error: the
+        // presented token is already consumed and cache-blocklisted, so there
+        // is nothing left to retry with and re-authentication is the only way
+        // forward (issue #3435). Anything else is a genuine fault and is
+        // rethrown untouched.
+        try {
+            const [refreshToken, refreshTokenPayload] = await this.refreshTokenIssuer.issue({
+                ...payload,
+                ...(options.confirmation ? { cnf: options.confirmation } : {}),
+                user_agent: options.userAgent ?? session.userAgent,
+                remote_address: options.ipAddress ?? session.ipAddress,
+                exp: this.refreshTokenIssuer.buildExp(),
+                parent_id: payload.jti,
+            });
 
-        const [accessToken, accessTokenPayload] = await this.accessTokenIssuer.issue({
-            ...payload,
-            ...(options.confirmation ? { cnf: options.confirmation } : {}),
-            user_agent: options.userAgent ?? session.userAgent,
-            remote_address: options.ipAddress ?? session.ipAddress,
-            exp: this.accessTokenIssuer.buildExp(),
-            refresh_token_id: refreshTokenPayload.jti,
-        });
+            const [accessToken, accessTokenPayload] = await this.accessTokenIssuer.issue({
+                ...payload,
+                ...(options.confirmation ? { cnf: options.confirmation } : {}),
+                user_agent: options.userAgent ?? session.userAgent,
+                remote_address: options.ipAddress ?? session.ipAddress,
+                exp: this.accessTokenIssuer.buildExp(),
+                refresh_token_id: refreshTokenPayload.jti,
+            });
 
-        return buildOAuth2BearerTokenResponse({
-            accessToken,
-            accessTokenPayload,
-            refreshToken,
-            refreshTokenPayload,
-        });
+            return buildOAuth2BearerTokenResponse({
+                accessToken,
+                accessTokenPayload,
+                refreshToken,
+                refreshTokenPayload,
+            });
+        } catch (e) {
+            if (isSessionTokenSessionMissingError(e)) {
+                this.logger?.debug('OAuth2 refresh token rotation lost the session mid-flight', {
+                    sessionId: payload.session_id,
+                    jti: payload.jti,
+                });
+
+                throw OAuth2GrantError.invalid('the session has been revoked');
+            }
+
+            throw e;
+        }
     }
 
     /**

--- a/apps/server-core/src/core/oauth2/grant-types/refresh-token.ts
+++ b/apps/server-core/src/core/oauth2/grant-types/refresh-token.ts
@@ -12,7 +12,7 @@ import type { Logger } from '@authup/server-kit';
 import type { IEventService } from '../../entities/index.ts';
 import type { IAuthFlowMetrics } from '../../metrics/index.ts';
 import { buildOAuth2BearerTokenResponse } from '../response/index.ts';
-import { isSessionTokenSessionMissingError } from '../session-token/index.ts';
+import { isSessionTokenRelationMissingError } from '../session-token/index.ts';
 import type { ISessionTokenRepository } from '../session-token/index.ts';
 import type { IOAuth2TokenIssuer, IOAuth2TokenRepository, IOAuth2TokenVerifier } from '../token/index.ts';
 import { OAuth2BaseGrant } from './base.ts';
@@ -138,13 +138,15 @@ export class OAuth2RefreshTokenGrant extends OAuth2BaseGrant<string | OAuth2Toke
         // request can revoke it (a replay reaction on this same family, an
         // explicit logout, an admin force-logout, the sweeper) before the
         // issuers write their inventory rows, and the write is then rejected by
-        // the session foreign key. Refusing the request is correct, since it
-        // must not receive tokens for a session that no longer exists, but it
-        // has to read as `invalid_grant` rather than as an internal error: the
-        // presented token is already consumed and cache-blocklisted, so there
-        // is nothing left to retry with and re-authentication is the only way
-        // forward (issue #3435). Anything else is a genuine fault and is
-        // rethrown untouched.
+        // the session foreign key. The client the tokens are attributed to can
+        // disappear in the same window, which the repository reports the same
+        // way: both parents cascade onto `auth_session_tokens`, so either loss
+        // has already deleted the presented token's own row. Refusing is
+        // therefore correct in both cases, but it has to read as
+        // `invalid_grant` rather than as an internal error: the presented token
+        // is already consumed and cache-blocklisted, so there is nothing left
+        // to retry with and re-authentication is the only way forward (issue
+        // #3435). Anything else is a genuine fault and is rethrown untouched.
         try {
             const [refreshToken, refreshTokenPayload] = await this.refreshTokenIssuer.issue({
                 ...payload,
@@ -171,9 +173,10 @@ export class OAuth2RefreshTokenGrant extends OAuth2BaseGrant<string | OAuth2Toke
                 refreshTokenPayload,
             });
         } catch (e) {
-            if (isSessionTokenSessionMissingError(e)) {
-                this.logger?.debug('OAuth2 refresh token rotation lost the session mid-flight', {
+            if (isSessionTokenRelationMissingError(e)) {
+                this.logger?.debug('OAuth2 refresh token rotation lost a referenced row mid-flight', {
                     sessionId: payload.session_id,
+                    clientId: payload.client_id,
                     jti: payload.jti,
                 });
 

--- a/apps/server-core/src/core/oauth2/session-token/error.ts
+++ b/apps/server-core/src/core/oauth2/session-token/error.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    ErrorCode,
+    ValidationError,
+    markInstanceof,
+    matchesInstanceof,
+} from '@authup/errors';
+
+export const SESSION_TOKEN_SESSION_MISSING_ERROR_INSTANCE = Symbol.for('@authup/server-core/SessionTokenSessionMissingError');
+
+/**
+ * The session a token row references no longer exists.
+ *
+ * Raised by the repository adapter when the inventory insert is rejected by the
+ * session foreign key, which happens when the session is deleted between the
+ * caller resolving it and the token being issued (a concurrent refresh-token
+ * replay reaction, an explicit logout, an admin force-logout, the session
+ * sweeper). Transport-agnostic on purpose: the refresh grant re-raises it as
+ * `invalid_grant`, every other issuing path lets it settle as the 400 its code
+ * maps to.
+ */
+export class SessionTokenSessionMissingError extends ValidationError {
+    constructor() {
+        super({
+            code: ErrorCode.ENTITY_RELATION_INVALID,
+            message: 'The session the token belongs to no longer exists.',
+        });
+        markInstanceof(this, SESSION_TOKEN_SESSION_MISSING_ERROR_INSTANCE);
+    }
+}
+
+/**
+ * Deliberately marker-only, with no `code` fallback: `ENTITY_RELATION_INVALID`
+ * is the shared code for every invalid relation reference (`sanitizeError`
+ * assigns it to typeorm-extension's join-column lookup failures too), so
+ * matching on it would claim unrelated errors. The error never crosses a wire
+ * boundary before it is caught, so there is nothing for a rehydrated match to
+ * recover.
+ */
+export function isSessionTokenSessionMissingError(input: unknown): input is SessionTokenSessionMissingError {
+    return matchesInstanceof(input, SESSION_TOKEN_SESSION_MISSING_ERROR_INSTANCE);
+}

--- a/apps/server-core/src/core/oauth2/session-token/error.ts
+++ b/apps/server-core/src/core/oauth2/session-token/error.ts
@@ -12,26 +12,36 @@ import {
     matchesInstanceof,
 } from '@authup/errors';
 
-export const SESSION_TOKEN_SESSION_MISSING_ERROR_INSTANCE = Symbol.for('@authup/server-core/SessionTokenSessionMissingError');
+export const SESSION_TOKEN_RELATION_MISSING_ERROR_INSTANCE = Symbol.for('@authup/server-core/SessionTokenRelationMissingError');
 
 /**
- * The session a token row references no longer exists.
+ * A row the token references no longer exists.
  *
- * Raised by the repository adapter when the inventory insert is rejected by the
- * session foreign key, which happens when the session is deleted between the
- * caller resolving it and the token being issued (a concurrent refresh-token
- * replay reaction, an explicit logout, an admin force-logout, the session
- * sweeper). Transport-agnostic on purpose: the refresh grant re-raises it as
+ * Raised by the repository adapter when the inventory insert is rejected by a
+ * foreign key. Both parents can vanish between the caller resolving them and
+ * the write landing: the session (a concurrent refresh-token replay reaction,
+ * an explicit logout, an admin force-logout, the session sweeper) and the
+ * client the token is attributed to (an admin deleting the application).
+ *
+ * The error deliberately does NOT name which one. Only postgres reports the
+ * failing constraint as a field; mysql buries it in the message text and sqlite
+ * reports nothing but "FOREIGN KEY constraint failed", so a per-relation
+ * classification would be unimplementable on the dialect the test suite runs
+ * on. It also would not buy anything: both parents cascade onto
+ * `auth_session_tokens`, so either one going missing has already deleted the
+ * token rows, and the answer for the caller is the same.
+ *
+ * Transport-agnostic on purpose: the refresh grant re-raises it as
  * `invalid_grant`, every other issuing path lets it settle as the 400 its code
  * maps to.
  */
-export class SessionTokenSessionMissingError extends ValidationError {
+export class SessionTokenRelationMissingError extends ValidationError {
     constructor() {
         super({
             code: ErrorCode.ENTITY_RELATION_INVALID,
-            message: 'The session the token belongs to no longer exists.',
+            message: 'A row the token references no longer exists.',
         });
-        markInstanceof(this, SESSION_TOKEN_SESSION_MISSING_ERROR_INSTANCE);
+        markInstanceof(this, SESSION_TOKEN_RELATION_MISSING_ERROR_INSTANCE);
     }
 }
 
@@ -43,6 +53,6 @@ export class SessionTokenSessionMissingError extends ValidationError {
  * boundary before it is caught, so there is nothing for a rehydrated match to
  * recover.
  */
-export function isSessionTokenSessionMissingError(input: unknown): input is SessionTokenSessionMissingError {
-    return matchesInstanceof(input, SESSION_TOKEN_SESSION_MISSING_ERROR_INSTANCE);
+export function isSessionTokenRelationMissingError(input: unknown): input is SessionTokenRelationMissingError {
+    return matchesInstanceof(input, SESSION_TOKEN_RELATION_MISSING_ERROR_INSTANCE);
 }

--- a/apps/server-core/src/core/oauth2/session-token/index.ts
+++ b/apps/server-core/src/core/oauth2/session-token/index.ts
@@ -5,4 +5,5 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './error.ts';
 export * from './types.ts';

--- a/apps/server-core/src/core/oauth2/session-token/types.ts
+++ b/apps/server-core/src/core/oauth2/session-token/types.ts
@@ -61,12 +61,14 @@ export interface ISessionTokenRepository {
     /**
      * Persist a newly issued session-token row.
      *
-     * Throws `SessionTokenSessionMissingError` when `sessionId` no longer names
-     * a live session. The row is written after the caller resolved the session,
-     * so a concurrent delete (a replay reaction, a logout, the sweeper) can land
-     * in between and the write is then rejected. Callers that own an OAuth2
-     * error vocabulary translate it; the rest let it settle as a plain
-     * validation failure.
+     * Throws `SessionTokenRelationMissingError` when a row the token references
+     * is gone: `sessionId`, or the `clientId` it is attributed to. Both are
+     * resolved before the write, so a concurrent delete (a replay reaction, a
+     * logout, the sweeper, an application being removed) can land in between
+     * and the write is then rejected. Which of the two it was is deliberately
+     * not reported, since both cascade onto this table and so leave the token
+     * equally unusable. Callers that own an OAuth2 error vocabulary translate
+     * it; the rest let it settle as a plain validation failure.
      */
     create(input: SessionTokenCreateInput): Promise<SessionToken>;
 

--- a/apps/server-core/src/core/oauth2/session-token/types.ts
+++ b/apps/server-core/src/core/oauth2/session-token/types.ts
@@ -60,6 +60,13 @@ export interface ISessionTokenRepository {
 
     /**
      * Persist a newly issued session-token row.
+     *
+     * Throws `SessionTokenSessionMissingError` when `sessionId` no longer names
+     * a live session. The row is written after the caller resolved the session,
+     * so a concurrent delete (a replay reaction, a logout, the sweeper) can land
+     * in between and the write is then rejected. Callers that own an OAuth2
+     * error vocabulary translate it; the rest let it settle as a plain
+     * validation failure.
      */
     create(input: SessionTokenCreateInput): Promise<SessionToken>;
 

--- a/apps/server-core/test/unit/adapters/database/driver-error.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/driver-error.spec.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest';
 import {
     getDatabaseDriverErrorCode,
+    isForeignKeyConstraintDatabaseError,
     isUniqueConstraintDatabaseError,
 } from '../../../../src/adapters/database/errors/index.ts';
 
@@ -41,6 +42,25 @@ describe('adapters/database/errors/driver', () => {
             expect(isUniqueConstraintDatabaseError({ code: '23503' })).toBe(false);
             expect(isUniqueConstraintDatabaseError(new Error('nope'))).toBe(false);
             expect(isUniqueConstraintDatabaseError(null)).toBe(false);
+        });
+    });
+
+    describe('isForeignKeyConstraintDatabaseError', () => {
+        it('matches every supported driver code, top-level or nested', () => {
+            expect(isForeignKeyConstraintDatabaseError({ code: 'ER_NO_REFERENCED_ROW' })).toBe(true);
+            expect(isForeignKeyConstraintDatabaseError({ code: 'ER_NO_REFERENCED_ROW_2' })).toBe(true);
+            expect(isForeignKeyConstraintDatabaseError({ code: 'ER_ROW_IS_REFERENCED' })).toBe(true);
+            expect(isForeignKeyConstraintDatabaseError({ code: 'ER_ROW_IS_REFERENCED_2' })).toBe(true);
+            expect(isForeignKeyConstraintDatabaseError({ code: '23503' })).toBe(true);
+            expect(isForeignKeyConstraintDatabaseError({ code: 'SQLITE_CONSTRAINT_FOREIGNKEY' })).toBe(true);
+            expect(isForeignKeyConstraintDatabaseError({ driverError: { code: '23503' } })).toBe(true);
+        });
+
+        it('is false for a different constraint / arbitrary errors', () => {
+            expect(isForeignKeyConstraintDatabaseError({ code: '23505' })).toBe(false);
+            expect(isForeignKeyConstraintDatabaseError({ code: 'ER_DUP_ENTRY' })).toBe(false);
+            expect(isForeignKeyConstraintDatabaseError(new Error('nope'))).toBe(false);
+            expect(isForeignKeyConstraintDatabaseError(null)).toBe(false);
         });
     });
 });

--- a/apps/server-core/test/unit/app/modules/oauth2/session-token-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/oauth2/session-token-repository.spec.ts
@@ -16,8 +16,8 @@ import {
     it,
 } from 'vitest';
 import { DataSourceOptionsBuilder } from '../../../../../src/adapters/database/data-source/options/module.ts';
-import { RealmEntity, SessionEntity } from '../../../../../src/adapters/database/domains/index.ts';
-import { isSessionTokenSessionMissingError } from '../../../../../src/core/index.ts';
+import { ClientEntity, RealmEntity, SessionEntity } from '../../../../../src/adapters/database/domains/index.ts';
+import { isSessionTokenRelationMissingError } from '../../../../../src/core/index.ts';
 import { SessionTokenRepositoryAdapter } from '../../../../../src/app/modules/oauth2/repositories/session-token/repository.ts';
 
 describe('app/modules/oauth2/repositories/session-token', () => {
@@ -59,10 +59,21 @@ describe('app/modules/oauth2/repositories/session-token', () => {
         return entity.id;
     }
 
-    function buildInput(sessionId: string) {
+    async function createClient() : Promise<string> {
+        const repository = dataSource.getRepository(ClientEntity);
+        const entity = await repository.save(repository.create({
+            name: `client-${randomUUID()}`,
+            realmId,
+        }));
+
+        return entity.id;
+    }
+
+    function buildInput(sessionId: string, clientId?: string) {
         return {
             id: randomUUID(),
             sessionId,
+            clientId: clientId ?? null,
             kind: 'refresh' as const,
             ipAddress: '203.0.113.10',
             userAgent: 'test-agent',
@@ -86,7 +97,7 @@ describe('app/modules/oauth2/repositories/session-token', () => {
     // writing the row (a concurrent replay revoke, an explicit logout, the
     // session sweeper). The foreign key rejects the insert, and the driver
     // error must not escape as an unhandled internal error (issue #3435).
-    it('raises a session-missing domain error when the session is gone', async () => {
+    it('raises a relation-missing domain error when the session is gone', async () => {
         const repository = new SessionTokenRepositoryAdapter(dataSource);
         const sessionId = await createSession();
 
@@ -99,6 +110,39 @@ describe('app/modules/oauth2/repositories/session-token', () => {
             error = e;
         }
 
-        expect(isSessionTokenSessionMissingError(error)).toBe(true);
+        expect(isSessionTokenRelationMissingError(error)).toBe(true);
+    });
+
+    // The client the row is attributed to can vanish in the same window, and it
+    // is reported the same way on purpose. Only postgres names the failing
+    // constraint on the error; sqlite reports "FOREIGN KEY constraint failed"
+    // and nothing else, so a per-relation verdict is not implementable here. It
+    // would also not change any caller: the client cascades onto this table
+    // too, so the token's rows are gone either way.
+    it('raises the same error when the attributed client is gone', async () => {
+        const repository = new SessionTokenRepositoryAdapter(dataSource);
+        const sessionId = await createSession();
+        const clientId = await createClient();
+
+        await dataSource.getRepository(ClientEntity).delete({ id: clientId });
+
+        let error : unknown;
+        try {
+            await repository.create(buildInput(sessionId, clientId));
+        } catch (e) {
+            error = e;
+        }
+
+        expect(isSessionTokenRelationMissingError(error)).toBe(true);
+    });
+
+    it('persists a token row attributed to a live client', async () => {
+        const repository = new SessionTokenRepositoryAdapter(dataSource);
+        const sessionId = await createSession();
+        const clientId = await createClient();
+
+        const row = await repository.create(buildInput(sessionId, clientId));
+
+        expect(row.clientId).toEqual(clientId);
     });
 });

--- a/apps/server-core/test/unit/app/modules/oauth2/session-token-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/oauth2/session-token-repository.spec.ts
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import { OAuth2SubKind } from '@authup/specs';
+import { DataSource } from 'typeorm';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { DataSourceOptionsBuilder } from '../../../../../src/adapters/database/data-source/options/module.ts';
+import { RealmEntity, SessionEntity } from '../../../../../src/adapters/database/domains/index.ts';
+import { isSessionTokenSessionMissingError } from '../../../../../src/core/index.ts';
+import { SessionTokenRepositoryAdapter } from '../../../../../src/app/modules/oauth2/repositories/session-token/repository.ts';
+
+describe('app/modules/oauth2/repositories/session-token', () => {
+    let dataSource : DataSource;
+    let realmId : string;
+
+    // Isolated in-memory database. The suite-shared file carries provisioned
+    // rows and is copied per worker; this spec only needs a schema whose
+    // foreign keys are enforced (better-sqlite3 runs `PRAGMA foreign_keys = ON`).
+    beforeAll(async () => {
+        dataSource = new DataSource(new DataSourceOptionsBuilder().buildWith({
+            type: 'better-sqlite3',
+            database: ':memory:',
+            synchronize: true,
+        }));
+        await dataSource.initialize();
+
+        const realm = await dataSource.getRepository(RealmEntity).save(
+            dataSource.getRepository(RealmEntity).create({ name: 'master', builtIn: true }),
+        );
+        realmId = realm.id;
+    });
+
+    afterAll(async () => {
+        await dataSource.destroy();
+    });
+
+    async function createSession() : Promise<string> {
+        const repository = dataSource.getRepository(SessionEntity);
+        const entity = await repository.save(repository.create({
+            sub: randomUUID(),
+            subKind: OAuth2SubKind.USER,
+            realmId,
+            ipAddress: '203.0.113.10',
+            userAgent: 'test-agent',
+            expiresAt: new Date(Date.now() + 100_000).toISOString(),
+        }));
+
+        return entity.id;
+    }
+
+    function buildInput(sessionId: string) {
+        return {
+            id: randomUUID(),
+            sessionId,
+            kind: 'refresh' as const,
+            ipAddress: '203.0.113.10',
+            userAgent: 'test-agent',
+            expiresAt: new Date(Date.now() + 100_000).toISOString(),
+        };
+    }
+
+    it('persists a token row for an existing session', async () => {
+        const repository = new SessionTokenRepositoryAdapter(dataSource);
+        const sessionId = await createSession();
+
+        const input = buildInput(sessionId);
+        const row = await repository.create(input);
+
+        expect(row.id).toEqual(input.id);
+        expect(row.sessionId).toEqual(sessionId);
+        expect(row.createdAt).toBeTypeOf('string');
+    });
+
+    // The session can be deleted between the grant resolving it and the issuer
+    // writing the row (a concurrent replay revoke, an explicit logout, the
+    // session sweeper). The foreign key rejects the insert, and the driver
+    // error must not escape as an unhandled internal error (issue #3435).
+    it('raises a session-missing domain error when the session is gone', async () => {
+        const repository = new SessionTokenRepositoryAdapter(dataSource);
+        const sessionId = await createSession();
+
+        await dataSource.getRepository(SessionEntity).delete({ id: sessionId });
+
+        let error : unknown;
+        try {
+            await repository.create(buildInput(sessionId));
+        } catch (e) {
+            error = e;
+        }
+
+        expect(isSessionTokenSessionMissingError(error)).toBe(true);
+    });
+});

--- a/apps/server-core/test/unit/core/oauth2/grant-types/refresh-token.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/grant-types/refresh-token.spec.ts
@@ -18,7 +18,7 @@ import {
     it,
 } from 'vitest';
 import { OAuth2RefreshTokenGrant } from '../../../../../src/core/oauth2/grant-types/refresh-token.ts';
-import { SessionTokenSessionMissingError } from '../../../../../src/core/oauth2/session-token/error.ts';
+import { SessionTokenRelationMissingError } from '../../../../../src/core/oauth2/session-token/error.ts';
 import {
     FakeAuthFlowMetrics,
     FakeEventService,
@@ -372,15 +372,16 @@ describe('OAuth2RefreshTokenGrant', () => {
     // Issue #3435. A concurrent revoke (a replay reaction on the same family,
     // an explicit logout, an admin force-logout, the sweeper) can delete the
     // session between the grant resolving it and the issuer writing the
-    // inventory row. The insert then violates the session foreign key. The
-    // client must see `invalid_grant` and re-authenticate, not a 500 it will
-    // treat as retryable with a token that is already consumed.
-    it('should answer invalid_grant when the session is revoked before the refresh token is issued', async () => {
+    // inventory row, and a deleted client takes the same path. The insert then
+    // violates a foreign key. The client must see `invalid_grant` and
+    // re-authenticate, not a 500 it will treat as retryable with a token that
+    // is already consumed.
+    it('should answer invalid_grant when a referenced row is gone before the refresh token is issued', async () => {
         const payload = await seed();
         const grant = build();
 
         refreshTokenIssuer.issue = async () => {
-            throw new SessionTokenSessionMissingError();
+            throw new SessionTokenRelationMissingError();
         };
 
         let error: unknown;
@@ -400,12 +401,12 @@ describe('OAuth2RefreshTokenGrant', () => {
         expect(metrics.refreshReplayCalls).toEqual(0);
     });
 
-    it('should answer invalid_grant when the session is revoked before the access token is issued', async () => {
+    it('should answer invalid_grant when a referenced row is gone before the access token is issued', async () => {
         const payload = await seed();
         const grant = build();
 
         accessTokenIssuer.issue = async () => {
-            throw new SessionTokenSessionMissingError();
+            throw new SessionTokenRelationMissingError();
         };
 
         let error: unknown;

--- a/apps/server-core/test/unit/core/oauth2/grant-types/refresh-token.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/grant-types/refresh-token.spec.ts
@@ -10,6 +10,7 @@ import type { Session } from '@authup/core-kit';
 import { EventName, EventRefType, EventScope } from '@authup/core-kit';
 import type { OAuth2TokenPayload } from '@authup/specs';
 import { OAuth2SubKind, OAuth2TokenKind, isOAuth2Error } from '@authup/specs';
+import { ErrorCode } from '@authup/errors';
 import {
     beforeEach,
     describe,
@@ -17,6 +18,7 @@ import {
     it,
 } from 'vitest';
 import { OAuth2RefreshTokenGrant } from '../../../../../src/core/oauth2/grant-types/refresh-token.ts';
+import { SessionTokenSessionMissingError } from '../../../../../src/core/oauth2/session-token/error.ts';
 import {
     FakeAuthFlowMetrics,
     FakeEventService,
@@ -365,6 +367,71 @@ describe('OAuth2RefreshTokenGrant', () => {
 
         expect(isOAuth2Error(error)).toBe(true);
         expect(sessionManager.revokeCalls).toContain(sessionId);
+    });
+
+    // Issue #3435. A concurrent revoke (a replay reaction on the same family,
+    // an explicit logout, an admin force-logout, the sweeper) can delete the
+    // session between the grant resolving it and the issuer writing the
+    // inventory row. The insert then violates the session foreign key. The
+    // client must see `invalid_grant` and re-authenticate, not a 500 it will
+    // treat as retryable with a token that is already consumed.
+    it('should answer invalid_grant when the session is revoked before the refresh token is issued', async () => {
+        const payload = await seed();
+        const grant = build();
+
+        refreshTokenIssuer.issue = async () => {
+            throw new SessionTokenSessionMissingError();
+        };
+
+        let error: unknown;
+        try {
+            await grant.runWith(payload);
+        } catch (e) {
+            error = e;
+        }
+
+        expect(isOAuth2Error(error)).toBe(true);
+        expect((error as { code?: string }).code).toEqual(ErrorCode.OAUTH_GRANT_INVALID);
+
+        // This is not a replay, so the family must not be revoked a second time
+        // and no audit event / metric may be recorded for it.
+        expect(sessionManager.revokeCalls).toHaveLength(0);
+        expect(eventService.recordCalls).toHaveLength(0);
+        expect(metrics.refreshReplayCalls).toEqual(0);
+    });
+
+    it('should answer invalid_grant when the session is revoked before the access token is issued', async () => {
+        const payload = await seed();
+        const grant = build();
+
+        accessTokenIssuer.issue = async () => {
+            throw new SessionTokenSessionMissingError();
+        };
+
+        let error: unknown;
+        try {
+            await grant.runWith(payload);
+        } catch (e) {
+            error = e;
+        }
+
+        expect(isOAuth2Error(error)).toBe(true);
+        expect((error as { code?: string }).code).toEqual(ErrorCode.OAUTH_GRANT_INVALID);
+    });
+
+    // Only the missing-session condition is translated. Anything else is a
+    // genuine fault and must keep surfacing as one, or the race handling would
+    // hide real breakage behind a routine OAuth2 error.
+    it('should rethrow an unrelated issuer failure untouched', async () => {
+        const payload = await seed();
+        const grant = build();
+
+        const failure = new Error('signing key unavailable');
+        refreshTokenIssuer.issue = async () => {
+            throw failure;
+        };
+
+        await expect(grant.runWith(payload)).rejects.toBe(failure);
     });
 
     it('should throw when the payload has no jti', async () => {


### PR DESCRIPTION
Closes #3435.

## Problem

A refresh-token rotation resolves the session and then issues, holding nothing in between:

```ts
const session = await this.sessionManager.findOneById(payload.session_id);
// ...
const [refreshToken, refreshTokenPayload] = await this.refreshTokenIssuer.issue({ ... });
```

A concurrent request can delete the `auth_sessions` row in that gap: the replay reaction on this same token family (two requests presenting one token, the loser calling `revokeFamily` while the winner is still issuing), an explicit logout, `DELETE /sessions/:id`, an admin force-logout, or the sweeper. The inventory insert is then rejected by `FK_auth_session_tokens_session_id` and the driver error escaped as an unhandled internal error.

Refusing the request is correct. The status was not: the client saw `500 internal_error`, which most OAuth2 clients treat as retryable, while its presented token was already consumed and cache-blocklisted, so there was nothing left to retry with. It also logged as a fault rather than the benign-and-expected race it is.

## Fix

Item (1) from the issue. Since `core/**` deliberately never imports `adapters/database/**`, the driver knowledge stays in the adapter and the translation happens in two hops:

- `adapters/database/errors/driver.ts` gains `isForeignKeyConstraintDatabaseError`, the sibling of the existing `isUniqueConstraintDatabaseError` that the consent-insert race already uses.
- `SessionTokenRepositoryAdapter.create` catches a foreign-key rejection and raises `SessionTokenSessionMissingError` (`core/oauth2/session-token/error.ts`), declared on the `ISessionTokenRepository.create` port. `session_id` is the only foreign key an insert there can violate, so the condition is unambiguous.
- `OAuth2RefreshTokenGrant.runWith` wraps both issuer calls and re-raises that one error as `invalid_grant`. Everything else is rethrown untouched, so a signing or cache fault still surfaces as a fault.

Items (2) and (3) from the issue are deliberately skipped. A pre-issue re-read closes nothing, since the delete can still land one statement later, and once (1) is in place the client-facing outcome is identical either way.

The new error extends `ValidationError` and reuses `ErrorCode.ENTITY_RELATION_INVALID`, so it adds nothing to the public error vocabulary and needs no new i18n copy. Its guard is marker-only on purpose: that code is shared with typeorm-extension's join-column lookup failures through `sanitizeError`, so a `code` fallback would claim unrelated errors.

Both issuers write inventory rows, so the error can also reach the password / authorize / identity / client-credentials / MFA-completion paths. Those create their session in the same request, making the race near-impossible, but if it ever happens they now settle at a 400 instead of a 500. They keep the error's own code rather than an OAuth2 grant error, since `invalid_grant` describes no grant artifact they hold.

## Verification

All three new tests were confirmed failing first, by stashing only the two behavioral source files. The 17 pre-existing grant tests stayed green throughout.

- `test/unit/core/oauth2/grant-types/refresh-token.spec.ts` — the missing-session error becomes `invalid_grant` from either issuer, with no second family revoke and no audit event or metric; an unrelated issuer failure is rethrown unchanged.
- `test/unit/app/modules/oauth2/session-token-repository.spec.ts` — new spec over an isolated in-memory database, deleting the session and triggering the real foreign-key violation.
- `test/unit/adapters/database/driver-error.spec.ts` — the code matrix.

Full server-core suite green (192 files, 2141 tests). Build, `check:types` and eslint clean.

The driver codes are the part a green suite cannot vouch for on its own, so they were checked against the running containers rather than assumed: postgres reports `23503`, mysql reports `ER_NO_REFERENCED_ROW_2` on insert and `ER_ROW_IS_REFERENCED_2` on delete, and sqlite's `SQLITE_CONSTRAINT_FOREIGNKEY` is exercised for real by the adapter spec.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved refresh-token handling when a session is deleted during token issuance.
  * Returns a standard OAuth `invalid_grant` response instead of exposing a database error.
  * Preserves existing behavior for unrelated failures and prevents replay side effects.

* **Tests**
  * Added coverage for database constraint detection, deleted-session token creation, and refresh/access-token issuance failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->