### PR TITLE
feat(server-core,core-http-kit): authorize info endpoint

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -771,7 +771,15 @@ into it):
   parameter leading back to the page.
   The trimmed anonymous DTOs (`ClientSummary`, `RealmSummary`) moved from
   local `Pick` aliases in the controller into `@authup/core-http-kit`, since
-  a second consumer now types against them.
+  a second consumer now types against them. `error` is `AuthorizeInfoError`
+  and deliberately NOT `Error`: the value is `sanitizeError`'s own
+  attributes plus `message`, so an `instanceof Error` check against it is
+  always false and `name` / `stack` are absent. `code` is the discriminator
+  a renderer branches on, which is why it is declared rather than left to
+  the index signature. Note the client side still declares this one `Error`
+  (`authorize.vue`, the kit's `Authorize.vue`), as it does `client: Client`
+  against the five-field summary: both are casts over an untyped payload,
+  so nothing type-checks across the boundary and neither was swept here.
 - **Template splicing goes through `replaceTemplateMarker`** (never a bare
   `String.prototype.replace` with a string replacement). A string
   replacement expands `$&`, `` $` ``, `$'` and `$$` **in the replacement

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -752,6 +752,26 @@ into it):
   console shares (Nuxt's `__NUXT__` model; each console is its own
   document, so the shapes never coexist — the account console injects its
   runtime config under the same name).
+- **`GET /authorize/info` answers that page's render input as JSON**
+  (`AuthorizeInfo` in `@authup/core-http-kit`, `client.authorize.getInfo()`;
+  plan 101 D2-1). `AuthorizeController.buildAuthorizeInfo(event)` is the ONE
+  producer, so the page and the endpoint cannot report different things:
+  `serve()` is now nothing but the render around it, and a spec asserts the
+  two answers are equal for one query. It is anonymous and
+  `Cache-Control: no-store` like the page GET, takes the page's own query
+  (`provider` and the closed `error` marker set included, since the answer
+  is derived from all of it), and a REFUSED request is a 200 carrying the
+  refusal under `error` rather than an error status. The page renders a
+  refusal, so a caller must be able to as well. The shape is deliberately
+  the complete `payload.data`, `federatedLogin` included, so the SSR
+  service D2-2 puts in front of it needs no contract bump;
+  `config.baseURL` is the only other render input and is that service's own
+  api url. `requestPath` is anchored on `/authorize` rather than on the
+  route that was called, because the page renders it as the `redirect`
+  parameter leading back to the page.
+  The trimmed anonymous DTOs (`ClientSummary`, `RealmSummary`) moved from
+  local `Pick` aliases in the controller into `@authup/core-http-kit`, since
+  a second consumer now types against them.
 - **Template splicing goes through `replaceTemplateMarker`** (never a bare
   `String.prototype.replace` with a string replacement). A string
   replacement expands `$&`, `` $` ``, `$'` and `$$` **in the replacement

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
@@ -17,11 +17,14 @@ import type { IAppEvent } from 'routup';
 import { isUUID } from '@authup/kit';
 import { useRequestQuery } from '@routup/basic/query';
 import type {
-    Client,
     OAuth2AuthorizationCodeRequest,
-    Realm,
     Scope,
 } from '@authup/core-kit';
+import type {
+    AuthorizeInfo,
+    ClientSummary,
+    RealmSummary,
+} from '@authup/core-http-kit';
 import {
     OAuth2AccessDeniedError,
     OAuth2ErrorCode,
@@ -36,9 +39,6 @@ import type { IOAuth2AuthorizationCodeRequestVerifier } from '../../../../../cor
 import { OAuth2AuthorizationCodeRequestValidator } from '../../../../../core/index.ts';
 import type { AuthorizeControllerContext, AuthorizeControllerOptions } from './types.ts';
 import { sanitizeError } from '../../../../../utils/index.ts';
-
-type RealmSummary = Pick<Realm, 'id' | 'name' | 'displayName'>;
-type ClientSummary = Pick<Client, 'id' | 'name' | 'displayName' | 'builtIn' | 'createdAt'>;
 
 @DController('/authorize')
 export class AuthorizeController {
@@ -114,8 +114,35 @@ export class AuthorizeController {
         }
     }
 
+    /**
+     * The page's render input as JSON, for a renderer that is not this
+     * process (plan 101 D2). Anonymous like the page GET, and answering
+     * the same query: a refused request is a 200 carrying the refusal,
+     * never an error status, so the caller renders what the page renders.
+     */
+    @DGet('/info', [])
+    async info(@DContext() event: IAppEvent): Promise<AuthorizeInfo> {
+        // The page inherits this from applyUIPageHeaders. A login context
+        // is per-request and must never be served from a cache.
+        event.response.headers.set('cache-control', 'no-store');
+
+        return this.buildAuthorizeInfo(event);
+    }
+
     @DGet('', [])
     async serve(@DContext() event: IAppEvent): Promise<string> {
+        return renderAuthConsolePage(event, {
+            url: '/authorize',
+            payload: {
+                config: { baseURL: this.options.baseURL },
+                data: await this.buildAuthorizeInfo(event),
+            },
+        });
+    }
+
+    // ---------------------------------------------------------
+
+    protected async buildAuthorizeInfo(event: IAppEvent): Promise<AuthorizeInfo> {
         let codeRequest : OAuth2AuthorizationCodeRequest | undefined;
 
         let client : ClientSummary | undefined;
@@ -211,23 +238,21 @@ export class AuthorizeController {
 
         const requestURL = new URL(event.request.url);
         requestURL.searchParams.delete('provider');
+        // Anchored on the page, never on the route that was called:
+        // `GET /authorize/info` answers the context of the same authorize
+        // request, and the value is rendered as a link back to the page.
+        requestURL.pathname = '/authorize';
 
-        return renderAuthConsolePage(event, {
-            url: '/authorize',
-            payload: {
-                config: { baseURL: this.options.baseURL },
-                data: {
-                    codeRequest,
-                    error,
-                    client,
-                    scopes,
-                    realm,
-                    redirectUriVerified,
-                    federatedLogin,
-                    features: this.options.features,
-                    requestPath: `${requestURL.pathname}${requestURL.search}`,
-                },
-            },
-        });
+        return {
+            codeRequest,
+            error,
+            client,
+            scopes,
+            realm,
+            redirectUriVerified,
+            federatedLogin,
+            features: this.options.features,
+            requestPath: `${requestURL.pathname}${requestURL.search}`,
+        };
     }
 }

--- a/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
+++ b/apps/server-core/src/adapters/http/controllers/workflows/authorize/module.ts
@@ -22,6 +22,7 @@ import type {
 } from '@authup/core-kit';
 import type {
     AuthorizeInfo,
+    AuthorizeInfoError,
     ClientSummary,
     RealmSummary,
 } from '@authup/core-http-kit';
@@ -157,7 +158,9 @@ export class AuthorizeController {
         // an unverified (pattern-less-client) redirect_uri.
         let redirectUriVerified = false;
 
-        let error : Error | undefined;
+        // A plain object, not an Error: it is spread onto the wire, where
+        // only data survives.
+        let error : AuthorizeInfoError | undefined;
 
         try {
             const merged = await readFromLocations(event, ['body', 'query']);

--- a/apps/server-core/test/unit/http/controllers/workflows/authorize-info.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/authorize-info.spec.ts
@@ -178,7 +178,12 @@ describe('src/http/controllers/workflows/authorize (info)', () => {
         const body = await response.json();
 
         expect(body.error).toBeDefined();
-        expect(body.error.message).toBeTruthy();
+        // the declared shape: a message to render and a code to branch on.
+        // It is data, never an Error, so nothing else is guaranteed.
+        expect(typeof body.error.message).toEqual('string');
+        expect(typeof body.error.code).toEqual('string');
+        expect(body.error.name).toBeUndefined();
+        expect(body.error.stack).toBeUndefined();
         expect(body.client).toBeUndefined();
         expect(body.codeRequest).toBeUndefined();
         expect(body.redirectUriVerified).toEqual(false);

--- a/apps/server-core/test/unit/http/controllers/workflows/authorize-info.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/authorize-info.spec.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import type { Client } from '@authup/core-kit';
+import { ScopeName } from '@authup/core-kit';
+import { ErrorCode } from '@authup/errors';
+import { OAuth2ErrorCode } from '@authup/specs';
+import { createFakeClient, httpRequest } from '../../../../utils';
+import { createTestApplication } from '../../../../app';
+
+/**
+ * `GET /authorize/info` answers the render input the `/authorize` page is
+ * built from, so a renderer outside this process can produce the same page
+ * (plan 101 D2). The assertions mirror the payload half of
+ * `ui-pages.spec.ts`: what the two routes report must not drift, since the
+ * page reads the very same object.
+ *
+ * The route itself renders nothing, so it needs no fake UI http client. The
+ * last case renders the page to compare the two answers, so the suite does
+ * need the built `@authup/client-auth-console` dist like every other page
+ * spec here.
+ */
+describe('src/http/controllers/workflows/authorize (info)', () => {
+    const suite = createTestApplication();
+
+    let client : Client;
+
+    beforeAll(async () => {
+        await suite.setup();
+
+        const { data: scope } = await suite.client.scope.getOne(ScopeName.GLOBAL);
+        const { data: created } = await suite.client.client.create(createFakeClient());
+        await suite.client.clientScope.create({ scopeId: scope.id, clientId: created.id });
+
+        client = created;
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    function buildQuery(extra: Record<string, string> = {}) {
+        return new URLSearchParams({
+            response_type: 'code',
+            client_id: client.id,
+            redirect_uri: 'https://example.com/redirect',
+            scope: ScopeName.GLOBAL,
+            ...extra,
+        });
+    }
+
+    function request(query: URLSearchParams) {
+        return httpRequest(suite, 'GET', `/authorize/info?${query.toString()}`);
+    }
+
+    it('should answer the render input of a valid code request', async () => {
+        const response = await request(buildQuery());
+
+        expect(response.status).toEqual(200);
+        expect(response.headers.get('content-type')).toContain('application/json');
+        // a login context, never served from a cache
+        expect(response.headers.get('cache-control')).toEqual('no-store');
+
+        const body = await response.json();
+
+        expect(body.error).toBeUndefined();
+        expect(body.codeRequest.client_id).toEqual(client.id);
+        expect(body.codeRequest.redirect_uri).toEqual('https://example.com/redirect');
+        expect(body.redirectUriVerified).toEqual(true);
+        expect(body.realm).toBeDefined();
+        expect(body.realm.id).toEqual(client.realmId);
+        expect(Array.isArray(body.scopes)).toBe(true);
+        expect(body.scopes.map((scope: { name: string }) => scope.name)).toContain(ScopeName.GLOBAL);
+        expect(body.features).toBeDefined();
+        expect(body.features.registration).toEqual(true);
+    });
+
+    it('should carry only the trimmed client summary', async () => {
+        const body = await (await request(buildQuery())).json();
+
+        expect(Object.keys(body.client).sort()).toEqual([
+            'builtIn',
+            'createdAt',
+            'displayName',
+            'id',
+            'name',
+        ]);
+
+        // the route is anonymous, so the row must never disclose the
+        // redirect_uri patterns, the grant types, the internal URLs, the
+        // authentication method or the secret storage flags
+        expect(body.client.redirectUri).toBeUndefined();
+        expect(body.client.postLogoutRedirectUri).toBeUndefined();
+        expect(body.client.grantTypes).toBeUndefined();
+        expect(body.client.baseUrl).toBeUndefined();
+        expect(body.client.rootUrl).toBeUndefined();
+        expect(body.client.authMethod).toBeUndefined();
+        expect(body.client.secret).toBeUndefined();
+        expect(body.client.secretHashed).toBeUndefined();
+        expect(body.client.accessPolicyId).toBeUndefined();
+    });
+
+    it('should require no credential', async () => {
+        // httpRequest sends no Authorization header at all, and the
+        // suite's own client is the admin one, so this is the assertion
+        // that the route is reachable by the anonymous visitor the page
+        // serves. It also answers through the typed client.
+        const anonymous = await request(buildQuery());
+        expect(anonymous.status).toEqual(200);
+
+        const typed = await suite.client.authorize.getInfo({
+            response_type: 'code',
+            client_id: client.id,
+            redirect_uri: 'https://example.com/redirect',
+            scope: ScopeName.GLOBAL,
+        });
+
+        expect(typed.client?.id).toEqual(client.id);
+        expect(typed.codeRequest?.client_id).toEqual(client.id);
+        expect(typed.redirectUriVerified).toEqual(true);
+    });
+
+    it('should forward a raw search string untouched', async () => {
+        // what a renderer in front of this endpoint hands over: the
+        // browser's own query, re-parsed by nobody
+        const query = buildQuery({ state: 'a b&c' });
+
+        const leading = await suite.client.authorize.getInfo(`?${query.toString()}`);
+        expect(leading.codeRequest?.state).toEqual('a b&c');
+        expect(leading.client?.id).toEqual(client.id);
+
+        const bare = await suite.client.authorize.getInfo(query.toString());
+        expect(bare.codeRequest?.state).toEqual('a b&c');
+    });
+
+    it('should point requestPath at the page, not at itself', async () => {
+        // The page renders it as the `redirect` parameter on its register
+        // and password links, so it has to lead back to the page.
+        const body = await (await request(buildQuery())).json();
+
+        expect(body.requestPath).toMatch(/^\/authorize\?/);
+        expect(body.requestPath).not.toContain('/authorize/info');
+        expect(body.requestPath).toContain(`client_id=${client.id}`);
+    });
+
+    it('should hand over the federated provider hint and keep it out of requestPath', async () => {
+        const PROVIDER_ID = '3f1d2c4e-7a4b-4c2e-9c8d-0b1a2c3d4e5f';
+
+        const body = await (await request(buildQuery({ provider: PROVIDER_ID }))).json();
+
+        // no secret in the answer: the pending login rides a cookie
+        expect(body.federatedLogin).toEqual({ providerId: PROVIDER_ID });
+        expect(body.requestPath).not.toContain('provider=');
+
+        // a value that is not an id never reaches the renderer
+        const injected = await (await request(buildQuery({ provider: '../token?' }))).json();
+        expect(injected.federatedLogin).toBeUndefined();
+    });
+
+    it('should answer a refused request with the refusal embedded', async () => {
+        const response = await httpRequest(suite, 'GET', '/authorize/info?response_type=code&client_id=unknown');
+
+        // the refusal is what the page renders, so it is a 200 and not an
+        // error status
+        expect(response.status).toEqual(200);
+
+        const body = await response.json();
+
+        expect(body.error).toBeDefined();
+        expect(body.error.message).toBeTruthy();
+        expect(body.client).toBeUndefined();
+        expect(body.codeRequest).toBeUndefined();
+        expect(body.redirectUriVerified).toEqual(false);
+        // the flags the renderer needs are there regardless
+        expect(body.features).toBeDefined();
+        expect(body.requestPath).toMatch(/^\/authorize\?/);
+    });
+
+    it('should map a recognized error marker and ignore any other', async () => {
+        // the federated callback bounces a disabled provider here with
+        // this marker; the text is server-side, never request-derived
+        let body = await (await request(buildQuery({ error: OAuth2ErrorCode.LOGIN_REQUIRED }))).json();
+        expect(body.error).toMatchObject({
+            code: ErrorCode.OAUTH_LOGIN_REQUIRED,
+            message: 'The identity provider is not available. Return to the application and start the login again.',
+        });
+        expect(body.client.id).toEqual(client.id);
+
+        body = await (await request(buildQuery({ error: OAuth2ErrorCode.ACCESS_DENIED }))).json();
+        expect(body.error).toMatchObject({ code: ErrorCode.OAUTH_ACCESS_DENIED });
+        expect(body.client.id).toEqual(client.id);
+
+        // the marker set is closed
+        body = await (await request(buildQuery({ error: 'whatever' }))).json();
+        expect(body.error).toBeUndefined();
+        expect(body.client.id).toEqual(client.id);
+    });
+
+    it('should report an unverified redirect_uri', async () => {
+        const body = await (await request(buildQuery({ redirect_uri: 'https://attacker.test/cb' }))).json();
+
+        // a redirect_uri matching no registered pattern is refused
+        // outright, so the renderer never offers a way back
+        expect(body.error).toBeDefined();
+        expect(body.redirectUriVerified).toEqual(false);
+    });
+
+    it('should answer the same context the page renders', async () => {
+        // the two routes read one builder; this fails if they ever stop
+        const query = buildQuery();
+
+        const info = await (await request(query)).json();
+
+        const page = await httpRequest(suite, 'GET', `/authorize?${query.toString()}`);
+        expect(page.status).toEqual(200);
+
+        const match = (await page.text()).match(/window\.__AUTHUP__ = (.+);/);
+        expect(match).toBeTruthy();
+
+        expect(JSON.parse(match![1]).data).toEqual(info);
+    });
+});

--- a/packages/core-http-kit/src/domains/workflows/oauth2/authorize/module.ts
+++ b/packages/core-http-kit/src/domains/workflows/oauth2/authorize/module.ts
@@ -8,9 +8,49 @@
 import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
 import { AuthorizeAPI } from '@hapic/oauth2';
 import { nullifyEmptyObjectProperties } from '../../../../utils';
-import type { IOAuth2AuthorizeAPI } from '../types';
+import type { AuthorizeInfo, IOAuth2AuthorizeAPI } from '../types';
 
 export class OAuth2AuthorizeAPI extends AuthorizeAPI implements IOAuth2AuthorizeAPI {
+    /**
+     * The render input of the hosted `/authorize` page, as JSON. The query
+     * is the page's own, `provider` and the `error` marker included: the
+     * answer is derived from all of it, so none of it may be dropped.
+     *
+     * Pass the raw search string to forward a browser's query untouched
+     * (what a renderer in front of this endpoint wants), or a record to
+     * build one. A record is serialized, so a value that is neither a
+     * scalar nor an array of scalars does not survive the trip.
+     *
+     * A refused request answers 200 with `error` filled, like the page.
+     */
+    async getInfo(
+        query?: string | Record<string, any>,
+    ) : Promise<AuthorizeInfo> {
+        let search : string;
+
+        if (typeof query === 'string') {
+            search = query.replace(/^\?/, '');
+        } else {
+            const params = new URLSearchParams();
+
+            const entries = Object.entries(query || {});
+            for (const [key, value] of entries) {
+                const values = Array.isArray(value) ? value : [value];
+                for (const item of values) {
+                    if (typeof item !== 'undefined' && item !== null) {
+                        params.append(key, `${item}`);
+                    }
+                }
+            }
+
+            search = params.toString();
+        }
+
+        const response = await this.client.get(`authorize/info${search ? `?${search}` : ''}`);
+
+        return response.data;
+    }
+
     async confirm(
         data: OAuth2AuthorizationCodeRequest,
     ) : Promise<{ url: string }> {

--- a/packages/core-http-kit/src/domains/workflows/oauth2/types.ts
+++ b/packages/core-http-kit/src/domains/workflows/oauth2/types.ts
@@ -79,6 +79,22 @@ export type ClientSummary = Pick<Client, 'id' | 'name' | 'displayName' | 'builtI
 export type RealmSummary = Pick<Realm, 'id' | 'name' | 'displayName'>;
 
 /**
+ * A refusal as it travels: the sanitized error's own enumerable
+ * attributes plus its `message`, which an Error does not carry as one.
+ *
+ * It is NOT an `Error`. Nothing survives the JSON trip but data, so an
+ * `instanceof Error` check against it is always false, and `name` and
+ * `stack` are absent. `code` is the discriminator to branch on; the
+ * remaining attributes are whatever the error class carries (`issues`
+ * on a validation failure, `data` on an OAuth2 one).
+ */
+export type AuthorizeInfoError = {
+    message: string,
+    code?: string,
+    [key: string]: any,
+};
+
+/**
  * The complete render input of the hosted `/authorize` page: what the
  * code-request verifier resolved, plus the feature flags and the request
  * path the page hands to its register / password-forgot links.
@@ -89,11 +105,7 @@ export type RealmSummary = Pick<Realm, 'id' | 'name' | 'displayName'>;
  */
 export type AuthorizeInfo = {
     codeRequest?: OAuth2AuthorizationCodeRequest,
-    /**
-     * The refusal, serialized: the sanitized error plus its `message`
-     * (which an Error does not carry as an enumerable own property).
-     */
-    error?: Error,
+    error?: AuthorizeInfoError,
     client?: ClientSummary,
     scopes?: Scope[],
     realm?: RealmSummary,

--- a/packages/core-http-kit/src/domains/workflows/oauth2/types.ts
+++ b/packages/core-http-kit/src/domains/workflows/oauth2/types.ts
@@ -5,7 +5,12 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { OAuth2AuthorizationCodeRequest } from '@authup/core-kit';
+import type {
+    Client,
+    OAuth2AuthorizationCodeRequest,
+    Realm,
+    Scope,
+} from '@authup/core-kit';
 import type {
     OAuth2TokenGrantResponse,
     OAuth2TokenIntrospectionResponse,
@@ -24,6 +29,7 @@ import type {
     TokenRevokeParameters,
 } from '@hapic/oauth2';
 import type { AuthorizationHeader, Response } from 'hapic';
+import type { StatusResponseFeatures } from '../status';
 
 /**
  * The OAuth2 protocol mechanics (and their parameter shapes) are owned
@@ -55,6 +61,61 @@ export type OAuth2TokenIntrospectParameters = TokenIntrospectParameters;
 export type OAuth2TokenRequestOptions = TokenBaseOptions;
 
 export type OAuth2AuthorizeParameters = Partial<AuthorizeParameters>;
+
+/**
+ * The client as an anonymous visitor may see it. `GET /authorize` and
+ * `GET /authorize/info` are both unauthenticated, so the row is trimmed
+ * to these five fields before it leaves the server: never the
+ * redirect_uri patterns (the trusted-origin set), the grant types, the
+ * internal base and root URLs, the authentication method or the secret
+ * storage flags.
+ */
+export type ClientSummary = Pick<Client, 'id' | 'name' | 'displayName' | 'builtIn' | 'createdAt'>;
+
+/**
+ * The client's realm, named so a page can render the realm-mismatch
+ * notice (`codeRequest.realm_id` carries only the id).
+ */
+export type RealmSummary = Pick<Realm, 'id' | 'name' | 'displayName'>;
+
+/**
+ * The complete render input of the hosted `/authorize` page: what the
+ * code-request verifier resolved, plus the feature flags and the request
+ * path the page hands to its register / password-forgot links.
+ *
+ * A refused request is not an error response. It answers with `error`
+ * filled and the resolved fields absent, exactly as the page renders it,
+ * so a caller renders the refusal instead of failing.
+ */
+export type AuthorizeInfo = {
+    codeRequest?: OAuth2AuthorizationCodeRequest,
+    /**
+     * The refusal, serialized: the sanitized error plus its `message`
+     * (which an Error does not carry as an enumerable own property).
+     */
+    error?: Error,
+    client?: ClientSummary,
+    scopes?: Scope[],
+    realm?: RealmSummary,
+    /**
+     * Whether the request `redirect_uri` matched a registered client
+     * pattern. False means the page must not offer a redirect back to
+     * the application.
+     */
+    redirectUriVerified: boolean,
+    /**
+     * A federated login waiting to be completed (plan 094). Only the
+     * provider is named; the pending login itself rides a cookie.
+     */
+    federatedLogin?: { providerId: string },
+    features: StatusResponseFeatures,
+    /**
+     * Path and query of the authorize request, `provider` stripped. A
+     * page carries it as the same-origin `redirect` parameter on the
+     * register / password links, so those lead back into this request.
+     */
+    requestPath: string,
+};
 
 // ------------------------------------------------------------------
 
@@ -97,6 +158,8 @@ export interface IOAuth2TokenAPI {
 
 export interface IOAuth2AuthorizeAPI {
     buildURL(parameters?: OAuth2AuthorizeParameters) : string;
+
+    getInfo(query?: string | Record<string, any>) : Promise<AuthorizeInfo>;
 
     confirm(data: OAuth2AuthorizationCodeRequest) : Promise<{ url: string }>;
 }


### PR DESCRIPTION
Plan 101 stage D2, PR 1. Additive: it adds the endpoint stage D2 is built on and changes nothing about how the `/authorize` page behaves.

## Why

The hosted `/authorize` page assembles its render input inside `AuthorizeController.serve()` and hands it straight to the in-process SSR renderer. Stage D2 moves that renderer out into `@authup/server-auth-console`, which needs the same input over HTTP. This PR exposes it and nothing else.

## What

`GET /authorize/info` answers that input as JSON.

- **One producer.** The assembly moved into `buildAuthorizeInfo(event)`, and `serve()` is now nothing but the render around it, so the page and the endpoint cannot report different things. A spec asserts the two answer equal objects for the same query, which is the guard that keeps them from drifting once a second renderer exists.
- **Anonymous and `Cache-Control: no-store`**, like the page GET. Everything it discloses, the page already discloses to the same anonymous visitor, through the same trimmed client DTO.
- **It takes the page's own query**, the `provider` hint and the closed `error` marker set included, because the answer is derived from all of it.
- **A refused request is a 200 carrying the refusal** under `error`, not an error status. A refusal is what the page renders, so a caller has to be able to render one too.

## Two things worth reviewing closely

**`requestPath` is anchored on `/authorize`, not on the route that was called.** The page renders it as the `redirect` parameter on its register and password links, so it has to lead back to the page; leaving it derived from the request path would make `/authorize/info` name itself there. For the page this changes nothing for any request whose path is already `/authorize`, and normalizes the pathological ones (a case- or slash-variant that routup still matches). Pinned by *should point requestPath at the page, not at itself*.

**The shape is deliberately the complete `payload.data`,** `federatedLogin` included, rather than the field list the plan sketched. That is the point of the endpoint: D2-2 must not need a contract bump. I checked the page reads its entire render input from the payload (its one `window.location` use is a browser-only history cleanup on mount), so `AuthorizeInfo` plus `config.baseURL`, which is the future service's own api url, is the whole of it.

`ClientSummary` and `RealmSummary` were local `Pick` aliases duplicated across three files; they move into `@authup/core-http-kit` next to the new `AuthorizeInfo` and `client.authorize.getInfo()`. The client method also accepts a raw search string, so a renderer can forward a browser query untouched instead of round-tripping it through a record.

## Verification

- Full server-core suite green: **215 files / 2508 tests** (baseline 214 / 2498, so the 10 new ones and no regression). The existing `ui-pages.spec.ts` authorize assertions are the additive-only gate and are untouched.
- `npm run build` green across the monorepo; `check:types` green for server-core.
- trapi picked the route up on its own: `/authorize/info` with a `$ref` to a generated `AuthorizeInfo` schema.
- Reviewed adversarially across four lenses with per-finding refutation; nothing survived. Two low findings were taken anyway: a wrong prerequisite claim in the suite docblock, and the raw-string form of `getInfo`.

`docs/` is deliberately untouched. `/authorize/info` is a renderer contract, not an RP endpoint, and documenting it in the OAuth2 guide would invite relying parties to build their own login UI against it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authorization information endpoint that returns authorization-page data as JSON.
  * Added client API support for retrieving authorization details using query strings or parameters.
  * Included authorization status, client and realm details, redirect verification, errors, and federated login information.
  * Authorization responses are not cached, and rendered authorization pages now use the same data source.

* **Bug Fixes**
  * Improved request-path handling and consistency between authorization JSON responses and rendered pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->