### PR TITLE
fix(server-core): make one external identity belong to one local user

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2656,8 +2656,18 @@ Domain type `Consent` (core-kit) + `EntityType.CONSENT`, TypeORM entity +
 
 ## Identity-Provider Account Linking (plan 091)
 
-`auth_identity_provider_accounts` (external identity → `userId`; unique
-`(providerId, userId)` — one link per provider per user) is surfaced as a
+`auth_identity_provider_accounts` (external identity → `userId`) carries TWO
+unique indexes: `(providerId, userId)` — one link per provider per user — and
+`(providerUserId, providerId)` — one external identity belongs to one local
+user (#3442). The second was application-only until then: `link()` and
+`save()` both read then write with no transaction and no row lock, so two
+concurrent completions for the same upstream subject could both insert, after
+which `findOneByProviderIdentity` returned whichever row the database ordered
+first. The column ORDER of that index is load-bearing — `providerUserId`
+leads the sequence the rapiq schema declares, so reversing it would fail
+`assertSchemaMatchesEntity` at boot and turn the migration into a rename.
+`link()` keeps its explicit check for the friendly `already_linked` message;
+the constraint is the backstop. The table is surfaced as a
 read+delete entity API and an explicit self-service link flow. No migration:
 the table predates the feature (federated login has always written it, and
 still auto-creates a NEW user for an unknown external identity — explicit

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2668,10 +2668,12 @@ leads the sequence the rapiq schema declares, so reversing it would fail
 `assertSchemaMatchesEntity` at boot and turn the migration into a rename.
 `link()` keeps its explicit check for the friendly `already_linked` message;
 the constraint is the backstop. The table is surfaced as a
-read+delete entity API and an explicit self-service link flow. No migration:
-the table predates the feature (federated login has always written it, and
-still auto-creates a NEW user for an unknown external identity — explicit
-linking is the only way to bind an external identity to an EXISTING user).
+read+delete entity API and an explicit self-service link flow. The LINKING
+FEATURE itself needed no migration (the table predates it: federated login
+has always written it, and still auto-creates a NEW user for an unknown
+external identity, so explicit linking is the only way to bind an external
+identity to an EXISTING user); the uniqueness flip above does ship one,
+`1786633352004-IdentityProviderAccountUniqueness` on both dialects.
 
 - **Unified repository port** — `IIdentityProviderAccountRepository`
   (`core/entities/identity-provider-account/types.ts`) carries the entity

--- a/apps/server-core/src/adapters/database/domains/identity-provider-account/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-account/entity.ts
@@ -29,7 +29,10 @@ import { IdentityProviderEntity } from '../identity-provider/index.ts';
 
 @Entity({ name: 'auth_identity_provider_accounts' })
 @Index(['providerId', 'userId'], { unique: true })
-@Index(['providerUserId', 'providerId'])
+// one external identity belongs to one local user. The column order is
+// load-bearing: `providerUserId` leads the sequence the rapiq schema
+// declares, and reversing it would fail the boot-time index assertion.
+@Index(['providerUserId', 'providerId'], { unique: true })
 export class IdentityProviderAccountEntity implements IdentityProviderAccount {
     @PrimaryGeneratedColumn('uuid')
     id: string;

--- a/apps/server-core/src/adapters/database/migrations/mysql/1786633352004-IdentityProviderAccountUniqueness.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1786633352004-IdentityProviderAccountUniqueness.ts
@@ -1,0 +1,55 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Make `(provider_user_id, provider_id)` unique.
+ *
+ * "One external identity belongs to one local user" was enforced only by a
+ * read-then-write in `IdentityProviderAccountManager` (issue #3442): no
+ * transaction, no row lock, and nothing behind it in the schema, so two
+ * concurrent completions for the same upstream subject could both observe
+ * "not linked" and both insert. After that the subject resolves to whichever
+ * row the database happens to order first.
+ *
+ * The column order matches the pre-existing non-unique index, so this is an
+ * in-place uniqueness flip under the same derived name rather than a rename.
+ *
+ * Pre-existing duplicates abort the boot with an actionable message. They
+ * would abort it anyway, since `CREATE UNIQUE INDEX` fails on them; the
+ * check only decides whether the operator reads a readable sentence or a
+ * hash-named driver error.
+ */
+export class IdentityProviderAccountUniqueness1786633352004 implements MigrationInterface {
+    name = 'IdentityProviderAccountUniqueness1786633352004';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const duplicates = await queryRunner.query(`
+            SELECT \`provider_id\`, \`provider_user_id\`, COUNT(*) AS \`count\`
+            FROM \`auth_identity_provider_accounts\`
+            GROUP BY \`provider_id\`, \`provider_user_id\`
+            HAVING COUNT(*) > 1
+        `);
+        if (duplicates.length > 0) {
+            throw new Error(
+                `Identity-provider account uniqueness migration aborted: "auth_identity_provider_accounts" holds ${duplicates.length} ` +
+                'duplicate (provider_id, provider_user_id) group(s). One external identity must belong to one local user. ' +
+                'Merge or delete the conflicting rows manually before re-running.',
+            );
+        }
+
+        await queryRunner.query(`
+            DROP INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\`
+        `);
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\` (\`provider_user_id\`, \`provider_id\`)
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\`
+        `);
+        await queryRunner.query(`
+            CREATE INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\` (\`provider_user_id\`, \`provider_id\`)
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/mysql/1786633352004-IdentityProviderAccountUniqueness.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1786633352004-IdentityProviderAccountUniqueness.ts
@@ -13,6 +13,12 @@ import type { MigrationInterface, QueryRunner } from 'typeorm';
  * The column order matches the pre-existing non-unique index, so this is an
  * in-place uniqueness flip under the same derived name rather than a rename.
  *
+ * MySQL commits DDL implicitly, so `migrationsTransactionMode: 'all'` cannot
+ * roll a partial run back. A DROP followed by a CREATE would leave the table
+ * with no index of that name if the process died between them, and every
+ * later attempt would then fail at the DROP. One ALTER carrying both is
+ * atomic, so the migration either applies or does not.
+ *
  * Pre-existing duplicates abort the boot with an actionable message. They
  * would abort it anyway, since `CREATE UNIQUE INDEX` fails on them; the
  * check only decides whether the operator reads a readable sentence or a
@@ -37,19 +43,17 @@ export class IdentityProviderAccountUniqueness1786633352004 implements Migration
         }
 
         await queryRunner.query(`
-            DROP INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\`
-        `);
-        await queryRunner.query(`
-            CREATE UNIQUE INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\` (\`provider_user_id\`, \`provider_id\`)
+            ALTER TABLE \`auth_identity_provider_accounts\`
+                DROP INDEX \`IDX_ccf3fd36253755bd9a5f43c516\`,
+                ADD UNIQUE INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` (\`provider_user_id\`, \`provider_id\`)
         `);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {
         await queryRunner.query(`
-            DROP INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\`
-        `);
-        await queryRunner.query(`
-            CREATE INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` ON \`auth_identity_provider_accounts\` (\`provider_user_id\`, \`provider_id\`)
+            ALTER TABLE \`auth_identity_provider_accounts\`
+                DROP INDEX \`IDX_ccf3fd36253755bd9a5f43c516\`,
+                ADD INDEX \`IDX_ccf3fd36253755bd9a5f43c516\` (\`provider_user_id\`, \`provider_id\`)
         `);
     }
 }

--- a/apps/server-core/src/adapters/database/migrations/postgres/1786633352004-IdentityProviderAccountUniqueness.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1786633352004-IdentityProviderAccountUniqueness.ts
@@ -1,0 +1,55 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Make `(provider_user_id, provider_id)` unique.
+ *
+ * "One external identity belongs to one local user" was enforced only by a
+ * read-then-write in `IdentityProviderAccountManager` (issue #3442): no
+ * transaction, no row lock, and nothing behind it in the schema, so two
+ * concurrent completions for the same upstream subject could both observe
+ * "not linked" and both insert. After that the subject resolves to whichever
+ * row the database happens to order first.
+ *
+ * The column order matches the pre-existing non-unique index, so this is an
+ * in-place uniqueness flip under the same derived name rather than a rename.
+ *
+ * Pre-existing duplicates abort the boot with an actionable message. They
+ * would abort it anyway, since `CREATE UNIQUE INDEX` fails on them; the
+ * check only decides whether the operator reads a readable sentence or a
+ * hash-named driver error.
+ */
+export class IdentityProviderAccountUniqueness1786633352004 implements MigrationInterface {
+    name = 'IdentityProviderAccountUniqueness1786633352004';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const duplicates = await queryRunner.query(`
+            SELECT "provider_id", "provider_user_id", COUNT(*) AS "count"
+            FROM "auth_identity_provider_accounts"
+            GROUP BY "provider_id", "provider_user_id"
+            HAVING COUNT(*) > 1
+        `);
+        if (duplicates.length > 0) {
+            throw new Error(
+                `Identity-provider account uniqueness migration aborted: "auth_identity_provider_accounts" holds ${duplicates.length} ` +
+                'duplicate (provider_id, provider_user_id) group(s). One external identity must belong to one local user. ' +
+                'Merge or delete the conflicting rows manually before re-running.',
+            );
+        }
+
+        await queryRunner.query(`
+            DROP INDEX "public"."IDX_ccf3fd36253755bd9a5f43c516"
+        `);
+        await queryRunner.query(`
+            CREATE UNIQUE INDEX "IDX_ccf3fd36253755bd9a5f43c516" ON "auth_identity_provider_accounts" ("provider_user_id", "provider_id")
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX "public"."IDX_ccf3fd36253755bd9a5f43c516"
+        `);
+        await queryRunner.query(`
+            CREATE INDEX "IDX_ccf3fd36253755bd9a5f43c516" ON "auth_identity_provider_accounts" ("provider_user_id", "provider_id")
+        `);
+    }
+}

--- a/apps/server-core/test/unit/core/identity/provider/account.spec.ts
+++ b/apps/server-core/test/unit/core/identity/provider/account.spec.ts
@@ -23,6 +23,8 @@ import {
     IdentityProviderRoleMapper,
 } from '../../../../../src/core';
 import claims from '../../../../data/jwt.json';
+import { IdentityProviderAccountEntity } from '../../../../../src/adapters/database/domains';
+import { isUniqueConstraintDatabaseError } from '../../../../../src/adapters/database/errors';
 import {
     IdentityProviderAccountRepositoryAdapter,
     IdentityProviderAttributeMappingRepository,
@@ -34,6 +36,7 @@ import {
     PermissionEntity,
     RealmEntity,
     RoleRepository,
+    UserEntity,
     UserIdentityRepository,
     UserPermissionEntity,
     UserRepository,
@@ -113,6 +116,51 @@ describe('core/identity/provider/account', () => {
 
         realm = undefined as unknown as Realm;
         accountManager = undefined as unknown as IdentityProviderAccountManager;
+    });
+
+    /**
+     * The "one external identity belongs to one local user" invariant was
+     * application-only until #3442: `link()` and `save()` both read then
+     * write, with no transaction and no row lock, so two concurrent
+     * completions for the same upstream subject could both insert. The
+     * insert below is what that race would produce.
+     *
+     * The second row deliberately points at a user holding NO account for
+     * this provider. Reusing an already-linked user would violate the
+     * pre-existing `(providerId, userId)` index instead, and the case would
+     * pass with or without the constraint under test.
+     */
+    it('should refuse a second account for the same external identity', async () => {
+        const account = await accountManager.save({
+            data: claims,
+            id: 'duplicate-subject',
+            attributeCandidates: { name: ['duplicate-one'] },
+            provider,
+        });
+
+        const userRepository = suite.dataSource.getRepository(UserEntity);
+        const user = await userRepository.save(userRepository.create({
+            name: 'duplicate-two',
+            email: 'duplicate-two@example.com',
+            realmId: realm.id,
+        }));
+
+        expect(user.id).not.toEqual(account.userId);
+
+        const repository = suite.dataSource.getRepository(IdentityProviderAccountEntity);
+
+        try {
+            await repository.insert({
+                providerId: provider.id,
+                providerRealmId: provider.realmId,
+                providerUserId: account.providerUserId,
+                userId: user.id,
+                userRealmId: user.realmId,
+            });
+            expect.fail('Expected the unique constraint to reject the duplicate');
+        } catch (e) {
+            expect(isUniqueConstraintDatabaseError(e)).toBeTruthy();
+        }
     });
 
     it('should create user', async () => {

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -5,7 +5,33 @@ Entries are grouped by release, newest first. Routine changes (features, fixes) 
 [changelog](https://github.com/authup/authup/blob/master/CHANGELOG.md); anything listed here
 either requires operator action or deliberately changes behavior.
 
-## Next release (after v1.0.0-beta.59)
+## Next release (after v1.0.0-beta.60)
+
+### `auth_identity_provider_accounts` gains a unique constraint
+
+`(provider_id, provider_user_id)` becomes unique, so one external identity
+belongs to exactly one local user. Until now that invariant was enforced only
+by a read-then-write in the application, with no transaction and no row lock,
+so two concurrent logins or link completions for the same upstream subject
+could both insert. After that the subject resolved to whichever row the
+database happened to order first.
+
+**Action required only if your deployment already holds such duplicates.**
+The migration checks first and aborts the boot with the number of affected
+groups rather than a hash-named driver error. Find them with:
+
+```sql
+SELECT provider_id, provider_user_id, COUNT(*)
+FROM auth_identity_provider_accounts
+GROUP BY provider_id, provider_user_id
+HAVING COUNT(*) > 1;
+```
+
+Keep the row whose `user_id` names the account the person actually uses, and
+delete the rest. The unique index cannot be created while duplicates exist,
+so the boot would fail either way; the check only makes the reason readable.
+
+## v1.0.0-beta.60
 
 ### Fixed: external identity-provider login
 


### PR DESCRIPTION
Closes #3442.

`IdentityProviderAccountManager.link()` enforced "one external identity belongs to one local user" with a `findOneByProviderIdentity` followed by a `save`: no transaction, no row lock, and nothing behind it in the schema. Two concurrent completions for the same upstream subject could both observe "not linked" and both insert, after which `findOneByProviderIdentity` returns whichever row the database happens to order first. The federated login path has the same shape through `save()`.

## The column order is kept, deliberately

The index is flipped **in place** to unique as `(provider_user_id, provider_id)`, not reordered to match the issue title. Reordering would break three things at once: the rapiq schema declares `['providerUserId', 'providerId']` and would lose its backing leftmost prefix (boot-time `assertSchemaMatchesEntity` failure), `providerUserId` would stop anchoring as a filter key, and the derived index name would change so the migration became a rename rather than a uniqueness flip.

## Pre-existing duplicates

The migration checks first and aborts with the number of affected groups. It would abort either way — `CREATE UNIQUE INDEX` fails on duplicates — so the check only decides whether the operator reads a readable sentence or a hash-named driver error. Follows the `1779267068441` precedent. `docs/src/guide/deployment/upgrading.md` carries the note and the query to find them.

That file's top section was still headed *Next release (after v1.0.0-beta.59)* although those entries shipped in beta.60 (verified with `git tag --contains`), so it is corrected to `## v1.0.0-beta.60` and a new *Next release* section opened above it.

## What is not in this change

No adapter-level translation of the driver error into `IdentityProviderAccountAlreadyLinkedError`. `save()` also serves the federated login, where a lost race is not "already linked"; the honest answer there is to re-read and return the winner's row, which is a larger change. Without translation the race loser gets `?linkError=link_failed` — correct, just less specific.

## Verification

- `test:migration-latest` (populated round-trip: drift, revert, re-run, FK cascade, reboot): **12/12 on postgres, 12/12 on mysql**
- **The generated postgres `down()` was corrected.** It recreated the index as `(provider_id, provider_user_id)`, but the released `1786436332251-QueryIndexes` created it as `(provider_user_id, provider_id)`, so as emitted a revert would have left a *different* index than existed before. Verified empirically: after `migration revert`, `pg_indexes` reports `USING btree (provider_user_id, provider_id)`, byte-identical to the released chain. This is the documented exception to committing generated DDL untouched — the generated statement was wrong, and the correction is pinned by observation rather than by reading.
- MySQL `down()` needs no FK-constraint wrapper: the index is being replaced under the same name rather than dropped, and the round-trip confirms it.
- New case *should refuse a second account for the same external identity* in `account.spec.ts`. It points the duplicate row at a user holding **no** account for that provider — the obvious version of this test reuses an already-linked user, which violates the pre-existing `(providerId, userId)` index instead and passes with or without the constraint under test. Caught by running the differential: the first version passed against a reverted entity.
- Differential: with the entity change reverted the new case fails; with it, 9 pass.
- `apps/server-core` full suite: **194 files / 2161 tests passed**; eslint clean.