### PR TITLE
fix(server-core): writable directory defaults

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -205,6 +205,22 @@ lists `vue` needs this before merge; its own CI already shows the failure.
 - Config keys in `app/modules/config/types.ts` match the service option names
 - Environment variable names use `SCREAMING_SNAKE_CASE` with `_ENABLED` suffix: `REGISTRATION_ENABLED`, `PASSWORD_RECOVERY_ENABLED`, `EMAIL_VERIFICATION_ENABLED`
 - Config file keys (`.conf`) use `camelCase` matching the TypeScript property name
+- **Every path key is resolved against `rootPath` after the `...parsed` spread**
+  in `normalizeConfig`, so consumers receive an absolute path and none of them
+  has to know what the process cwd was: `writableDirectoryPath`,
+  `themeDirectoryPath`, `authConsolePath`, `accountConsolePath`. A new path key
+  joins that block; computing it *before* the spread reads a default `rootPath`
+  rather than the configured one (the `writableDirectoryPath` bug, fixed after
+  v1.0.0-beta.62 — it silently ignored `rootPath` and stayed relative).
+- **`writableDirectoryPath` does not hold the database.** It holds the
+  production log files and is where `<dir>/provisioning` is read from; that is
+  the whole of it. The sqlite file comes from `db.database` / `DB_DATABASE`,
+  which typeorm-extension resolves against the process cwd
+  (`resolveSQLiteDatabasePath`), so pointing `WRITABLE_DIRECTORY_PATH` at a
+  volume does NOT move the database onto it. The Docker image defaults the key
+  to `/var/lib/authup`; everything else defaults to `<rootPath>/writable`,
+  which is what keeps an unprivileged `npx` start working (any absolute system
+  path needs root or a pre-chowned directory).
 
 ## Upstream (Own) Libraries
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,11 +15,11 @@ COPY ./entrypoint.sh ./entrypoint.sh
 
 RUN chmod +x ./entrypoint.sh
 
-RUN mkdir -p ./writable
+RUN mkdir -p /var/lib/authup
 
 ENV PORT=3000
 ENV NODE_ENV=production
-ENV WRITABLE_DIRECTORY_PATH=/usr/src/app/writable
+ENV WRITABLE_DIRECTORY_PATH=/var/lib/authup
 
 EXPOSE 3000
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To run the backend application with default settings on http://localhost:3001/, 
 
 ```shell
 $ docker run \
-  -v authup:/usr/src/app/writable \
+  -v authup:/var/lib/authup \
   -p 3001:3000 \
   authup/authup:latest server/core start
 ```

--- a/apps/server-core/src/app/modules/config/normalize.ts
+++ b/apps/server-core/src/app/modules/config/normalize.ts
@@ -21,9 +21,6 @@ import type { Config, ConfigInput } from './types.ts';
 export async function normalizeConfig(input: ConfigInput = {}): Promise<Config> {
     const parsed = await parseConfig(input);
 
-    const writableDirectoryPath = parsed.writableDirectoryPath ||
-        path.join(process.cwd(), 'writable');
-
     const port = parsed.port ?? 3001;
     let host = parsed.host || '0.0.0.0';
 
@@ -73,7 +70,7 @@ export async function normalizeConfig(input: ConfigInput = {}): Promise<Config> 
     const config : Config = {
         env,
         rootPath: process.cwd(),
-        writableDirectoryPath,
+        writableDirectoryPath: 'writable',
         // '' = theming disabled. Deliberately NOT defaulted under
         // writableDirectoryPath: that directory is process-writable, and
         // pairing "process-writable" with "content injected into the login
@@ -150,6 +147,11 @@ export async function normalizeConfig(input: ConfigInput = {}): Promise<Config> 
     // After the spread, so a relative value supplied by any config surface
     // is resolved. Every consumer then receives an absolute path and none
     // of them has to care what the process cwd was.
+    config.writableDirectoryPath = path.resolve(
+        config.rootPath,
+        config.writableDirectoryPath || 'writable',
+    );
+
     if (config.themeDirectoryPath) {
         config.themeDirectoryPath = path.resolve(config.rootPath, config.themeDirectoryPath);
     }

--- a/apps/server-core/src/app/modules/config/types.ts
+++ b/apps/server-core/src/app/modules/config/types.ts
@@ -29,6 +29,14 @@ export type Config = {
      */
     rootPath: string,
     /**
+     * Directory the application writes to at runtime (log files in
+     * production) and reads file-based provisioning from
+     * (`<writableDirectoryPath>/provisioning`).
+     *
+     * The SQLite database is NOT placed here - its path comes from the
+     * database configuration (`db.database` / `DB_DATABASE`), resolved
+     * against the process working directory by typeorm-extension.
+     *
      * Relative or absolute path.
      * If the path is relative, the rootPath will be appended.
      *

--- a/apps/server-core/test/unit/config/index.spec.ts
+++ b/apps/server-core/test/unit/config/index.spec.ts
@@ -150,6 +150,37 @@ describe('src/config/*.ts', () => {
             expect(config.port).toEqual(0);
         });
 
+        it('should default the root path to the working directory', async () => {
+            const config = await normalizeConfig();
+
+            expect(config.rootPath).toEqual(process.cwd());
+            expect(config.writableDirectoryPath).toEqual(path.join(process.cwd(), 'writable'));
+        });
+
+        it('should honor a configured root path', async () => {
+            const config = await normalizeConfig({ rootPath: path.join(path.sep, 'srv', 'authup') });
+
+            expect(config.rootPath).toEqual(path.join(path.sep, 'srv', 'authup'));
+        });
+
+        it('should resolve a relative writableDirectoryPath against the root path', async () => {
+            const config = await normalizeConfig({
+                rootPath: path.join(path.sep, 'srv', 'authup'),
+                writableDirectoryPath: 'writable',
+            });
+
+            expect(config.writableDirectoryPath).toEqual(path.join(path.sep, 'srv', 'authup', 'writable'));
+        });
+
+        it('should keep an absolute writableDirectoryPath', async () => {
+            const config = await normalizeConfig({
+                rootPath: path.join(path.sep, 'srv', 'authup'),
+                writableDirectoryPath: path.join(path.sep, 'var', 'lib', 'authup'),
+            });
+
+            expect(config.writableDirectoryPath).toEqual(path.join(path.sep, 'var', 'lib', 'authup'));
+        });
+
         it('should default passwordMinLength to 10', async () => {
             const config = await normalizeConfig();
 

--- a/docs/src/.vitepress/theme/components/CodeTabs.vue
+++ b/docs/src/.vitepress/theme/components/CodeTabs.vue
@@ -57,7 +57,7 @@ export default defineComponent({
 docker run -d \\
   --name authup \\
   -p 3000:3000 \\
-  -v authup:/usr/src/app/writable \\
+  -v authup:/var/lib/authup \\
   authup/authup:latest \\
   server/core start`,
             },

--- a/docs/src/.vitepress/theme/components/IntegrationSpotlight.vue
+++ b/docs/src/.vitepress/theme/components/IntegrationSpotlight.vue
@@ -53,7 +53,7 @@ export default defineComponent({
     image: authup/authup:latest
     restart: unless-stopped
     volumes:
-      - authup:/usr/src/app/writable
+      - authup:/var/lib/authup
     ports:
       - "3001:3000"
     environment:

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -45,8 +45,11 @@ export default {
     rootPath: '/usr/src/app',
 
     /**
-     * Directory for runtime-generated files (SQLite database, generated
-     * artifacts, ...). Relative paths are resolved against rootPath.
+     * Directory the application writes to at runtime (log files in
+     * production) and reads file-based provisioning from
+     * (<writableDirectoryPath>/provisioning). Relative paths are resolved
+     * against rootPath. The SQLite database is NOT placed here - its path
+     * comes from the database configuration (db.database / DB_DATABASE).
      * env: WRITABLE_DIRECTORY_PATH
      * default: writable
      */

--- a/docs/src/guide/deployment/docker-compose.md
+++ b/docs/src/guide/deployment/docker-compose.md
@@ -36,9 +36,9 @@ services:
       restart: unless-stopped
       volumes:
         # Docker managed volume
-        - authup:/usr/src/app/writable
+        - authup:/var/lib/authup
         # storage in mounted volume
-        #- ./writable:/usr/src/app/writable
+        #- ./writable:/var/lib/authup
       ports:
         - "3001:3000"
       command: server/core start
@@ -110,7 +110,7 @@ services:
     container_name: authup
     restart: unless-stopped
     volumes:
-      - authup:/usr/src/app/writable
+      - authup:/var/lib/authup
     ports:
       - "3001:3000"
     environment:
@@ -173,7 +173,7 @@ services:
         container_name: server-core
         restart: unless-stopped
         volumes:
-            - authup_data:/usr/src/app/writable
+            - authup_data:/var/lib/authup
         ports:
             - "3001:3000"
         depends_on:

--- a/docs/src/guide/deployment/docker.md
+++ b/docs/src/guide/deployment/docker.md
@@ -40,7 +40,7 @@ To start each service, the following command should be executed depending on the
 **`API`**
 ```shell
 docker run \
-  -v authup:/usr/src/app/writable \
+  -v authup:/var/lib/authup \
   -p 3001:3000 \
   authup/authup:latest server/core start
 

--- a/docs/src/guide/deployment/provisioning.md
+++ b/docs/src/guide/deployment/provisioning.md
@@ -235,7 +235,7 @@ immediately.
 
 Place one or more provisioning files in the `provisioning/` subdirectory of the writable directory.
 The writable directory defaults to `./writable` (relative to the application root) and can be configured
-via the `WRITABLE_DIRECTORY_PATH` environment variable.
+via the `WRITABLE_DIRECTORY_PATH` environment variable. The Docker image sets it to `/var/lib/authup`.
 
 Supported formats: `.json`, `.yaml`, `.yml`, `.ts`, `.mts`, `.mjs`, `.js`.
 
@@ -261,7 +261,7 @@ dropped. Write provisioning files in camelCase.
 Mount your provisioning files into the container's writable directory:
 
 ```bash
-docker run -v /path/to/provisioning:/usr/src/app/writable/provisioning authup/authup
+docker run -v /path/to/provisioning:/var/lib/authup/provisioning authup/authup
 ```
 
 Or set the writable directory explicitly:

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -5,6 +5,49 @@ Entries are grouped by release, newest first. Routine changes (features, fixes) 
 [changelog](https://github.com/authup/authup/blob/master/CHANGELOG.md); anything listed here
 either requires operator action or deliberately changes behavior.
 
+## Next release (after v1.0.0-beta.62)
+
+### Docker: the writable directory moved to `/var/lib/authup`
+
+The image wrote its runtime files to `/usr/src/app/writable`, inside the
+application install directory. It now uses `/var/lib/authup`, which is where
+the filesystem hierarchy standard puts mutable application state and which is
+a cleaner mount point than a path nested in the install tree.
+
+**Action required if you mount a volume at the old path.** Update the mount
+target; the volume itself is unchanged.
+
+```diff
+ volumes:
+-  - authup:/usr/src/app/writable
++  - authup:/var/lib/authup
+```
+
+The same applies to a bind-mounted provisioning directory:
+`-v /path/to/provisioning:/var/lib/authup/provisioning`.
+
+Miss this and nothing fails loudly: the container starts, writes its
+production log files inside the container layer instead of the volume, and
+finds no provisioning files, so file-based provisioning silently stops being
+applied. Set `WRITABLE_DIRECTORY_PATH=/usr/src/app/writable` to keep the old
+location instead.
+
+Only the image default changed. Running outside Docker still defaults to
+`writable` relative to the application root, so an unprivileged `npx` or
+bare-metal start is unaffected.
+
+### A relative `writableDirectoryPath` now resolves against `rootPath`
+
+The documented behavior - a relative path is resolved against `rootPath` -
+was implemented for `themeDirectoryPath`, `authConsolePath` and
+`accountConsolePath` but not for `writableDirectoryPath`, which stayed
+relative to the process working directory and ignored `rootPath` entirely.
+It now resolves like its siblings.
+
+This only changes behavior for a deployment that sets `rootPath` to something
+other than the working directory **and** gives `writableDirectoryPath` a
+relative value. Absolute values, and the default, are unaffected.
+
 ## v1.0.0-beta.62
 
 ### `auth_identity_provider_accounts` gains a unique constraint


### PR DESCRIPTION
Two related changes to `writableDirectoryPath`, plus the doc corrections they turned up.

## `writableDirectoryPath` now resolves against `rootPath`

`normalizeConfig` resolves every path key against `rootPath` after the `...parsed` spread, so consumers receive an absolute path and none of them has to know what the process cwd was. `themeDirectoryPath`, `authConsolePath` and `accountConsolePath` were in that block; `writableDirectoryPath` was not — it was computed *before* the spread off `process.cwd()` and never resolved afterwards. So a configured relative value stayed relative, and setting `rootPath` moved the three console/theme paths while leaving the writable directory behind.

Only a deployment that sets `rootPath` away from the working directory **and** gives `writableDirectoryPath` a relative value sees a change. Absolute values and the default are unaffected.

Four tests pin the behaviour (default, configured root, relative-resolves, absolute-wins).

## Docker: writable directory moved to `/var/lib/authup`

The image wrote to `/usr/src/app/writable`, inside the application install directory. `/var/lib/<app>` is the filesystem hierarchy standard location for mutable application state, and a cleaner mount point than a path nested in the install tree.

**Only the image default moves.** The code default stays `<rootPath>/writable`, which is what keeps an unprivileged `npx @authup/authup start` and a bare-metal run working — every absolute system path (`/etc/authup`, `/opt/authup`, `/var/lib/authup` alike) needs root or a pre-chowned directory, so making one the built-in default would turn a working quickstart into EACCES on the first production log write.

### Breaking, and silently so

A deployment mounting a volume at the old path keeps starting fine: the container writes its production log files into the container layer instead of the volume, and finds no provisioning files, so file-based provisioning stops being applied with nothing in the log to say why. `upgrading.md` carries the mount diff and the `WRITABLE_DIRECTORY_PATH=/usr/src/app/writable` escape hatch.

The mount target is updated at all 10 places it appears (README, `docker.md`, `docker-compose.md` ×4, `provisioning.md`, and the two VitePress components).

**The helm chart lives in `authup/helm` and needs the same mount path change there.**

## Doc corrections

Both `configuration-server-core.md` and the `Config` type claimed the writable directory holds the SQLite database. It never has — the file comes from `db.database` / `DB_DATABASE`, which typeorm-extension resolves against the process cwd (`resolveSQLiteDatabasePath`), so pointing `WRITABLE_DIRECTORY_PATH` at a volume does **not** move the database onto it. What actually lands there is the production log files, plus `<dir>/provisioning` on the read side. `.agents/conventions.md` records both facts so the next path key joins the resolution block and nobody re-derives the database misconception.

## Not included

Defaulting the SQLite `database` to `<writable>/db.sql`. With `db` unset and no `DB_TYPE`, `buildDataSourceOptions` throws outright today, so that default would be purely additive and would finally put the file that actually needs a volume onto the volume — but it is a separate call from this one.

## Verification

- `npm run build -w apps/server-core` — clean
- `npx eslint --fix` on the changed TypeScript — clean
- full server-core suite — **197 files / 2256 tests passed**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Docker deployments now use `/var/lib/authup` for persistent writable files, including logs and provisioning data.
  - Relative writable-directory paths resolve consistently from the configured application root.

- **Bug Fixes**
  - Absolute writable-directory paths remain unchanged, while default and relative paths are normalized reliably.

- **Documentation**
  - Updated Docker, provisioning, configuration, and upgrade guidance, including volume-mount migration instructions.
  - Clarified that SQLite database storage is configured separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->