### PR TITLE
chore: prepare v1.0.0-beta.60

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2718,9 +2718,23 @@ linking is the only way to bind an external identity to an EXISTING user).
   and NEVER runs mappers, mutates the user, mints a code or creates a
   session. The redirect back is fixed and server-derived:
   `<publicUrl>/account/connected-accounts?linked=<providerId>` or
-  `?linkError=already_linked|link_failed`. Takeover posture: linking an
-  attacker's external identity to a victim requires a state blob carrying
-  the victim's userId, which only the victim's bearer can mint.
+  `?linkError=already_linked|link_failed`. **Takeover posture — reason about
+  BOTH directions.** Linking an attacker's external identity to a victim
+  requires a state blob carrying the victim's userId, which only the
+  victim's bearer can mint. The reverse direction is the one that bites:
+  the attacker mints a state carrying their OWN userId and gets the victim
+  to follow it, so the victim's callback binds the VICTIM's external
+  identity to the ATTACKER's account, and the victim's next federated login
+  resolves through that row into it. State unguessability does not defend
+  this — the attacker is not guessing a state, they are supplying one — so
+  the ONLY control is the state's ip/user-agent binding, and both values
+  are chosen by whoever minted the state (`verify` skips a check whose
+  STORED value is falsy, and under the shipped `trustProxy: true` the ip is
+  the client-supplied left-most `X-Forwarded-For` entry). `completeLink`
+  therefore refuses a state carrying no binding at all. That is a stopgap
+  for the absent-binding hole only, not for a guessed one; issue #3439
+  moves the write behind a bearer-authenticated confirmation, after which
+  the guard and the state-carried userId both go away.
 - **Events** — `identityProviderLinked` (recorded in the callback branch)
   / `identityProviderUnlinked` (recorded in the service delete), IDENTITY
   scope, `refType: identityProviderAccount`, metadata only (provider

--- a/apps/authup/src/index.ts
+++ b/apps/authup/src/index.ts
@@ -15,3 +15,4 @@ Promise.resolve()
         consola.error(normalizeError(error).message);
         process.exit(1);
     });
+

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -360,8 +360,9 @@ export class IdentityProviderController {
 
         const data = await this.verifyAuthorizationState(event);
 
-        if (data.link) {
-            return this.completeLink(event, entity, data.link);
+        const { link } = data;
+        if (link) {
+            return this.completeLink(event, entity, data, link);
         }
 
         if (
@@ -559,6 +560,7 @@ export class IdentityProviderController {
     private async completeLink(
         event: IAppEvent,
         provider: OAuth2IdentityProvider | OpenIDIdentityProvider,
+        state: OAuth2AuthorizationState,
         link: OAuth2AuthorizationStateLink,
     ) {
         // Fixed, server-derived return target (the account console page).
@@ -574,6 +576,30 @@ export class IdentityProviderController {
             // complete a link after its provider was disabled.
             if (link.providerId !== provider.id || !provider.enabled) {
                 throw new BadRequestError('The identity provider is not available for account linking.');
+            }
+
+            // The state must be bound to the browser that minted it. Both
+            // bindings come from the minting request itself
+            // (`saveAuthorizationState` stores its ip and user-agent) and
+            // `OAuth2AuthorizationStateManager.verify` skips a check whose
+            // STORED value is falsy, so an absent binding is a choice the
+            // minter made rather than a property of the network — and it
+            // leaves the state completable in any browser.
+            //
+            // On the login path that is a session-fixation nuisance. Here it
+            // is a durable credential binding: an attacker who mints a state
+            // carrying their OWN userId and gets a victim to follow it binds
+            // the VICTIM's external identity to the attacker's account, and
+            // the victim's next federated login then lands in it. Refuse an
+            // unbound state instead of linking on it.
+            //
+            // This closes the absent-binding hole only. ip + user-agent
+            // remain guessable, and with the shipped `trustProxy: true` the
+            // ip is the client-supplied left-most X-Forwarded-For entry, so
+            // this is a stopgap: see issue #3439 for moving the write behind
+            // a bearer-authenticated confirmation.
+            if (!state.ip || !state.userAgent) {
+                throw new BadRequestError('The account link request is not bound to a browser.');
             }
 
             if (typeof code !== 'string' || code.length === 0) {

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/link.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/link.spec.ts
@@ -275,6 +275,53 @@ describe('identity-provider link flow', () => {
         tokenEndpointError = undefined;
     });
 
+    it('refuses to link on a state that carries no browser binding', async () => {
+        // `verify` skips a binding check whose STORED value is falsy, and both
+        // stored values come from the request that minted the state. A minter
+        // that sends no user-agent therefore produces a state completable in
+        // ANY browser — and this path performs a durable credential binding,
+        // so an attacker could mint one carrying their own userId and have a
+        // victim's browser bind the VICTIM's external identity to it.
+        //
+        // A fresh external subject AND a fresh user, so nothing else can
+        // refuse this link: without the guard it succeeds outright, which is
+        // what makes the two assertions below discriminate.
+        externalUserId = 'external-user-unbound';
+
+        const password = generateOAuth2CodeVerifier();
+        const { data: victimUser } = await suite.client.user.create(createFakeUser({
+            realmId: realm.id,
+            password,
+        }));
+        const login = await suite.client.token.createWithPassword({
+            username: victimUser.name,
+            password,
+            realm_id: realm.id,
+        });
+
+        // mint with no user-agent, then complete from a different browser
+        const response = await httpRequest(suite, 'POST', `identity-providers/${provider.id}/link-request`, {
+            headers: {
+                Authorization: `Bearer ${login.access_token}`,
+                'user-agent': '',
+            },
+        });
+        expect(response.status).toEqual(200);
+
+        const state = new URL((await response.json()).url).searchParams.get('state');
+        expect(state).toBeTruthy();
+
+        const target = await completeCallback(state as string);
+
+        expect(target.searchParams.get('linked')).toBeNull();
+        expect(target.searchParams.get('linkError')).toEqual('link_failed');
+
+        const rows = await suite.client.get(`identity-provider-accounts?filter[userId]=${victimUser.id}`);
+        expect(rows.data.data).toHaveLength(0);
+
+        externalUserId = 'external-user-1';
+    });
+
     it('rejects a link state replayed against a different provider callback', async () => {
         // a second provider in the same realm; a state minted for `provider`
         // must not complete a link on `otherProvider`'s callback.

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -68,8 +68,11 @@ denies new authorization-code admission (and code redemption) for the admin
 console to identities that fail the policy. It is admission control, not
 continuous enforcement: the `refresh_token` grant is not re-evaluated, so
 already-issued refresh tokens keep working until they expire. To evict an
-identity that was admitted before the policy changed, revoke its sessions
-(`DELETE /sessions?filter[clientId]=...` or the sessions UI).
+identity that was admitted before the policy changed, revoke the tokens issued
+for that application (`DELETE /session-tokens?filter[clientId]=...`). This
+leaves the browser session alive, so the other applications riding it stay
+signed in. To sign one identity out everywhere instead, revoke its sessions
+(`DELETE /sessions?filter[userId]=...` or the sessions UI).
 
 One more caveat: the gate evaluates identity data only (realm, identity
 type, time windows, compositions thereof); role-membership conditions are

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -5,7 +5,85 @@ Entries are grouped by release, newest first. Routine changes (features, fixes) 
 [changelog](https://github.com/authup/authup/blob/master/CHANGELOG.md); anything listed here
 either requires operator action or deliberately changes behavior.
 
-## Next release (after v1.0.0-beta.58)
+## Next release (after v1.0.0-beta.59)
+
+### Fixed: external identity-provider login
+
+The token exchange against an external OAuth2 / OIDC provider never sent the
+`code` parameter, so **every federated login has failed since
+v1.0.0-beta.28** with an `invalid_request` from the provider's token
+endpoint. The callback passed the raw code string where the authenticator
+expected `{ code }`, and the HTTP client spread it into indexed body keys
+(`0=d&1=b&...`). **No action is required** beyond upgrading. A callback that
+arrives without a code is now rejected with a `400` instead of an opaque
+upstream failure.
+
+### `auth_sessions.client_id` is the client-subject foreign key only
+
+One browser session legitimately serves several applications (the hosted auth
+pages and the account console share the IdP origin by design), so a single
+column could never name all of them: it was last-writer-wins and accurate for
+none. Per-application attribution moved one level down, onto
+`auth_session_tokens.client_id`.
+
+`auth_sessions.client_id` now means what its foreign key always implied — the
+subject of a **client** session — and is `NULL` for a user's session. Nothing
+writes the authorizing application there anymore.
+
+- **Runbooks that sign an identity out of one application must change**:
+  `DELETE /sessions?filter[clientId]=...` no longer matches user sessions.
+  Use `DELETE /session-tokens?filter[clientId]=...`, which revokes that
+  application's tokens and leaves the session alive so the others stay signed
+  in. To sign an identity out everywhere, filter by `userId` instead.
+- **Sessions created before the upgrade keep the old value.** No backfill
+  ships, because the column is behind `ON DELETE CASCADE`: until those rows
+  expire (session lifetime, three days by default), deleting a retired client
+  still force-logs-out the users whose sessions recorded it. Either wait out
+  the lifetime before deleting a client, or run
+  `UPDATE auth_sessions SET client_id = NULL WHERE sub_kind <> 'client'`.
+
+### Schema migration: constraint names, MySQL column widths, 140 indexes
+
+Two migrations apply. Both are safe to run on a populated database, and the
+round trip is verified in CI against MySQL and PostgreSQL, but the second one
+is not instant on a large instance. **Run `authup migration run` before the
+rolling restart** rather than letting the first pod apply it under traffic.
+
+- Index, unique and foreign-key names move onto the values TypeORM derives
+  from the entity metadata. Names have no runtime meaning; this only ends a
+  split where two naming regimes coexisted and every generated migration
+  emitted 32 renames before its actual change.
+- **MySQL only**: 15 `uuid` columns widen from `varchar(36)` to the
+  `varchar(255)` TypeORM derives for them. This rewrites those tables, blocks
+  writes for the duration and needs disk headroom for the copy. It runs first
+  and is re-runnable, so an interrupted upgrade retries cleanly.
+- 140 indexes are added, backing the filter and sort vocabulary each entity
+  advertises (see below) and the remaining foreign-key columns. On PostgreSQL
+  the migrations run in one transaction, so the largest tables
+  (`auth_events`, `auth_sessions`, `auth_session_tokens`) are locked for the
+  duration of the build.
+- Three orphaned tables are **dropped with their rows**:
+  `auth_authorization_codes`, `auth_refresh_tokens` and
+  `auth_identity_provider_roles`. Each was superseded years ago (codes moved
+  to cache blobs, refresh tokens to `auth_session_tokens`, provider roles to
+  `auth_identity_provider_role_mappings`) and no entity has described them
+  since. Back them up first if you still read them out of band.
+
+### API: `meta.schema.sort` is now `meta.schema.sorts`
+
+The query-capable `GET` endpoints describe their vocabulary under
+`meta.schema`. Its sort key was renamed `sort` → `sorts` (rapiq 2.1.0, which
+made `sorts` canonical on every developer-authored surface). **A client that
+reads `meta.schema.sort` must follow**; there is no alias. The `?sort=-name`
+URL parameter is unchanged.
+
+Filters and sorts are also index-anchored now: every key an endpoint allows
+is backed by a real index, so single-key filters and sorts behave exactly as
+before. The one narrowing is a **multi-key sort** with no matching composite
+index prefix, which is now dropped whole rather than executed — the request
+still succeeds, unsorted.
+
+## v1.0.0-beta.59
 
 ### Security fix: redirect patterns with a host wildcard
 

--- a/packages/client-web-kit-theme/src/index.ts
+++ b/packages/client-web-kit-theme/src/index.ts
@@ -60,3 +60,4 @@ export default function clientWebKitTheme() {
         },
     });
 }
+

--- a/packages/core-realtime-kit/src/index.ts
+++ b/packages/core-realtime-kit/src/index.ts
@@ -10,3 +10,4 @@ export * from './event';
 export * from './helpers';
 export * from './types';
 
+

--- a/packages/server-adapter-node/src/index.ts
+++ b/packages/server-adapter-node/src/index.ts
@@ -9,3 +9,4 @@ export * from './middleware';
 export * from './types';
 export * from './verify-request';
 
+

--- a/packages/server-adapter-socket-io/src/index.ts
+++ b/packages/server-adapter-socket-io/src/index.ts
@@ -9,3 +9,4 @@ export * from './middleware';
 export * from './types';
 export * from './verify-socket';
 
+

--- a/packages/server-adapter-web/src/index.ts
+++ b/packages/server-adapter-web/src/index.ts
@@ -7,3 +7,4 @@
 
 export * from './types';
 export * from './verify-request';
+

--- a/packages/specs/src/index.ts
+++ b/packages/specs/src/index.ts
@@ -10,3 +10,4 @@ export * from './json-web-token';
 export * from './oauth2';
 export * from './openid';
 
+

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,7 +1,7 @@
 {
     "include-component-in-tag": false,
     "release-type": "node",
-    "release-as": "1.0.0-beta.59",
+    "release-as": "1.0.0-beta.60",
     "packages": {
         ".": {"component": "root", "extra-files": ["CITATION.cff"]},
 


### PR DESCRIPTION
Release preparation for `v1.0.0-beta.60`, plus one security stopgap found while auditing the range.

Reviewed range: `1aaa52bbc..master` (22 commits since `v1.0.0-beta.59`).

## 1. Release mechanics

`release-please-config.json` still pinned `release-as: 1.0.0-beta.59` — the version already published — so the open release PR proposed a no-op for most packages and a bogus `1.0.1-beta.59` for seven of them. Bumped to `1.0.0-beta.60` and touched those seven so the linked group moves together.

The seven were derived independently (packages with no `fix:`/`feat:` commit since the last release) and the set matched exactly what release-please had mis-versioned: `apps/authup`, `client-web-kit-theme`, `core-realtime-kit`, the three `server-adapter-*`, `specs`.

## 2. Docs

**`provisioning.md`** — the "Restricting the admin console" tip told operators to evict an already-admitted identity with `DELETE /sessions?filter[clientId]=…`. Since 6027f849f that column is the client-**subject** foreign key and is null for a user's session, so the call matches nothing and answers `{ count: 0 }`. A documented security remediation that silently did nothing. Now points at `DELETE /session-tokens?filter[clientId]=…`, with `filter[userId]` given as the sign-out-everywhere alternative.

**`upgrading.md`** — still labelled the beta.59 notes "Next release (after v1.0.0-beta.58)" and had no section for this window. Adds one covering the four things that need an operator decision:

- the federated-login fix (broken since **v1.0.0-beta.28**, verified via `git tag --contains a55da4190`)
- the `auth_sessions.client_id` semantics change and the absence of a backfill for it
- migration cost: MySQL uuid column widening, 140 indexes, three legacy tables dropped **with their rows**
- the wire-visible `meta.schema.sort` → `sorts` rename

## 3. Security stopgap (please read)

`fix: refuse an account link on a state with no browser binding`

The account-linking callback (plan 091) is unauthenticated, so the linking user's id rides the OAuth2 state blob. The only thing separating "the browser that started this link" from any other browser is the state's ip / user-agent binding — and that binding is optional: `verify` skips a check whose **stored** value is falsy, and both stored values come from the request that minted the state.

State unguessability does not cover this direction: the attacker supplies their own state and *wants* the victim to use it. So an attacker who mints a state carrying their own `userId` (no `User-Agent`, spoofed `X-Forwarded-For` — the shipped `trustProxy: true` returns the client-supplied left-most entry) can have a victim's callback bind the **victim's** external identity to the **attacker's** account. The victim's next federated login then lands in it.

This closes the absent-binding hole only; ip + user-agent stay guessable. The real fix — moving the write behind a bearer-authenticated confirmation — is #3439, targeted at the release after next.

The spec uses a fresh external subject *and* a fresh user so nothing else can refuse the link. Verified as a differential: with the guard removed the link succeeds outright and the test fails on both assertions.

## Verification

- server-core suite, sqlite: 194 files / 2160 tests pass
- server-core suite, postgres: 194 files / 2159 tests pass (pre-guard run)
- `check:types`, eslint, `build`, docs site build: clean
- CI on the tip of `master` was green across all 9 jobs, including both migration round-trips and the schema-drift gate

## Not included

The `BREAKING CHANGE` footer on #3404 describes write-once "first authorizer" semantics that a later commit in the same PR reverted, so release-please will regenerate incorrect text into `CHANGELOG.md`. It cannot be fixed from a branch — it needs a manual edit on the release PR before merge. The correct wording is in `upgrading.md` and can be lifted from there.