### PR TITLE
fix(server-core): declare a sort allow-list for the client-scope schema

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -362,6 +362,20 @@ usable at the service level and nothing in core depends on TypeORM:
   ran. It now carries a *should have sort allow-lists to check* guard;
   keep that guard, and prefer it whenever a spec derives its subject
   from an upstream shape.
+  **A missing `sorts` block is not fail-soft, it is a 500.** With no
+  sort allow-list rapiq falls back to a syntactic name check, so an
+  arbitrary root key survives decode and reaches `ORDER BY` on a column
+  that does not exist; the driver rejects it and `sanitizeError` maps
+  that to `INTERNAL_ERROR`, where every declaring sibling answers with
+  unsorted rows. `clientScope` was the sole schema without the block
+  (#3441, missed by the #3425 sweep). The property is now pinned per
+  schema rather than per endpoint — *should strip an unknown sort key
+  for %s* decodes a bogus key through the real codec for all 26 — so
+  the next schema that forgets the block fails the suite instead of one
+  endpoint. Note the fix direction: the narrow sibling list would have
+  demoted `default`/`clientId`/`scopeId` and the two owner-realm keys
+  from working-and-sorted to silently unsorted, so client-scope
+  allow-lists every column it already indexes.
   Structures whose leading column is not queryable (session
   `ipAddress`/`userAgent`, `user.email`) stay undeclared on purpose:
   the declaration describes the query surface, not the whole table.

--- a/apps/server-core/src/adapters/database/domains/client-scope/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/client-scope/entity.ts
@@ -42,9 +42,11 @@ export class ClientScopeEntity implements ClientScope {
 
     // ------------------------------------------------------------------
 
+    @Index()
     @CreateDateColumn({ name: 'created_at', transformer: dateToISOStringTransformer })
     createdAt: string;
 
+    @Index()
     @UpdateDateColumn({ name: 'updated_at', transformer: dateToISOStringTransformer })
     updatedAt: string;
 

--- a/apps/server-core/src/adapters/database/migrations/mysql/1786631686318-ClientScopeSortIndexes.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1786631686318-ClientScopeSortIndexes.ts
@@ -1,0 +1,31 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Index `auth_client_scopes.created_at` and `updated_at`.
+ *
+ * `clientScopeSchema` was the only registered schema with no `sorts`
+ * allow-list, so rapiq fell back to a syntactic name check and handed an
+ * arbitrary `?sort=` key to `ORDER BY` (issue #3441). Declaring the
+ * allow-list requires every listed key to lead a real entity index; the
+ * two timestamp columns were the only ones missing theirs.
+ */
+export class ClientScopeSortIndexes1786631686318 implements MigrationInterface {
+    name = 'ClientScopeSortIndexes1786631686318';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE INDEX \`IDX_52f59535945c8cdbd62439bba5\` ON \`auth_client_scopes\` (\`created_at\`)
+        `);
+        await queryRunner.query(`
+            CREATE INDEX \`IDX_04264aebc8b6625b1da88e23df\` ON \`auth_client_scopes\` (\`updated_at\`)
+        `);
+    }
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX \`IDX_04264aebc8b6625b1da88e23df\` ON \`auth_client_scopes\`
+        `);
+        await queryRunner.query(`
+            DROP INDEX \`IDX_52f59535945c8cdbd62439bba5\` ON \`auth_client_scopes\`
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1786631686318-ClientScopeSortIndexes.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1786631686318-ClientScopeSortIndexes.ts
@@ -1,0 +1,31 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Index `auth_client_scopes.created_at` and `updated_at`.
+ *
+ * `clientScopeSchema` was the only registered schema with no `sorts`
+ * allow-list, so rapiq fell back to a syntactic name check and handed an
+ * arbitrary `?sort=` key to `ORDER BY` (issue #3441). Declaring the
+ * allow-list requires every listed key to lead a real entity index; the
+ * two timestamp columns were the only ones missing theirs.
+ */
+export class ClientScopeSortIndexes1786631686318 implements MigrationInterface {
+    name = 'ClientScopeSortIndexes1786631686318';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE INDEX "IDX_52f59535945c8cdbd62439bba5" ON "auth_client_scopes" ("created_at")
+        `);
+        await queryRunner.query(`
+            CREATE INDEX "IDX_04264aebc8b6625b1da88e23df" ON "auth_client_scopes" ("updated_at")
+        `);
+    }
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "public"."IDX_04264aebc8b6625b1da88e23df"
+        `);
+        await queryRunner.query(`
+            DROP INDEX "public"."IDX_52f59535945c8cdbd62439bba5"
+        `);
+    }
+}

--- a/apps/server-core/src/core/entities/client-scope/schema.ts
+++ b/apps/server-core/src/core/entities/client-scope/schema.ts
@@ -21,6 +21,8 @@ export const clientScopeSchema = defineSchema<ClientScope>({
         ['default'],
         ['clientRealmId'],
         ['scopeRealmId'],
+        ['createdAt'],
+        ['updatedAt'],
     ],
     // see user-role schema — explicit root projection for include= decodes
     fields: {
@@ -37,6 +39,19 @@ export const clientScopeSchema = defineSchema<ClientScope>({
     },
     filters: { allowed: ['clientId', 'scopeId', 'default', 'id', 'clientRealmId', 'scopeRealmId'], indexed: true },
     relations: { allowed: ['client', 'scope'], validate: createRelationsReadGate(schemaMapping) },
+    sorts: {
+        allowed: [
+            'id',
+            'default',
+            'clientId',
+            'clientRealmId',
+            'scopeId',
+            'scopeRealmId',
+            'createdAt',
+            'updatedAt',
+        ],
+        indexed: true,
+    },
     pagination: { maxLimit: 50 },
     schemaMapping,
 });

--- a/apps/server-core/src/core/entities/client-scope/schema.ts
+++ b/apps/server-core/src/core/entities/client-scope/schema.ts
@@ -39,6 +39,10 @@ export const clientScopeSchema = defineSchema<ClientScope>({
     },
     filters: { allowed: ['clientId', 'scopeId', 'default', 'id', 'clientRealmId', 'scopeRealmId'], indexed: true },
     relations: { allowed: ['client', 'scope'], validate: createRelationsReadGate(schemaMapping) },
+    // wider than the junction siblings' id/createdAt/updatedAt on purpose:
+    // every column here is already indexed and already sorts today through
+    // the missing-allow-list fallback, so a narrow list would demote the
+    // rest from working-and-sorted to silently unsorted (#3441)
     sorts: {
         allowed: [
             'id',

--- a/apps/server-core/test/unit/core/query/indexed-invariant.spec.ts
+++ b/apps/server-core/test/unit/core/query/indexed-invariant.spec.ts
@@ -62,9 +62,12 @@ describe('core/query (indexed invariant)', () => {
      * positive while one schema's block went missing and was silently
      * skipped by the loops' `|| []`.
      *
-     * The block is asserted, never a non-empty `allowed`, because an
-     * absent allow-list is legitimate — `clientScope` declares no sort
-     * vocabulary at all, so its `sorts.allowed` is null by design.
+     * The block is asserted rather than a non-empty `allowed`, because
+     * `describe()` reports a block for an undeclared parameter too. What
+     * makes an undeclared sort allow-list unacceptable is a different
+     * property, pinned separately below: rapiq falls back to a syntactic
+     * name check without one, so an arbitrary key survives decode and
+     * reaches `ORDER BY` (#3441).
      */
     it.each(['filters', 'sorts'] as const)('should describe %s for every schema', (parameter) => {
         const missing = schemas
@@ -104,6 +107,26 @@ describe('core/query (indexed invariant)', () => {
 
         expect(offenders).toEqual([]);
     });
+
+    /**
+     * A schema with no `sorts` allow-list falls back to rapiq's syntactic
+     * name check, so an arbitrary root key survives decode and is handed
+     * to the adapter as an `ORDER BY` on a column that does not exist —
+     * the driver rejects it and `sanitizeError` maps that to a 500, where
+     * every declaring sibling fails soft and returns unsorted rows
+     * (#3441, `clientScope` was the sole outlier).
+     *
+     * Asserted per schema rather than per endpoint: a per-endpoint case
+     * would leave the next schema that forgets the block unguarded.
+     */
+    it.each(schemas.map((schema) => [schema.describe().name as string, schema] as const))(
+        'should strip an unknown sort key for %s',
+        async (_name, schema) => {
+            const parsed = await decodeQuery({ sort: 'totallyBogusColumn' }, { schema });
+
+            expect(JSON.stringify(parsed.sorts ?? null)).not.toContain('totallyBogusColumn');
+        },
+    );
 
     /**
      * The console's list search, end to end through the real encoder: the

--- a/packages/client-web-kit/test/unit/components/utility/entity-collection.spec.ts
+++ b/packages/client-web-kit/test/unit/components/utility/entity-collection.spec.ts
@@ -175,6 +175,36 @@ describe('defineEntityCollectionManager (rapiq IR composition)', () => {
     });
 
     /**
+     * The shape every filter control has to use (#3443). A load that omits
+     * `pagination` inherits the retained `meta` offset, so a control that
+     * narrows the result set from page 2 or later requests rows past the end
+     * of the narrower set: an empty list under a non-zero total. `ASearch`
+     * has always reset it by hand; the sessions page's subject-kind select
+     * was the first control that did not.
+     */
+    it('an assembled filter load carrying offset 0 returns to the first page', async () => {
+        const { wrapper, httpClient } = mountCollection({ query: { filters: { realmId: ['realm-1', null] } } });
+        await flushPromises();
+
+        await (wrapper.vm as any).load({ pagination: { limit: 10, offset: 20 } });
+
+        // what the page hands the manager: an assembled Query, no limit
+        await (wrapper.vm as any).load(defineQuery({
+            filters: { name: 'foo' },
+            pagination: { offset: 0 },
+        }));
+
+        const requests = listRequests(httpClient.requests);
+        // the encoder omits an offset of 0, so absent and "0" both mean the
+        // first page. Without the reset this reads "20" and the page renders
+        // empty under a non-zero total.
+        expect(requests[2].searchParams.get('page[offset]') ?? '0').toEqual('0');
+        // the retained page size survives, because `Pagination.merge` is
+        // per-property and the input carries no limit
+        expect(requests[2].searchParams.get('page[limit]')).toEqual('10');
+    });
+
+    /**
      * rapiq 2.1.0 (#906) made `sorts` the canonical build-input key and
      * kept `sort` as a deprecated alias. The per-parameter replace must
      * recognize both, or a load carrying the canonical spelling is


### PR DESCRIPTION
Closes #3441

The sessions-page half of this PR (#3443) landed separately via #3462, so that commit was dropped in a rebase onto master. What remains is the client-scope fix plus the kit spec that pins the offset-reset contract at the collection manager (the place a regression would reappear; #3462 shipped without one).

## `#3441` — `clientScopeSchema` declared no sort allow-list

It was the sole outlier among the 26 registered schemas (missed by the `#3425` sweep). Without the block rapiq falls back to a syntactic name check, so `GET /client-scopes?sort=totallyBogusColumn` reached `ORDER BY clientScope.totallyBogusColumn` and surfaced as a **500**, where every sibling endpoint fails soft and returns unsorted rows.

**The allow-list is wide on purpose.** `default`, `clientId`, `scopeId`, `clientRealmId` and `scopeRealmId` all sort correctly *today* through the missing-allow-list fallback and are all already indexed, so the narrow junction-sibling triple would have demoted them from working-and-sorted to silently unsorted. `createdAt` / `updatedAt` were the only listed keys with no backing index, which is what the migration adds.

### Coverage

The new case is per schema, not per endpoint: a per-endpoint test would leave the next schema that forgets the block equally unguarded. It decodes `{ sort: 'totallyBogusColumn' }` through the real codec for all 26 schemas and asserts the key is stripped.

Verified differentially: with the schema change reverted the suite reports exactly one failure (`should strip an unknown sort key for clientScope`); with it, the cases pass.

### Kit spec: the offset reset a filter load has to carry

`entity-collection.spec.ts` drives the manager to page 3, then hands it the shape a filter control uses (an assembled Query carrying `filters` plus `pagination: { offset: 0 }`) and asserts the request returns to the first page with the retained page size intact. Dropping the reset from the load input makes the request carry offset 20, the #3443 bug.

### Verification (after the rebase)

- `apps/server-core` full suite: **196 files / 2214 tests passed**; `indexed-invariant.spec.ts` + `console-search-surface.spec.ts`: 70 passed; kit `entity-collection.spec.ts`: 16 passed
- postgres round trip on a scratch DB: `migration run` / `revert` / `run` clean, `test:schema-drift` matches; `1786631686318-ClientScopeSortIndexes` is the newest migration (master's `1786436332251-QueryIndexes` shipped in beta.60/61, so a new file is correct)
- generated DDL touches `auth_client_scopes` only, and neither column is a foreign key, so the MySQL implicit-FK-index `down()` trap does not apply
- `check:types` clean, eslint clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client-scope sorting performance for creation and update dates.
  * Prevented unsupported sort fields from causing database errors or server failures.
  * Fixed pagination so resetting the offset returns to the first results while preserving the selected page size.
* **Tests**
  * Added regression coverage for invalid sort fields across schemas and pagination resets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->