### PR TITLE
fix(client-web-kit)!: retain the introspection email on store.user

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -5638,15 +5638,55 @@ the refresh fallback. The two must not be separated.
 
 **The user is derived from the introspection, not fetched.** `postIntrospect`
 resolves the token's subject server-side and spreads its OpenID claims into the
-response (`OAuth2OpenIDClaimsBuilder`: `name`, and `displayName` under
+response (`OAuth2OpenIDClaimsBuilder`: `name`, `email`, and `displayName` under
 `nickname` / `preferred_username`), so `store.user` is built from a response the
-store already awaits. It is typed to what is rendered,
-`Pick<User, 'id' | 'name' | 'displayName'>` — the id every owner-scoped query
-filters on, plus the account chip's and the authorize page's "continue as"
-label. No consumer ever read a field outside those three; the one surface that
-needs the whole record, the account console's profile form, loads it itself —
+store already awaits. It is typed to what a consumer renders,
+`Pick<User, 'id' | 'name' | 'displayName' | 'email'>`: the id every owner-scoped
+query filters on, the account chip's and the authorize page's "continue as"
+label, and the address an avatar hash is derived from. The one surface that
+needs the whole record, the account console's profile form, loads it itself,
 from `/userinfo` rather than `/users/@me`, because `email` is `select: false`
 and therefore absent from the entity endpoint's default projection.
+
+**`email` is in the pick because dropping a claim already on the wire fails
+silently** (issue #3506). Gravatar keys an avatar on `md5(trim(lower(email)))`,
+so a consumer without the address cannot render one at all, and substituting
+any other stable string still answers 200, since the default `d=` generates a
+fallback image from whatever hash it is given: the page looks right and shows
+the wrong person. Recovering it by re-introspecting per render repeats the
+round-trip this shape exists to remove. It is not the `user` COOKIE coming
+back. That was an unbounded record (`extendOneWithEA` flattens every user
+attribute onto `/userinfo` after the projection) riding the Cookie header on
+every request to the origin, static assets included. The address is not new to
+the browser either: the id_token spreads the SAME claims
+(`OAuth2OpenIDTokenIssuer.issueWithIdentity`) and the kit persists it under
+`CookieName.ID_TOKEN`, so in bearer mode the email already rides that header,
+base64-decodable, on every same-path request. What the ref adds on the wire is
+nothing, and for a Nuxt consumer one more field in an SSR payload that already
+carries the access and refresh tokens off the same store.
+
+**`UserMinimal` is spelled in THREE places and only two of them are guarded.**
+`buildUser` returns the shape and `setUser` re-picks it again at the sink,
+deliberately (callers hand over whole entity rows, and the ref is what a Nuxt
+consumer's SSR payload carries). Both are contextually typed against the alias
+and a pure `Pick` makes every member required, so omitting a newly picked field
+at either site is a compile error, TS2741 in `buildUser` and TS2322 at the sink,
+never a silent drop. Note the guard is `build:types` alone: vitest transpiles
+through SWC, so the suite runs an un-type-checked tree and reports the omission
+as a runtime absence instead. The genuinely unguarded site is the alias ITSELF,
+declared independently in `core/store/create.ts` and
+`core/store/dispatcher/types.ts` with nothing tying the two together. Widening
+one and not the other compiles clean, and the `USER_UPDATED` payload type then
+understates what is emitted. They stay separate because both are private
+aliases, so sharing one would mean exporting it and growing the published
+surface to fix a documentation problem.
+
+The server half is droppable once per SURFACE. The claim maps from a
+`select: false` column that survives only because `UserIdentityRepository.find()`
+re-selects every one of them, and each endpoint then spreads the claims itself,
+so both spreads are pinned: `introspect.spec.ts` for `POST /token/introspect`
+and `console-session.spec.ts` for `GET /sessions/@me/introspect`, the one a
+cookie-mode console hydrates from.
 
 The claims are read through a local `SubjectClaims` shape rather than off
 `OAuth2TokenIntrospectionResponse`. Typing the response as an

--- a/apps/client-account-console/src/pages/overview.vue
+++ b/apps/client-account-console/src/pages/overview.vue
@@ -31,8 +31,8 @@ export default defineComponent({
         const { realmId } = storeToRefs(store);
 
         // The store carries only the identity the token asserts (id, name,
-        // display name), so the page loads the record whose every column this
-        // form writes. It is the one surface that needs the whole user, and it
+        // display name, email), so the page loads the record whose every
+        // column this form writes. It is the one surface that needs the whole user, and it
         // reads `/userinfo` rather than `/users/@me`: `email` is `select:false`,
         // so it is absent from the entity endpoint's default projection, and
         // the form would render an empty email box and submit a null over the

--- a/apps/server-core/test/unit/http/controllers/workflows/account/console-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/account/console-session.spec.ts
@@ -114,7 +114,8 @@ describe.each(CONSOLES)('$name console session', ({
 
     it('signs a user in and out through the opaque session credential', async () => {
         const password = 'console-session-round-trip';
-        const { data: user } = await suite.client.user.create(createFakeUser({ password }));
+        const userData = createFakeUser({ password });
+        const { data: user } = await suite.client.user.create(userData);
         const { data: realm } = await suite.client.realm.getOne('master');
 
         // 1) the kick: PKCE + state are minted server-side and parked behind
@@ -231,6 +232,11 @@ describe.each(CONSOLES)('$name console session', ({
         expect(sessionBody.sub).toEqual(user.id);
         expect(sessionBody.session_id).toBeDefined();
         expect(sessionBody.realm_id).toEqual(realm.id);
+        // the claim a console keys an avatar on (issue #3506). Cookie mode is
+        // the surface the account console runs on, and it reaches the claims
+        // through this endpoint's own `...subject.claims` spread rather than
+        // through `POST /token/introspect`.
+        expect(sessionBody.email).toEqual(userData.email);
 
         // 5) and the credential drives ordinary, identity-gated API routes —
         //    the same ones every other client reaches with a bearer.

--- a/apps/server-core/test/unit/http/controllers/workflows/token/introspect.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/introspect.spec.ts
@@ -11,7 +11,12 @@ import {
     expect,
     it,
 } from 'vitest';
-import { CLIENT_ADMIN_CONSOLE_NAME, PermissionName, REALM_MASTER_NAME } from '@authup/core-kit';
+import {
+    CLIENT_ADMIN_CONSOLE_NAME,
+    PermissionName,
+    REALM_MASTER_NAME,
+    buildUserFakeEmail,
+} from '@authup/core-kit';
 import { ClientAuthenticationHook, Client as HTTPClient } from '@authup/core-http-kit';
 import { ErrorCode } from '@authup/errors';
 import { OAuth2InjectionToken } from '../../../../../../src/app/modules/oauth2/constants';
@@ -102,6 +107,27 @@ describe('token-introspect', () => {
         expect(introspection.active).toBe(true);
         expect(Array.isArray(introspection.permissions)).toBe(true);
         expect(introspection.permissions!.length).toBeGreaterThan(0);
+    });
+
+    // The kit's `store.user` is built from these claims and nothing else, so
+    // a consumer keys its gravatar on the address this response carries
+    // (issue #3506). Nothing pinned it: the claim is mapped from a
+    // `select: false` column that only survives because the identity
+    // repository re-selects it, and both halves are silently droppable.
+    it('should carry the subject email claim for a live token', async () => {
+        const grant = await suite.client
+            .token
+            .createWithPassword({
+                username: 'admin',
+                password: 'start123',
+            });
+
+        const introspection = await suite.client
+            .token
+            .introspect({ token: grant.access_token }, { authorizationHeaderInherit: true });
+
+        expect(introspection.active).toBe(true);
+        expect(introspection.email).toEqual(buildUserFakeEmail('admin'));
     });
 
     // Without the controller deriving `active` from `exp`, this is the

--- a/docs/src/sdks/javascript/client-web-kit/session.md
+++ b/docs/src/sdks/javascript/client-web-kit/session.md
@@ -4,7 +4,8 @@ Session management is handled via `pinia`. The tokens and the active management
 realm are stored as cookies in the browser, so a server-side render can read
 them from the request. The user is not stored: `resolve()` derives it from the
 token introspection that validates the session anyway, and carries the id, name
-and display name that identify the subject.
+and display name that identify the subject, plus the email address an avatar
+hash is derived from.
 
 
 ## Login
@@ -80,7 +81,7 @@ export default defineComponent({
         console.log(store.userId); // xxxx-xxxx-...
         console.log(store.realmId); // xxxx-xxxx-...
         console.log(store.realmName); // xxx
-        console.log(store.user); // null | { id: 'xxxx-xxxx-...', name: 'xxx', displayName: 'xxx' | null }
+        console.log(store.user); // null | { id: 'xxxx-xxxx-...', name: 'xxx', displayName: 'xxx' | null, email: 'xxx' }
     }
 })
 ```

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -63,7 +63,7 @@ function createPromiseShareWrapperFn<F extends InputFn>(
 }
 
 type RealmMinimal = Pick<Realm, 'id' | 'name'>;
-type UserMinimal = Pick<User, 'id' | 'name' | 'displayName'>;
+type UserMinimal = Pick<User, 'id' | 'name' | 'displayName' | 'email'>;
 
 /**
  * The subject claims the introspection endpoint answers with, alongside the
@@ -76,6 +76,7 @@ type UserMinimal = Pick<User, 'id' | 'name' | 'displayName'>;
 type SubjectClaims = {
     name?: string | null,
     nickname?: string | null,
+    email?: string | null,
 };
 
 export function createStore(context: StoreCreateContext) {
@@ -170,11 +171,11 @@ export function createStore(context: StoreCreateContext) {
     // --------------------------------------------------------------------
 
     /**
-     * The token's subject, narrowed to what is actually rendered: the id every
-     * owner-scoped query filters on, and the name / display name the account
-     * chip and the authorize page's "continue as" label read. A full `User` was
-     * held here once, at the cost of a `/userinfo` round-trip per restore, and
-     * no consumer ever read a field outside these three.
+     * The token's subject, narrowed to what a consumer renders: the id every
+     * owner-scoped query filters on, the name / display name the account chip
+     * and the authorize page's "continue as" label read, and the address an
+     * avatar hash is derived from. A full `User` was held here once, at the
+     * cost of a `/userinfo` round-trip per restore.
      */
     const user = ref<UserMinimal | null>(null);
     const userId = computed<string | null>(() => (user.value ? user.value.id : null));
@@ -187,6 +188,7 @@ export function createStore(context: StoreCreateContext) {
             id: input.id,
             name: input.name,
             displayName: input.displayName,
+            email: input.email,
         } : null;
 
         context.dispatcher.emit(StoreDispatcherEventName.USER_UPDATED, user.value);
@@ -412,9 +414,9 @@ export function createStore(context: StoreCreateContext) {
     /**
      * The introspected token's subject, built from the response itself: the
      * introspection endpoint resolves the identity server-side and answers
-     * with its OpenID claims (`name`, and `displayName` under `nickname`), so
-     * a second `/userinfo` round-trip fetched a whole entity to restate three
-     * fields the store already had in hand.
+     * with its OpenID claims (`name`, `email`, and `displayName` under
+     * `nickname`), so a second `/userinfo` round-trip fetched a whole entity
+     * to restate fields the store already had in hand.
      *
      * Deriving it also settles the identity question the predecessor had to ask
      * separately: the held user cannot drift from the token, because it IS the
@@ -433,12 +435,17 @@ export function createStore(context: StoreCreateContext) {
             return null;
         }
 
-        const { name, nickname } = introspection as SubjectClaims;
+        const {
+            name,
+            nickname,
+            email,
+        } = introspection as SubjectClaims;
 
         return {
             id: introspection.sub,
             name: name || '',
             displayName: nickname || null,
+            email: email || '',
         };
     };
 

--- a/packages/client-web-kit/src/core/store/dispatcher/types.ts
+++ b/packages/client-web-kit/src/core/store/dispatcher/types.ts
@@ -10,7 +10,7 @@ import type { EventEmitter } from '@posva/event-emitter';
 import type { StoreDispatcherEventName } from './constants';
 
 type RealmMinimal = Pick<Realm, 'id' | 'name'>;
-type UserMinimal = Pick<User, 'id' | 'name' | 'displayName'>;
+type UserMinimal = Pick<User, 'id' | 'name' | 'displayName' | 'email'>;
 
 export type StoreDispatcherEvents = {
     [StoreDispatcherEventName.LOGGING_IN]: [],

--- a/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/install-cookies.spec.ts
@@ -30,7 +30,7 @@ const INTROSPECTION_RESPONSE = {
     active: true,
     exp: 9999999999,
     // the endpoint resolves the subject and answers with its OpenID claims —
-    // the store builds `user` out of these three
+    // the store builds `user` out of these
     sub: 'user-1',
     sub_kind: 'user',
     name: 'admin',

--- a/packages/client-web-kit/test/unit/core/store/lifecycle.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/lifecycle.spec.ts
@@ -22,7 +22,7 @@ const INTROSPECTION_RESPONSE = {
     active: true,
     exp: 9999999999,
     // the endpoint resolves the subject and answers with its OpenID claims —
-    // the store builds `user` out of these three
+    // the store builds `user` out of these
     sub: 'user-1',
     sub_kind: 'user',
     name: 'admin',

--- a/packages/client-web-kit/test/unit/core/store/revalidate.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/revalidate.spec.ts
@@ -22,6 +22,7 @@ function buildStore() {
                 sub: TOKEN_SUBJECT,
                 sub_kind: 'user',
                 name: 'admin',
+                email: 'admin@example.com',
                 session_id: 'sess-1',
                 realm_id: 'realm-1',
                 realm_name: 'master',
@@ -87,6 +88,9 @@ describe('core/store/revalidate', () => {
         expect(store.user.value).toMatchObject({
             id: TOKEN_SUBJECT,
             name: 'admin',
+            // the address a consumer keys a gravatar on: it is on the wire,
+            // and dropping it left no way to derive the hash
+            email: 'admin@example.com',
         });
     });
 

--- a/packages/client-web-kit/test/unit/core/store/status.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/status.spec.ts
@@ -63,7 +63,7 @@ const INTROSPECTION_RESPONSE = {
     active: true,
     exp: 9999999999,
     // the endpoint resolves the subject and answers with its OpenID claims —
-    // the store builds `user` out of these three
+    // the store builds `user` out of these
     sub: 'user-1',
     sub_kind: 'user',
     name: 'admin',


### PR DESCRIPTION
Closes #3506.

`store.user` is built from the token introspection, whose response already carries `email`. `buildUser` destructured only `name` and `nickname`, so the address arrived in the browser and was discarded with no accessor left for it. A consumer cannot derive a gravatar without it (gravatar keys an avatar on `md5(trim(lower(email)))`), and substituting any other stable string still answers 200, because the default `d=` generates a fallback image from whatever hash it is given: the page looks right and shows the wrong person.

### The issue's suggested edit list is incomplete

It names four edits. Applying exactly those still drops the email, because **the pick is narrowed twice**: `buildUser` reads the claim and `setUser` re-picks the fields again at the sink (`create.ts`). The field has to be added at both, or it is written into the type, read out of the response, and then silently discarded on write.

A **required** member is what forces the sink to spell the key. `email?: string` compiles unchanged and keeps the bug, which is why the field is not optional.

### Shape

`UserMinimal` stays a pure `Pick<User, 'id' | 'name' | 'displayName' | 'email'>`. The two coercion sites differ deliberately, following the rule the file already applies:

- `buildUser` coerces per field to mirror the column: `name || ''` (non-nullable), `nickname || null` (nullable), so `email || ''`. Unreachable in practice, see below.
- `setUser` passes all four through raw. There a partial entity row **is** reachable (a caller can hand over a `client.user.getOne()` row, whose `email` is `select: false` and absent from the entity endpoint's default projection), and coercing it to `''` would turn a loud throw into a silently wrong avatar, which is the failure class this PR is about.

The claim is always on the wire for a user subject: there is one production `IIdentityResolver` (the LDAP one is a bodyless stub), and `UserIdentityRepository.find()` re-selects every `select: false` column before `getOne()`.

### This does not put the address back into a cookie

What #3481 removed was an unbounded record (`extendOneWithEA` flattens every user attribute onto `/userinfo` after the projection) riding the `Cookie` header on every request to the origin, static assets included.

Worth stating plainly, because the issue's own rationale is slightly off: `store.user` is not purely in-memory for a Nuxt consumer, where `@pinia/nuxt` serializes the store into `__NUXT_DATA__`. The conclusion survives on a stronger footing. The id_token spreads the **same** claims (`OAuth2OpenIDTokenIssuer.issueWithIdentity`) and the kit persists it under `CookieName.ID_TOKEN`, so in bearer mode the email already rides that header today, base64-decodable, on every same-path request. Marginal exposure of this change is zero on the wire, and for a Nuxt consumer one more field in an SSR payload that already carries the access and refresh tokens off the same store.

### The server half was unpinned, on both surfaces

The claim maps from a `select: false` column that survives only because of that re-select loop, and each endpoint then carries its own droppable spread. Both are now asserted:

- `POST /token/introspect` (`introspect.spec.ts`)
- `GET /sessions/@me/introspect` (`console-session.spec.ts`), which is the path the account console actually hydrates from in cookie mode, and the surface most likely to render an avatar.

Each assertion was mutation-checked: commenting out `email: 'email'` in the claims builder fails only the first, and commenting out `...subject.claims` in the session controller fails only the second (on both console variants). Deleting either narrowing site in the kit fails the kit assertion.

### Notes for review

- **Possible breaking change for a downstream that CONSTRUCTS a user.** Reads are unaffected; a consumer calling the `@deprecated` `store.setUser({ id, name, displayName })` with an object literal now needs `email`. #3481, which narrowed this same type, was marked breaking. Happy to add `!` / a `BREAKING CHANGE:` trailer if you want the major bump; I left it as `fix` because the only affected surface is a deprecated setter.
- **Split recommendation** for the issue's "Related, same root cause" half (declaring the OIDC claims on `OAuth2TokenIntrospectionResponse`). Not just review surface: `JWTClaims` already declares `[key: string]: any` (`packages/specs/src/json-web-token/types.ts:24`), so `introspection.email` type-checks today and nothing is blocked, and the kit's local `SubjectClaims` exists for the null-vs-absent mismatch (a nullable column arrives as `nickname: null`, where OIDC models an absent claim as an omitted string), not for a missing declaration. Widening the response type would therefore not remove that cast. Worth its own issue, with the `sub_name` / hub silently-`undefined` story attached.
- **Unrelated, spotted while tracing the claims builder and deliberately not touched:** `OAuth2OpenIDClaimsBuilder` maps `email_verified: 'active'`, i.e. the user's account-active column stands in for email verification. Those are different facts.

### Verification

`client-web-kit` 247/247 · `introspect.spec.ts` 26/26 · `console-session.spec.ts` 16/16 · server-core token workflows 127/127 · `vue-tsc` builds of the kit, both static consoles and `client-web-nuxt` all clean · eslint clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session identity data now includes the signed-in user’s email address.
  - Token and session introspection responses expose the email claim.
  - Client-side user information preserves the email for display and related features.

- **Documentation**
  - Updated SDK and architecture documentation to reflect the expanded user information.

- **Tests**
  - Added coverage confirming email values are retained across session, token, and user-store flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->