### PR TITLE
fix(client-admin-console): reset pagination when the sessions subject-kind filter changes

### DIFF
--- a/apps/client-admin-console/pages/sessions/index/index.vue
+++ b/apps/client-admin-console/pages/sessions/index/index.vue
@@ -98,13 +98,13 @@ export default defineNuxtComponent({
             { value: 'client', label: translationClient.value },
         ]);
 
-        const applySubjectKind = (load: (input: IQuery) => Promise<unknown>) => {
-            if (subjectKind.value === 'all') {
-                return load(defineQuery<Session>({ filters: {} }));
-            }
-
-            return load(defineQuery<Session>({ filters: { subKind: subjectKind.value } }));
-        };
+        // The offset reset is load-bearing (same shape as `ASearch`): a load omitting
+        // `pagination` inherits the current meta offset, so switching the filter from
+        // page 2+ would ask for rows past the end of the freshly filtered set.
+        const applySubjectKind = (load: (input: IQuery) => Promise<unknown>) => load(defineQuery<Session>({
+            filters: subjectKind.value === 'all' ? {} : { subKind: subjectKind.value },
+            pagination: { offset: 0 },
+        }));
 
         const columns = computed<TableColumn<Session>[]>(() => [
             {


### PR DESCRIPTION
Closes #3443

The subject-kind filter on `/sessions` loaded with `filters` only. The collection manager merges the current `meta` pagination into a load that omits it, so switching the filter from page 2+ requested rows past the end of the freshly filtered set and rendered an empty table with a non-zero total.

Both branches (`all` and a concrete `subKind`) now carry `pagination: { offset: 0 }`, the same shape `ASearch` uses.

Swept `apps/client-admin-console/pages/**`, `components/**` and `apps/client-account-console/src/**` for the same shape: this was the only filter control invoking a collection `load` with a query; every other non-pagination `load` call is a post-mutation reload with no query.

Verification: `eslint` clean, `npm run build:types -w apps/client-admin-console` (nuxi typecheck) passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session lists now reset to the first page when applying or changing a subject-kind filter.
  * Filtering sessions consistently starts from the beginning of the results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->