### PR TITLE
fix(server-core)!: read the CLI meta from the package, refuse stray positionals on start/worker

### DIFF
--- a/apps/server-core/src/cli/config.ts
+++ b/apps/server-core/src/cli/config.ts
@@ -14,12 +14,10 @@ export const CLI_CONFIG_ARGS = {
     configDirectory: {
         type: 'string',
         description: 'Config directory path',
-        alias: 'cD',
     },
     configFile: {
         type: 'string',
         description: 'Name of one or more configuration files.',
-        alias: 'cF',
     },
 } satisfies ArgsDef;
 

--- a/apps/server-core/src/cli/module.ts
+++ b/apps/server-core/src/cli/module.ts
@@ -5,11 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { ParsedArgs } from 'citty';
 import { defineCommand } from 'citty';
 import fs from 'node:fs';
 import path from 'node:path';
-import process from 'node:process';
 import type { ConfigReadFsOptions } from '../app/index.ts';
+import { PACKAGE_PATH } from '../path.ts';
 import { CLI_CONFIG_ARGS, applyCLIConfigArgs } from './config.ts';
 import {
     defineCLIHealthCheckCommand,
@@ -18,9 +19,21 @@ import {
     defineCLIWorkerCommand,
 } from './commands/index.ts';
 
+const CLI_COMMANDS_WITHOUT_POSITIONALS = new Set(['start', 'worker']);
+
+export function assertNoStrayPositionals(args: Pick<ParsedArgs, '_'>) : void {
+    const [command, ...rest] = args._;
+
+    if (!command || !CLI_COMMANDS_WITHOUT_POSITIONALS.has(command) || rest.length === 0) {
+        return;
+    }
+
+    throw new Error(`Unexpected argument "${rest[0]}" for command "${command}".`);
+}
+
 export async function createCLIEntryPointCommand() {
     const pkgRaw = await fs.promises.readFile(
-        path.join(process.cwd(), 'package.json'),
+        path.join(PACKAGE_PATH, 'package.json'),
         { encoding: 'utf8' },
     );
     const pkg = JSON.parse(pkgRaw);
@@ -41,6 +54,7 @@ export async function createCLIEntryPointCommand() {
         },
         args: CLI_CONFIG_ARGS,
         setup(context) {
+            assertNoStrayPositionals(context.args);
             applyCLIConfigArgs(configFs, context.args);
         },
     });

--- a/apps/server-core/test/unit/cli/index.spec.ts
+++ b/apps/server-core/test/unit/cli/index.spec.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { execFile } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { promisify } from 'node:util';
+import {
+    afterEach,
+    beforeEach,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { DIST_PATH } from '../../../src/path';
+
+const execFileAsync = promisify(execFile);
+
+describe('src/cli/index', () => {
+    let directory : string;
+
+    beforeEach(async () => {
+        directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'authup-cli-'));
+    });
+
+    afterEach(async () => {
+        await fs.promises.rm(directory, { recursive: true, force: true });
+    });
+
+    it('should print the usage from a directory without a package.json', async () => {
+        const { stdout } = await execFileAsync(
+            process.execPath,
+            [path.join(DIST_PATH, 'cli', 'index.mjs'), '--help'],
+            {
+                cwd: directory,
+                env: { ...process.env, NO_COLOR: '1' },
+            },
+        );
+
+        expect(stdout).toContain('@authup/server-core');
+        expect(stdout).toContain('USAGE');
+    }, 30_000);
+});

--- a/apps/server-core/test/unit/cli/module.spec.ts
+++ b/apps/server-core/test/unit/cli/module.spec.ts
@@ -7,8 +7,15 @@
 
 import { parseArgs, runCommand } from 'citty';
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it } from 'vitest';
+import process from 'node:process';
+import {
+    describe,
+    expect,
+    it,
+    vi,
+} from 'vitest';
 import { CLI_CONFIG_ARGS } from '../../../src/cli/config';
 import { assertNoStrayPositionals, createCLIEntryPointCommand } from '../../../src/cli/module';
 import { PACKAGE_PATH } from '../../../src/path';
@@ -35,16 +42,24 @@ describe('src/cli/module', () => {
             { encoding: 'utf8' },
         ));
 
-        const command = await createCLIEntryPointCommand();
-        const meta = await (typeof command.meta === 'function' ?
-            command.meta() :
-            command.meta);
+        const directory = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'authup-cli-'));
+        const cwd = vi.spyOn(process, 'cwd').mockReturnValue(directory);
 
-        expect(meta).toEqual({
-            name: '@authup/server-core',
-            version: pkg.version,
-            description: pkg.description,
-        });
+        try {
+            const command = await createCLIEntryPointCommand();
+            const meta = await (typeof command.meta === 'function' ?
+                command.meta() :
+                command.meta);
+
+            expect(meta).toEqual({
+                name: '@authup/server-core',
+                version: pkg.version,
+                description: pkg.description,
+            });
+        } finally {
+            cwd.mockRestore();
+            await fs.promises.rm(directory, { recursive: true, force: true });
+        }
     });
 
     describe('assertNoStrayPositionals', () => {

--- a/apps/server-core/test/unit/cli/module.spec.ts
+++ b/apps/server-core/test/unit/cli/module.spec.ts
@@ -5,8 +5,13 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { parseArgs, runCommand } from 'citty';
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { createCLIEntryPointCommand } from '../../../src/cli/module';
+import { CLI_CONFIG_ARGS } from '../../../src/cli/config';
+import { assertNoStrayPositionals, createCLIEntryPointCommand } from '../../../src/cli/module';
+import { PACKAGE_PATH } from '../../../src/path';
 
 describe('src/cli/module', () => {
     it('should register the worker subcommand', async () => {
@@ -22,5 +27,90 @@ describe('src/cli/module', () => {
             'start',
             'worker',
         ]);
+    });
+
+    it('should read the command meta from the package, not the cwd', async () => {
+        const pkg = JSON.parse(await fs.promises.readFile(
+            path.join(PACKAGE_PATH, 'package.json'),
+            { encoding: 'utf8' },
+        ));
+
+        const command = await createCLIEntryPointCommand();
+        const meta = await (typeof command.meta === 'function' ?
+            command.meta() :
+            command.meta);
+
+        expect(meta).toEqual({
+            name: '@authup/server-core',
+            version: pkg.version,
+            description: pkg.description,
+        });
+    });
+
+    describe('assertNoStrayPositionals', () => {
+        it('should refuse a stray positional on start', () => {
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['start', 'client.admin-console'],
+                CLI_CONFIG_ARGS,
+            ))).toThrow('Unexpected argument "client.admin-console" for command "start".');
+        });
+
+        it('should refuse a stray positional on worker', () => {
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['worker', 'client.admin-console'],
+                CLI_CONFIG_ARGS,
+            ))).toThrow('Unexpected argument "client.admin-console" for command "worker".');
+        });
+
+        it('should accept the space form of the config flags on start', () => {
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['start', '--configDirectory', '/etc/authup'],
+                CLI_CONFIG_ARGS,
+            ))).not.toThrow();
+
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['start', '--configFile', 'authup.conf'],
+                CLI_CONFIG_ARGS,
+            ))).not.toThrow();
+        });
+
+        it('should accept the equals form of the config flags on worker', () => {
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['worker', '--configDirectory=/etc/authup'],
+                CLI_CONFIG_ARGS,
+            ))).not.toThrow();
+        });
+
+        it('should keep the migration operation positional', () => {
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['migration', 'status'],
+                CLI_CONFIG_ARGS,
+            ))).not.toThrow();
+
+            expect(() => assertNoStrayPositionals(parseArgs(
+                ['migration', 'run', '--configDirectory', '/etc/authup'],
+                CLI_CONFIG_ARGS,
+            ))).not.toThrow();
+        });
+
+        it('should ignore a bare invocation', () => {
+            expect(() => assertNoStrayPositionals(parseArgs([], CLI_CONFIG_ARGS))).not.toThrow();
+        });
+    });
+
+    it('should refuse a stray positional on start before the subcommand runs', async () => {
+        const command = await createCLIEntryPointCommand();
+
+        await expect(runCommand(command, { rawArgs: ['start', 'client.admin-console'] }))
+            .rejects
+            .toThrow('Unexpected argument "client.admin-console" for command "start".');
+    });
+
+    it('should refuse a stray positional on worker before the subcommand runs', async () => {
+        const command = await createCLIEntryPointCommand();
+
+        await expect(runCommand(command, { rawArgs: ['worker', 'client.admin-console'] }))
+            .rejects
+            .toThrow('Unexpected argument "client.admin-console" for command "worker".');
     });
 });

--- a/docs/src/guide/deployment/configuration.md
+++ b/docs/src/guide/deployment/configuration.md
@@ -20,8 +20,8 @@ Configuration files are discovered in the **current working directory** of the p
 Every CLI command (`start`, `migration`, `healthcheck`) honors them, and the lookup
 can be redirected with two global CLI flags:
 
-- `--configDirectory <path>` (alias `-cD`) — directory to search instead of the cwd.
-- `--configFile <path>` (alias `-cF`) — load one (or more) explicit file(s) instead of discovering.
+- `--configDirectory <path>`: directory to search instead of the cwd.
+- `--configFile <path>`: load one (or more) explicit file(s) instead of discovering.
 
 Two file naming styles are supported (formats: `.conf`, `.json`, `.yml`/`.yaml`, `.js`, `.ts`):
 


### PR DESCRIPTION
## Summary

- `createCLIEntryPointCommand` read `process.cwd()/package.json` for citty's meta, so `authup-server --help` (and the quick start `npx authup start` in a fresh directory) died with ENOENT in any directory without one. It now reads `PACKAGE_PATH/package.json`.
- citty 0.2.2 never throws on undeclared positionals, so `authup-server start client.admin-console` (a leftover launcher selector) booted a server. The root command's `setup` now refuses a stray positional on `start` and `worker` and exits 1 having started nothing. The guard lives on the root command on purpose: citty re-parses the subcommand tail against the subcommand's own (empty) arg list, so the documented space form `start --configDirectory <path>` lands `<path>` in the subcommand's `_` while the root's `_` is `['start']`. `migration` keeps its required positional.
- The `-cD` / `-cF` aliases are dropped from `CLI_CONFIG_ARGS` and the docs: citty parses a two-character short alias as `-c -D`, so the documented spelling never set anything (the undocumented `--cD` / `--cF` did, and is gone too).

First step of plan 099 (console mounts / launcher retirement / console role).

## Breaking

`authup-server start|worker` refuse positional arguments; the undocumented `--cD` / `--cF` spellings are removed. Use `--configDirectory` / `--configFile`.

## Test plan

- `apps/server-core/test/unit/cli/module.spec.ts`: meta pinned to `@authup/server-core`; the guard fed by citty's real root parse (`start client.admin-console` / `worker x` refused; `start --configDirectory <path>` space form, `--configFile`, `migration status`, `migration run --configDirectory ...` accepted); end-to-end `runCommand` rejections for `start` and `worker`.
- `apps/server-core/test/unit/cli/index.spec.ts`: spawns `node dist/cli/index.mjs --help` from an empty temp dir, expects exit 0 + usage.
- `npm run test -w apps/server-core -- test/unit/cli`: 3 files, 16 tests pass; `check:types`, build and eslint clean.
- Manual from `mktemp -d`: `--help` exit 0; `start client.admin-console` exit 1 with `Unexpected argument "client.admin-console" for command "start".`, nothing listening on 3001.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The CLI now rejects unexpected positional arguments for `start` and `worker` commands.
  - CLI metadata is loaded correctly regardless of the current working directory.
  - Configuration options now consistently use their full names: `--configDirectory` and `--configFile`.

- **Documentation**
  - Updated deployment configuration guidance to reflect the removal of short option aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->