### PR TITLE
fix(server-core): batch the event retention sweep

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -4287,7 +4287,16 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   mirror) deletes `expiring = true AND expiresAt < now` (hub's cleaner shape);
   scheduled only when
   `eventLogEnabled && eventLogRetentionDays > 0`. Per-action retention later is
-  per-action stamping — no schema change.
+  per-action stamping — no schema change. The delete is **batched**
+  (`EVENT_RETENTION_SWEEP_BATCH_SIZE`, 1000): steady state removes a trickle,
+  but the first sweep after lowering `eventLogRetentionDays` (or the day a
+  full retention window first matures) can match millions of rows, and a
+  single unbounded `DELETE` would be one long transaction issued concurrently
+  by every replica. Batching selects ids then deletes by id, because
+  `DELETE ... LIMIT` is MySQL-only; the loop drains, and a batch that removes
+  nothing means another replica's sweep owns those rows, so it stops and the
+  next tick takes the remainder. `SessionTokenRepositoryAdapter.deleteExpired`
+  (the oauth2 cleaner's half) still carries the unbatched shape.
 - **Failed-login throttle (plan 053, default off):** `LoginThrottleService`
   (`core/authentication/login-throttle/`) counts recent `LOGIN_FAILED` rows via
   the indexed `countRecent` — keyed on the **(identifier, ip) pair** (never

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -130,7 +130,16 @@ export class EventRepositoryAdapter implements IEventRepository {
     }
 
     async deleteExpired(now: string, options: EventDeleteExpiredOptions = {}): Promise<number> {
-        const batchSize = options.batchSize ?? EVENT_RETENTION_SWEEP_BATCH_SIZE;
+        // A non-positive or non-integral size must never reach `take`: typeorm
+        // ignores a falsy one, which would silently restore the single
+        // unbounded DELETE this batching exists to prevent, and the rest reach
+        // the driver as invalid SQL. Fall back to the default instead.
+        const requested = options.batchSize;
+        const batchSize = typeof requested === 'number' &&
+            Number.isSafeInteger(requested) &&
+            requested > 0 ?
+            requested :
+            EVENT_RETENTION_SWEEP_BATCH_SIZE;
 
         let total = 0;
 

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -8,14 +8,16 @@
 import type { Event } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
-import { LessThan } from 'typeorm';
+import { In, LessThan } from 'typeorm';
 import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type {
     EventCountRecentFilter,
+    EventDeleteExpiredOptions,
     EventFindManyOptions,
     IEventRepository,
 } from '../../../../../core/index.ts';
+import { EVENT_RETENTION_SWEEP_BATCH_SIZE } from '../../../../../core/index.ts';
 import { applyRealmScopeSelect } from '../helpers.ts';
 
 export class EventRepositoryAdapter implements IEventRepository {
@@ -127,12 +129,42 @@ export class EventRepositoryAdapter implements IEventRepository {
         return qb.getCount();
     }
 
-    async deleteExpired(now: string): Promise<number> {
-        const result = await this.repository.delete({
-            expiring: true,
-            expiresAt: LessThan(now),
-        });
+    async deleteExpired(now: string, options: EventDeleteExpiredOptions = {}): Promise<number> {
+        const batchSize = options.batchSize ?? EVENT_RETENTION_SWEEP_BATCH_SIZE;
 
-        return result.affected ?? 0;
+        let total = 0;
+
+        for (;;) {
+            const rows = await this.repository.find({
+                select: { id: true },
+                where: {
+                    expiring: true,
+                    expiresAt: LessThan(now),
+                },
+                take: batchSize,
+            });
+
+            if (rows.length === 0) {
+                break;
+            }
+
+            const result = await this.repository.delete({ id: In(rows.map((row) => row.id)) });
+
+            // A driver that does not report affected rows still made
+            // progress, so count the batch rather than returning 0.
+            total += result.affected ?? rows.length;
+
+            // Another replica's sweep already owns these rows. Stop rather
+            // than re-selecting them; the next tick picks up whatever is left.
+            if (result.affected === 0) {
+                break;
+            }
+
+            if (rows.length < batchSize) {
+                break;
+            }
+        }
+
+        return total;
     }
 }

--- a/apps/server-core/src/core/entities/event/constants.ts
+++ b/apps/server-core/src/core/entities/event/constants.ts
@@ -13,6 +13,16 @@
 export const EVENT_LOG_RETENTION_DAYS_DEFAULT = 90;
 
 /**
+ * Rows removed per statement by the retention sweep. The sweep runs every
+ * minute on every replica, and the first one after a retention change (or the
+ * day a full retention window first matures) can match millions of rows. A
+ * single unbounded DELETE would then be one long transaction, issued
+ * concurrently by every replica. Batching keeps each statement bounded; the
+ * sweep still drains by looping.
+ */
+export const EVENT_RETENTION_SWEEP_BATCH_SIZE = 1000;
+
+/**
  * Column bound for the denormalized actor name. Shared by the write boundary
  * (EventService.record truncates to it) and every reader that matches stored
  * rows by actor name (the login throttle) so the two cannot drift — an

--- a/apps/server-core/src/core/entities/event/types.ts
+++ b/apps/server-core/src/core/entities/event/types.ts
@@ -67,10 +67,19 @@ export interface IEventRepository {
     /**
      * Retention sweep: drop every expiring row whose expiresAt lies before
      * the given instant (non-expiring rows are kept forever). Returns the
-     * number of removed rows.
+     * number of removed rows. Removal is batched (see
+     * EVENT_RETENTION_SWEEP_BATCH_SIZE).
      */
-    deleteExpired(now: string): Promise<number>;
+    deleteExpired(now: string, options?: EventDeleteExpiredOptions): Promise<number>;
 }
+
+export type EventDeleteExpiredOptions = {
+    /**
+     * Rows removed per statement. Defaults to
+     * EVENT_RETENTION_SWEEP_BATCH_SIZE.
+     */
+    batchSize?: number,
+};
 
 export type EventRecordInput = {
     scope: `${EventScope}`,

--- a/apps/server-core/src/core/entities/event/types.ts
+++ b/apps/server-core/src/core/entities/event/types.ts
@@ -76,7 +76,8 @@ export interface IEventRepository {
 export type EventDeleteExpiredOptions = {
     /**
      * Rows removed per statement. Defaults to
-     * EVENT_RETENTION_SWEEP_BATCH_SIZE.
+     * EVENT_RETENTION_SWEEP_BATCH_SIZE, which anything that is not a positive
+     * safe integer also falls back to.
      */
     batchSize?: number,
 };

--- a/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
@@ -142,18 +142,23 @@ describe('app/modules/database/repositories/event', () => {
 
             const ormRepository = suite.dataSource.getRepository<Event>(EventEntity);
             const adapter = new EventRepositoryAdapter(ormRepository);
-            const spy = vi.spyOn(ormRepository, 'delete');
+            const findSpy = vi.spyOn(ormRepository, 'find');
+            const deleteSpy = vi.spyOn(ormRepository, 'delete');
 
             await adapter.deleteExpired(new Date().toISOString(), { batchSize: 2 });
 
-            // 5 rows at 2 per batch: three DELETEs, none wider than the batch.
-            expect(spy).toHaveBeenCalledTimes(3);
-            for (const call of spy.mock.calls) {
-                const criteria = call[0] as { id: { _value: string[] } };
-                expect(criteria.id._value.length).toBeLessThanOrEqual(2);
+            // 5 rows at 2 per batch: three DELETEs rather than one sweeping
+            // statement. Each is fed by a select bounded to the batch size,
+            // which is what keeps the DELETE itself bounded.
+            expect(deleteSpy).toHaveBeenCalledTimes(3);
+            // asserted so the bound check below can never pass vacuously
+            expect(findSpy).toHaveBeenCalledTimes(3);
+            for (const [options] of findSpy.mock.calls) {
+                expect(options?.take).toEqual(2);
             }
 
-            spy.mockRestore();
+            findSpy.mockRestore();
+            deleteSpy.mockRestore();
         });
 
         it('keeps rows that have not expired and rows that never expire', async () => {

--- a/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
@@ -14,6 +14,7 @@ import {
     describe,
     expect,
     it,
+    vi,
 } from 'vitest';
 import { EventEntity } from '../../../../../src/adapters/database/domains/index.ts';
 import { EventRepositoryAdapter } from '../../../../../src/app/modules/database/repositories/index.ts';
@@ -61,6 +62,10 @@ describe('app/modules/database/repositories/event', () => {
         }));
     };
 
+    const countByRef = async (refId: string) => suite.dataSource
+        .getRepository<Event>(EventEntity)
+        .countBy({ refId });
+
     it('counts a just-written row inside the window (host-timezone independent)', async () => {
         // the login-throttle window: the bound `since` must compare correctly
         // against the DB-clock-stamped created_at regardless of the HOST's
@@ -93,5 +98,81 @@ describe('app/modules/database/repositories/event', () => {
         });
 
         expect(count).toEqual(0);
+    });
+
+    describe('deleteExpired', () => {
+        const recordExpiring = async (refId: string, expiresAt: string) => {
+            await repository.save(repository.create({
+                id: randomUUID(),
+                scope: EventScope.ENTITY,
+                name: EventName.CREATED,
+                refId,
+                expiring: true,
+                expiresAt,
+            }));
+        };
+
+        it('drains every expired row across several batches', async () => {
+            // The sweep must never issue one unbounded DELETE: a first sweep
+            // after a retention change can match millions of rows, and the
+            // cleaner re-runs it every minute on every replica. Batching only
+            // holds if the loop also DRAINS. A single bounded statement would
+            // silently leave a permanent backlog behind.
+            const refId = `sweep-batch-${randomUUID()}`;
+            const past = new Date(Date.now() - 60_000).toISOString();
+            for (let i = 0; i < 5; i++) {
+                await recordExpiring(refId, past);
+            }
+
+            const deleted = await repository.deleteExpired(
+                new Date().toISOString(),
+                { batchSize: 2 },
+            );
+
+            expect(deleted).toEqual(5);
+            expect(await countByRef(refId)).toEqual(0);
+        });
+
+        it('bounds each statement to the batch size', async () => {
+            const refId = `sweep-bound-${randomUUID()}`;
+            const past = new Date(Date.now() - 60_000).toISOString();
+            for (let i = 0; i < 5; i++) {
+                await recordExpiring(refId, past);
+            }
+
+            const ormRepository = suite.dataSource.getRepository<Event>(EventEntity);
+            const adapter = new EventRepositoryAdapter(ormRepository);
+            const spy = vi.spyOn(ormRepository, 'delete');
+
+            await adapter.deleteExpired(new Date().toISOString(), { batchSize: 2 });
+
+            // 5 rows at 2 per batch: three DELETEs, none wider than the batch.
+            expect(spy).toHaveBeenCalledTimes(3);
+            for (const call of spy.mock.calls) {
+                const criteria = call[0] as { id: { _value: string[] } };
+                expect(criteria.id._value.length).toBeLessThanOrEqual(2);
+            }
+
+            spy.mockRestore();
+        });
+
+        it('keeps rows that have not expired and rows that never expire', async () => {
+            const refId = `sweep-keep-${randomUUID()}`;
+            const future = new Date(Date.now() + 600_000).toISOString();
+
+            await recordExpiring(refId, future);
+            await repository.save(repository.create({
+                id: randomUUID(),
+                scope: EventScope.ENTITY,
+                name: EventName.CREATED,
+                refId,
+                expiring: false,
+            }));
+
+            const deleted = await repository.deleteExpired(new Date().toISOString());
+
+            expect(deleted).toEqual(0);
+            expect(await countByRef(refId)).toEqual(2);
+        });
     });
 });

--- a/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
@@ -17,6 +17,7 @@ import {
     vi,
 } from 'vitest';
 import { EventEntity } from '../../../../../src/adapters/database/domains/index.ts';
+import { EVENT_RETENTION_SWEEP_BATCH_SIZE } from '../../../../../src/core/index.ts';
 import { EventRepositoryAdapter } from '../../../../../src/app/modules/database/repositories/index.ts';
 import { createTestDatabaseApplication } from '../../../../app';
 
@@ -161,6 +162,32 @@ describe('app/modules/database/repositories/event', () => {
             deleteSpy.mockRestore();
         });
 
+        it.each([0, -1, 2.5, Number.POSITIVE_INFINITY, Number.NaN])(
+            'falls back to the default batch size for an unusable batchSize (%s)',
+            async (batchSize) => {
+                // A batchSize of 0 is the one that matters: typeorm ignores a
+                // falsy take, so the sweep would silently revert to the single
+                // unbounded DELETE this batching exists to prevent. The rest
+                // would reach the driver as invalid SQL. Neither is reachable
+                // today, but the option sits on a port, so pin the fallback.
+                const refId = `sweep-guard-${randomUUID()}`;
+                await recordExpiring(refId, new Date(Date.now() - 60_000).toISOString());
+
+                const ormRepository = suite.dataSource.getRepository<Event>(EventEntity);
+                const adapter = new EventRepositoryAdapter(ormRepository);
+                const findSpy = vi.spyOn(ormRepository, 'find');
+
+                await adapter.deleteExpired(new Date().toISOString(), { batchSize });
+
+                expect(findSpy).toHaveBeenCalled();
+                for (const [options] of findSpy.mock.calls) {
+                    expect(options?.take).toEqual(EVENT_RETENTION_SWEEP_BATCH_SIZE);
+                }
+
+                findSpy.mockRestore();
+            },
+        );
+
         it('keeps rows that have not expired and rows that never expire', async () => {
             const refId = `sweep-keep-${randomUUID()}`;
             const future = new Date(Date.now() + 600_000).toISOString();
@@ -174,9 +201,11 @@ describe('app/modules/database/repositories/event', () => {
                 expiring: false,
             }));
 
-            const deleted = await repository.deleteExpired(new Date().toISOString());
+            await repository.deleteExpired(new Date().toISOString());
 
-            expect(deleted).toEqual(0);
+            // scoped to this test's own rows: the sweep is table-wide, so a
+            // global deleted-count assertion would couple this to whatever
+            // other specs happen to leave behind.
             expect(await countByRef(refId)).toEqual(2);
         });
     });


### PR DESCRIPTION
## Problem

`EventRepositoryAdapter.deleteExpired` issued a single unbounded statement:

```ts
await this.repository.delete({ expiring: true, expiresAt: LessThan(now) });
```

`components/event-cleaner` re-runs it every minute, and every replica runs its own cron. In steady state that removes a trickle. The pathological cases are the first sweep after someone lowers `eventLogRetentionDays`, and the day a full retention window first matures: both can match millions of rows in one long transaction, issued concurrently by N pods.

## Change

Remove rows in bounded batches (`EVENT_RETENTION_SWEEP_BATCH_SIZE`, 1000): select ids, delete by id, loop until drained.

Two details worth review:

- **Why an id select and not `DELETE ... LIMIT`.** typeorm's `DeleteQueryBuilder.limit()` is MySQL-only; postgres has no `DELETE ... LIMIT`. The id select is the portable form across all three supported drivers.
- **Why the loop can stop early.** A batch that removes nothing means another replica's sweep already owns those rows. Stopping avoids re-selecting them; the sweep is idempotent and the next tick takes the remainder. Termination otherwise comes from the short final batch.

Cross-replica coordination is deliberately unchanged: this bounds each statement, it does not serialize sweeps between processes.

## Not included

`SessionTokenRepositoryAdapter.deleteExpired` (the oauth2 cleaner's half) carries the identical unbatched shape. Left out to keep this reviewable; happy to fold it in or file it separately.

## Verification

- New specs in `test/unit/app/modules/database/event-repository.spec.ts`, written test-first. The batching spec failed as `expected "delete" to be called 3 times, but got 1 times` against the old code, which is the defect stated as an assertion.
  - drains every expired row across several batches
  - bounds each statement to the batch size
  - keeps rows that have not expired and rows that never expire
- Full server-core suite: 197 files, 2 247 tests, all passing.
- `npm run build -w apps/server-core` and eslint clean.

The sweep's end-to-end behaviour was also confirmed by hand against a populated sqlite database before and after: 2 205 rows with 1 896 aged out swept to 0 residual expired rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expired security events are now removed in controlled batches, improving cleanup reliability and reducing the impact of large retention sweeps.
  * Cleanup can continue safely across concurrent service instances without repeatedly processing the same records.

* **Bug Fixes**
  * Prevented retention cleanup from stopping prematurely when database operations report incomplete affected-row counts.
  * Ensured active and non-expiring events remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->