### PR TITLE
fix(client-web-theme,client-admin-console): restore the admin console full height chain

### DIFF
--- a/apps/client-admin-console/test/unit/mount-height.spec.ts
+++ b/apps/client-admin-console/test/unit/mount-height.spec.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+// The suite runs under happy-dom, where `import.meta.url` is a browser url
+// rather than a file one, so the paths come from vitest's root instead.
+const APP_PATH = process.cwd();
+const REPOSITORY_PATH = path.join(APP_PATH, '..', '..');
+
+const html = fs.readFileSync(path.join(APP_PATH, 'index.html'), 'utf-8');
+const main = fs.readFileSync(path.join(APP_PATH, 'src', 'main.ts'), 'utf-8');
+const css = fs.readFileSync(
+    path.join(REPOSITORY_PATH, 'packages', 'client-web-theme', 'assets', 'css', 'styles', 'root.css'),
+    'utf-8',
+);
+
+const mountIds = Array.from(
+    new Set(Array.from(main.matchAll(/app\.mount\(\s*'#([\w-]+)'\s*\)/g)).map((match) => match[1])),
+);
+
+/**
+ * Selectors of every rule that sets a full height, as written.
+ */
+function fullHeightSelectors() : string[] {
+    return css
+        .split('}')
+        .filter((block) => /height\s*:\s*100%/.test(block))
+        .map((block) => block.slice(block.lastIndexOf('*/') + 1).split('{')[0]);
+}
+
+/**
+ * The console mounts on an element that has to carry html and body's 100%
+ * down to the layout. A percentage height resolves against an auto-height
+ * parent as auto, so a mount id absent from the theme's height chain
+ * collapses the shell to content height and the footer leaves the bottom of
+ * the viewport. Nothing throws and no build fails, which is exactly why it
+ * is pinned here: the console shipped that way when it moved off nuxt onto
+ * `#root` while the chain still listed only the nuxt ids and `#app`.
+ */
+describe('the mount element', () => {
+    it('reads the files it is asserting on', () => {
+        // A wrong root would leave every assertion below vacuously true.
+        expect(html).toContain('<div id=');
+        expect(main).toContain('app.mount(');
+        expect(css).toMatch(/height\s*:\s*100%/);
+    });
+
+    it('is declared, and is the one index.html provides', () => {
+        expect(mountIds.length).toBeGreaterThan(0);
+
+        for (const id of mountIds) {
+            expect(html).toContain(`id="${id}"`);
+        }
+    });
+
+    it('carries the theme full height chain', () => {
+        const selectors = fullHeightSelectors();
+
+        for (const id of mountIds) {
+            expect(
+                selectors.some((selector) => new RegExp(`#${id}\\s*(,|$)`).test(selector.trim())),
+                `#${id} is mounted on but sets no full height, so the shell collapses`,
+            ).toBe(true);
+        }
+    });
+});

--- a/packages/client-web-theme/assets/css/styles/root.css
+++ b/packages/client-web-theme/assets/css/styles/root.css
@@ -5,9 +5,25 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+/*
+The full-height chain every console layout hangs off. `html, body` are 100%
+below, and this carries that through the element the app mounts on.
+
+A percentage height resolves against an auto-height parent as auto, so a
+mount id missing from this list silently collapses the shell to content
+height and the footer leaves the bottom of the viewport. Nothing errors,
+which is how the admin console shipped broken when it moved off nuxt: it
+mounts on `#root`, and only the two nuxt ids and `#app` were listed.
+
+The ids are mount points, not decoration. `#root` is the admin console,
+`#app` the account and auth consoles (and the admin layout's own wrapper
+inside `#root`). `#__nuxt` and `#__layout` are nuxt's own, kept for
+downstream nuxt apps consuming this theme.
+*/
 #__nuxt,
 #__layout,
-#app {
+#app,
+#root {
     height: 100%;
 }
 


### PR DESCRIPTION
The admin console's shell collapses to content height, so the footer sits under the content instead of at the bottom of the viewport.

## Cause

`packages/client-web-theme/assets/css/styles/root.css` carries the full height chain that every console layout hangs off. `html, body` are `100%`, and one rule carries that through the element the app mounts on. That rule listed `#__nuxt`, `#__layout` and `#app`.

The admin console mounts on `#root` (`apps/client-admin-console/src/main.ts`), which appears in no rule. A percentage height resolves against an auto-height parent as auto, so the chain dies at the mount element: `#app`, the layout's own wrapper inside `#root`, still asks for `height: 100%` and gets nothing to measure against.

The mount element changed when the console moved off nuxt onto vite (#3501). The account and auth consoles were never affected, because they mount on `#app`, which the rule already listed. That is also the natural experiment: two consoles on `#app` work, the one on `#root` does not.

It is not a dev-mode artefact. The built stylesheet shipped `#__nuxt,#__layout,#app{height:100%}`, so the released console has it too.

## Fix

Add `#root` to the chain. `#__nuxt` and `#__layout` stay for downstream nuxt apps consuming this theme.

## Why it needs a test

Nothing throws and no build fails when a mount id is missing from the chain; the page just renders wrong. That is how it shipped. `apps/client-admin-console/test/unit/mount-height.spec.ts` now reads the app's own mount call, its `index.html` and the theme rule, and fails with a named message when the element the console mounts on sets no full height. Removing `#root` again turns it red:

```
AssertionError: #root is mounted on but sets no full height, so the shell collapses
```

The spec also asserts it actually read the three files, so a wrong root cannot make it vacuously green.

## Not addressed here

The admin console mounts on `#root` and then renders its own `<div id="app">` wrapper inside, a nuxt-era leftover the other two consoles do not have. Collapsing those into a single mount element would make the three consoles consistent and let the rule stop listing historical mount ids, but it touches the layout, the entry and `index.html`, so it does not belong in a fix for a visual regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the admin console shell collapsing to content height by ensuring its mount point inherits the full-height layout.
  - Added coverage to verify application mount points are correctly declared and styled for full-height rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->