### PR TITLE
fix(client-account-console): scope console session cookies to the deployment base path

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1350,6 +1350,21 @@ choice"):
   `hydrationStore` — nothing to hand off), `vc-locale`/`vc-color-mode`
   cookie continuity with the auth pages, own `NuxtIconBundle` scan
   (app src + kit src + vuecs icon preset).
+- **Session cookies are scoped to the deployment base path** (issue
+  #3495): both authup surfaces on the IdP origin — this console and the
+  hosted auth pages — pass the kit `cookiePath` derived from the sub-path
+  authup is served under (`resolveCookiePath` in `src/config.ts` over a
+  same-origin `apiUrl`; the auth console derives the same value from its
+  payload baseURL). Root-scoped cookies collided with a host application
+  that embeds authup under its own origin (e.g. hub at `/` with authup at
+  `/auth`) and itself uses the kit's cookie names: each side hydrated,
+  rotated, cleanup-revoked and clobbered the other's tokens, and two apps
+  presenting one shared refresh token tripped the strict rotation's replay
+  detection — family revocation killed every session on the origin within
+  seconds of an account-console login. A path-less `publicUrl` and a
+  cross-origin (standalone) `apiUrl` keep `/`, so nothing changes for
+  root deployments; the two consoles still share one session because both
+  scope to the same base path.
 - **Feature flag `accountConsoleEnabled`** (env `ACCOUNT_CONSOLE_ENABLED`,
   default `true`): rides `StatusResponseFeatures.accountConsole`
   (`buildUIFeatures` → status endpoint + the injected config); disabled →
@@ -2247,7 +2262,12 @@ variables always beat file values.
 **Unsupported:** sharing one `COOKIE_DOMAIN` between client-admin-console and the
 hosted auth pages — both surfaces embed the kit store under identical cookie
 names, so a widened cookie domain has the two apps clobbering each other's
-session cookies.
+session cookies. The same-ORIGIN variant of this collision — a host
+application at `/` embedding authup under a sub-path — is defused by the
+consoles scoping their cookies to the base path (see *Account Console →
+Session cookies are scoped to the deployment base path*); the residual
+corner is a console visit finding no own cookies while the host app's
+root-path records exist, which the console still hydrates.
 
 ## Authorize Realm Binding (plan 041)
 

--- a/apps/client-account-console/src/config.ts
+++ b/apps/client-account-console/src/config.ts
@@ -5,6 +5,8 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { getURLBasePath } from '@authup/kit';
+
 export type AccountConsoleConfigInput = {
     /**
      * Public URL of the authup server (server-core). Optional: when absent,
@@ -40,6 +42,13 @@ export type AccountConsoleConfigInput = {
 export type AccountConsoleConfig = {
     apiUrl: string,
     basePath: string,
+    /**
+     * Path the kit store scopes its session cookies to. The authup surfaces
+     * on an origin (the hosted auth pages and this console) share one
+     * session, so the scope is the sub-path authup is served under — derived
+     * from a same-origin `apiUrl`. See {@link resolveCookiePath}.
+     */
+    cookiePath: string,
     enabled: boolean,
     ref?: string,
 };
@@ -70,14 +79,14 @@ export function resolveAccountConsoleConfig(
         {};
 
     const basePath = normalizeBasePath(injected.basePath ?? '/account');
+    const origin = location?.origin ??
+        (typeof window !== 'undefined' ? window.location.origin : '');
 
     let { apiUrl } = injected;
     if (!apiUrl && typeof import.meta.env !== 'undefined') {
         apiUrl = import.meta.env.VITE_API_URL;
     }
     if (!apiUrl) {
-        const origin = location?.origin ??
-            (typeof window !== 'undefined' ? window.location.origin : '');
         const prefix = basePath.endsWith('/account') ?
             basePath.slice(0, -'/account'.length) :
             '';
@@ -85,12 +94,46 @@ export function resolveAccountConsoleConfig(
         apiUrl = `${origin}${prefix}`;
     }
 
+    apiUrl = apiUrl.replace(/\/+$/, '');
+
     return {
-        apiUrl: apiUrl.replace(/\/+$/, ''),
+        apiUrl,
         basePath,
+        cookiePath: resolveCookiePath(apiUrl, origin),
         enabled: injected.features?.accountConsole !== false,
         ref: injected.ref,
     };
+}
+
+/**
+ * The path the kit store's session cookies are scoped to.
+ *
+ * The hosted auth pages and the account console share one session on the
+ * IdP origin, so the scope is the sub-path authup is publicly served under
+ * (the pathname of a same-origin `apiUrl`) — the same value the auth
+ * console derives from its payload's baseURL. Root-scoped cookies would
+ * share their records with a host application at `/` that embeds authup
+ * under a sub-path and itself uses the kit's cookie names: each side then
+ * hydrates, rotates and revokes the other's tokens, and the strict refresh
+ * rotation escalates the shared refresh token into family revocation.
+ *
+ * A cross-origin `apiUrl` (standalone hosting) says nothing about this
+ * origin's layout, so it keeps the root path — the pre-existing behavior.
+ */
+function resolveCookiePath(apiUrl: string, origin: string) : string {
+    if (!origin) {
+        return '/';
+    }
+
+    try {
+        if (new URL(apiUrl).origin !== origin) {
+            return '/';
+        }
+    } catch {
+        return '/';
+    }
+
+    return getURLBasePath(apiUrl) || '/';
 }
 
 function normalizeBasePath(input: string) : string {

--- a/apps/client-account-console/src/main.ts
+++ b/apps/client-account-console/src/main.ts
@@ -217,6 +217,11 @@ install(app, {
     baseURL: config.apiUrl,
     pinia,
     translatorLocale: matchLocale(localeHandles.resolved.value),
+    // Scope the session cookies to the sub-path authup is served under
+    // (shared with the hosted auth pages — one session per deployment).
+    // Root-scoped cookies collide with a same-origin host application that
+    // uses the kit's cookie names; see resolveCookiePath in ./config.ts.
+    cookiePath: config.cookiePath,
 });
 
 // One-way: ilingo (authup catalogs) follows vuecs's resolved locale.

--- a/apps/client-account-console/test/unit/config.spec.ts
+++ b/apps/client-account-console/test/unit/config.spec.ts
@@ -48,4 +48,47 @@ describe('src/config', () => {
         expect(config.apiUrl).toEqual('https://example.com');
         expect(config.basePath).toEqual('/self-service');
     });
+
+    // The session cookies are shared with the hosted auth pages, so their
+    // scope is the sub-path authup is served under — never the root of an
+    // origin a host application may occupy with the same cookie names.
+    it('should scope the cookie path to a same-origin sub-path deployment', () => {
+        const config = resolveAccountConsoleConfig(
+            {
+                apiUrl: 'https://app.example.com/auth',
+                basePath: '/auth/account',
+            },
+            { origin: 'https://app.example.com' },
+        );
+
+        expect(config.cookiePath).toEqual('/auth');
+    });
+
+    it('should keep the root cookie path for a root deployment', () => {
+        const config = resolveAccountConsoleConfig(
+            { apiUrl: 'https://auth.example.com' },
+            { origin: 'https://auth.example.com' },
+        );
+
+        expect(config.cookiePath).toEqual('/');
+    });
+
+    it('should keep the root cookie path for a cross-origin api url', () => {
+        const config = resolveAccountConsoleConfig(
+            { apiUrl: 'https://auth.example.com/auth' },
+            { origin: 'https://static.example.com' },
+        );
+
+        expect(config.cookiePath).toEqual('/');
+    });
+
+    it('should derive the cookie path alongside a derived api url', () => {
+        const config = resolveAccountConsoleConfig(
+            { basePath: '/auth/account' },
+            { origin: 'https://app.example.com' },
+        );
+
+        expect(config.apiUrl).toEqual('https://app.example.com/auth');
+        expect(config.cookiePath).toEqual('/auth');
+    });
 });

--- a/apps/client-auth-console/src/app.ts
+++ b/apps/client-auth-console/src/app.ts
@@ -156,6 +156,14 @@ export function createApp(payload: HydrationPayload, options: CreateAppOptions =
         pinia,
         translatorLocale: matchLocale(localeHandles.resolved.value),
         isServer: !isClient,
+        // Scope the session cookies to the sub-path authup is served under.
+        // On a shared origin (a host application at `/` embedding authup at
+        // e.g. `/auth`), the default root path would put them into the same
+        // cookie records a host app using the kit reads and writes: each side
+        // then hydrates, rotates and revokes the other's tokens, and the
+        // strict refresh rotation escalates the shared refresh token into
+        // family revocation. A path-less baseURL keeps the root path.
+        cookiePath: basePath || '/',
         hydrationStore: {
             get: <T>(key: string) => hydration[key] as T | undefined,
             set: (key: string, value: unknown) => {


### PR DESCRIPTION
Closes #3495.

## Problem

On a same-origin sub-path deployment (host application at `/`, authup at `/auth` - the hub topology), the auth console and the account console wrote their session cookies at `path=/` under the same names the host application's own kit install uses. The applications hydrated, rotated, cleanup-revoked and clobbered each other's tokens, and two applications presenting one shared refresh token tripped the strict rotation's replay detection: `revokeFamily` killed every session on the origin within seconds of an account-console login. Observable as the reported bug: account console login succeeds (chooser -> overview), the first tab navigation 401s, the console logs out, and the single-realm auto-select bounces back to the auth console. Full evidence chain (cookie records, event log with `refreshReplayDetected` 565ms after the consent, server verdicts on the fresh token pair) in #3495.

## Change

Both consoles now pass the kit's `cookiePath` install option (in place since #3384, previously unused) scoped to the sub-path authup is served under:

- `apps/client-auth-console/src/app.ts` - `cookiePath: basePath || '/'` from the payload baseURL (the value the router base already derives).
- `apps/client-account-console/src/config.ts` - new derived `cookiePath` config field (`resolveCookiePath`): the pathname of a **same-origin** `apiUrl`, `/` otherwise; `src/main.ts` passes it to `install()`.

Consequences:

- The console records are invisible to a host application at `/` (path `/auth` is not sent there), and they deterministically shadow the host's root-path records for console reads (longer path is listed first).
- The auth console and the account console keep sharing one session - both derive the same scope.
- Root deployments (`publicUrl` without a pathname) and standalone hosting (cross-origin `apiUrl`) resolve to `/`: behavior unchanged.
- The kit's shadowing sweep already respects a non-root `cookiePath` (paths between the scope and the document), pinned by the existing `install-cookies.spec.ts` host-declared-path case; no kit change needed.

## Not addressed (follow-up, discussed in #3495)

A console visit that finds no own cookies still hydrates a same-origin host application's root-path records - the names are indistinguishable from `document.cookie` - and a subsequent console login's `cleanup()` then revokes what it hydrated. Fully separating the surfaces needs per-surface cookie names or the plan-063 server-side session cookie; that is a design decision beyond this fix.

## Verification

- Reproduced the failure end to end on the hub preview (`hub-pr-182.preview.privateaim.dev`, authup `1.0.0-beta.63`) and traced it to the shared-cookie replay revocation (#3495).
- New `config.spec.ts` cases pin the `cookiePath` derivation (sub-path same-origin, root, cross-origin, derived-apiUrl).
- `npm run build` (all 24 projects), kit suite (236 tests), account console suite (24), auth console suite (4) all pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session cookies are now scoped to the deployment path, preventing conflicts when Authup is hosted under a sub-path alongside another application.
  * Root deployments and cross-origin configurations continue using the existing root cookie scope.
  * Account and hosted authentication consoles now share sessions correctly within the same deployment path.

* **Documentation**
  * Updated deployment guidance to clarify supported cookie-scoping scenarios and remaining limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->