### PR TITLE
fix(server-core): derive the federated identity from id_token and userinfo claims

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2654,6 +2654,50 @@ Domain type `Consent` (core-kit) + `EntityType.CONSENT`, TypeORM entity +
   `isUniqueConstraintDatabaseError` (`adapters/database/errors/driver.ts`, the
   reusable driver-error-code unwrapper covering mysql/postgres/sqlite).
 
+## Federated Identity Claims
+
+`IdentityProviderOAuth2Authenticator.buildIdentityWithTokenGrantResponse`
+derives the external identity from three sources, richest last:
+**access token, then `id_token`, then userinfo**. The access token is only
+the floor because it is opaque by contract (OIDC Core §2) and authup's own
+carries `sub`, `kind` and `realm_name` and no username at all, so reading
+it alone provisioned every federated user under the remote subject UUID
+plus a `<uuid>@example.com` placeholder (#3434).
+
+- **The name ladder is `preferred_username, nickname, name, sub`.**
+  Keycloak and Authentik put the username in `preferred_username` while
+  their `name` is a display name; authup's own claims builder maps BOTH
+  `preferred_username` and `nickname` onto the **nullable** `displayName`
+  and puts the real username in `name`, so a ladder without `name` still
+  falls through to `sub` for authup-to-authup federation. Candidates are
+  consumed reactively — `validateAttributes` only substitutes one when the
+  validator raises an issue for that exact path — so a first candidate
+  failing `isUserNameValid` degrades to the next rather than failing the
+  login, and adding candidates for OPTIONAL keys (`firstName`/`lastName`)
+  would be dead code.
+- **`identity.id` stays the ACCESS token `sub`, always.** It becomes
+  `provider_user_id` and keys `findOneByProviderIdentity`, so sourcing it
+  from a richer claim set would orphan every existing
+  `auth_identity_provider_accounts` row and silently provision duplicate
+  users on the next login. Pinned by *should key the account on the access
+  token subject, never the id_token*.
+- **userinfo is called only when the provider declares `userInfoUrl`**, and
+  its failure is logged and swallowed. The guard is load-bearing: the hapic
+  client is constructed with no `baseURL`, so the `/userinfo` default would
+  be a relative fetch URL that throws. It is the only fix for a plain
+  `protocol: oauth2` provider whose remote client has no `openid` scope
+  bound (no `openid` scope, no id_token), and it is what stops the
+  admin-editable `userInfoUrl` field being silently inert.
+- **`identity.data` is deliberately still the access-token payload alone.**
+  Mappers (`IIdentityProviderMapper`) pattern-match over it, so merging the
+  richer claims in would change every existing mapper's input.
+- The `IdentityProviderOpenIDAuthenticator` override is gone: the base
+  ladder now covers what it did. The five presets (github, facebook,
+  instagram, paypal, google) still override the builder and are untouched.
+- **Forward-only.** The account manager's UPDATE branch never rewrites
+  `user.name` (it is `nameLocked` at creation), so users already
+  provisioned under a UUID keep it.
+
 ## Identity-Provider Account Linking (plan 091)
 
 `auth_identity_provider_accounts` (external identity → `userId`; unique

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -680,6 +680,7 @@ export class IdentityProviderController {
         return createIdentityProviderOAuth2Authenticator({
             accountManager: this.accountManager,
             provider,
+            logger: this.logger,
             options: {
                 baseURL: this.options.baseURL,
                 clientId: options.clientId,

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/module.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/module.ts
@@ -23,6 +23,12 @@ import type {
     OAuth2AuthorizationCodeGrantPayload,
 } from './types.ts';
 
+/**
+ * Bound on the optional userinfo enrichment. Short by design: the caller is
+ * a browser sitting on a redirect, and the login proceeds without it.
+ */
+const USERINFO_TIMEOUT = 5000;
+
 export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator<User> {
     protected client : OAuth2Client;
 
@@ -122,9 +128,15 @@ export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator
                     ...claims,
                     ...extractTokenPayload(input.id_token),
                 };
-            } catch {
+            } catch (e) {
                 // an encrypted (five-segment JWE) id_token is not decodable
-                // here, and was ignored outright before it was read at all
+                // here, and was ignored outright before it was read at all.
+                // Logged rather than swallowed silently: every other reason
+                // to land here leaves the user provisioned under the remote
+                // subject, which is the defect this method exists to fix.
+                this.logger?.warn(
+                    `The identity provider (${this.provider.id}) id_token could not be read: ${(e as Error).message}`,
+                );
             }
         }
 
@@ -132,12 +144,27 @@ export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator
             // the guard is load-bearing: the client carries no baseURL, so
             // hapic's `/userinfo` default would be a relative fetch URL
             try {
-                const userInfo = await this.client.userInfo.get({
+                const userInfo = await this.withTimeout(this.client.userInfo.get({
                     type: 'Bearer',
                     token: input.access_token,
-                });
+                }));
 
-                claims = { ...claims, ...userInfo };
+                // OIDC Core 5.3.2: a userinfo response whose `sub` does not
+                // match the token's MUST NOT be used. Without this a
+                // mis-routed response (a multi-tenant gateway, a token
+                // mix-up) would name and, worse, EMAIL the local user after
+                // somebody else.
+                if (
+                    typeof userInfo.sub === 'string' &&
+                    typeof payload.sub === 'string' &&
+                    userInfo.sub !== payload.sub
+                ) {
+                    this.logger?.warn(
+                        `The identity provider (${this.provider.id}) userinfo subject does not match the token subject.`,
+                    );
+                } else {
+                    claims = { ...claims, ...userInfo };
+                }
             } catch (e) {
                 // enrichment, never a login blocker
                 this.logger?.warn(
@@ -147,6 +174,23 @@ export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator
         }
 
         return claims;
+    }
+
+    /**
+     * hapic passes no `signal` to `fetch`, so an endpoint that accepts the
+     * connection and never answers would hold the login for undici's 300s
+     * headers timeout. Enrichment must not outlast the request it enriches.
+     */
+    protected withTimeout<T>(promise: Promise<T>) : Promise<T> {
+        return Promise.race([
+            promise,
+            new Promise<T>((_resolve, reject) => {
+                setTimeout(
+                    () => reject(new Error(`the request exceeded ${USERINFO_TIMEOUT}ms`)),
+                    USERINFO_TIMEOUT,
+                ).unref();
+            }),
+        ]);
     }
 
     protected async buildIdentityWithTokenGrantResponse(input: TokenGrantResponse) : Promise<IdentityProviderIdentity> {

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/module.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/module.ts
@@ -9,6 +9,8 @@ import type { OAuth2IdentityProvider, OpenIDIdentityProvider, User } from '@auth
 import { buildIdentityProviderAuthorizeCallbackPath } from '@authup/core-kit';
 import { ValidationError } from '@authup/errors';
 import type { Result } from '@authup/kit';
+import type { JWTClaims } from '@authup/specs';
+import type { Logger } from '@authup/server-kit';
 import { extractTokenPayload } from '@authup/server-kit';
 import type { AuthorizeParameters, TokenGrantResponse } from '@hapic/oauth2';
 import { OAuth2Client } from '@hapic/oauth2';
@@ -30,12 +32,15 @@ export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator
 
     protected provider : OAuth2IdentityProvider | OpenIDIdentityProvider;
 
+    protected logger? : Logger;
+
     //----------------------------------------------------------------------
 
     constructor(ctx: IdentityProviderOAuth2AuthenticatorContext) {
         this.options = ctx.options;
         this.accountManager = ctx.accountManager;
         this.provider = ctx.provider;
+        this.logger = ctx.logger;
 
         this.client = new OAuth2Client({
             options: {
@@ -100,17 +105,71 @@ export class IdentityProviderOAuth2Authenticator implements IOAuth2Authenticator
 
     //----------------------------------------------------------------------
 
+    /**
+     * The claims an external identity is described by, richest source last.
+     *
+     * The access token is opaque by contract (OIDC Core §2), so it is only
+     * the floor: authup's own carries `sub`, `kind` and `realm_name` and no
+     * username at all, which is why a federated user used to be provisioned
+     * under the remote subject UUID.
+     */
+    protected async resolveClaims(input: TokenGrantResponse, payload: JWTClaims) : Promise<JWTClaims> {
+        let claims = payload;
+
+        if (typeof input.id_token === 'string') {
+            try {
+                claims = {
+                    ...claims,
+                    ...extractTokenPayload(input.id_token),
+                };
+            } catch {
+                // an encrypted (five-segment JWE) id_token is not decodable
+                // here, and was ignored outright before it was read at all
+            }
+        }
+
+        if (this.provider.userInfoUrl) {
+            // the guard is load-bearing: the client carries no baseURL, so
+            // hapic's `/userinfo` default would be a relative fetch URL
+            try {
+                const userInfo = await this.client.userInfo.get({
+                    type: 'Bearer',
+                    token: input.access_token,
+                });
+
+                claims = { ...claims, ...userInfo };
+            } catch (e) {
+                // enrichment, never a login blocker
+                this.logger?.warn(
+                    `The identity provider (${this.provider.id}) userinfo request failed: ${(e as Error).message}`,
+                );
+            }
+        }
+
+        return claims;
+    }
+
     protected async buildIdentityWithTokenGrantResponse(input: TokenGrantResponse) : Promise<IdentityProviderIdentity> {
         const payload = extractTokenPayload(input.access_token);
+        const claims = await this.resolveClaims(input, payload);
 
         return {
+            // the account key: sourcing it from a richer claim set would
+            // orphan every existing auth_identity_provider_accounts row
             id: payload.sub!,
             attributeCandidates: {
                 name: [
-                    payload.sub,
+                    // keycloak/authentik put the username here, authup its
+                    // (nullable) display name; a candidate failing name
+                    // validation shifts to the next one
+                    claims.preferred_username,
+                    claims.nickname,
+                    // authup's own id_token: the real user name
+                    claims.name,
+                    claims.sub,
                 ],
                 email: [
-                    payload.email,
+                    claims.email,
                 ],
             },
             data: payload,

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/types.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/oauth2/types.ts
@@ -6,6 +6,7 @@
  */
 import type { OAuth2IdentityProvider, OpenIDIdentityProvider } from '@authup/core-kit';
 import type { ObjectLiteral, Result } from '@authup/kit';
+import type { Logger } from '@authup/server-kit';
 import type { AuthorizeParameters } from '@hapic/oauth2';
 import type { IIdentityProviderAccountManager } from '../../../account/index.ts';
 import type { IdentityProviderIdentity } from '../../../types.ts';
@@ -39,4 +40,5 @@ export type IdentityProviderOAuth2AuthenticatorContext = {
     options: IdentityProviderOAuth2AuthenticatorOptions,
     accountManager: IIdentityProviderAccountManager
     provider: OAuth2IdentityProvider | OpenIDIdentityProvider,
+    logger?: Logger,
 };

--- a/apps/server-core/src/core/identity/provider/authentication/protocols/open-id/module.ts
+++ b/apps/server-core/src/core/identity/provider/authentication/protocols/open-id/module.ts
@@ -5,10 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import { extractTokenPayload } from '@authup/server-kit';
 import { mergeOAuth2Scopes } from '@authup/specs';
-import type { TokenGrantResponse } from '@hapic/oauth2';
-import type { IdentityProviderIdentity } from '../../../types.ts';
 import type { IdentityProviderOAuth2AuthenticatorContext } from '../oauth2/index.ts';
 import { IdentityProviderOAuth2Authenticator } from '../oauth2/index.ts';
 
@@ -21,25 +18,5 @@ export class IdentityProviderOpenIDAuthenticator extends IdentityProviderOAuth2A
         );
 
         super(ctx);
-    }
-
-    protected async buildIdentityWithTokenGrantResponse(input: TokenGrantResponse): Promise<IdentityProviderIdentity> {
-        const payload = extractTokenPayload(input.access_token);
-
-        return {
-            id: payload.sub!,
-            attributeCandidates: {
-                name: [
-                    payload.preferred_username,
-                    payload.nickname,
-                    payload.sub,
-                ],
-                email: [
-                    payload.email,
-                ],
-            },
-            data: payload,
-            provider: this.provider,
-        };
     }
 }

--- a/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
@@ -87,7 +87,9 @@ class TestableAuthenticator extends IdentityProviderOAuth2Authenticator {
     }
 
     stubUserInfo(claims: Record<string, any>) {
-        this.client.userInfo.get = () => Promise.resolve(claims);
+        // `UserInfoAPI.get` is generic over its return, so the stub has to
+        // be too: a concrete Record is not assignable to an arbitrary T
+        this.client.userInfo.get = <T extends Record<string, any>>() => Promise.resolve(claims as T);
     }
 
     failUserInfo(error: Error) {
@@ -217,7 +219,7 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             .buildIdentity({ access_token: ACCESS_TOKEN } as TokenGrantResponse);
 
         expect(identity.id).toEqual('external-user-1');
-        expect(identity.attributeCandidates.name).toEqual([
+        expect(identity.attributeCandidates?.name).toEqual([
             undefined,
             undefined,
             undefined,
@@ -240,13 +242,13 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             }),
         } as TokenGrantResponse);
 
-        expect(identity.attributeCandidates.name).toEqual([
+        expect(identity.attributeCandidates?.name).toEqual([
             null,
             null,
             'peter',
             'external-user-1',
         ]);
-        expect(identity.attributeCandidates.email).toEqual(['peter@example.com']);
+        expect(identity.attributeCandidates?.email).toEqual(['peter@example.com']);
     });
 
     it('should prefer preferred_username, the keycloak-style username', async () => {
@@ -258,7 +260,7 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             }),
         } as TokenGrantResponse);
 
-        expect(identity.attributeCandidates.name?.[0]).toEqual('kc-user');
+        expect(identity.attributeCandidates?.name?.[0]).toEqual('kc-user');
     });
 
     it('should key the account on the access token subject, never the id_token', async () => {
@@ -280,7 +282,7 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
         } as TokenGrantResponse);
 
         expect(identity.id).toEqual('external-user-1');
-        expect(identity.attributeCandidates.name?.[3]).toEqual('external-user-1');
+        expect(identity.attributeCandidates?.name?.[3]).toEqual('external-user-1');
     });
 
     it('should not call userinfo when the provider declares no endpoint', async () => {
@@ -303,7 +305,7 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             id_token: encodeToken({ name: 'id-token-user' }),
         } as TokenGrantResponse);
 
-        expect(identity.attributeCandidates.name?.[0]).toEqual('userinfo-user');
+        expect(identity.attributeCandidates?.name?.[0]).toEqual('userinfo-user');
     });
 
     it('should discard a userinfo document whose subject does not match', async () => {
@@ -323,8 +325,8 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             id_token: encodeToken({ name: 'id-token-user', email: 'peter@example.com' }),
         } as TokenGrantResponse);
 
-        expect(identity.attributeCandidates.name).not.toContain('somebody-else');
-        expect(identity.attributeCandidates.email).toEqual(['peter@example.com']);
+        expect(identity.attributeCandidates?.name).not.toContain('somebody-else');
+        expect(identity.attributeCandidates?.email).toEqual(['peter@example.com']);
     });
 
     it('should read an id_token whose claims are not ASCII', async () => {
@@ -340,8 +342,8 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             }),
         } as TokenGrantResponse);
 
-        expect(identity.attributeCandidates.name?.[0]).toEqual('Пётр');
-        expect(identity.attributeCandidates.name?.[2]).toEqual('Peter 😀');
+        expect(identity.attributeCandidates?.name?.[0]).toEqual('Пётр');
+        expect(identity.attributeCandidates?.name?.[2]).toEqual('Peter 😀');
     });
 
     it('should degrade rather than fail the login when userinfo errors', async () => {
@@ -353,6 +355,6 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
             id_token: encodeToken({ name: 'id-token-user' }),
         } as TokenGrantResponse);
 
-        expect(identity.attributeCandidates.name?.[2]).toEqual('id-token-user');
+        expect(identity.attributeCandidates?.name?.[2]).toEqual('id-token-user');
     });
 });

--- a/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
@@ -9,7 +9,8 @@ import type { OAuth2IdentityProvider, OpenIDIdentityProvider, Realm } from '@aut
 import { IdentityProviderProtocol } from '@authup/core-kit';
 import { createNanoID } from '@authup/kit';
 import { ValidationError, isValidationError } from '@authup/errors';
-import type { IIdentityProviderAccountManager } from '../../../../../src/core';
+import type { TokenGrantResponse } from '@hapic/oauth2';
+import type { IIdentityProviderAccountManager, IdentityProviderIdentity } from '../../../../../src/core';
 import {
     IdentityProviderGoogleAuthenticator,
     IdentityProviderOAuth2Authenticator,
@@ -66,6 +67,36 @@ function createAuthenticator(authorizeURL: string) {
     return new IdentityProviderOAuth2Authenticator(
         createAuthenticatorContext(createProvider({ authorizeUrl: authorizeURL })),
     );
+}
+
+const encodeSegment = (input: Record<string, any>) => Buffer.from(JSON.stringify(input)).toString('base64url');
+
+const encodeToken = (claims: Record<string, any>) => [
+    encodeSegment({ alg: 'none', typ: 'JWT' }),
+    encodeSegment(claims),
+    'x',
+].join('.');
+
+/**
+ * `buildIdentityWithTokenGrantResponse` is protected, and it is the whole
+ * subject of #3434 — the claim-to-candidate mapping had no coverage at all.
+ */
+class TestableAuthenticator extends IdentityProviderOAuth2Authenticator {
+    buildIdentity(input: TokenGrantResponse) : Promise<IdentityProviderIdentity> {
+        return this.buildIdentityWithTokenGrantResponse(input);
+    }
+
+    stubUserInfo(claims: Record<string, any>) {
+        this.client.userInfo.get = () => Promise.resolve(claims);
+    }
+
+    failUserInfo(error: Error) {
+        this.client.userInfo.get = () => Promise.reject(error);
+    }
+}
+
+function createTestableAuthenticator(provider: Partial<OAuth2IdentityProvider> = {}) {
+    return new TestableAuthenticator(createAuthenticatorContext(createProvider(provider)));
 }
 
 describe('IdentityProviderOAuth2Authenticator', () => {
@@ -164,5 +195,126 @@ describe('IdentityProviderGoogleAuthenticator', () => {
         const parsed = new URL(authenticator.buildRedirectURL({ state: 'abc' }));
         expect(parsed.searchParams.get('scope'))
             .toEqual('openid profile email https://www.googleapis.com/auth/calendar.readonly');
+    });
+});
+
+/**
+ * #3434 — a federated user used to be provisioned under the remote subject
+ * UUID, because the identity was derived from the access token alone. An
+ * access token is opaque by contract, and authup's carries `sub`, `kind` and
+ * `realm_name` and no username at all.
+ */
+describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
+    // what an authup access token actually looks like
+    const ACCESS_TOKEN = encodeToken({
+        sub: 'external-user-1',
+        kind: 'access_token',
+        realm_name: 'master',
+    });
+
+    it('should fall back to the subject when nothing richer is offered', async () => {
+        const identity = await createTestableAuthenticator()
+            .buildIdentity({ access_token: ACCESS_TOKEN } as TokenGrantResponse);
+
+        expect(identity.id).toEqual('external-user-1');
+        expect(identity.attributeCandidates.name).toEqual([
+            undefined,
+            undefined,
+            undefined,
+            'external-user-1',
+        ]);
+    });
+
+    it('should read the authup id_token `name` claim ahead of the subject', async () => {
+        // preferred_username / nickname both map to the NULLABLE displayName
+        // in authup's own claims builder, so a ladder without `name` still
+        // lands on the subject — which is the reported bug
+        const identity = await createTestableAuthenticator().buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({
+                sub: 'external-user-1',
+                preferred_username: null,
+                nickname: null,
+                name: 'peter',
+                email: 'peter@example.com',
+            }),
+        } as TokenGrantResponse);
+
+        expect(identity.attributeCandidates.name).toEqual([
+            null,
+            null,
+            'peter',
+            'external-user-1',
+        ]);
+        expect(identity.attributeCandidates.email).toEqual(['peter@example.com']);
+    });
+
+    it('should prefer preferred_username, the keycloak-style username', async () => {
+        const identity = await createTestableAuthenticator().buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({
+                preferred_username: 'kc-user',
+                name: 'Peter Placzek',
+            }),
+        } as TokenGrantResponse);
+
+        expect(identity.attributeCandidates.name?.[0]).toEqual('kc-user');
+    });
+
+    it('should key the account on the access token subject, never the id_token', async () => {
+        // provider_user_id keys findOneByProviderIdentity: sourcing it from a
+        // richer claim set would orphan every existing account row
+        const identity = await createTestableAuthenticator().buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({ sub: 'a-different-subject', name: 'peter' }),
+        } as TokenGrantResponse);
+
+        expect(identity.id).toEqual('external-user-1');
+    });
+
+    it('should ignore an id_token it cannot decode', async () => {
+        // a five-segment JWE was ignored outright before it was read at all
+        const identity = await createTestableAuthenticator().buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: 'a.b.c.d.e',
+        } as TokenGrantResponse);
+
+        expect(identity.id).toEqual('external-user-1');
+        expect(identity.attributeCandidates.name?.[3]).toEqual('external-user-1');
+    });
+
+    it('should not call userinfo when the provider declares no endpoint', async () => {
+        // the guard is load-bearing: the client carries no baseURL, so
+        // hapic's `/userinfo` default would be a relative fetch URL
+        const authenticator = createTestableAuthenticator();
+        authenticator.failUserInfo(new Error('userinfo must not be called'));
+
+        const identity = await authenticator.buildIdentity({ access_token: ACCESS_TOKEN } as TokenGrantResponse);
+
+        expect(identity.id).toEqual('external-user-1');
+    });
+
+    it('should let userinfo claims win over the id_token', async () => {
+        const authenticator = createTestableAuthenticator({ userInfoUrl: 'https://idp.example.com/userinfo' });
+        authenticator.stubUserInfo({ preferred_username: 'userinfo-user' });
+
+        const identity = await authenticator.buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({ name: 'id-token-user' }),
+        } as TokenGrantResponse);
+
+        expect(identity.attributeCandidates.name?.[0]).toEqual('userinfo-user');
+    });
+
+    it('should degrade rather than fail the login when userinfo errors', async () => {
+        const authenticator = createTestableAuthenticator({ userInfoUrl: 'https://idp.example.com/userinfo' });
+        authenticator.failUserInfo(new Error('gateway timeout'));
+
+        const identity = await authenticator.buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({ name: 'id-token-user' }),
+        } as TokenGrantResponse);
+
+        expect(identity.attributeCandidates.name?.[2]).toEqual('id-token-user');
     });
 });

--- a/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/authenticator.spec.ts
@@ -306,6 +306,44 @@ describe('IdentityProviderOAuth2Authenticator (identity build)', () => {
         expect(identity.attributeCandidates.name?.[0]).toEqual('userinfo-user');
     });
 
+    it('should discard a userinfo document whose subject does not match', async () => {
+        // OIDC Core 5.3.2. A mis-routed response (a multi-tenant gateway, a
+        // token mix-up) would otherwise name AND email the local user after
+        // somebody else, and `auth_users.email` carries no unique constraint,
+        // so that third party could then drive password recovery on it.
+        const authenticator = createTestableAuthenticator({ userInfoUrl: 'https://idp.example.com/userinfo' });
+        authenticator.stubUserInfo({
+            sub: 'somebody-else',
+            preferred_username: 'somebody-else',
+            email: 'somebody-else@example.com',
+        });
+
+        const identity = await authenticator.buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({ name: 'id-token-user', email: 'peter@example.com' }),
+        } as TokenGrantResponse);
+
+        expect(identity.attributeCandidates.name).not.toContain('somebody-else');
+        expect(identity.attributeCandidates.email).toEqual(['peter@example.com']);
+    });
+
+    it('should read an id_token whose claims are not ASCII', async () => {
+        // base64URL (`-`/`_`) plus UTF-8, both of which the previous `atob`
+        // decode rejected outright, so the enrichment silently no-opped for
+        // exactly the users most likely to carry a non-ASCII display name
+        const identity = await createTestableAuthenticator().buildIdentity({
+            access_token: ACCESS_TOKEN,
+            id_token: encodeToken({
+                preferred_username: 'Пётр',
+                name: 'Peter 😀',
+                email: 'peter@example.com',
+            }),
+        } as TokenGrantResponse);
+
+        expect(identity.attributeCandidates.name?.[0]).toEqual('Пётр');
+        expect(identity.attributeCandidates.name?.[2]).toEqual('Peter 😀');
+    });
+
     it('should degrade rather than fail the login when userinfo errors', async () => {
         const authenticator = createTestableAuthenticator({ userInfoUrl: 'https://idp.example.com/userinfo' });
         authenticator.failUserInfo(new Error('gateway timeout'));

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
@@ -104,7 +104,11 @@ describe('identity-provider login flow', () => {
                 userInfoRequests += 1;
                 res.setHeader('content-type', 'application/json');
                 res.end(JSON.stringify({
-                    sub: 'external-user-2',
+                    // MUST match the token subject: OIDC Core 5.3.2 requires a
+                    // mismatched document to be discarded, and it is
+                    // (`should discard a userinfo document whose subject does
+                    // not match` in the authenticator spec)
+                    sub: 'external-user-1',
                     preferred_username: 'userinfo-user',
                     email: 'userinfo@example.com',
                 }));

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/login.spec.ts
@@ -42,6 +42,7 @@ describe('identity-provider login flow', () => {
     let provider: IdentityProvider;
 
     let tokenRequestBody: URLSearchParams | undefined;
+    let userInfoRequests = 0;
 
     beforeAll(async () => {
         // A minimal external IdP. Unlike a permissive stub, its token
@@ -75,12 +76,38 @@ describe('identity-provider login flow', () => {
                         return;
                     }
 
+                    // An authup-shaped access token: subject, kind and realm,
+                    // and no username at all. It is the whole reason the
+                    // id_token has to be read (#3434).
                     const accessToken = `${encode({ alg: 'none', typ: 'JWT' })}.${encode({
                         sub: 'external-user-1',
+                        kind: 'access_token',
+                        realm_name: 'master',
+                    })}.x`;
+                    const idToken = `${encode({ alg: 'none', typ: 'JWT' })}.${encode({
+                        sub: 'external-user-1',
+                        // authup carries the username here; preferred_username
+                        // and nickname map to the nullable display name
+                        name: 'external-user',
                         email: 'external@example.com',
                     })}.x`;
-                    res.end(JSON.stringify({ access_token: accessToken, token_type: 'Bearer' }));
+                    res.end(JSON.stringify({
+                        access_token: accessToken,
+                        id_token: idToken,
+                        token_type: 'Bearer',
+                    }));
                 });
+                return;
+            }
+
+            if (req.url && req.url.startsWith('/userinfo')) {
+                userInfoRequests += 1;
+                res.setHeader('content-type', 'application/json');
+                res.end(JSON.stringify({
+                    sub: 'external-user-2',
+                    preferred_username: 'userinfo-user',
+                    email: 'userinfo@example.com',
+                }));
                 return;
             }
 
@@ -190,5 +217,73 @@ describe('identity-provider login flow', () => {
         expect(body.code).toEqual(ErrorCode.UPSTREAM_ERROR);
         // the outbound target must not be echoed back to the caller
         expect(JSON.stringify(body)).not.toContain(idpURL);
+    });
+
+    /**
+     * The reported defect (#3434): federating authup to authup provisioned
+     * the local user under the remote subject UUID, because the identity was
+     * derived from the access token alone and authup's carries no username.
+     */
+    it('provisions the user from the id_token claims rather than the subject', async () => {
+        const state = await authorizeOut();
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code-2`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+        expect(response.status).toEqual(302);
+
+        // and not the remote subject, which is a UUID against another authup
+        const { data: users } = await suite.client.user.getMany({ filters: { realmId: realm.id } });
+        expect(users.map((user) => user.name)).toContain('external-user');
+
+        // `email` is a select:false column, so no read surface returns it and
+        // the placeholder it replaces is not assertable here. The candidate
+        // ladder that feeds it is pinned in the authenticator spec instead.
+    });
+
+    it('enriches the identity from userinfo when the provider declares one', async () => {
+        const userInfoProvider = (await suite.client.identityProvider.create(createFakeOAuth2IdentityProvider({
+            realmId: realm.id,
+            tokenUrl: `${idpURL}/token`,
+            authorizeUrl: `${idpURL}/authorize`,
+            userInfoUrl: `${idpURL}/userinfo`,
+        }))).data;
+
+        userInfoRequests = 0;
+
+        const outResponse = await httpRequest(suite, 'GET', `identity-providers/${userInfoProvider.id}/authorize-out`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        const state = new URL(outResponse.headers.get('location') as string).searchParams.get('state');
+
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${userInfoProvider.id}/authorize-in?state=${state}&code=external-code-3`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+        expect(response.status).toEqual(302);
+        expect(userInfoRequests).toEqual(1);
+
+        const { data: users } = await suite.client.user.getMany({ filters: { realmId: realm.id } });
+        // userinfo is the richest source, so its preferred_username wins the
+        // ladder over the id_token's `name`
+        expect(users.map((user) => user.name)).toContain('userinfo-user');
+
+        // the account key stays the ACCESS token subject: deriving it from a
+        // richer claim set would orphan every existing account row
+        const { data: accounts } = await suite.client.identityProviderAccount.getMany({ filters: { providerId: userInfoProvider.id } });
+        expect(accounts).toHaveLength(1);
+        expect(accounts[0].providerUserId).toEqual('external-user-1');
     });
 });

--- a/packages/server-kit/src/crypto/json-web-token/extract.ts
+++ b/packages/server-kit/src/crypto/json-web-token/extract.ts
@@ -64,9 +64,16 @@ export function extractTokenPayload(
     const [, payloadBase64] = parts;
 
     try {
-        const payload = atob(payloadBase64);
+        // A JWT payload is base64URL (RFC 7515 §2), which `atob` rejects on
+        // its `-`/`_` characters, and `atob` yields latin1 while the payload
+        // is UTF-8 (RFC 7519 §3). Any claim outside ASCII produces one or the
+        // other, so a token carrying a name like `Пётр` or an emoji failed to
+        // decode at all.
+        const normalized = payloadBase64.replace(/-/g, '+').replace(/_/g, '/');
+        const binary = atob(normalized);
+        const bytes = Uint8Array.from(binary, (character) => character.charCodeAt(0));
 
-        return JSON.parse(payload);
+        return JSON.parse(new TextDecoder().decode(bytes));
     } catch {
         throw JWTError.payloadInvalid('The token payload could not be extracted.');
     }


### PR DESCRIPTION
Closes #3434.

## The defect

An external identity was built from the **access token alone**, which is opaque by contract (OIDC Core §2). Authup's own access token carries `sub`, `kind` and `realm_name` and no username, so federating authup to authup provisioned every local user under the remote subject UUID plus a `<uuid>@example.com` placeholder.

## Why the issue's direction (1) alone would not have fixed it

Reading the `id_token` is necessary but **not sufficient**. Authup's `OAuth2OpenIDClaimsBuilder` maps *both* `preferred_username` and `nickname` onto the **nullable** `displayName`, and puts the real username in `name`. The previous ladder was `preferred_username, nickname, sub`, so against an authup id_token it still fell through to `sub`.

The ladder is now `preferred_username, nickname, name, sub`. `preferred_username` stays first because Keycloak and Authentik put the username there while their `name` is a display name. A candidate that fails `isUserNameValid` shifts to the next one, so a bad first candidate degrades rather than failing the login.

## userinfo

Called only when the provider declares a `userInfoUrl`; failures are logged and swallowed. The guard is load-bearing — the hapic client is constructed with no `baseURL`, so the `/userinfo` default would be a relative fetch URL that throws.

This is the only fix for a plain `protocol: oauth2` provider whose remote client has no `openid` scope bound (no `openid`, no id_token), which is a plausible reading of the reported config, and it is what stops the admin-editable `userInfoUrl` being silently inert.

## What deliberately did not change

- **`identity.id` stays the ACCESS token `sub`.** It is `provider_user_id` and keys `findOneByProviderIdentity`, so sourcing it from a richer claim set would orphan every existing `auth_identity_provider_accounts` row and silently provision duplicate users on the next login. Pinned by a dedicated case.
- **`identity.data` stays the access-token payload.** `IIdentityProviderMapper` pattern-matches over it, so merging richer claims in would change every existing mapper's input. Separable, and a product call rather than a bug fix.
- **Forward-only.** The account manager's UPDATE branch never rewrites `user.name` (`nameLocked` at creation), so users already provisioned under a UUID keep it.
- The five presets (github, facebook, instagram, paypal, google) override the builder themselves and are untouched. The OIDC subclass override became identical to the base and is deleted.

## Coverage

`buildIdentityWithTokenGrantResponse` had **zero** coverage — the existing authenticator spec only tested `buildRedirectURL` and scope merging. Added 8 unit cases (subject fallback, the authup `name` shape, Keycloak ordering, the account-key invariant, an undecodable JWE id_token, the userInfoUrl guard, userinfo precedence, userinfo failure degrading) plus 2 end-to-end cases where the fake IdP now returns an authup-shaped access token with an id_token beside it.

Verified differentially: with the source fix reverted, **8 of the 23 fail**; with it, all 23 pass. (The first attempt at this check was itself wrong — the appended block had landed in the wrong working copy and the unit tests were never running. The differential is what caught that.)

- `apps/server-core` full suite: **194 files / 2170 tests passed**
- eslint clean, `apps/server-core` build green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Federated sign-in now builds user identities from access-token claims, ID-token claims, and optional userinfo.
  - Usernames and email addresses use the most complete available claims, with clear fallback behavior.
  - Existing account identifiers remain stable and are based on the access-token subject.

- **Bug Fixes**
  - Invalid, encrypted, or unavailable identity tokens no longer block authentication.
  - Userinfo service failures are handled gracefully while allowing sign-in to continue.

- **Documentation**
  - Added documentation describing federated identity claim handling and account stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->