### PR TITLE
fix(server-core)!: gate the identity provider record read

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2951,6 +2951,18 @@ a guaranteed 400 is worse than no button. The hosted `/authorize` page always
 passes one; a host embedding `ALoginForm` without one gets the password login
 alone.
 
+**The provider LIST is the anonymous surface, the provider RECORD is not
+(#3480).** `GET /identity-providers` stays ungated: the hosted login page
+renders its provider buttons before anyone has authenticated, and `findMany`
+ships the schema's `fields.default` projection alone.
+`GET /identity-providers/:id` requires an identity and one of
+`IDENTITY_PROVIDER_READ`/`UPDATE`/`DELETE` with a realm match, because the
+record read resolves through `findOneById` and splices the extra attributes on
+after the query (`extendOneWithEA`), so the OAuth2 `clientSecret` and the LDAP
+bind password sit outside every rapiq field gate. An anonymous caller wanting
+one provider reads it from the collection (`?filter[id]=<uuid>`), which is the
+same projection.
+
 ## Federated Identity Claims
 
 `IdentityProviderOAuth2Authenticator.buildIdentityWithTokenGrantResponse`
@@ -4406,7 +4418,14 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   any key matching the secret denylist
   `/(password|secret|hash|token|credential)/i` are dropped fail-closed,
   strings truncated to 512; `sanitizeEventData`'s dedicated `diff` branch
-  re-checks the same regex at the write boundary. Created/deleted rows carry
+  re-checks the same regex at the write boundary. **A generic `(name, value)` row
+  gets no diff at all** (`ENTITY_OPAQUE_VALUE_TYPES`: the four `*_attributes`
+  types): their payload column is literally called `value`, so a key-name
+  denylist cannot see that it holds an identity provider's `clientSecret` or
+  LDAP bind password. The same reasoning applies one layer out, on the
+  realtime bus: `IdentityProviderAttributeSubscriber` overrides `publish` to
+  null the `value` on both the current and previous payload, since the
+  domain-event content is shipped verbatim to redis and socket consumers. Created/deleted rows carry
   `data: null` (no column dumps). Rows self-prune on a short per-row TTL via
   `EventRecordInput.retentionDays` (config `eventLogEntityEnabled` default
   `true` / `eventLogEntityRetentionDays` default `7` days, env

--- a/apps/server-core/src/adapters/database/domains/identity-provider-attribute/subscriber.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-attribute/subscriber.ts
@@ -5,7 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { IdentityProviderAttribute } from '@authup/core-kit';
+import type { EntityDefaultEventName, IdentityProviderAttribute } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
 import { buildRedisKeyPath } from '@authup/server-kit';
 import { EventSubscriber } from 'typeorm';
@@ -29,5 +29,23 @@ export class IdentityProviderAttributeSubscriber extends EntitySubscriber<Identi
                 ],
             },
         });
+    }
+
+    /**
+     * The row's `value` holds the provider's OAuth2 clientSecret or LDAP bind
+     * password, so it must never reach the realtime bus. Stripped on both
+     * sides: the previous payload is what an update would otherwise carry the
+     * OLD secret in.
+     */
+    protected override async publish(
+        event: `${EntityDefaultEventName}`,
+        data: IdentityProviderAttribute,
+        dataPrevious?: IdentityProviderAttribute,
+    ): Promise<void> {
+        await super.publish(
+            event,
+            { ...data, value: null },
+            dataPrevious ? { ...dataPrevious, value: null } : undefined,
+        );
     }
 }

--- a/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/entities/identity-provider/module.ts
@@ -143,6 +143,11 @@ export class IdentityProviderController {
 
     // ---------------------------------------------------------
 
+    // Deliberately anonymous and ungated: the hosted login page lists a
+    // realm's providers before anyone signs in. Safe only because findMany
+    // does not extend with extra attributes, so the response is the schema's
+    // fields.default projection. The record read below carries them and is
+    // gated for exactly that reason.
     @DGet('', [])
     async getProviders(
         @DContext() event: IAppEvent,
@@ -157,24 +162,6 @@ export class IdentityProviderController {
             }),
         );
 
-        try {
-            const permissionEvaluator = useRequestPermissionEvaluator(event);
-            await permissionEvaluator.preEvaluate({ name: PermissionName.IDENTITY_PROVIDER_READ });
-
-            for (const datum of data) {
-                try {
-                    await permissionEvaluator.evaluate({
-                        name: PermissionName.IDENTITY_PROVIDER_READ,
-                        data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: datum, [BuiltInPolicyType.REALM_MATCH]: datum.realmId ?? null }),
-                    });
-                } catch {
-                    // do nothing
-                }
-            }
-        } catch {
-            // do nothing
-        }
-
         return {
             data,
             meta: {
@@ -184,7 +171,7 @@ export class IdentityProviderController {
         };
     }
 
-    @DGet('/:id', [])
+    @DGet('/:id', [ForceLoggedInMiddleware])
     async getProvider(
         @DPath('id') id: string,
         @DContext() event: IAppEvent,
@@ -200,15 +187,14 @@ export class IdentityProviderController {
             throw new EntityNotFoundError();
         }
 
-        try {
-            const permissionEvaluator = useRequestPermissionEvaluator(event);
-            await permissionEvaluator.evaluate({
-                name: PermissionName.IDENTITY_PROVIDER_READ,
-                data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realmId ?? null }),
-            });
-        } catch {
-            // do nothing
-        }
+        await useRequestPermissionEvaluator(event).evaluateOneOf({
+            name: [
+                PermissionName.IDENTITY_PROVIDER_READ,
+                PermissionName.IDENTITY_PROVIDER_UPDATE,
+                PermissionName.IDENTITY_PROVIDER_DELETE,
+            ],
+            data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, [BuiltInPolicyType.REALM_MATCH]: entity.realmId ?? null }),
+        });
 
         return { data: entity, meta: { schema: describeQuerySchema(identityProviderSchema, RECORD_QUERY_PARAMETERS) } };
     }

--- a/apps/server-core/src/core/entities/event/entity-event-handler.ts
+++ b/apps/server-core/src/core/entities/event/entity-event-handler.ts
@@ -32,6 +32,21 @@ const ENTITY_EVENT_NAME_MAP : Record<string, `${EventName}`> = {
     [EntityDefaultEventName.DELETED]: EventName.DELETED,
 };
 
+/**
+ * Entity types whose rows are generic (name, value) pairs. Their payload
+ * column is always called `value`, so {@link buildEntityDiff}'s key-name
+ * denylist cannot see what it holds - and for an identity provider it holds
+ * the OAuth2 `clientSecret` or the LDAP bind password. The diff is dropped
+ * wholesale rather than the denylist widened, because no regex over the
+ * column name can ever decide this.
+ */
+const ENTITY_OPAQUE_VALUE_TYPES = new Set<string>([
+    EntityType.IDENTITY_PROVIDER_ATTRIBUTE,
+    EntityType.POLICY_ATTRIBUTE,
+    EntityType.ROLE_ATTRIBUTE,
+    EntityType.USER_ATTRIBUTE,
+]);
+
 const ENTITY_REALM_KEY_MAP : Record<`${EntityType}`, string> = {
     [EntityType.CLIENT]: 'realmId',
     [EntityType.CLIENT_PERMISSION]: 'clientRealmId',
@@ -110,7 +125,12 @@ export class EntityEventHandler implements IDomainEventHandler {
                 undefined;
 
             let data : Record<string, any> | null = null;
-            if (name === EventName.UPDATED && isObject(ctx.content.data) && isObject(ctx.dataPrevious)) {
+            if (
+                name === EventName.UPDATED &&
+                !ENTITY_OPAQUE_VALUE_TYPES.has(ctx.content.type) &&
+                isObject(ctx.content.data) &&
+                isObject(ctx.dataPrevious)
+            ) {
                 const diff = buildEntityDiff(ctx.content.data, ctx.dataPrevious);
                 if (Object.keys(diff).length > 0) {
                     data = { diff };

--- a/apps/server-core/test/unit/adapters/database/identity-provider-attribute-subscriber.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/identity-provider-attribute-subscriber.spec.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { randomUUID } from 'node:crypto';
+import type { IdentityProviderAttribute } from '@authup/core-kit';
+import type { DomainEventPublishContext, IDomainEventPublisher } from '@authup/server-kit';
+import type { InsertEvent, UpdateEvent } from 'typeorm';
+import { describe, expect, it } from 'vitest';
+import { IdentityProviderAttributeSubscriber } from '../../../../src/adapters/database/domains/identity-provider-attribute/subscriber.ts';
+
+const attributeId = randomUUID();
+const realmId = randomUUID();
+const providerId = randomUUID();
+
+function buildAttribute(value: string): IdentityProviderAttribute {
+    return {
+        id: attributeId,
+        name: 'clientSecret',
+        value,
+        providerId,
+        realmId,
+    } as IdentityProviderAttribute;
+}
+
+function buildUpdateEvent(
+    entity: IdentityProviderAttribute,
+    databaseEntity: IdentityProviderAttribute,
+): UpdateEvent<IdentityProviderAttribute> {
+    // The subscriber only reads entity / databaseEntity / connection, and
+    // dropCacheKeys returns early without a queryResultCache.
+    return {
+        entity,
+        databaseEntity,
+        connection: {},
+    } as unknown as UpdateEvent<IdentityProviderAttribute>;
+}
+
+function buildInsertEvent(entity: IdentityProviderAttribute): InsertEvent<IdentityProviderAttribute> {
+    return {
+        entity,
+        connection: {},
+    } as unknown as InsertEvent<IdentityProviderAttribute>;
+}
+
+function createPublisherSpy() {
+    const calls : DomainEventPublishContext[] = [];
+
+    const publisher : IDomainEventPublisher = {
+        async publish(ctx) {
+            calls.push(ctx);
+        },
+        async safePublish(ctx) {
+            calls.push(ctx);
+        },
+    };
+
+    return { calls, publisher };
+}
+
+describe('IdentityProviderAttributeSubscriber', () => {
+    it('never publishes the attribute value', async () => {
+        const { calls, publisher } = createPublisherSpy();
+
+        const subscriber = new IdentityProviderAttributeSubscriber();
+        subscriber.setPublisher(publisher);
+
+        await subscriber.afterUpdate(buildUpdateEvent(
+            buildAttribute('next-secret'),
+            buildAttribute('previous-secret'),
+        ));
+
+        expect(calls).toHaveLength(1);
+
+        const [ctx] = calls;
+        expect(ctx.content.data.value).toBeNull();
+        expect(ctx.dataPrevious?.value).toBeNull();
+        expect(JSON.stringify(ctx)).not.toContain('next-secret');
+        expect(JSON.stringify(ctx)).not.toContain('previous-secret');
+
+        // the rest of the row still rides, so consumers keep their attribution
+        expect(ctx.content.data.id).toEqual(attributeId);
+        expect(ctx.content.data.name).toEqual('clientSecret');
+    });
+
+    it('never publishes the attribute value on insert', async () => {
+        const { calls, publisher } = createPublisherSpy();
+
+        const subscriber = new IdentityProviderAttributeSubscriber();
+        subscriber.setPublisher(publisher);
+
+        await subscriber.afterInsert(buildInsertEvent(buildAttribute('fresh-secret')));
+
+        expect(calls).toHaveLength(1);
+        expect(calls[0].content.data.value).toBeNull();
+        expect(calls[0].dataPrevious).toBeUndefined();
+        expect(JSON.stringify(calls[0])).not.toContain('fresh-secret');
+    });
+});

--- a/apps/server-core/test/unit/core/entities/event/entity-event-handler.spec.ts
+++ b/apps/server-core/test/unit/core/entities/event/entity-event-handler.spec.ts
@@ -224,6 +224,36 @@ describe('EntityEventHandler', () => {
         expect(call.data).toEqual({ diff: { description: { next: 'after', previous: 'before' } } });
     });
 
+    it.each([
+        EntityType.IDENTITY_PROVIDER_ATTRIBUTE,
+        EntityType.POLICY_ATTRIBUTE,
+        EntityType.ROLE_ATTRIBUTE,
+        EntityType.USER_ATTRIBUTE,
+    ])('records no diff for %s, whose value column is opaque', async (type) => {
+        await buildHandler().handle(buildPublishContext({
+            content: {
+                type,
+                event: 'updated',
+                data: {
+                    id: entityId,
+                    realmId,
+                    name: 'clientSecret',
+                    value: 'rotated-secret',
+                },
+            },
+            dataPrevious: {
+                id: entityId,
+                realmId,
+                name: 'clientSecret',
+                value: 'previous-secret',
+            },
+        }));
+
+        const [call] = eventService.recordCalls;
+        expect(call.name).toEqual(EventName.UPDATED);
+        expect(call.data).toBeNull();
+    });
+
     it('records null data for an updated event without a previous snapshot', async () => {
         await buildHandler().handle(buildPublishContext({ content: { event: 'updated' } }));
 

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
@@ -26,6 +26,7 @@ import {
     createFakeLdapIdentityProvider,
     createFakeOAuth2IdentityProvider,
     expectPropertiesEqualToSrc,
+    httpRequest,
 } from '../../../../../utils';
 import { createTestApplication } from '../../../../../app';
 
@@ -104,6 +105,16 @@ describe('src/http/controllers/identity-provider', () => {
         expect(response).toBeDefined();
 
         expectPropertiesEqualToSrc(oAuth2IdentityProvider, response);
+    });
+
+    it('should not read resource without authentication', async () => {
+        const response = await httpRequest(suite, 'GET', `/identity-providers/${oAuth2IdentityProvider.id!}`);
+
+        expect(response.status).toEqual(401);
+
+        // the record read carries the EA-extended entity, so an ungated
+        // response hands out the provider's client secret (issue #3480)
+        expect(await response.text()).not.toContain(oAuth2IdentityProvider.clientSecret);
     });
 
     it('should update resource', async () => {

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/module.spec.ts
@@ -12,10 +12,12 @@ import {
     expect, 
     it,
 } from 'vitest';
+import { Client as HTTPClient } from '@authup/core-http-kit';
 import type { OAuth2IdentityProvider } from '@authup/core-kit';
 import {
     IdentityProviderPreset,
     IdentityProviderProtocol,
+    PermissionName,
     ScopeName,
     buildIdentityProviderAuthorizeCallbackPath,
     buildIdentityProviderAuthorizePath,
@@ -25,6 +27,8 @@ import {
     createFakeClient,
     createFakeLdapIdentityProvider,
     createFakeOAuth2IdentityProvider,
+    createFakeRealm,
+    expectClientError,
     expectPropertiesEqualToSrc,
     httpRequest,
 } from '../../../../../utils';
@@ -43,6 +47,41 @@ describe('src/http/controllers/identity-provider', () => {
 
     const oAuth2IdentityProvider = createFakeOAuth2IdentityProvider();
     const ldapIdentityProvider = createFakeLdapIdentityProvider();
+
+    const createIdentity = async (options: {
+        realmId?: string,
+        permissionNames?: PermissionName[],
+    } = {}) => {
+        const secret = 'identity-provider-gate-secret';
+
+        const { data: client } = await suite.client.client.create({
+            ...createFakeClient(),
+            ...(options.realmId ? { realmId: options.realmId } : {}),
+            authMethod: 'secret',
+            tokenBindingMethod: 'none',
+            secret,
+            secretHashed: false,
+            secretEncrypted: false,
+        });
+
+        for (const permissionName of options.permissionNames ?? []) {
+            const { data: permission } = await suite.client.permission.getOne(permissionName);
+            await suite.client.clientPermission.create({
+                clientId: client.id,
+                permissionId: permission.id,
+            });
+        }
+
+        const token = await suite.client.token.createWithClientCredentials({
+            client_id: client.id,
+            client_secret: secret,
+        });
+
+        const httpClient = new HTTPClient({ baseURL: suite.baseURL });
+        httpClient.setAuthorizationHeader({ type: 'Bearer', token: token.access_token });
+
+        return httpClient;
+    };
 
     it('should create resource (oauth2)', async () => {
         const { data: response } = await suite.client
@@ -115,6 +154,49 @@ describe('src/http/controllers/identity-provider', () => {
         // the record read carries the EA-extended entity, so an ungated
         // response hands out the provider's client secret (issue #3480)
         expect(await response.text()).not.toContain(oAuth2IdentityProvider.clientSecret);
+    });
+
+    it('should not read resource without a provider permission', async () => {
+        const client = await createIdentity();
+
+        // the record read is the surface that carries the provider's extra
+        // attributes, so the permission check must decide it - the middleware
+        // alone only answers the anonymous case (issue #3480)
+        await expectClientError(
+            () => client.identityProvider.getOne(oAuth2IdentityProvider.id!),
+            { status: 403 },
+        );
+    });
+
+    it('should not read a resource of another realm', async () => {
+        const { data: realm } = await suite.client.realm.create(createFakeRealm());
+        const client = await createIdentity({
+            realmId: realm.id,
+            permissionNames: [PermissionName.IDENTITY_PROVIDER_READ],
+        });
+
+        // holds the permission, but its default `own` realm reach cannot
+        // reach the master-realm provider
+        await expectClientError(
+            () => client.identityProvider.getOne(oAuth2IdentityProvider.id!),
+            { status: 403 },
+        );
+    });
+
+    it('should not carry extra attributes on the anonymous collection', async () => {
+        const response = await httpRequest(
+            suite,
+            'GET',
+            `/identity-providers?filter[id]=${oAuth2IdentityProvider.id!}`,
+        );
+
+        expect(response.status).toEqual(200);
+
+        // the documented anonymous substitute for the gated record read: it
+        // stays safe only while findMany does not extend with extra attributes
+        const body = await response.text();
+        expect(body).toContain(oAuth2IdentityProvider.id!);
+        expect(body).not.toContain(oAuth2IdentityProvider.clientSecret);
     });
 
     it('should update resource', async () => {

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -48,6 +48,31 @@ This only changes behavior for a deployment that sets `rootPath` to something
 other than the working directory **and** gives `writableDirectoryPath` a
 relative value. Absolute values, and the default, are unaffected.
 
+### `GET /identity-providers/:id` now requires authentication
+
+The endpoint was anonymous. It now requires an identity holding one of
+`IDENTITY_PROVIDER_READ`, `IDENTITY_PROVIDER_UPDATE` or
+`IDENTITY_PROVIDER_DELETE` for that provider's realm. A request without a
+token answers `401`; an authenticated caller lacking the permission answers
+`403` with code `permission_evaluation_failed`.
+
+The record read carries the provider's extra attributes, which for an OAuth2
+provider include `clientSecret` and for an LDAP provider the bind password.
+The previous behavior handed those to anyone who knew a provider id.
+
+**Action required only if you read a single provider without a token.** The
+collection stays anonymous, because the hosted login page lists providers
+before anyone signs in, and it never carries the extra attributes. Read the
+one provider from it instead:
+
+```
+GET /identity-providers?filter[id]=<provider-id>
+GET /identity-providers?filter[name]=<provider-name>
+```
+
+Both key forms the record route accepted are filterable, so a caller
+addressing a provider by name has a substitute too.
+
 ## v1.0.0-beta.62
 
 ### `auth_identity_provider_accounts` gains a unique constraint

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -65,7 +65,7 @@ collection stays anonymous, because the hosted login page lists providers
 before anyone signs in, and it never carries the extra attributes. Read the
 one provider from it instead:
 
-```
+```http
 GET /identity-providers?filter[id]=<provider-id>
 GET /identity-providers?filter[name]=<provider-name>
 ```


### PR DESCRIPTION
Closes #3480.

## The leak

`GET /identity-providers/:id` was anonymous and returned the provider's extra attributes, which carry the OAuth2 `clientSecret` and the LDAP bind password. Three things lined up, and only one of them mattered:

- **the swallowed check (the actual bug)** — the route's `IDENTITY_PROVIDER_READ` evaluation sat inside `catch { // do nothing }`, so the permission decided nothing;
- the missing `ForceLoggedInMiddleware` — real, but cosmetic on its own: an anonymous actor holds no grants and is denied once the check is enforced;
- the ungated EA splice — deliberately left alone. `findOneById` is the same call the federated login path uses, and it genuinely needs `clientSecret`/`tokenUrl`. Making the splice conditional needs a second port method and buys nothing once the route is gated.

Enforcing the check also activates its `REALM_MATCH` term, which is what stops a realm admin reading another realm's provider: on the flat mount `getRequestRealmID(event)` is `undefined`, so `findOneByName(name, undefined)` matches any realm's row by guessed name.

`evaluateOneOf` over READ|UPDATE|DELETE mirrors `UserService.getOne`, so a realm admin holding only UPDATE can still open the admin edit page.

## The collection stays anonymous

The hosted login page lists a realm's providers before anyone signs in. That is safe because `findMany` does not EA-extend, unlike `findOneById`/`findOneByName`/`findByProtocol`, so it ships the schema's `fields.default` projection alone. An anonymous caller wanting a single provider reads it from the collection: `?filter[id]=<uuid>` or `?filter[name]=<name>`, both filterable and index-leading, same 9 columns.

Nothing in-repo used the record route anonymously. Its only caller is the admin console edit page, already logged-in and permission-gated. `getAuthorizeUri()` builds its URL locally with no request.

## Two sibling egress paths for the same value

The record route was one of three places the attribute value escaped, so the other two are closed here rather than filed separately:

- **`auth_events` recorded a rotated `clientSecret` in plaintext**, default-on, readable by any `EVENT_READ` holder. `buildEntityDiff` denylists by key *name*, and an attribute row's payload column is generically called `value`, so no regex over that name can decide what it holds. Updates to the four `*_attributes` types now record no diff at all. Fail-closed, rather than widening a regex that structurally cannot see the key.
- **the identity provider attribute subscriber shipped the row verbatim** to redis and socket consumers. It now nulls `value` on both the current and the previous payload. (Only the strip. A realm-namespaced destination was tried and reverted: `buildEntityDestinations` always keeps the global destination, so adding one only widens delivery and closes nothing.)

Also drops a dead per-row permission loop in the collection handler that evaluated a verdict and discarded it.

## Verification

- `2330 passed (203 files)`, lint and `check:types` clean.
- The new cases were each confirmed to **fail without their fix**: source reverted, re-ran, 6 failures; restored, green.
- A full-suite run showed 8 failures at one point, all `requiredAmr`/`requiredAcr` assertions. The cause was a stale `packages/core-kit/dist` predating #3479, not this branch. Rebuilding core-kit turned the suite fully green.

## Deliberately not in scope

`GET /users` splices every `auth_user_attributes` row onto the user record under `USER_READ`, while `/user-attributes` gates foreign rows behind `USER_UPDATE`. That asymmetry is real, but it is a permission-model decision rather than a credential leak, and it can be resolved in either direction (strip attributes from the user record, or let `USER_READ` list them). It does not belong in a security fix that changes a public response shape. Worth its own issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Protected individual identity-provider details behind authentication and appropriate permissions.
  * Prevented sensitive provider secrets and attribute values from appearing in API and realtime event data.
  * Anonymous collection queries remain available with safe default fields.

* **Documentation**
  * Documented the updated access requirements, error responses, and migration guidance for identity-provider lookups.

* **Bug Fixes**
  * Prevented audit diffs from exposing opaque attribute values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->