### PR TITLE
fix: return the federated login code to the relying party

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2654,6 +2654,57 @@ Domain type `Consent` (core-kit) + `EntityType.CONSENT`, TypeORM entity +
   `isUniqueConstraintDatabaseError` (`adapters/database/errors/driver.ts`, the
   reusable driver-error-code unwrapper covering mysql/postgres/sqlite).
 
+## Federated Login Completion (`authorize-in`)
+
+The external-IdP callback completes the RP's **original** authorization
+request. It re-verifies the code request that `authorize-out` stored on the
+state blob, mints an authup code from that whole verified request, and
+redirects to the client's own `redirect_uri` carrying `code` and `state` (RFC
+6749 §4.1.2). Three properties are load-bearing, and each of the first two was
+a shipped bug (issue #3446):
+
+- **The code goes to the RP, never to the hosted `/authorize` page.** It is
+  bound to the RP's `client_id` and `redirect_uri`, so the RP is the only party
+  that can redeem it. The callback used to hand it to the hosted page instead,
+  where the router guard's `store.exchangeAuthorizationCode(code)` answered 401
+  `invalid_client` (`/token` authenticates a client unconditionally, and the
+  auth console deliberately holds no client row). The guard swallows that
+  error, so a federated login died silently on a re-rendered login form.
+- **The WHOLE verified request reaches `codeIssuer.issue`,** never a
+  hand-picked subset. `code_challenge` / `code_challenge_method`, `nonce` and
+  `acr_values` all ride the code. A code that lost its challenge cannot be
+  redeemed by a public client at all (`PKCE is required for public clients`),
+  which is every console client, so dropping those four fields broke the RP leg
+  too.
+- **The re-verification IS the redirect gate.** `redirectUriVerified` is the
+  only thing on this path that knows the `redirect_uri` matched a registered
+  pattern, so the redirect is gated on it. The flag is set from the match
+  itself (never from mere presence), because a consumer now makes a redirect
+  decision on it. Re-verifying also re-resolves the client at completion time
+  (active, grant allowlist, scopes), which fails a login closed when the client
+  was deactivated while the user was away at the provider.
+
+The completion additionally refuses a **disabled provider** and an **inactive
+user**, both checked at the callback rather than only when the login started.
+The first mirrors the link flow, which always re-checked its provider; the
+second mirrors the local login path, which throws `EntityInactiveError`, so a
+federated login cannot become the way around a deactivation. Both run before
+the provider's single-use code is spent, so a refused completion contacts the
+provider not at all and provisions no user.
+
+The hosted page is not part of this completion, so consent, the MFA challenge
+and the prompt ladder do not run for a federated login. Both exclusions are
+deliberate and predate this (see *Intentional enforcement boundaries* and
+`.agents/references/authentik.md`): the upstream provider is the trusted
+authentication. The access-policy denial is the one case that still bounces to
+the hosted page, because the person is at the browser and the denial card is
+the only surface that can say why.
+
+A request carrying no `redirect_uri` keeps the older hosted-page and
+`baseURL` fallbacks. Such a request could never complete anyway
+(`authorizeInner` refuses a code request without one), so the fallbacks carry
+the previous shape rather than inventing a destination.
+
 ## Identity-Provider Account Linking (plan 091)
 
 `auth_identity_provider_accounts` (external identity → `userId`; unique

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2688,9 +2688,12 @@ The completion additionally refuses a **disabled provider** and an **inactive
 user**, both checked at the callback rather than only when the login started.
 The first mirrors the link flow, which always re-checked its provider; the
 second mirrors the local login path, which throws `EntityInactiveError`, so a
-federated login cannot become the way around a deactivation. Both run before
-the provider's single-use code is spent, so a refused completion contacts the
-provider not at all and provisions no user.
+federated login cannot become the way around a deactivation. Only the provider
+check runs before the provider's single-use code is spent, so that refusal
+contacts the provider not at all and provisions no user. The user is not known
+until the exchange has resolved the external identity, so an inactive one is
+refused after the code was spent. It still gets no authup code, which is the
+part that matters.
 
 The hosted page is not part of this completion, so consent, the MFA challenge
 and the prompt ladder do not run for a federated login. Both exclusions are

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -42,7 +42,7 @@ import {
     isOAuth2IdentityProvider,
     isOpenIDIdentityProvider,
 } from '@authup/core-kit';
-import { BadRequestError, EntityNotFoundError } from '@authup/errors';
+import { BadRequestError, EntityInactiveError, EntityNotFoundError } from '@authup/errors';
 import type { Logger } from '@authup/server-kit';
 import { describeError, resolveURL } from '../../../../../utils/index.ts';
 import { useRequestQuery } from '@routup/basic/query';
@@ -65,7 +65,6 @@ import type {
     IOAuth2AuthorizationCodeIssuer,
     IOAuth2AuthorizationCodeRequestVerifier,
     IOAuth2AuthorizationStateManager,
-    IOAuth2ClientRepository,
     IRealmRepository,
     OAuth2AuthorizationState,
     OAuth2AuthorizationStateLink,
@@ -102,8 +101,6 @@ export class IdentityProviderController {
 
     protected realmRepository: IRealmRepository;
 
-    protected clientRepository: IOAuth2ClientRepository;
-
     protected accountManager: IIdentityProviderAccountManager;
 
     protected codeRequestVerifier : IOAuth2AuthorizationCodeRequestVerifier;
@@ -126,7 +123,6 @@ export class IdentityProviderController {
         this.options = ctx.options;
         this.repository = ctx.repository;
         this.realmRepository = ctx.realmRepository;
-        this.clientRepository = ctx.clientRepository;
         this.accountManager = ctx.accountManager;
         this.codeIssuer = ctx.codeIssuer;
         this.codeRequestVerifier = ctx.codeRequestVerifier;
@@ -380,57 +376,82 @@ export class IdentityProviderController {
             throw new BadRequestError('The authorization code is missing.');
         }
 
-        const authenticator = this.buildProviderAuthenticator(entity, { clientId: data.codeRequest?.client_id });
+        // Re-verify the code request that authorize-out stored on the state,
+        // BEFORE the provider's single-use code is spent. It re-resolves the
+        // client (active, grant allowlist, scopes) and re-matches the
+        // redirect_uri against the client's registered patterns, so a client
+        // deactivated (or a pattern removed) while the user was away at the
+        // provider cannot still receive a code, and a refused completion
+        // provisions no user. Same fail-closed-at-completion rule the link path
+        // applies to the provider.
+        //
+        // The redirect below rests on the MATCH, which the verifier enforces by
+        // throwing `redirectUriMismatch`; `redirectUriVerified` is the flag
+        // that survives to report it. Nothing else on this path knows whether
+        // the uri was ever matched.
+        const verified = data.codeRequest ?
+            await this.codeRequestVerifier.verify(data.codeRequest) :
+            undefined;
+
+        // The provider must still be enabled, the rule the link path already
+        // applies. Disabling a provider has to stop logins in flight too,
+        // otherwise it only stops new ones.
+        if (!entity.enabled) {
+            throw new BadRequestError('The identity provider is not enabled.');
+        }
+
+        const authenticator = this.buildProviderAuthenticator(entity, { clientId: verified?.data.client_id });
 
         const user = await authenticator.authenticate({ code });
 
+        // The local login path refuses an inactive user (EntityInactiveError),
+        // and a federated login must not be the way around that. Only reachable
+        // for an already-linked user: a first login provisions an active one.
+        if (!user.active) {
+            throw new EntityInactiveError({ entity: 'user' });
+        }
+
         const realm = await this.realmRepository.resolve(entity.realmId, true);
 
-        // Application access policy (plan 052), federated leg: the callback
-        // never redirects to the RP directly — a denial bounces back to the
-        // hosted authorize page with error=access_denied, so no
-        // redirectUriVerified threading through the state blob is needed.
-        // A policy id with no wired evaluator denies (fail closed); a
-        // since-deleted client is skipped (the /token backstop still covers it).
-        if (data.codeRequest?.client_id) {
-            const client = await this.clientRepository.findOneByIdOrName(
-                data.codeRequest.client_id,
-                data.codeRequest.realm_id,
-            );
+        // Application access policy (plan 052), federated leg. The denial
+        // bounces back to the hosted authorize page, which renders it as a
+        // denial card, rather than becoming an error redirect to the RP: the
+        // person is standing in front of the browser and the card is the only
+        // surface that can tell them why. A policy id with no wired evaluator
+        // denies (fail closed).
+        if (verified?.client.accessPolicyId) {
+            let allowed = false;
 
-            if (client?.accessPolicyId) {
-                let allowed = false;
+            const subject = toIdentityPolicyData({
+                type: IdentityType.USER,
+                data: {
+                    ...user,
+                    realm,
+                },
+            });
+            if (this.accessPolicyEvaluator && subject) {
+                allowed = await this.accessPolicyEvaluator.evaluate(
+                    verified.client.accessPolicyId,
+                    subject,
+                );
+            }
 
-                const subject = toIdentityPolicyData({
-                    type: IdentityType.USER,
-                    data: {
-                        ...user,
-                        realm,
-                    },
-                });
-                if (this.accessPolicyEvaluator && subject) {
-                    allowed = await this.accessPolicyEvaluator.evaluate(
-                        client.accessPolicyId,
-                        subject,
-                    );
-                }
+            if (!allowed) {
+                const url = this.buildHostedAuthorizeURL(verified.data);
+                url.searchParams.set('error', OAuth2ErrorCode.ACCESS_DENIED);
 
-                if (!allowed) {
-                    const url = this.buildHostedAuthorizeURL(data.codeRequest);
-                    url.searchParams.set('error', OAuth2ErrorCode.ACCESS_DENIED);
-
-                    return sendRedirect(event, url.href);
-                }
+                return sendRedirect(event, url.href);
             }
         }
 
+        // The WHOLE verified request reaches the issuer, never a hand-picked
+        // subset: it carries code_challenge / code_challenge_method and nonce
+        // (plus acr_values, which no redemption path reads yet). A code that
+        // lost its PKCE challenge cannot be redeemed by a public client at all
+        // (`PKCE is required for public clients`), which is every console
+        // client.
         const authorizationCode = await this.codeIssuer.issue(
-            {
-                response_type: 'code',
-                client_id: data.codeRequest?.client_id,
-                redirect_uri: data.codeRequest?.redirect_uri,
-                scope: data.codeRequest?.scope,
-            },
+            verified?.data ?? { response_type: 'code' },
             {
                 type: IdentityType.USER,
                 data: {
@@ -441,13 +462,52 @@ export class IdentityProviderController {
             { authMethod: SessionAuthMethod.EXTERNAL },
         );
 
-        if (data.codeRequest) {
-            const url = this.buildHostedAuthorizeURL(data.codeRequest);
+        // The interactive path records this in OAuth2Authorization.authorize();
+        // this leg issues its code directly, so without an emit here a
+        // federated authorization leaves no trace in auth_events while every
+        // other one does. `reason: federated` is what tells the two apart:
+        // there was no consent step to report. No session exists yet (the
+        // /token exchange creates it), hence a null sessionId. Metrics stay
+        // uninstrumented on this leg, as they already are.
+        await this.eventService?.record({
+            scope: EventScope.OAUTH2,
+            name: EventName.AUTHORIZE,
+            refType: EventRefType.CLIENT,
+            refId: verified?.data.client_id ?? null,
+            clientId: verified?.data.client_id ?? null,
+            sessionId: null,
+            actorType: IdentityType.USER,
+            actorId: user.id,
+            actorName: user.name,
+            realmId: verified?.data.realm_id ?? realm.id,
+            requestIpAddress: getRequestIP(event) ?? null,
+            requestUserAgent: getRequestHeader(event, 'user-agent') ?? null,
+            data: {
+                reason: 'federated',
+                providerId: entity.id,
+                providerName: entity.name,
+                ...(verified?.data.scope ? { scope: verified.data.scope } : {}),
+            },
+        });
+
+        // RFC 6749 §4.1.2: the code goes back to the client that asked for it.
+        // It is bound to that client_id and that redirect_uri, so the RP is the
+        // only party able to redeem it. Handing it to any other page strands
+        // the login there (issue #3446).
+        if (verified?.redirectUriVerified && verified.data.redirect_uri) {
+            const url = new URL(verified.data.redirect_uri);
             url.searchParams.set('code', authorizationCode.id);
+            if (verified.data.state) {
+                url.searchParams.set('state', verified.data.state);
+            }
 
             return sendRedirect(event, url.href);
         }
 
+        // Only reachable when the state carried no code request at all: a
+        // stored one always has a redirect_uri, because that mount is required
+        // in OAuth2AuthorizationCodeRequestValidator (unlike `state`), so a
+        // verified request is always a verified redirect target.
         const url = new URL(this.options.baseURL);
         url.searchParams.set('code', authorizationCode.id);
 

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/types.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/types.ts
@@ -14,7 +14,6 @@ import type {
     IOAuth2AuthorizationCodeIssuer,
     IOAuth2AuthorizationCodeRequestVerifier,
     IOAuth2AuthorizationStateManager,
-    IOAuth2ClientRepository,
     IRealmRepository,
 } from '../../../../../core/index.ts';
 
@@ -27,7 +26,6 @@ export type IdentityProviderControllerContext = {
 
     repository: IIdentityProviderRepository,
     realmRepository: IRealmRepository,
-    clientRepository: IOAuth2ClientRepository,
 
     accountManager: IIdentityProviderAccountManager,
     codeIssuer: IOAuth2AuthorizationCodeIssuer,

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -545,8 +545,6 @@ export class HTTPControllerModule {
 
             repository,
             realmRepository: new RealmRepositoryAdapter(realmRepository),
-            clientRepository: container.resolve(OAuth2InjectionToken.ClientRepository),
-
             accountManager,
 
             codeIssuer,

--- a/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
+++ b/apps/server-core/src/core/oauth2/authorization/code-request/verifier/module.ts
@@ -113,7 +113,11 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
         // pattern (pattern-less clients were rejected above). A request without
         // a redirect_uri (e.g. the GET page render) stays unverified so
         // consumers never auto-redirect without a match.
-        const redirectUriVerified = !!data.redirect_uri;
+        //
+        // Set from the match itself, never from mere presence: consumers make
+        // redirect decisions on this flag, so it must not survive a refactor
+        // that turns the throw below into a soft branch.
+        let redirectUriVerified = false;
         if (data.redirect_uri) {
             const redirectUris = client.redirectUri.split(',');
 
@@ -125,6 +129,8 @@ export class OAuth2AuthorizationCodeRequestVerifier implements IOAuth2Authorizat
             if (!isSimpleURLMatch(data.redirect_uri, redirectUris)) {
                 throw OAuth2GrantError.redirectUriMismatch();
             }
+
+            redirectUriVerified = true;
         }
 
         return {

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/federation-e2e.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/federation-e2e.spec.ts
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { Client, IdentityProvider, Realm } from '@authup/core-kit';
+import { ScopeName } from '@authup/core-kit';
+import {
+    ApplicationBuilder,
+    ConfigInjectionKey,
+    ConfigModule, 
+    DatabaseModule, 
+} from '../../../../../../src';
+import type { Config } from '../../../../../../src';
+import { normalizeConfig } from '../../../../../../src/app/modules/config/normalize.ts';
+import { readConfigRawFromEnv } from '../../../../../../src/app/modules/config/read/index.ts';
+import { PACKAGE_PATH } from '../../../../../../src/path.ts';
+import { TestHTTPApplication } from '../../../../../app/http.ts';
+import {
+    createFakeClient,
+    createFakeOAuth2IdentityProvider,
+    createFakeRealm,
+    httpRequest,
+} from '../../../../../utils';
+import { createTestApplication } from '../../../../../app';
+
+/**
+ * Two REAL authup instances, each with its own database: a downstream one that
+ * brokers a login to an upstream one. Every fake-IdP spec stubs the provider's
+ * token endpoint, so none of them proves that authup can consume authup. This
+ * one does the whole round trip against the real endpoints.
+ */
+
+const DATABASE_DIRECTORY_PATH = path.join(PACKAGE_PATH, 'writable');
+const TEMPLATE_DATABASE_PATH = path.join(DATABASE_DIRECTORY_PATH, 'test.sql');
+
+const UPSTREAM_CLIENT_NAME = 'downstream-broker';
+const UPSTREAM_CLIENT_SECRET = 'downstream-broker-secret';
+
+const RP_REDIRECT_URI = 'https://rp.example.com/login/callback';
+const RP_STATE = 'rp-state-value';
+const CODE_VERIFIER = 'aVeryLongCodeVerifierValueUsedByThePublicClient1234567890';
+
+/**
+ * A second application on its own sqlite file. The suite module pins one
+ * database per vitest worker, so two instances sharing it would be one logical
+ * IdP with two ports, which is exactly what this test must not be.
+ */
+const upstreamDatabasePath = path.join(
+    DATABASE_DIRECTORY_PATH,
+    `test-upstream-${process.env.VITEST_POOL_ID || '0'}.sql`,
+);
+
+function createUpstreamApplication(): TestHTTPApplication {
+    const database = upstreamDatabasePath;
+
+    const modules = new ApplicationBuilder()
+        .withConfig(new ConfigModule(async () => {
+            const config = await normalizeConfig(readConfigRawFromEnv()) as Config;
+            config.port = 0;
+            config.middlewareRateLimit = false;
+            config.middlewarePrometheus = false;
+            config.middlewareSwagger = false;
+            config.userAdminEnabled = true;
+            config.userAuthBasic = true;
+            config.redis = false;
+            return config;
+        }))
+        .withLogger()
+        .withCache()
+        .withLdap()
+        .withMail()
+        .withDatabase(new DatabaseModule({
+            prepareBuild: async (container) => {
+                const config = container.resolve(ConfigInjectionKey);
+                config.db = {
+                    type: 'better-sqlite3',
+                    database,
+                };
+                container.register(ConfigInjectionKey, { useValue: config });
+            },
+            setup: async () => {
+                fs.rmSync(database, { force: true });
+                fs.copyFileSync(TEMPLATE_DATABASE_PATH, database);
+            },
+            migrate: async (_container, dataSource) => {
+                await dataSource.synchronize();
+            },
+        }))
+        .withAuthentication()
+        .withIdentity()
+        .withOAuth2()
+        .withHTTP()
+        .buildModules();
+
+    return new TestHTTPApplication({ modules });
+}
+
+describe('authup federating to authup', () => {
+    const downstream = createTestApplication();
+    const upstream = createUpstreamApplication();
+
+    let realm: Realm;
+    let provider: IdentityProvider;
+    let rpClient: Client;
+    let codeChallenge: string;
+    // The downstream builds its callback URL from publicUrl, not from the
+    // random test port, so the upstream must allow that origin and the
+    // callback has to be delivered back to the port the instance listens on.
+    let downstreamPublicURL: string;
+
+    beforeAll(async () => {
+        const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(CODE_VERIFIER));
+        codeChallenge = Buffer.from(new Uint8Array(digest)).toString('base64url');
+
+        await downstream.setup();
+        await upstream.setup();
+
+        downstreamPublicURL = downstream.container
+            .resolve(ConfigInjectionKey)
+            .publicUrl
+            .replace(/\/$/, '');
+
+        // Downstream: the realm the federated users land in, plus the public
+        // PKCE client the relying party authenticates with.
+        realm = (await downstream.client.realm.create(createFakeRealm())).data;
+
+        rpClient = (await downstream.client.client.create(createFakeClient({
+            realmId: realm.id,
+            authMethod: 'none',
+            redirectUri: 'https://rp.example.com/**',
+        }))).data;
+
+        for (const scopeName of [ScopeName.GLOBAL, ScopeName.OPEN_ID]) {
+            const { data: scope } = await downstream.client.scope.getOne(scopeName);
+            await downstream.client.clientScope.create({ scopeId: scope.id, clientId: rpClient.id });
+        }
+
+        // Upstream first: a real setup registers the client on the provider
+        // and pastes its id/secret into the downstream provider config.
+        const upstreamClient = (await upstream.client.client.create(createFakeClient({
+            name: UPSTREAM_CLIENT_NAME,
+            secret: UPSTREAM_CLIENT_SECRET,
+            secretHashed: false,
+            secretEncrypted: false,
+            authMethod: 'secret',
+            redirectUri: `${downstreamPublicURL}/identity-providers/**`,
+        }))).data;
+
+        provider = (await downstream.client.identityProvider.create(createFakeOAuth2IdentityProvider({
+            realmId: realm.id,
+            clientId: upstreamClient.id,
+            clientSecret: UPSTREAM_CLIENT_SECRET,
+            authorizeUrl: `${upstream.baseURL}/authorize`,
+            tokenUrl: `${upstream.baseURL}/token`,
+            scope: ScopeName.GLOBAL,
+        }))).data;
+
+        for (const scopeName of [ScopeName.GLOBAL, ScopeName.OPEN_ID]) {
+            const { data: scope } = await upstream.client.scope.getOne(scopeName);
+            await upstream.client.clientScope.create({ scopeId: scope.id, clientId: upstreamClient.id });
+        }
+    });
+
+    afterAll(async () => {
+        await downstream.teardown();
+        await upstream.teardown();
+
+        // The global setup only sweeps the per-worker `test-<n>.sql` files, so
+        // this one cleans up after itself.
+        fs.rmSync(upstreamDatabasePath, { force: true });
+    });
+
+    it('completes a login brokered from one instance to the other', async () => {
+        const codeRequest = Buffer.from(JSON.stringify({
+            response_type: 'code',
+            client_id: rpClient.id,
+            realm_id: realm.id,
+            redirect_uri: RP_REDIRECT_URI,
+            scope: `${ScopeName.GLOBAL} ${ScopeName.OPEN_ID}`,
+            state: RP_STATE,
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+        })).toString('base64url');
+
+        // 1. The relying party's request reaches the downstream instance, which
+        //    sends the browser to the upstream instance.
+        const out = await httpRequest(downstream, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${codeRequest}`, { redirect: 'manual' });
+        expect(out.status).toEqual(302);
+
+        const upstreamURL = new URL(out.headers.get('location') as string);
+        expect(upstreamURL.origin).toEqual(new URL(upstream.baseURL).origin);
+
+        const brokerState = upstreamURL.searchParams.get('state') as string;
+        expect(brokerState).toBeTruthy();
+
+        // 2. The person authenticates on the upstream instance and approves.
+        //    Its hosted page posts exactly this once the session exists.
+        const upstreamToken = await upstream.client.token.createWithPassword({
+            username: 'admin',
+            password: 'start123',
+        });
+
+        const approve = await httpRequest(upstream, 'POST', 'authorize', {
+            headers: {
+                authorization: `Bearer ${upstreamToken.access_token}`,
+                'content-type': 'application/json',
+            },
+            body: JSON.stringify({
+                response_type: 'code',
+                client_id: upstreamURL.searchParams.get('client_id'),
+                redirect_uri: upstreamURL.searchParams.get('redirect_uri'),
+                scope: upstreamURL.searchParams.get('scope'),
+                state: brokerState,
+            }),
+        });
+        expect(approve.status).toEqual(200);
+
+        const { url: callbackURL } = await approve.json();
+        expect(new URL(callbackURL).origin).toEqual(new URL(downstreamPublicURL).origin);
+
+        // The browser resolves publicUrl to the running instance; here that is
+        // the random test port.
+        const callback = new URL(callbackURL);
+        const callbackTarget = `${downstream.baseURL}${callback.pathname}${callback.search}`;
+
+        // 3. The upstream code comes back to the downstream callback, which
+        //    redeems it at the upstream token endpoint for real.
+        // httpRequest passes an absolute url straight through.
+        const back = await httpRequest(downstream, 'GET', callbackTarget, { redirect: 'manual' });
+        expect(back.status).toEqual(302);
+
+        // 4. The downstream instance returns its own code to the relying party.
+        const rpURL = new URL(back.headers.get('location') as string);
+        expect(`${rpURL.origin}${rpURL.pathname}`).toEqual(RP_REDIRECT_URI);
+        expect(rpURL.searchParams.get('state')).toEqual(RP_STATE);
+
+        // 5. The relying party redeems it with the PKCE verifier it generated.
+        const token = await httpRequest(downstream, 'POST', 'token', {
+            form: {
+                grant_type: 'authorization_code',
+                code: rpURL.searchParams.get('code') as string,
+                client_id: rpClient.id,
+                redirect_uri: RP_REDIRECT_URI,
+                code_verifier: CODE_VERIFIER,
+            },
+        });
+
+        expect(token.status).toEqual(200);
+        await expect(token.json()).resolves.toMatchObject({
+            access_token: expect.any(String),
+            refresh_token: expect.any(String),
+        });
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/login-completion.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/login-completion.spec.ts
@@ -1,0 +1,524 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { createServer } from 'node:http';
+import type { Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { Client, IdentityProvider, Realm } from '@authup/core-kit';
+import {
+    EventName,
+    EventRefType,
+    EventScope,
+    IdentityProviderProtocol,
+    IdentityType,
+    ScopeName,
+} from '@authup/core-kit';
+import { OAuth2ErrorCode } from '@authup/specs';
+import {
+    createFakeClient,
+    createFakeOAuth2IdentityProvider,
+    createFakeRealm,
+    httpRequest,
+} from '../../../../../utils';
+import { createTestApplication } from '../../../../../app';
+
+const USER_AGENT = 'login-completion-spec-agent';
+
+const REDIRECT_URI = 'https://example.com/login/callback';
+const STATE = 'rp-state-value';
+const NONCE = 'rp-nonce-value';
+
+// PKCE pair, exactly as a public client sends it: every provisioned console
+// client is authMethod `none`, so the code flow is unusable without one.
+const CODE_VERIFIER = 'aVeryLongCodeVerifierValueUsedByThePublicClient1234567890';
+
+const encode = (input: Record<string, any>) => Buffer.from(JSON.stringify(input)).toString('base64url');
+
+const decodeJWTPayload = (token: string) => JSON.parse(
+    Buffer.from(token.split('.')[1], 'base64url').toString('utf-8'),
+);
+
+describe('identity-provider login completion', () => {
+    const suite = createTestApplication();
+
+    let idpServer: Server;
+    let idpURL: string;
+
+    let realm: Realm;
+    let provider: IdentityProvider;
+    let client: Client;
+    let codeChallenge: string;
+    let providerTokenCalls = 0;
+
+    beforeAll(async () => {
+        const digest = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(CODE_VERIFIER));
+        codeChallenge = Buffer.from(new Uint8Array(digest)).toString('base64url');
+
+        // A minimal external provider: its token endpoint answers with an
+        // unsigned JWT whose `sub` identifies the external user. It counts its
+        // calls, because "the provider was never contacted" is the only
+        // observable proof that a refused completion spends neither the
+        // provider's single-use code nor a local user row.
+        idpServer = createServer((req, res) => {
+            if (req.url && req.url.startsWith('/token')) {
+                providerTokenCalls += 1;
+                req.on('data', () => { /* drain */ });
+                req.on('end', () => {
+                    res.setHeader('content-type', 'application/json');
+                    res.end(JSON.stringify({
+                        access_token: `${encode({ alg: 'none', typ: 'JWT' })}.${encode({
+                            sub: 'external-user-completion',
+                            email: 'external-completion@example.com',
+                        })}.x`,
+                        token_type: 'Bearer',
+                    }));
+                });
+                return;
+            }
+
+            res.statusCode = 404;
+            res.end();
+        });
+        await new Promise<void>((resolve) => {
+            idpServer.listen(0, '127.0.0.1', resolve);
+        });
+        idpURL = `http://127.0.0.1:${(idpServer.address() as AddressInfo).port}`;
+
+        await suite.setup();
+
+        realm = (await suite.client.realm.create(createFakeRealm())).data;
+        provider = (await suite.client.identityProvider.create(createFakeOAuth2IdentityProvider({
+            realmId: realm.id,
+            tokenUrl: `${idpURL}/token`,
+            authorizeUrl: `${idpURL}/authorize`,
+        }))).data;
+
+        // A PUBLIC client, like every provisioned console client: authMethod
+        // none, so PKCE and state are mandatory at /authorize and PKCE is
+        // enforced again at /token.
+        client = (await suite.client.client.create(createFakeClient({
+            realmId: realm.id,
+            authMethod: 'none',
+            redirectUri: 'https://example.com/**',
+        }))).data;
+
+        for (const scopeName of [ScopeName.GLOBAL, ScopeName.OPEN_ID]) {
+            const { data: scope } = await suite.client.scope.getOne(scopeName);
+            await suite.client.clientScope.create({ scopeId: scope.id, clientId: client.id });
+        }
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+        await new Promise<void>((resolve, reject) => {
+            idpServer.close((err) => (err ? reject(err) : resolve()));
+        });
+    });
+
+    function buildCodeRequest(overrides: Record<string, any> = {}) {
+        return Buffer.from(JSON.stringify({
+            response_type: 'code',
+            client_id: client.id,
+            realm_id: realm.id,
+            redirect_uri: REDIRECT_URI,
+            scope: `${ScopeName.GLOBAL} ${ScopeName.OPEN_ID}`,
+            state: STATE,
+            nonce: NONCE,
+            code_challenge: codeChallenge,
+            code_challenge_method: 'S256',
+            ...overrides,
+        })).toString('base64url');
+    }
+
+    /**
+     * The federated round trip: /authorize -> provider -> the callback.
+     * Returns the Location the browser is sent to afterwards.
+     */
+    async function runFederatedLogin(codeRequest = buildCodeRequest()): Promise<URL> {
+        const out = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${codeRequest}`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        expect(out.status).toEqual(302);
+
+        const state = new URL(out.headers.get('location') as string).searchParams.get('state');
+        expect(state).toBeTruthy();
+
+        const back = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+        expect(back.status).toEqual(302);
+
+        return new URL(back.headers.get('location') as string);
+    }
+
+    const exchange = (form: Record<string, string>) => httpRequest(suite, 'POST', 'token', {
+        form: {
+            grant_type: 'authorization_code',
+            ...form,
+        },
+    });
+
+    it('returns the browser to the relying party, not to the hosted authorize page', async () => {
+        const location = await runFederatedLogin();
+
+        // The code is bound to this client_id and this redirect_uri, so the RP
+        // is the only party that can redeem it. Sending the browser anywhere
+        // else strands the login on a page that cannot use the code.
+        expect(`${location.origin}${location.pathname}`).toEqual(REDIRECT_URI);
+        expect(location.searchParams.get('code')).toBeTruthy();
+        expect(location.searchParams.get('state')).toEqual(STATE);
+    });
+
+    it('mints a code the public client redeems with its PKCE verifier', async () => {
+        const location = await runFederatedLogin();
+
+        const response = await exchange({
+            code: location.searchParams.get('code') as string,
+            client_id: client.id,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: CODE_VERIFIER,
+        });
+
+        expect(response.status).toEqual(200);
+        await expect(response.json()).resolves.toMatchObject({
+            access_token: expect.any(String),
+            refresh_token: expect.any(String),
+        });
+    });
+
+    it('carries the PKCE challenge onto the code rather than dropping it', async () => {
+        const location = await runFederatedLogin();
+
+        // The complement of the test above: a code minted WITHOUT the
+        // challenge would accept any verifier (nothing to compare against),
+        // so only a rejected wrong verifier proves the challenge is on the code.
+        const response = await exchange({
+            code: location.searchParams.get('code') as string,
+            client_id: client.id,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: `${CODE_VERIFIER}-wrong`,
+        });
+
+        expect(response.status).toEqual(400);
+        await expect(response.json()).resolves.toMatchObject({
+            error: OAuth2ErrorCode.INVALID_GRANT,
+            message: expect.stringContaining('code_verifier'),
+        });
+    });
+
+    it('carries the nonce onto the id_token of an openid login', async () => {
+        const location = await runFederatedLogin();
+
+        const response = await exchange({
+            code: location.searchParams.get('code') as string,
+            client_id: client.id,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: CODE_VERIFIER,
+        });
+
+        const body = await response.json();
+        expect(body.id_token).toBeTruthy();
+        expect(decodeJWTPayload(body.id_token)).toMatchObject({
+            nonce: NONCE,
+            aud: client.id,
+        });
+
+        // The id_token is minted at this exchange, so its `sid` must name the
+        // session this exchange created rather than anything the callback held.
+        const introspection = await suite.client.token.introspect({ token: body.access_token });
+        expect(decodeJWTPayload(body.id_token).sid).toEqual(introspection.session_id);
+    });
+
+    // These two document /token's binding contract, which predates and
+    // survives this fix. They are here because that contract is the reason the
+    // code has to be delivered to the RP: keep them as context, not as the
+    // regression guard for the delivery itself.
+    it('refuses the code to anyone but the client it was issued to', async () => {
+        // No client at all - the shape the hosted page's router guard sends,
+        // and the reason handing it that code stranded the login.
+        const anonymousCode = (await runFederatedLogin()).searchParams.get('code') as string;
+
+        const anonymous = await exchange({
+            code: anonymousCode,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: CODE_VERIFIER,
+        });
+        expect(anonymous.status).toEqual(401);
+        await expect(anonymous.json()).resolves.toMatchObject({ error: OAuth2ErrorCode.INVALID_CLIENT });
+
+        // The refusal happened before the code was looked at, so the RP can
+        // still redeem it. Without this the next assertion could not tell
+        // "wrong client" from "code already burnt".
+        const afterAnonymous = await exchange({
+            code: anonymousCode,
+            client_id: client.id,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: CODE_VERIFIER,
+        });
+        expect(afterAnonymous.status).toEqual(200);
+
+        // A different client, correctly authenticated as itself, against a
+        // code no other attempt has touched.
+        const secret = 'other-client-secret';
+        const other = (await suite.client.client.create(createFakeClient({
+            realmId: realm.id,
+            secret,
+            secretHashed: false,
+            secretEncrypted: false,
+            authMethod: 'secret',
+            redirectUri: 'https://example.com/**',
+        }))).data;
+
+        const foreign = await exchange({
+            code: (await runFederatedLogin()).searchParams.get('code') as string,
+            client_id: other.id,
+            client_secret: secret,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: CODE_VERIFIER,
+        });
+        expect(foreign.status).toEqual(400);
+        await expect(foreign.json()).resolves.toMatchObject({ error: OAuth2ErrorCode.INVALID_GRANT });
+    });
+
+    it('lets the code be redeemed once only', async () => {
+        const location = await runFederatedLogin();
+        const form = {
+            code: location.searchParams.get('code') as string,
+            client_id: client.id,
+            redirect_uri: REDIRECT_URI,
+            code_verifier: CODE_VERIFIER,
+        };
+
+        expect((await exchange(form)).status).toEqual(200);
+
+        // The code now travels over a redirect to a third-party origin, so it
+        // reaches proxies, referrers and browser history. Single use is what
+        // bounds that exposure.
+        const replay = await exchange(form);
+        expect(replay.status).toEqual(400);
+        await expect(replay.json()).resolves.toMatchObject({ error: OAuth2ErrorCode.INVALID_GRANT });
+    });
+
+    it('records the authorization in the audit log', async () => {
+        await runFederatedLogin();
+
+        // The interactive path records this inside OAuth2Authorization; this
+        // leg issues its code directly, so a federated login would otherwise be
+        // the one authorization that leaves no trace.
+        const { data: events } = await suite.client.event.getMany({
+            filters: {
+                name: EventName.AUTHORIZE,
+                clientId: client.id,
+            },
+            sort: { createdAt: 'DESC' },
+            pagination: { limit: 5 },
+        });
+
+        expect(events.length).toBeGreaterThan(0);
+        expect(events[0]).toMatchObject({
+            scope: EventScope.OAUTH2,
+            name: EventName.AUTHORIZE,
+            refType: EventRefType.CLIENT,
+            refId: client.id,
+            clientId: client.id,
+            actorType: IdentityType.USER,
+        });
+        expect(events[0].data).toMatchObject({
+            reason: 'federated',
+            providerId: provider.id,
+        });
+    });
+
+    it('issues no code once the provider was disabled', async () => {
+        const payload = createFakeOAuth2IdentityProvider({
+            realmId: realm.id,
+            tokenUrl: `${idpURL}/token`,
+            authorizeUrl: `${idpURL}/authorize`,
+        });
+        const disabledProvider = (await suite.client.identityProvider.create(payload)).data;
+
+        const out = await httpRequest(suite, 'GET', `identity-providers/${disabledProvider.id}/authorize-out?codeRequest=${buildCodeRequest()}`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        const state = new URL(out.headers.get('location') as string).searchParams.get('state');
+
+        // Disabling a provider has to stop the logins already in flight, not
+        // only the ones that have yet to start.
+        // The update carries the whole payload: protocol and the OAuth2
+        // attributes are required in every validator group.
+        await suite.client.identityProvider.update(disabledProvider.id, {
+            ...payload,
+            protocol: IdentityProviderProtocol.OAUTH2,
+            enabled: false,
+        });
+
+        providerTokenCalls = 0;
+
+        const back = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${disabledProvider.id}/authorize-in?state=${state}&code=external-code`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+
+        expect(back.status).toEqual(400);
+        expect(back.headers.get('location')).toBeNull();
+        expect(providerTokenCalls).toEqual(0);
+    });
+
+    it('issues no code to an inactive user', async () => {
+        // Provision the external user through a first, successful login.
+        await runFederatedLogin();
+
+        const { data: users } = await suite.client.user.getMany({ filters: { realmId: realm.id } });
+        const user = users.find((row) => row.name !== 'admin');
+        expect(user).toBeDefined();
+
+        await suite.client.user.update((user as { id: string }).id, { active: false });
+
+        const out = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${buildCodeRequest()}`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        const state = new URL(out.headers.get('location') as string).searchParams.get('state');
+
+        // A federated login must not be the way around the deactivation the
+        // local login path enforces.
+        const back = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+
+        expect(back.headers.get('location')).toBeNull();
+        expect(back.status).toBeGreaterThanOrEqual(400);
+
+        await suite.client.user.update((user as { id: string }).id, { active: true });
+    });
+
+    it('issues no code when the redirect_uri stopped matching a registered pattern', async () => {
+        const moved = (await suite.client.client.create(createFakeClient({
+            realmId: realm.id,
+            authMethod: 'none',
+            redirectUri: 'https://example.com/**',
+        }))).data;
+
+        const { data: scope } = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        await suite.client.clientScope.create({ scopeId: scope.id, clientId: moved.id });
+
+        const codeRequest = buildCodeRequest({ client_id: moved.id, scope: ScopeName.GLOBAL });
+
+        const out = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${codeRequest}`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        const state = new URL(out.headers.get('location') as string).searchParams.get('state');
+
+        // The redirect below is only safe because the verifier throws on a
+        // pattern mismatch. Nothing else on the callback path re-checks it, so
+        // this is the test that stops that throw being refactored away.
+        await suite.client.client.update(moved.id, { redirectUri: 'https://elsewhere.example.org/**' });
+
+        const back = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+
+        expect(back.status).toEqual(400);
+        expect(back.headers.get('location')).toBeNull();
+        await expect(back.json()).resolves.toMatchObject({ error: OAuth2ErrorCode.INVALID_GRANT });
+    });
+
+    it('refuses the code to a redirect_uri other than the one it was bound to', async () => {
+        const location = await runFederatedLogin();
+
+        const response = await exchange({
+            code: location.searchParams.get('code') as string,
+            client_id: client.id,
+            redirect_uri: 'https://example.com/elsewhere',
+            code_verifier: CODE_VERIFIER,
+        });
+
+        expect(response.status).toEqual(400);
+        await expect(response.json()).resolves.toMatchObject({ error: OAuth2ErrorCode.INVALID_GRANT });
+    });
+
+    it('issues no code when the client was deactivated while the user was away', async () => {
+        const disabled = (await suite.client.client.create(createFakeClient({
+            realmId: realm.id,
+            authMethod: 'none',
+            redirectUri: 'https://example.com/**',
+        }))).data;
+
+        for (const scopeName of [ScopeName.GLOBAL]) {
+            const { data: scope } = await suite.client.scope.getOne(scopeName);
+            await suite.client.clientScope.create({ scopeId: scope.id, clientId: disabled.id });
+        }
+
+        const codeRequest = buildCodeRequest({ client_id: disabled.id, scope: ScopeName.GLOBAL });
+
+        const out = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${codeRequest}`, {
+            headers: { 'user-agent': USER_AGENT },
+            redirect: 'manual',
+        });
+        const state = new URL(out.headers.get('location') as string).searchParams.get('state');
+
+        // The client is verified again at completion, so a deactivation that
+        // lands while the user is at the provider still takes effect.
+        await suite.client.client.update(disabled.id, { active: false });
+
+        providerTokenCalls = 0;
+
+        const back = await httpRequest(
+            suite,
+            'GET',
+            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code`,
+            {
+                headers: { 'user-agent': USER_AGENT },
+                redirect: 'manual',
+            },
+        );
+
+        // An inactive client is refused (401 invalid_client), and crucially the
+        // browser is not redirected anywhere carrying a code.
+        expect(back.status).toEqual(401);
+        expect(back.headers.get('location')).toBeNull();
+        await expect(back.json()).resolves.toMatchObject({ error: OAuth2ErrorCode.INVALID_CLIENT });
+
+        // The refusal happens before the provider is contacted, so a doomed
+        // completion spends neither the provider's single-use code nor a local
+        // user row. This is what pins the verify-then-authenticate order.
+        expect(providerTokenCalls).toEqual(0);
+    });
+});

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/login-completion.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/login-completion.spec.ts
@@ -398,28 +398,34 @@ describe('identity-provider login completion', () => {
 
         await suite.client.user.update((user as { id: string }).id, { active: false });
 
-        const out = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${buildCodeRequest()}`, {
-            headers: { 'user-agent': USER_AGENT },
-            redirect: 'manual',
-        });
-        const state = new URL(out.headers.get('location') as string).searchParams.get('state');
-
-        // A federated login must not be the way around the deactivation the
-        // local login path enforces.
-        const back = await httpRequest(
-            suite,
-            'GET',
-            `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code`,
-            {
+        // The subject is shared with every other federated login in this file,
+        // so the reactivation belongs in `finally`. Left to the happy path, one
+        // failed assertion here would deactivate the user for the rest of the
+        // run and fail every later test that logs in.
+        try {
+            const out = await httpRequest(suite, 'GET', `identity-providers/${provider.id}/authorize-out?codeRequest=${buildCodeRequest()}`, {
                 headers: { 'user-agent': USER_AGENT },
                 redirect: 'manual',
-            },
-        );
+            });
+            const state = new URL(out.headers.get('location') as string).searchParams.get('state');
 
-        expect(back.headers.get('location')).toBeNull();
-        expect(back.status).toBeGreaterThanOrEqual(400);
+            // A federated login must not be the way around the deactivation the
+            // local login path enforces.
+            const back = await httpRequest(
+                suite,
+                'GET',
+                `identity-providers/${provider.id}/authorize-in?state=${state}&code=external-code`,
+                {
+                    headers: { 'user-agent': USER_AGENT },
+                    redirect: 'manual',
+                },
+            );
 
-        await suite.client.user.update((user as { id: string }).id, { active: true });
+            expect(back.headers.get('location')).toBeNull();
+            expect(back.status).toBeGreaterThanOrEqual(400);
+        } finally {
+            await suite.client.user.update((user as { id: string }).id, { active: true });
+        }
     });
 
     it('issues no code when the redirect_uri stopped matching a registered pattern', async () => {

--- a/apps/server-core/test/unit/http/controllers/workflows/token/grant-idp-authorize.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/grant-idp-authorize.spec.ts
@@ -182,6 +182,12 @@ describe('identity-provider authorization code grant', () => {
         expect(authupCode).toBeDefined();
         expect(authupCode!.length).toBeGreaterThan(0);
 
+        // A confidential client takes the same delivery: the code goes to its
+        // own redirect_uri, not to the hosted authorize page. This request
+        // carries no `state`, so none is echoed (never `state=undefined`).
+        expect(`${inURL.origin}${inURL.pathname}`).toEqual('https://example.com/redirect');
+        expect(inURL.searchParams.has('state')).toBe(false);
+
         const tokenResponse = await suite.client
             .token
             .createWithAuthorizationCode({


### PR DESCRIPTION
## The bug

Authenticating with an external identity provider left the browser sitting on
`<publicUrl>/authorize?...&code=<code>` with nothing happening.

The callback minted an authorization code bound to the relying party
(`client_id` + `redirect_uri`) and then redirected to the **hosted authorize
page**. Nothing there can redeem such a code. The auth console deliberately
holds no client row, so its router guard's bare
`store.exchangeAuthorizationCode(code)` is answered `401 invalid_client` by
`/token`, which authenticates a client unconditionally. The guard swallows the
error, so the page re-rendered the login form with `?code=` still in the URL.

Reproduced before fixing:

| exchange | result |
|---|---|
| bare `{ code }`, what the page sends | `invalid_client` - Client authentication failed |
| RP-style `client_id` + `redirect_uri` + `code_verifier` | `invalid_grant` - PKCE is required for public clients |

The second row is a separate defect: the callback hand-picked four fields when
minting and dropped `code_challenge`, `code_challenge_method`, `nonce` and
`acr_values`, so even the RP could not have redeemed the code. Every console
client is public.

## The fix

The callback re-verifies the stored code request, passes the **whole** verified
request to the issuer, and redirects to the client's own `redirect_uri` with
`code` and `state` (RFC 6749 4.1.2).

Re-verification runs **before** the provider's single-use code is spent and
doubles as the redirect gate: `redirectUriVerified` is the only thing on this
path that knows the uri matched a registered pattern. It is now set from the
match rather than from mere presence, because a consumer makes a redirect
decision on it.

Three fail-closed checks that were missing on this leg come with it:

- the **provider must still be enabled**, the rule the link path already applied
- the **user must be active**, which the local login path enforces and a
  federated login must not be the way around
- the authorization is **recorded in `auth_events`**, which the interactive path
  does inside `OAuth2Authorization` while this leg issues its code directly

The dead `clientRepository` dependency is dropped: the verifier already returns
the client the access-policy check needs.

## Tests

`login-completion.spec.ts`, 12 tests, all against a **public PKCE client** - the
configuration the pre-existing spec never exercised, which is how the PKCE
defect survived it.

Every assertion was checked against a reverted tree rather than trusted green:
reverting the source fails 9 of 15, removing just the provider/user guards fails
exactly their 2, removing just the audit emit fails exactly its 1.

Full server-core suite: 2172 passing. Types and lint clean.

## Known limitations, unchanged by this PR

Federated logins still bypass consent, the MFA challenge and the prompt ladder.
Both exclusions predate this and are documented; the flow simply never reached
them, because it never completed at all. Routing this leg through
`OAuth2Authorization.authorize()` is the tidy-looking fix and is a trap: that
path's MFA backstop reads `session?.mfaAt`, this leg has no session, so every
user with a confirmed factor would be locked out of federation. Tracked
separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Federated login now redirects directly to the verified application callback with an authorization code and state.
  - PKCE, OIDC, nonce, and authorization request details are preserved throughout login completion.
  - Authorization events are recorded for federated login flows.
  - Access policies continue to be enforced during federated authentication.

- **Bug Fixes**
  - Added stricter validation for redirect URIs, clients, providers, and user status.
  - Disabled providers, inactive users, and invalid clients are rejected before authorization codes are consumed.
  - Authorization codes remain single-use and securely bound to the requesting application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Two-instance coverage

`federation-e2e.spec.ts` boots **two real authup instances**, each on its own
database, and drives a brokered login through the real endpoints on both sides:
`authorize-out`, the upstream `POST /authorize`, the callback, the upstream
token exchange, and the relying party redeeming the downstream code with its
PKCE verifier.

This is the configuration the bug was reported in, and the one every existing
spec's fake provider cannot reproduce, because the fake stands in for exactly
the half that already worked. Against the pre-fix controller it fails with the
reported symptom, naming both sides of it:

```
expected 'http://localhost:3001/authorize'
to deeply equal 'https://rp.example.com/login/callback'
```
