### PR TITLE
docs: file the federated hardening notes under the release that shipped them

### DIFF
--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -5,7 +5,7 @@ Entries are grouped by release, newest first. Routine changes (features, fixes) 
 [changelog](https://github.com/authup/authup/blob/master/CHANGELOG.md); anything listed here
 either requires operator action or deliberately changes behavior.
 
-## Next release (after v1.0.0-beta.61)
+## v1.0.0-beta.62
 
 ### `auth_identity_provider_accounts` gains a unique constraint
 
@@ -30,19 +30,6 @@ HAVING COUNT(*) > 1;
 Keep the row whose `user_id` names the account the person actually uses, and
 delete the rest. The unique index cannot be created while duplicates exist,
 so the boot would fail either way; the check only makes the reason readable.
-
-## v1.0.0-beta.60
-
-### Fixed: external identity-provider login
-
-The token exchange against an external OAuth2 / OIDC provider never sent the
-`code` parameter, so **every federated login has failed since
-v1.0.0-beta.28** with an `invalid_request` from the provider's token
-endpoint. The callback passed the raw code string where the authenticator
-expected `{ code }`, and the HTTP client spread it into indexed body keys
-(`0=d&1=b&...`). **No action is required** beyond upgrading. A callback that
-arrives without a code is now rejected with a `400` instead of an opaque
-upstream failure.
 
 ### Federated login: completion hardening
 
@@ -80,6 +67,19 @@ upstream failure.
   against render contract version 2, which adds the interstitial route
   `/identity-providers/:id/authorize-in` and its `IdentityProviderCallbackPayload`;
   a package exporting an older `CONTRACT_VERSION` is refused at boot.
+
+## v1.0.0-beta.60
+
+### Fixed: external identity-provider login
+
+The token exchange against an external OAuth2 / OIDC provider never sent the
+`code` parameter, so **every federated login has failed since
+v1.0.0-beta.28** with an `invalid_request` from the provider's token
+endpoint. The callback passed the raw code string where the authenticator
+expected `{ code }`, and the HTTP client spread it into indexed body keys
+(`0=d&1=b&...`). **No action is required** beyond upgrading. A callback that
+arrives without a code is now rejected with a `400` instead of an opaque
+upstream failure.
 
 ### `auth_sessions.client_id` is the client-subject foreign key only
 


### PR DESCRIPTION
The `### Federated login: completion hardening` block on the upgrading page sits under `## v1.0.0-beta.60`, but `git blame` attributes every line of it to `d70de50e` (#3464), which shipped in **v1.0.0-beta.62**. The page currently tells operators that the hardening landed two releases before it did, which matters because two of those bullets need action.

Every bullet in the block is beta.62 behaviour, verified against the tags rather than the PR text:

| Bullet | Evidence |
| --- | --- |
| `authorize-out` refuses a request without `codeRequest` | at `v1.0.0-beta.61` the controller reads `if (typeof query.codeRequest === 'string')`, at `v1.0.0-beta.62` it throws on the negation |
| `getAuthorizeUri(id, { codeRequest })` | the options parameter is added in the beta.61..beta.62 diff of `core-http-kit` |
| custom-scheme interstitial, render contract 2 | `AUTH_CONSOLE_CONTRACT_VERSION = 2` exists only at beta.62 |
| userinfo and unsafe-scheme refusals | `packages/kit/src/is-safe-redirect-url-scheme.ts` is new in beta.62 |
| state moved to its own cache namespace | `CacheOAuth2Prefix.AUTHORIZATION_STATE` is new in beta.62 |

So the block moves into the beta.62 section, and that section is renamed from `Next release (after v1.0.0-beta.61)` now that it is out (the same rename #3463 did for beta.60).

Nothing else moved. The other three entries under `## v1.0.0-beta.60` all come from `f33982bb` (`chore: prepare v1.0.0-beta.60`), and the `meta.schema.sorts` one is correctly filed there: `@rapiq/core` went `^2.0.0-beta.15` to `^2.1.0` between beta.59 and beta.60.

## Verification

Sorting both versions of the file and diffing them yields exactly one changed line, the heading, which proves the block was moved rather than rewritten:

```
149d148
< ## Next release (after v1.0.0-beta.61)
152a152
> ## v1.0.0-beta.62
```

Found while writing the v1.0.0-beta.62 release notes, which link to this page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the upgrade guide to identify version `v1.0.0-beta.62` as the latest release.
  - Organized the federated login fix under the `v1.0.0-beta.60` release section.
  - Documented improved handling for OAuth callbacks missing a required authorization code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->