### PR TITLE
feat(server-core): complete an identity-provider link on an authenticated request

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2771,8 +2771,9 @@ linking is the only way to bind an external identity to an EXISTING user).
   id/name — never tokens).
 - **UI** — account console page `/connected-accounts` (realm providers ×
   own linked rows; Connect = `createLinkRequest` navigation, Disconnect =
-  confirm + delete; reads and strips the `linked`/`linkError` return
-  params) + admin console tab `users/[id]/identity-provider-accounts`
+  confirm + delete; auto-POSTs the `linkHandle` return param to the confirm
+  endpoint, then strips it and `linkError` from the URL)
+  + admin console tab `users/[id]/identity-provider-accounts`
   (kit collection `AIdentityProviderAccounts`, gated on
   `IDENTITY_PROVIDER_ACCOUNT_READ` like the sessions tab).
 - **Tests** — service matrix + guardrail

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2698,44 +2698,74 @@ linking is the only way to bind an external identity to an EXISTING user).
   has no password (`IdentityProviderAccountUnlinkBlockedError`,
   `ErrorCode.IDENTITY_PROVIDER_ACCOUNT_UNLINK_BLOCKED`, 400): the row may
   be the only way into the account. An admin sets a password first.
-- **Link flow (server-completed)** — server auth is header-only, so the
-  browser round-trip cannot carry a bearer; the link intent rides the
-  one-time, IP+UA-bound `stateManager` blob instead:
-  `POST /identity-providers/:id/link-request` (ForceLoggedIn, user
-  identities only; provider must be OAuth2/OIDC, enabled, and in the
-  actor's realm) saves a state with the new optional
-  `link: { userId }` field (`OAuth2AuthorizationState`; cache blob, no
-  migration) and returns `{ url }` = the external authorize URL
-  (`IdentityProviderLinkRequestResponse` in core-http-kit;
-  `client.identityProvider.createLinkRequest(id)`). The `authorize-in`
-  callback branches on `state.link`: `authenticator.resolveIdentity(code)`
-  (token exchange + identity build, extracted from `authenticate()` —
-  which is now `resolveIdentity` + `accountManager.save`, login path
-  unchanged) then `accountManager.link(identity, userId)`: rejects an
-  identity linked to a DIFFERENT user
-  (`IdentityProviderAccountAlreadyLinkedError`), refreshes idempotently
-  for the same user, verifies user existence + provider/user realm match,
-  and NEVER runs mappers, mutates the user, mints a code or creates a
-  session. The redirect back is fixed and server-derived:
-  `<publicUrl>/account/connected-accounts?linked=<providerId>` or
-  `?linkError=already_linked|link_failed`. **Takeover posture — reason about
-  BOTH directions.** Linking an attacker's external identity to a victim
-  requires a state blob carrying the victim's userId, which only the
-  victim's bearer can mint. The reverse direction is the one that bites:
-  the attacker mints a state carrying their OWN userId and gets the victim
-  to follow it, so the victim's callback binds the VICTIM's external
-  identity to the ATTACKER's account, and the victim's next federated login
-  resolves through that row into it. State unguessability does not defend
-  this — the attacker is not guessing a state, they are supplying one — so
-  the ONLY control is the state's ip/user-agent binding, and both values
-  are chosen by whoever minted the state (`verify` skips a check whose
-  STORED value is falsy, and under the shipped `trustProxy: true` the ip is
-  the client-supplied left-most `X-Forwarded-For` entry). `completeLink`
-  therefore refuses a state carrying no binding at all. That is a stopgap
-  for the absent-binding hole only, not for a guessed one; issue #3439
-  moves the write behind a bearer-authenticated confirmation, after which
-  the guard and the state-carried userId both go away.
-- **Events** — `identityProviderLinked` (recorded in the callback branch)
+- **Link flow (two steps, the write is bearer-authenticated)** — server
+  auth is header-only, so the browser round-trip cannot carry a bearer.
+  The flow is therefore split, and the credential binding happens only on
+  the authenticated half (issue #3439):
+  1. `POST /identity-providers/:id/link-request` (ForceLoggedIn, user
+     identities only; provider must be OAuth2/OIDC, enabled, and in the
+     actor's realm) saves an `OAuth2AuthorizationState` carrying
+     `link: { userId, providerId }` and returns `{ url }` = the external
+     authorize URL (`IdentityProviderLinkRequestResponse` in core-http-kit;
+     `client.identityProvider.createLinkRequest(id)`).
+  2. The `authorize-in` callback branches on `state.link`:
+     `authenticator.resolveIdentity(code)` (token exchange + identity
+     build, extracted from `authenticate()`), then **stashes** a
+     four-scalar projection (`IdentityProviderAccountLink`: providerId,
+     userId, providerUserId, providerUserName/Email) under a one-time
+     handle and redirects to
+     `<publicUrl>/account/connected-accounts?linkHandle=<handle>&provider=<id>`
+     (or `?linkError=link_failed`). It writes NOTHING.
+  3. The account console auto-POSTs the handle to
+     `POST /identity-providers/:id/link-confirm` with its bearer
+     (`client.identityProvider.confirmLinkRequest(id, handle)`), and the
+     server links the stashed identity to the **authenticated** user.
+  **Why the split.** The callback is unauthenticated, so before it the only
+  thing separating "the browser that started this link" from any other was
+  the state's ip / user-agent binding, and both values are chosen by
+  whoever minted the state (`verify` skips a check whose STORED value is
+  falsy, and under the shipped `trustProxy: true` the ip is the
+  client-supplied left-most `X-Forwarded-For` entry). The attack that
+  bites is the reverse of the obvious one: the attacker mints a state
+  carrying their OWN userId and gets the victim to follow it, so the
+  victim's callback binds the VICTIM's external identity to the ATTACKER's
+  account and the victim's next federated login resolves into it
+  (federated account pre-hijacking). State unguessability is no defense —
+  the attacker supplies the state rather than guessing it.
+  **What makes the handle inert.** It is redeemable only by the user the
+  link-request was minted for (`stash.userId === authenticated user id`)
+  and only against that provider, and it is consumed on read. So a handle
+  leaking through browser history, a referer or a proxy log authorizes
+  nothing on its own. Keeping `userId` in the stash is what allows that
+  check: dropping it (as the issue sketched) would make a leaked handle
+  redeemable by anyone, which is the same pre-hijacking in a new shape.
+  The predecessor's stopgap — refusing a state carrying no browser binding
+  at all — is gone with the hole it patched.
+  **Stash contents.** Deliberately four scalars, never the
+  `IdentityProviderIdentity`: that object carries the full provider entity
+  (including the EA-loaded `clientSecret`) and the raw external token
+  payload, and they are exactly what `link()` reads. The confirm rebuilds
+  a minimal identity around the freshly loaded provider. TTL is 5 minutes
+  (`IDENTITY_PROVIDER_ACCOUNT_LINK_TTL`) — it is redeemed by the very next
+  page load, so the state blob's 30 minutes would leave a redeemable
+  binding lying around far longer than the flow that produced it. The
+  store is `IIdentityProviderAccountLinkStore`
+  (`app/modules/identity/repositories/provider/link.ts` over
+  `CacheInjectionKey`, DI key
+  `IdentityInjectionKey.ProviderAccountLinkStore`) rather than a second
+  `OAuth2AuthorizationStateManager` blob, which would inherit that TTL and
+  re-apply the ip check to an XHR from the SPA (a network flip between
+  callback and confirm would break the link).
+  `link()` itself is unchanged: rejects an identity linked to a DIFFERENT
+  user (`IdentityProviderAccountAlreadyLinkedError`), refreshes
+  idempotently for the same user, verifies user existence + provider/user
+  realm match, and NEVER runs mappers, mutates the user, mints a code or
+  creates a session. **Deployment note:** the callback and the confirm must
+  reach the same cache, so a multi-replica deployment without Redis needs
+  sticky routing across one more hop than before.
+- **Events** — `identityProviderLinked` (recorded on the authenticated
+  confirm, so it carries actor and session attribution the callback could
+  not)
   / `identityProviderUnlinked` (recorded in the service delete), IDENTITY
   scope, `refType: identityProviderAccount`, metadata only (provider
   id/name — never tokens).

--- a/apps/client-account-console/src/pages/connected-accounts.vue
+++ b/apps/client-account-console/src/pages/connected-accounts.vue
@@ -7,7 +7,6 @@
 <script lang="ts">
 /* global window */
 import type { IdentityProvider, IdentityProviderAccount } from '@authup/core-kit';
-import { ErrorCode } from '@authup/errors';
 import {
     TranslatorTranslationActionKey,
     TranslatorTranslationAppKey,
@@ -110,39 +109,52 @@ export default defineComponent({
             }
         };
 
-        // Surface the link round-trip outcome, then strip the marker params
-        // from the URL (single use, reload-safe).
+        // Complete the link round-trip, then strip the marker params from
+        // the URL (single use, reload-safe).
+        //
+        // The callback that resolved the external identity is unauthenticated
+        // and deliberately writes nothing (issue #3439). It hands back a
+        // one-time handle, and the account row is created HERE, on a request
+        // carrying this browser's bearer, so the binding is made for whoever
+        // is actually signed in rather than for a userId the callback was
+        // told to trust.
         const consumeReturnParams = async () => {
-            const linked = typeof route.query.linked === 'string' ? route.query.linked : undefined;
+            const handle = typeof route.query.linkHandle === 'string' ? route.query.linkHandle : undefined;
             const linkError = typeof route.query.linkError === 'string' ? route.query.linkError : undefined;
-            if (!linked && !linkError) {
+            const providerId = typeof route.query.provider === 'string' ? route.query.provider : undefined;
+            if (!handle && !linkError) {
                 return;
             }
 
-            if (linked) {
-                toasts.success(await translate({
-                    namespace: TranslatorTranslationNamespace.APP,
-                    key: TranslatorTranslationAppKey.IDENTITY_PROVIDER_LINK_SUCCESS,
-                }));
+            if (handle && providerId) {
+                try {
+                    await httpClient.identityProvider.confirmLinkRequest(providerId, handle);
+
+                    toasts.success(await translate({
+                        namespace: TranslatorTranslationNamespace.APP,
+                        key: TranslatorTranslationAppKey.IDENTITY_PROVIDER_LINK_SUCCESS,
+                    }));
+                } catch (e) {
+                    // carries the server's own message, including the
+                    // localized "already linked to another user"
+                    await toasts.error(e);
+                }
             }
 
             if (linkError) {
-                const description = linkError === 'already_linked' ?
-                    await translate({
-                        namespace: TranslatorTranslationNamespace.ERROR,
-                        key: ErrorCode.IDENTITY_PROVIDER_ACCOUNT_ALREADY_LINKED,
-                    }) :
-                    await translate({
+                toast.add({
+                    description: await translate({
                         namespace: TranslatorTranslationNamespace.APP,
                         key: TranslatorTranslationAppKey.IDENTITY_PROVIDER_LINK_FAILED,
-                    });
-
-                toast.add({ description, color: 'error' });
+                    }),
+                    color: 'error',
+                });
             }
 
             const query = { ...route.query };
-            delete query.linked;
+            delete query.linkHandle;
             delete query.linkError;
+            delete query.provider;
             await router.replace({ path: route.path, query });
         };
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -94,6 +94,7 @@ import {
     getBodyRealmID,
     getRequestParamID,
     getRequestRealmID,
+    useRequestEventContext,
     useRequestIdentityOrFail,
     useRequestParamID,
     useRequestPermissionEvaluator,
@@ -701,6 +702,10 @@ export class IdentityProviderController {
             identity.id,
         );
 
+        // the confirm runs under a bearer, so unlike the callback it CAN be
+        // attributed to a session and a route (the unlink emit's shape)
+        const requestContext = useRequestEventContext();
+
         await this.eventService?.record({
             scope: EventScope.IDENTITY,
             name: EventName.IDENTITY_PROVIDER_LINKED,
@@ -709,8 +714,12 @@ export class IdentityProviderController {
             realmId: account.userRealmId ?? provider.realmId ?? null,
             actorType: IdentityType.USER,
             actorId: account.userId,
-            requestIpAddress: getRequestIP(event) ?? null,
-            requestUserAgent: getRequestHeader(event, 'user-agent') ?? null,
+            actorName: identity.data.name ?? null,
+            sessionId: requestContext?.sessionId ?? null,
+            requestPath: requestContext?.requestPath ?? null,
+            requestMethod: requestContext?.requestMethod ?? null,
+            requestIpAddress: requestContext?.requestIpAddress ?? getRequestIP(event) ?? null,
+            requestUserAgent: requestContext?.requestUserAgent ?? getRequestHeader(event, 'user-agent') ?? null,
             data: { providerId: provider.id, providerName: provider.name },
         });
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -6,7 +6,12 @@
  */
 
 import { BuiltInPolicyType, definePolicyData } from '@authup/access';
-import { ValidatorGroup, base64URLDecode, isUUID } from '@authup/kit';
+import { 
+    ValidatorGroup, 
+    base64URLDecode, 
+    isObject, 
+    isUUID, 
+} from '@authup/kit';
 import {
     DBody,
     DContext,
@@ -26,6 +31,7 @@ import {
 } from 'routup';
 import type {
     IdentityProvider,
+    IdentityProviderAccount,
     OAuth2AuthorizationCodeRequest,
     OAuth2IdentityProvider,
     OpenIDIdentityProvider,
@@ -52,6 +58,7 @@ import type {
     EntityCollectionResponse,
     EntityRecordResponse,
     IdentityProviderCreatePayload,
+    IdentityProviderLinkConfirmPayload,
     IdentityProviderLinkRequestResponse,
     IdentityProviderSavePayload,
     IdentityProviderUpdatePayload,
@@ -59,6 +66,7 @@ import type {
 import { URL } from 'node:url';
 import type {
     IEventService,
+    IIdentityProviderAccountLinkStore,
     IIdentityProviderAccountManager,
     IIdentityProviderRepository,
     IOAuth2AccessPolicyEvaluator,
@@ -67,6 +75,7 @@ import type {
     IOAuth2AuthorizationStateManager,
     IOAuth2ClientRepository,
     IRealmRepository,
+    IdentityProviderIdentity,
     OAuth2AuthorizationState,
     OAuth2AuthorizationStateLink,
 } from '../../../../../core/index.ts';
@@ -77,7 +86,6 @@ import {
     decodeQuery,
     describeQuerySchema,
     identityProviderSchema,
-    isIdentityProviderAccountAlreadyLinkedError,
     toIdentityPolicyData,
 } from '../../../../../core/index.ts';
 import {
@@ -106,6 +114,8 @@ export class IdentityProviderController {
 
     protected accountManager: IIdentityProviderAccountManager;
 
+    protected linkStore: IIdentityProviderAccountLinkStore;
+
     protected codeRequestVerifier : IOAuth2AuthorizationCodeRequestVerifier;
 
     protected codeRequestValidator : OAuth2AuthorizationCodeRequestValidator;
@@ -128,6 +138,7 @@ export class IdentityProviderController {
         this.realmRepository = ctx.realmRepository;
         this.clientRepository = ctx.clientRepository;
         this.accountManager = ctx.accountManager;
+        this.linkStore = ctx.linkStore;
         this.codeIssuer = ctx.codeIssuer;
         this.codeRequestVerifier = ctx.codeRequestVerifier;
         this.codeRequestValidator = new OAuth2AuthorizationCodeRequestValidator();
@@ -578,30 +589,6 @@ export class IdentityProviderController {
                 throw new BadRequestError('The identity provider is not available for account linking.');
             }
 
-            // The state must be bound to the browser that minted it. Both
-            // bindings come from the minting request itself
-            // (`saveAuthorizationState` stores its ip and user-agent) and
-            // `OAuth2AuthorizationStateManager.verify` skips a check whose
-            // STORED value is falsy, so an absent binding is a choice the
-            // minter made rather than a property of the network — and it
-            // leaves the state completable in any browser.
-            //
-            // On the login path that is a session-fixation nuisance. Here it
-            // is a durable credential binding: an attacker who mints a state
-            // carrying their OWN userId and gets a victim to follow it binds
-            // the VICTIM's external identity to the attacker's account, and
-            // the victim's next federated login then lands in it. Refuse an
-            // unbound state instead of linking on it.
-            //
-            // This closes the absent-binding hole only. ip + user-agent
-            // remain guessable, and with the shipped `trustProxy: true` the
-            // ip is the client-supplied left-most X-Forwarded-For entry, so
-            // this is a stopgap: see issue #3439 for moving the write behind
-            // a bearer-authenticated confirmation.
-            if (!state.ip || !state.userAgent) {
-                throw new BadRequestError('The account link request is not bound to a browser.');
-            }
-
             if (typeof code !== 'string' || code.length === 0) {
                 throw new BadRequestError('The authorization code is missing.');
             }
@@ -609,35 +596,139 @@ export class IdentityProviderController {
             const authenticator = this.buildProviderAuthenticator(provider);
 
             const identity = await authenticator.resolveIdentity({ code });
-            const account = await this.accountManager.link(identity, link.userId);
 
-            await this.eventService?.record({
-                scope: EventScope.IDENTITY,
-                name: EventName.IDENTITY_PROVIDER_LINKED,
-                refType: EventRefType.IDENTITY_PROVIDER_ACCOUNT,
-                refId: account.id,
-                realmId: account.userRealmId ?? provider.realmId ?? null,
-                actorType: IdentityType.USER,
-                actorId: account.userId,
-                requestIpAddress: getRequestIP(event) ?? null,
-                requestUserAgent: getRequestHeader(event, 'user-agent') ?? null,
-                data: { providerId: provider.id, providerName: provider.name },
+            // A provider answering without a subject has nothing to bind. The
+            // callback used to reach `link()`, which rejected it; the stash
+            // would otherwise carry an empty providerUserId to the confirm.
+            if (!identity.id) {
+                throw new BadRequestError('The identity provider returned no subject.');
+            }
+
+            // Nothing is written here. This request is unauthenticated — the
+            // browser round-trip cannot carry a bearer — so the only thing
+            // distinguishing the browser that started the link from any other
+            // would be the state's ip / user-agent binding, and both values
+            // are chosen by whoever minted the state. An attacker minting a
+            // state carrying their OWN userId and getting a victim to follow
+            // it would otherwise bind the VICTIM's external identity to the
+            // attacker's account (issue #3439).
+            //
+            // The resolved identity is stashed under a one-time handle
+            // instead, and the account console confirms it with its bearer.
+            // The stash keeps the requesting userId so the confirm can
+            // require it to equal the AUTHENTICATED user: the handle is a
+            // URL parameter, so it reaches browser history and proxy logs,
+            // and on its own it must authorize nothing.
+            const handle = await this.linkStore.save({
+                providerId: provider.id,
+                userId: link.userId,
+                providerUserId: identity.id,
+                providerUserName: this.pickIdentityCandidate(identity, 'name'),
+                providerUserEmail: this.pickIdentityCandidate(identity, 'email'),
             });
 
-            url.searchParams.set('linked', provider.id);
+            url.searchParams.set('linkHandle', handle);
+            url.searchParams.set('provider', provider.id);
         } catch (e) {
             // The failure is swallowed into a redirect marker, so the log is
             // the only surface it can reach. Without this an unreachable or
             // rejecting provider is indistinguishable from a stale state.
             this.logger?.error(describeError(e, 'The identity-provider account link failed.'));
 
-            url.searchParams.set(
-                'linkError',
-                isIdentityProviderAccountAlreadyLinkedError(e) ? 'already_linked' : 'link_failed',
-            );
+            url.searchParams.set('linkError', 'link_failed');
         }
 
         return sendRedirect(event, url.href);
+    }
+
+    /**
+     * The bearer-authenticated half of the link (issue #3439): the account
+     * row is written here, for the AUTHENTICATED user, never in the callback.
+     */
+    @DPost('/:id/link-confirm', [ForceLoggedInMiddleware])
+    async confirmLink(
+        @DPath('id') _id: string,
+        @DBody() _data: IdentityProviderLinkConfirmPayload,
+        @DContext() event: IAppEvent,
+    ) : Promise<EntityRecordResponse<IdentityProviderAccount>> {
+        const id = useRequestParamID(event);
+        const provider = await this.resolve(id);
+
+        if (!isOAuth2IdentityProvider(provider) && !isOpenIDIdentityProvider(provider)) {
+            throw new BadRequestError('Only an identity-provider based on the oauth protocol supports account linking.');
+        }
+
+        if (!provider.enabled) {
+            throw new BadRequestError('The identity provider is not enabled.');
+        }
+
+        const identity = useRequestIdentityOrFail(event);
+        if (identity.type !== IdentityType.USER) {
+            throw new BadRequestError('Only a user can link an identity provider account.');
+        }
+
+        const body = await readRequestBody(event);
+        const handle = isObject(body) ? body.handle : undefined;
+        if (typeof handle !== 'string' || handle.length === 0) {
+            throw new BadRequestError('The account link handle is missing.');
+        }
+
+        const link = await this.linkStore.consume(handle);
+        if (!link) {
+            throw new BadRequestError('The account link request is unknown or expired.');
+        }
+
+        // The two checks that make the handle inert on its own: it may only
+        // be redeemed by the user it was minted for, and only against the
+        // provider it was minted for.
+        if (link.userId !== identity.id || link.providerId !== provider.id) {
+            throw new BadRequestError('The account link request does not belong to the authenticated user.');
+        }
+
+        const account = await this.accountManager.link(
+            {
+                id: link.providerUserId,
+                // deliberately rebuilt from the stashed scalars: the resolved
+                // identity carries the provider secret and the raw external
+                // token payload, neither of which belongs in a cache
+                attributeCandidates: {
+                    name: [link.providerUserName],
+                    email: [link.providerUserEmail],
+                },
+                data: {},
+                provider,
+            },
+            identity.id,
+        );
+
+        await this.eventService?.record({
+            scope: EventScope.IDENTITY,
+            name: EventName.IDENTITY_PROVIDER_LINKED,
+            refType: EventRefType.IDENTITY_PROVIDER_ACCOUNT,
+            refId: account.id,
+            realmId: account.userRealmId ?? provider.realmId ?? null,
+            actorType: IdentityType.USER,
+            actorId: account.userId,
+            requestIpAddress: getRequestIP(event) ?? null,
+            requestUserAgent: getRequestHeader(event, 'user-agent') ?? null,
+            data: { providerId: provider.id, providerName: provider.name },
+        });
+
+        return { data: account, meta: {} };
+    }
+
+    private pickIdentityCandidate(
+        identity: IdentityProviderIdentity,
+        key: 'name' | 'email',
+    ) : string | null {
+        const candidates = identity.attributeCandidates?.[key] || [];
+        for (const candidate of candidates) {
+            if (typeof candidate === 'string' && candidate.length > 0) {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
     // ---------------------------------------------------------

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/types.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/types.ts
@@ -8,6 +8,7 @@
 import type { Logger } from '@authup/server-kit';
 import type {
     IEventService,
+    IIdentityProviderAccountLinkStore,
     IIdentityProviderAccountManager,
     IIdentityProviderRepository,
     IOAuth2AccessPolicyEvaluator,
@@ -30,6 +31,7 @@ export type IdentityProviderControllerContext = {
     clientRepository: IOAuth2ClientRepository,
 
     accountManager: IIdentityProviderAccountManager,
+    linkStore: IIdentityProviderAccountLinkStore,
     codeIssuer: IOAuth2AuthorizationCodeIssuer,
     codeRequestVerifier: IOAuth2AuthorizationCodeRequestVerifier,
     stateManager: IOAuth2AuthorizationStateManager,

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -526,6 +526,7 @@ export class HTTPControllerModule {
         const dataSource = container.resolve(DatabaseInjectionKey.DataSource);
 
         const accountManager = container.resolve(IdentityInjectionKey.ProviderAccountManager);
+        const linkStore = container.resolve(IdentityInjectionKey.ProviderAccountLinkStore);
 
         const codeIssuer = container.resolve(OAuth2InjectionToken.AuthorizationCodeIssuer);
 
@@ -548,6 +549,7 @@ export class HTTPControllerModule {
             clientRepository: container.resolve(OAuth2InjectionToken.ClientRepository),
 
             accountManager,
+            linkStore,
 
             codeIssuer,
             codeRequestVerifier,

--- a/apps/server-core/src/app/modules/identity/constants.ts
+++ b/apps/server-core/src/app/modules/identity/constants.ts
@@ -8,6 +8,7 @@
 import { TypedToken } from 'eldin';
 import type {
     IIdentityPermissionProvider,
+    IIdentityProviderAccountLinkStore,
     IIdentityProviderAccountManager,
     IIdentityResolver,
     IIdentityRoleProvider,
@@ -19,5 +20,6 @@ export const IdentityInjectionKey = {
     PermissionProvider: new TypedToken<IIdentityPermissionProvider>('IdentityPermissionProvider'),
     RoleProvider: new TypedToken<IIdentityRoleProvider>('IdentityRoleProvider'),
     ProviderAccountManager: new TypedToken<IIdentityProviderAccountManager>('AccountManager'),
+    ProviderAccountLinkStore: new TypedToken<IIdentityProviderAccountLinkStore>('ProviderAccountLinkStore'),
     ProviderLdapCollectionAuthenticator: new TypedToken<IdentityProviderLdapCollectionAuthenticator>('ProviderLdapCollectionAuthenticator'),
 } as const;

--- a/apps/server-core/src/app/modules/identity/module.ts
+++ b/apps/server-core/src/app/modules/identity/module.ts
@@ -15,6 +15,7 @@ import type {
 import type { Repository } from 'typeorm';
 import {
     ClientIdentityRepository,
+    IdentityProviderAccountLinkStore,
     IdentityProviderAttributeMappingRepository,
     IdentityProviderPermissionMappingRepository,
     IdentityProviderRoleMappingRepository,
@@ -51,6 +52,7 @@ import {
     IdentityRoleProvider,
 } from '../../../core/index.ts';
 import { LDAPInjectionKey } from '../ldap/index.ts';
+import { CacheInjectionKey } from '../cache/index.ts';
 
 import type { IModule } from 'orkos';
 import { ModuleName } from '../constants.ts';
@@ -138,6 +140,16 @@ export class IdentityModule implements IModule {
                 roleMapper,
                 permissionMapper,
             }),
+        });
+
+        container.register(IdentityInjectionKey.ProviderAccountLinkStore, {
+            // lazy: the cache module is not a declared dependency of this
+            // one, and a factory only runs once something resolves the store
+            useFactory: (c) => {
+                const cache = c.resolve(CacheInjectionKey);
+
+                return new IdentityProviderAccountLinkStore(cache);
+            },
         });
 
         // ---------------------------------------------

--- a/apps/server-core/src/app/modules/identity/repositories/constants.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/constants.ts
@@ -1,11 +1,10 @@
 /*
- * Copyright (c) 2025.
+ * Copyright (c) 2026.
  * Author Peter Placzek (tada5hi)
  * For the full copyright and license information,
  * view the LICENSE file that was distributed with this source code.
  */
 
-export * from './constants.ts';
-export * from './error.ts';
-export * from './module.ts';
-export * from './types.ts';
+export enum CacheIdentityPrefix {
+    PROVIDER_ACCOUNT_LINK = 'identity_provider_account_link',
+}

--- a/apps/server-core/src/app/modules/identity/repositories/index.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/index.ts
@@ -7,5 +7,7 @@
 
 export * from './provider/index.ts';
 
+export * from './constants.ts';
+
 export * from './client.ts';
 export * from './user.ts';

--- a/apps/server-core/src/app/modules/identity/repositories/provider/index.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/provider/index.ts
@@ -6,3 +6,4 @@
  */
 
 export * from './mapper/index.ts';
+export * from './link.ts';

--- a/apps/server-core/src/app/modules/identity/repositories/provider/link.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/provider/link.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createNanoID } from '@authup/kit';
+import type { ICache } from '@authup/server-kit';
+import { buildCacheKey } from '@authup/server-kit';
+import type {
+    IIdentityProviderAccountLinkStore,
+    IdentityProviderAccountLink,
+} from '../../../../../core/index.ts';
+import { IDENTITY_PROVIDER_ACCOUNT_LINK_TTL } from '../../../../../core/index.ts';
+import { CacheIdentityPrefix } from '../constants.ts';
+
+export class IdentityProviderAccountLinkStore implements IIdentityProviderAccountLinkStore {
+    protected cache : ICache;
+
+    constructor(cache: ICache) {
+        this.cache = cache;
+    }
+
+    async save(data: IdentityProviderAccountLink): Promise<string> {
+        const handle = createNanoID();
+
+        await this.cache.set(
+            buildCacheKey({
+                prefix: CacheIdentityPrefix.PROVIDER_ACCOUNT_LINK,
+                key: handle,
+            }),
+            data,
+            { ttl: IDENTITY_PROVIDER_ACCOUNT_LINK_TTL },
+        );
+
+        return handle;
+    }
+
+    async consume(handle: string): Promise<IdentityProviderAccountLink | null> {
+        const key = buildCacheKey({
+            prefix: CacheIdentityPrefix.PROVIDER_ACCOUNT_LINK,
+            key: handle,
+        });
+
+        const payload = await this.cache.get<IdentityProviderAccountLink>(key);
+        if (!payload) {
+            return null;
+        }
+
+        // single use, dropped before the caller can act on it
+        await this.cache.drop(key);
+
+        return payload;
+    }
+}

--- a/apps/server-core/src/app/modules/identity/repositories/provider/link.ts
+++ b/apps/server-core/src/app/modules/identity/repositories/provider/link.ts
@@ -43,14 +43,10 @@ export class IdentityProviderAccountLinkStore implements IIdentityProviderAccoun
             key: handle,
         });
 
-        const payload = await this.cache.get<IdentityProviderAccountLink>(key);
-        if (!payload) {
-            return null;
-        }
-
-        // single use, dropped before the caller can act on it
-        await this.cache.drop(key);
-
-        return payload;
+        // `pop` is the atomic read-and-drop (redis GETDEL, one tick on the
+        // memory adapter). A get followed by a drop is two round-trips, and
+        // two simultaneous redemptions of one handle would both read the
+        // payload before either drop landed.
+        return this.cache.pop<IdentityProviderAccountLink>(key);
     }
 }

--- a/apps/server-core/src/core/identity/provider/account/constants.ts
+++ b/apps/server-core/src/core/identity/provider/account/constants.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Lifetime of a pending account link (issue #3439).
+ *
+ * The handle is redeemed by the very next page load, so it needs to cover a
+ * redirect and a bootstrap, not a user's attention span. The authorization
+ * state's 30 minutes would leave a redeemable credential-binding handle
+ * lying in browser history far longer than the flow that produced it.
+ */
+export const IDENTITY_PROVIDER_ACCOUNT_LINK_TTL = 1000 * 60 * 5;

--- a/apps/server-core/src/core/identity/provider/account/types.ts
+++ b/apps/server-core/src/core/identity/provider/account/types.ts
@@ -15,6 +15,44 @@ import type { IIdentityProviderAccountRepository } from '../../../entities/ident
 
 export type { IIdentityProviderAccountRepository } from '../../../entities/identity-provider-account/types.ts';
 
+/**
+ * A resolved external identity awaiting a bearer-authenticated confirmation
+ * (issue #3439). The callback that resolved it is unauthenticated, so it may
+ * not perform the credential binding itself; it stashes this projection under
+ * a one-time handle and the account console redeems it with its bearer.
+ *
+ * Deliberately four scalars rather than the `IdentityProviderIdentity` it was
+ * projected from: that object carries the full provider entity (including the
+ * EA-loaded `clientSecret`) and the raw external token payload, neither of
+ * which belongs in a cache. They are also exactly what `link()` reads.
+ */
+export type IdentityProviderAccountLink = {
+    providerId: string,
+    /**
+     * The user the link-request was minted for. The confirm endpoint
+     * requires it to equal the AUTHENTICATED user, which is what stops an
+     * attacker-minted handle from binding a victim's external identity to
+     * the attacker's account.
+     */
+    userId: string,
+    providerUserId: string,
+    providerUserName?: string | null,
+    providerUserEmail?: string | null,
+};
+
+export interface IIdentityProviderAccountLinkStore {
+    /**
+     * @returns the one-time handle
+     */
+    save(data: IdentityProviderAccountLink) : Promise<string>;
+
+    /**
+     * Reads and DROPS the stash. Single use: a handle that reaches a log or
+     * a browser history entry must not be redeemable twice.
+     */
+    consume(handle: string) : Promise<IdentityProviderAccountLink | null>;
+}
+
 export type IdentityProviderAccountManagerContext = {
     attributeMapper: IIdentityProviderMapper,
     permissionMapper: IIdentityProviderMapper,

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/link.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/link.spec.ts
@@ -154,6 +154,25 @@ describe('identity-provider link flow', () => {
         return new URL(location as string);
     }
 
+    function handleOf(target: URL): string {
+        const handle = target.searchParams.get('linkHandle');
+        expect(handle).toBeTruthy();
+        expect(target.searchParams.get('provider')).toEqual(provider.id);
+
+        return handle as string;
+    }
+
+    function confirmLink(handle: string, token: string, providerId: string = provider.id) {
+        return httpRequest(suite, 'POST', `identity-providers/${providerId}/link-confirm`, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                'user-agent': USER_AGENT,
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify({ handle }),
+        });
+    }
+
     it('links the external identity to the requesting user', async () => {
         const { url, state } = await requestLink(userToken);
 
@@ -164,8 +183,16 @@ describe('identity-provider link flow', () => {
 
         const target = await completeCallback(state);
         expect(target.pathname).toContain('account/connected-accounts');
-        expect(target.searchParams.get('linked')).toEqual(provider.id);
         expect(target.searchParams.get('linkError')).toBeNull();
+
+        const handle = handleOf(target);
+
+        // the callback is unauthenticated, so it writes NOTHING (#3439)
+        const before = await suite.client.get(`identity-provider-accounts?filter[userId]=${user.id}`);
+        expect(before.data.data).toHaveLength(0);
+
+        const confirmed = await confirmLink(handle, userToken);
+        expect(confirmed.status).toEqual(200);
 
         const rows = await suite.client.get(`identity-provider-accounts?filter[userId]=${user.id}`);
         expect(rows.data.data).toHaveLength(1);
@@ -178,7 +205,8 @@ describe('identity-provider link flow', () => {
         const { state } = await requestLink(userToken);
         const target = await completeCallback(state);
 
-        expect(target.searchParams.get('linked')).toEqual(provider.id);
+        const confirmed = await confirmLink(handleOf(target), userToken);
+        expect(confirmed.status).toEqual(200);
 
         const rows = await suite.client.get(`identity-provider-accounts?filter[userId]=${user.id}`);
         expect(rows.data.data).toHaveLength(1);
@@ -199,8 +227,10 @@ describe('identity-provider link flow', () => {
         const { state } = await requestLink(login.access_token);
         const target = await completeCallback(state);
 
-        expect(target.searchParams.get('linked')).toBeNull();
-        expect(target.searchParams.get('linkError')).toEqual('already_linked');
+        // the callback no longer decides this: the conflict surfaces on the
+        // authenticated confirm, where it can carry a real localized error
+        const confirmed = await confirmLink(handleOf(target), login.access_token);
+        expect(confirmed.status).toEqual(400);
 
         // still linked to the FIRST user only
         const rows = await suite.client.get(`identity-provider-accounts?filter[providerId]=${provider.id}`);
@@ -275,18 +305,20 @@ describe('identity-provider link flow', () => {
         tokenEndpointError = undefined;
     });
 
-    it('refuses to link on a state that carries no browser binding', async () => {
-        // `verify` skips a binding check whose STORED value is falsy, and both
-        // stored values come from the request that minted the state. A minter
-        // that sends no user-agent therefore produces a state completable in
-        // ANY browser — and this path performs a durable credential binding,
-        // so an attacker could mint one carrying their own userId and have a
-        // victim's browser bind the VICTIM's external identity to it.
-        //
-        // A fresh external subject AND a fresh user, so nothing else can
-        // refuse this link: without the guard it succeeds outright, which is
-        // what makes the two assertions below discriminate.
-        externalUserId = 'external-user-unbound';
+    /**
+     * The attack the split exists to close (#3439): the attacker mints a link
+     * state carrying their OWN userId and gets a victim to follow it, so the
+     * victim's callback resolves the VICTIM's external identity. Before the
+     * split the callback wrote the row there and then, binding the victim's
+     * external identity to the attacker's account, and only the state's
+     * ip / user-agent binding stood in the way — values chosen by whoever
+     * minted the state.
+     *
+     * Now the write happens on the confirm, under the redeeming browser's
+     * bearer, and the handle is inert for anyone else.
+     */
+    it('refuses a handle minted for another user', async () => {
+        externalUserId = 'external-user-victim';
 
         const password = generateOAuth2CodeVerifier();
         const { data: victimUser } = await suite.client.user.create(createFakeUser({
@@ -299,25 +331,76 @@ describe('identity-provider link flow', () => {
             realm_id: realm.id,
         });
 
-        // mint with no user-agent, then complete from a different browser
-        const response = await httpRequest(suite, 'POST', `identity-providers/${provider.id}/link-request`, {
-            headers: {
-                Authorization: `Bearer ${login.access_token}`,
-                'user-agent': '',
-            },
-        });
-        expect(response.status).toEqual(200);
+        // the ATTACKER mints the state, the VICTIM's browser completes it
+        const { state } = await requestLink(userToken);
+        const target = await completeCallback(state);
 
-        const state = new URL((await response.json()).url).searchParams.get('state');
-        expect(state).toBeTruthy();
+        const response = await confirmLink(handleOf(target), login.access_token);
+        expect(response.status).toEqual(400);
 
-        const target = await completeCallback(state as string);
-
-        expect(target.searchParams.get('linked')).toBeNull();
-        expect(target.searchParams.get('linkError')).toEqual('link_failed');
-
-        const rows = await suite.client.get(`identity-provider-accounts?filter[userId]=${victimUser.id}`);
+        const rows = await suite.client.get(`identity-provider-accounts?filter[providerUserId]=${externalUserId}`);
         expect(rows.data.data).toHaveLength(0);
+
+        externalUserId = 'external-user-1';
+    });
+
+    it('rejects a confirmation without a bearer', async () => {
+        externalUserId = 'external-user-anonymous';
+
+        const { state } = await requestLink(userToken);
+        const target = await completeCallback(state);
+
+        const response = await httpRequest(suite, 'POST', `identity-providers/${provider.id}/link-confirm`, {
+            headers: { 'user-agent': USER_AGENT, 'content-type': 'application/json' },
+            body: JSON.stringify({ handle: handleOf(target) }),
+        });
+        expect(response.status).toEqual(401);
+
+        externalUserId = 'external-user-1';
+    });
+
+    it('rejects a replayed handle', async () => {
+        externalUserId = 'external-user-replay';
+
+        // a fresh user: `(providerId, userId)` is unique, so the user linked
+        // above could not take a second account for this provider
+        const password = generateOAuth2CodeVerifier();
+        const { data: replayUser } = await suite.client.user.create(createFakeUser({
+            realmId: realm.id,
+            password,
+        }));
+        const login = await suite.client.token.createWithPassword({
+            username: replayUser.name,
+            password,
+            realm_id: realm.id,
+        });
+
+        const { state } = await requestLink(login.access_token);
+        const target = await completeCallback(state);
+        const handle = handleOf(target);
+
+        expect((await confirmLink(handle, login.access_token)).status).toEqual(200);
+        // single use: the handle rides a URL parameter, so it reaches browser
+        // history and proxy logs
+        expect((await confirmLink(handle, login.access_token)).status).toEqual(400);
+
+        externalUserId = 'external-user-1';
+    });
+
+    it('rejects a handle redeemed against a different provider', async () => {
+        externalUserId = 'external-user-cross-provider';
+
+        const otherProvider = (await suite.client.identityProvider.create(createFakeOAuth2IdentityProvider({
+            realmId: realm.id,
+            tokenUrl: `${idpURL}/token`,
+            authorizeUrl: `${idpURL}/authorize`,
+        }))).data;
+
+        const { state } = await requestLink(userToken);
+        const target = await completeCallback(state);
+
+        const response = await confirmLink(handleOf(target), userToken, otherProvider.id);
+        expect(response.status).toEqual(400);
 
         externalUserId = 'external-user-1';
     });

--- a/packages/core-http-kit/src/domains/entities/identity-provider/module.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/module.ts
@@ -7,7 +7,7 @@
 
 import type { EntityQueryInput } from '../../../helpers';
 import { buildQueryString } from '../../../helpers';
-import type { IdentityProvider } from '@authup/core-kit';
+import type { IdentityProvider, IdentityProviderAccount } from '@authup/core-kit';
 import { buildIdentityProviderAuthorizePath } from '@authup/core-kit';
 import { cleanDoubleSlashes, nullifyEmptyObjectProperties } from '../../../utils';
 import type { EntityCollectionResponse, EntityRecordResponse } from '../../types-base';
@@ -15,6 +15,7 @@ import { BaseAPI } from '../../base';
 import type {
     IIdentityProviderAPI,
     IdentityProviderCreatePayload,
+    IdentityProviderLinkConfirmPayload,
     IdentityProviderLinkRequestResponse,
     IdentityProviderSavePayload,
     IdentityProviderUpdatePayload,
@@ -27,6 +28,16 @@ export class IdentityProviderAPI extends BaseAPI implements IIdentityProviderAPI
 
     async createLinkRequest(id: IdentityProvider['id']): Promise<IdentityProviderLinkRequestResponse> {
         const response = await this.client.post(`identity-providers/${id}/link-request`);
+
+        return response.data;
+    }
+
+    async confirmLinkRequest(
+        id: IdentityProvider['id'],
+        handle: string,
+    ): Promise<EntityRecordResponse<IdentityProviderAccount>> {
+        const payload : IdentityProviderLinkConfirmPayload = { handle };
+        const response = await this.client.post(`identity-providers/${id}/link-confirm`, payload);
 
         return response.data;
     }

--- a/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
+++ b/packages/core-http-kit/src/domains/entities/identity-provider/types.ts
@@ -7,7 +7,7 @@
 
 import type { EntityRecordResponse, IEntityAPI } from '../../types-base';
 
-import type { IdentityProvider } from '@authup/core-kit';
+import type { IdentityProvider, IdentityProviderAccount } from '@authup/core-kit';
 
 // Mirrors `IdentityProviderValidator` mounts in @authup/core-kit. IdPs carry per-protocol
 // attributes (e.g. clientId/clientSecret for OAuth2) handled by an attributes validator
@@ -31,8 +31,19 @@ export type IdentityProviderLinkRequestResponse = {
     url: string,
 };
 
+/**
+ * Body of `POST /identity-providers/:id/link-confirm` (issue #3439): the
+ * one-time handle the callback returned on the account console URL. The
+ * account row is written for the AUTHENTICATED caller, so the handle names
+ * a pending link rather than authorizing one on its own.
+ */
+export type IdentityProviderLinkConfirmPayload = {
+    handle: string,
+};
+
 export interface IIdentityProviderAPI extends IEntityAPI<IdentityProvider, IdentityProviderCreatePayload, IdentityProviderUpdatePayload> {
     getAuthorizeUri(id: IdentityProvider['id']) : string;
     createOrUpdate(idOrName: string, data: IdentityProviderSavePayload) : Promise<EntityRecordResponse<IdentityProvider>>;
     createLinkRequest(id: IdentityProvider['id']) : Promise<IdentityProviderLinkRequestResponse>;
+    confirmLinkRequest(id: IdentityProvider['id'], handle: string) : Promise<EntityRecordResponse<IdentityProviderAccount>>;
 }


### PR DESCRIPTION
Closes #3439.

## The problem

The account-linking callback performed a **durable credential binding from an unauthenticated request**. The browser round-trip cannot carry a bearer, so the linking user's id rode the OAuth2 state blob and the callback trusted it. The only thing separating "the browser that started this link" from any other was the state's ip / user-agent binding, and both values are chosen by whoever minted the state (`verify` skips a check whose *stored* value is falsy; under the shipped `trustProxy: true` the ip is the client-supplied left-most `X-Forwarded-For` entry).

The attack is the reverse of the obvious one: an attacker mints a link request for their **own** account, gets a victim to follow it, and the victim's callback binds the **victim's** external identity to the **attacker's** account. The victim's next federated login then resolves into it. State unguessability defends nothing, because the attacker supplies the state rather than guessing it.

## The split

1. `link-request` is unchanged.
2. `authorize-in` resolves the external identity, **stashes** a four-scalar projection under a one-time handle, and redirects to `.../connected-accounts?linkHandle=…&provider=…`. It writes nothing.
3. The account console auto-POSTs the handle to the new `POST /identity-providers/:id/link-confirm` **with its bearer**, and the row is written for the *authenticated* user.

The #3440 stopgap (refusing a state with no browser binding) is deleted along with the hole it patched.

## Two decisions worth reviewing

**The stash keeps `userId`, and the confirm requires `stash.userId === authenticated user`.** The issue sketched dropping it, since the state "no longer needs to carry" it. That would make a *leaked handle redeemable by anyone* — and the handle rides a URL query parameter, so it reaches browser history, referers and proxy logs. That is the same pre-hijacking in a new shape. Keeping it is both stronger (two-sided: who started it *and* who is finishing it) and a smaller diff. The handle is additionally single-use and bound to its provider, so on its own it authorizes nothing.

**A dedicated 5-minute cache store, not a second `OAuth2AuthorizationStateManager` blob.** Reuse looks smaller but inherits the state's 30-minute TTL for a value redeemed one page load later, and re-applies the ip check to an XHR from the SPA, so a network flip between callback and confirm would break the link.

The stash holds four scalars rather than the `IdentityProviderIdentity`: that object carries the provider entity including the EA-loaded `clientSecret` plus the raw external token payload, neither of which belongs in a cache. They are also exactly what `link()` reads.

## Behavior changes

- **Return params**: `linked=<id>` → `linkHandle=<handle>&provider=<id>`. Only the bundled account console consumes them, but it is a documented URL contract for a self-hosted one, so it is in the upgrade notes.
- **`already_linked` surfaces on the confirm response** instead of a redirect marker, so the SPA shows the server's own localized error rather than a string it has to map.
- **The `identityProviderLinked` event moves to the confirm**, where the request context can supply actor and session attribution the unauthenticated callback could not.
- **The callback also rejects a subject-less identity** now. It used to reach `link()`, which refused it; without the guard an empty `providerUserId` would be stashed.
- **Deployment**: callback and confirm must reach the same cache, so a multi-replica deployment on the in-process memory cache needs sticky routing across one more hop. Redis removes it. Documented.

## Verification

- `link.spec.ts` rewritten to the two-step flow, now 13 cases: the callback writes **no row** before confirmation, the confirm links, idempotency, already-linked, **a handle minted for another user is refused**, no bearer → 401, replay → 400, wrong provider → 400.
- **Mutation-tested the guard that matters**: deleting `link.userId !== identity.id` from the confirm makes exactly *refuses a handle minted for another user* fail, and nothing else.
- `apps/server-core` full suite: **194 files / 2163 tests passed**; eslint clean; server-core, core-http-kit and account-console builds green.

Not addressed here (pre-existing, called out in the issue): the login path's `authorize-out` state has the same weak binding, and the callback's return target is hard-coded to `publicUrl`, so a standalone-hosted account console never receives the handle.