### PR TITLE
fix!: email_verified gets a column of its own, and the OIDC claims get declared

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -5688,14 +5688,31 @@ so both spreads are pinned: `introspect.spec.ts` for `POST /token/introspect`
 and `console-session.spec.ts` for `GET /sessions/@me/introspect`, the one a
 cookie-mode console hydrates from.
 
-The claims are read through a local `SubjectClaims` shape rather than off
-`OAuth2TokenIntrospectionResponse`. Typing the response as an
-`OpenIDTokenPayload` was tried and reverted: the endpoint maps entity columns
-onto claim names and passes a nullable column straight through, so a user
-without a display name answers `nickname: null`, where the OIDC claim types
-model an absent claim as an omitted string. That mismatch is not theoretical —
+The claims are read straight off `OAuth2TokenIntrospectionResponse`, which
+declares them (`OpenIDClaims` in `@authup/specs`, the OIDC Core 5.1 set,
+intersected by both that response and `OpenIDTokenPayload`). A local
+`SubjectClaims` alias stood here until #3518 because the two sides disagreed
+about NULL: the endpoint mapped entity columns onto claim names and passed a
+nullable one straight through, so a user without a display name answered
+`nickname: null`, where the OIDC claim types model an absent claim as an
+omitted key. That mismatch was not theoretical —
 `packages/server-adapter-kit/test/data/token.ts` is a captured response and
-carries `family_name: null`.
+carried `family_name: null`.
+
+It was resolved on the SERVER side rather than by widening the claim types to
+`string | null`: `OAuth2OpenIDClaimsBuilder.extract` now skips a nullish value,
+so an absent claim is an omitted key on the wire, which is what OIDC describes
+and what the id_token needed anyway (a JSON `null` claim value is not something
+a relying party expects). Widening the types instead would have encoded the
+deviation permanently and kept the alias alive. Do not re-add a `| null` to
+these claims; fix the producer.
+
+Declaring them is what buys the compile-time check. `JWTClaims` opens with
+`[key: string]: any`, so every claim read was `any` and a renamed one compiled
+and failed at runtime — which had already cost a downstream consumer real time
+via `OAuth2TokenPayload.sub_name`. A declared property NARROWS that index
+signature on read (verified, not assumed), while an unknown key still resolves
+through it, so nothing else in the payload was constrained.
 
 A commit does not overwrite a held user whose id already matches: the account
 console re-seeds the store from its own profile-form response, and a commit

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -2597,7 +2597,7 @@ Each policy is a built-in `ATTRIBUTE_NAMES` policy with `invert: true`, where `n
 | Policy | Denylist `names` |
 |---|---|
 | `system.client-names-self-manage` | `active, realmId, authMethod, tokenBindingMethod, secretHashed, secretEncrypted` |
-| `system.user-names-self-manage` | `active, nameLocked, status, statusMessage, realmId` |
+| `system.user-names-self-manage` | `active, nameLocked, status, statusMessage, realmId, emailVerified` |
 
 The client denylist additionally blocks `authMethod` (switching away from
 `secret` clears the secret), `tokenBindingMethod`, and the `secretHashed` /

--- a/apps/server-core/src/adapters/database/domains/user/entity.ts
+++ b/apps/server-core/src/adapters/database/domains/user/entity.ts
@@ -76,6 +76,13 @@ export class UserEntity implements User {
     email: string;
 
     @Column({
+        name: 'email_verified',
+        type: 'boolean',
+        default: false,
+    })
+    emailVerified: boolean;
+
+    @Column({
         type: 'varchar',
         length: 512,
         default: null,

--- a/apps/server-core/src/adapters/database/migrations/mysql/1788335794793-UserEmailVerified.ts
+++ b/apps/server-core/src/adapters/database/migrations/mysql/1788335794793-UserEmailVerified.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Issue #3519: the OIDC `email_verified` claim gets a column of its own.
+ *
+ * The claim was mapped onto `auth_users.active`, which is the account's
+ * enable flag and carries no statement about the address. It was wrong in
+ * both directions: registration sets `active` outright when email
+ * verification is off (the default), and a federated or provisioned user is
+ * created active with a synthesized `<name>@example.com`, so authup asserted
+ * a verified address nobody had ever received mail at; conversely an admin
+ * deactivating a user who DID complete activation flipped the claim back to
+ * false.
+ *
+ * NOT NULL DEFAULT false, so the ALTER backfills every existing row itself.
+ * False is the only safe backfill: `activate_hash` is null both after a
+ * completed activation and for a user who was never asked to verify, so the
+ * two states are indistinguishable and no row can be proven verified. An
+ * operator repairs a known-good address through the API — the column is
+ * admin-settable, and denied on the self-edit path by
+ * `system.user-names-self-manage`.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserEmailVerified1788335794793 implements MigrationInterface {
+    name = 'UserEmailVerified1788335794793';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`auth_users\`
+            ADD \`email_verified\` tinyint NOT NULL DEFAULT 0
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE \`auth_users\` DROP COLUMN \`email_verified\`
+        `);
+    }
+}

--- a/apps/server-core/src/adapters/database/migrations/postgres/1788335794793-UserEmailVerified.ts
+++ b/apps/server-core/src/adapters/database/migrations/postgres/1788335794793-UserEmailVerified.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * Issue #3519: the OIDC `email_verified` claim gets a column of its own.
+ *
+ * The claim was mapped onto `auth_users.active`, which is the account's
+ * enable flag and carries no statement about the address. It was wrong in
+ * both directions: registration sets `active` outright when email
+ * verification is off (the default), and a federated or provisioned user is
+ * created active with a synthesized `<name>@example.com`, so authup asserted
+ * a verified address nobody had ever received mail at; conversely an admin
+ * deactivating a user who DID complete activation flipped the claim back to
+ * false.
+ *
+ * NOT NULL DEFAULT false, so the ALTER backfills every existing row itself.
+ * False is the only safe backfill: `activate_hash` is null both after a
+ * completed activation and for a user who was never asked to verify, so the
+ * two states are indistinguishable and no row can be proven verified. An
+ * operator repairs a known-good address through the API — the column is
+ * admin-settable, and denied on the self-edit path by
+ * `system.user-names-self-manage`.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class UserEmailVerified1788335794793 implements MigrationInterface {
+    name = 'UserEmailVerified1788335794793';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "auth_users"
+            ADD "email_verified" boolean NOT NULL DEFAULT false
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "auth_users" DROP COLUMN "email_verified"
+        `);
+    }
+}

--- a/apps/server-core/src/app/modules/provisioning/sources/default/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/sources/default/module.ts
@@ -116,6 +116,9 @@ export class DefaultProvisioningSource implements IProvisioningSource {
                         'status',
                         'statusMessage',
                         'realmId',
+                        // A self-edit must not assert its own address is
+                        // verified — that is the whole point of the claim.
+                        'emailVerified',
                     ],
                 },
             },

--- a/apps/server-core/src/core/entities/user/schema.ts
+++ b/apps/server-core/src/core/entities/user/schema.ts
@@ -31,6 +31,7 @@ export const userSchema = defineSchema<User>({
             'firstName',
             'lastName',
             'displayName',
+            'emailVerified',
             'avatar',
             'cover',
             'active',

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -262,6 +262,27 @@ export class UserService extends AbstractEntityService implements IUserService {
             const originalName = entity.name;
             const originalNameLocked = entity.nameLocked;
 
+            // A changed address carries none of the old one's verification, and
+            // `email` is NOT on the self-manage denylist, so without this a user
+            // verifies their own address and then edits it to someone else's
+            // while the claim keeps asserting `email_verified: true` — the very
+            // account-linking takeover the claim is read for (#3519).
+            //
+            // The old value has to be re-read: the entity loaded above carries
+            // no `email` at all, because the column is `select: false`. Read
+            // BEFORE the merge below, which writes the new address onto that
+            // same entity. An explicit `emailVerified` in the same payload
+            // skips the check, so an admin can change the address and vouch for
+            // the new one in one request.
+            let emailChanged = false;
+            if (
+                validated.email &&
+                typeof validated.emailVerified === 'undefined'
+            ) {
+                const current = await this.repository.findOneByWithEmail({ id: entity.id });
+                emailChanged = !!current && current.email !== validated.email;
+            }
+
             if (isSelfEdit) {
                 await actor.permissionEvaluator.evaluate({
                     name: PermissionName.USER_SELF_MANAGE,
@@ -295,6 +316,10 @@ export class UserService extends AbstractEntityService implements IUserService {
                         [BuiltInPolicyType.REALM_MATCH]: validated.realmId ?? entity.realmId ?? null,
                     }),
                 });
+            }
+
+            if (emailChanged) {
+                entity.emailVerified = false;
             }
 
             if (validated.password) {

--- a/apps/server-core/src/core/entities/user/service.ts
+++ b/apps/server-core/src/core/entities/user/service.ts
@@ -271,13 +271,22 @@ export class UserService extends AbstractEntityService implements IUserService {
             // The old value has to be re-read: the entity loaded above carries
             // no `email` at all, because the column is `select: false`. Read
             // BEFORE the merge below, which writes the new address onto that
-            // same entity. An explicit `emailVerified` in the same payload
-            // skips the check, so an admin can change the address and vouch for
-            // the new one in one request.
+            // same entity.
+            //
+            // An `emailVerified` that DIFFERS from the stored value is a
+            // deliberate assertion and wins, so an admin can change the address
+            // and vouch for the new one in one request. One merely ECHOED back
+            // is not: `AUserForm` posts its whole reactive state on every save,
+            // hydrated from the record it loaded, so treating presence alone as
+            // an assertion made the rule unreachable from the console — every
+            // address change there carried the stale `true` straight through.
             let emailChanged = false;
             if (
                 validated.email &&
-                typeof validated.emailVerified === 'undefined'
+                (
+                    typeof validated.emailVerified === 'undefined' ||
+                    validated.emailVerified === entity.emailVerified
+                )
             ) {
                 const current = await this.repository.findOneByWithEmail({ id: entity.id });
                 emailChanged = !!current && current.email !== validated.email;

--- a/apps/server-core/src/core/identity/registration/service.ts
+++ b/apps/server-core/src/core/identity/registration/service.ts
@@ -126,9 +126,13 @@ export class RegistrationService implements IRegistrationService {
             throw new EntityNotFoundError();
         }
 
+        // Following the mailed code IS the proof of control over the address,
+        // and it is the only place authup obtains one — which is why the claim
+        // is stamped here rather than derived from `active` (#3519).
         const merged = this.repository.merge(entity, {
             active: true,
             activateHash: null,
+            emailVerified: true,
         });
 
         await this.repository.save(merged);

--- a/apps/server-core/src/core/oauth2/openid/claims.ts
+++ b/apps/server-core/src/core/oauth2/openid/claims.ts
@@ -59,7 +59,7 @@ export class OAuth2OpenIDClaimsBuilder {
         ],
 
         email: 'email',
-        email_verified: 'active',
+        email_verified: 'emailVerified',
     };
 
     /**
@@ -83,6 +83,16 @@ export class OAuth2OpenIDClaimsBuilder {
         return this.extract(this.userMap, input);
     }
 
+    /**
+     * A claim is emitted only for a value that exists AND is not nullish.
+     *
+     * The map reads entity columns, several of which are nullable, and OIDC
+     * models an unavailable claim as one that is not returned rather than one
+     * returned as `null` — so a user without a display name must omit
+     * `nickname`, not answer `nickname: null` (#3518). Emitting the null also
+     * put a JSON `null` claim value into every id_token, which no relying
+     * party expects.
+     */
     protected extract<T extends ObjectLiteral = ObjectLiteral>(
         attributeMap: AttributeMap<T>,
         attributes: T,
@@ -92,17 +102,32 @@ export class OAuth2OpenIDClaimsBuilder {
         const keys = Object.keys(attributeMap);
         for (const key_ of keys) {
             const attribute = attributeMap[key_];
+
+            let value : unknown;
             if (typeof attribute === 'string') {
-                if (hasOwnProperty(attributes, attribute)) {
-                    result[key_] = attributes[attribute];
+                if (!hasOwnProperty(attributes, attribute)) {
+                    continue;
                 }
+
+                value = attributes[attribute];
             } else {
                 const [key, transformer] = attribute as AttributeMapTuple<T>;
 
-                if (hasOwnProperty(attributes, key)) {
-                    result[key_] = transformer(attributes[key]);
+                if (!hasOwnProperty(attributes, key)) {
+                    continue;
                 }
+
+                value = transformer(attributes[key]);
             }
+
+            if (
+                typeof value === 'undefined' ||
+                value === null
+            ) {
+                continue;
+            }
+
+            result[key_] = value;
         }
 
         return result;

--- a/apps/server-core/src/core/oauth2/openid/claims.ts
+++ b/apps/server-core/src/core/oauth2/openid/claims.ts
@@ -11,7 +11,7 @@ import type {
     User,
 } from '@authup/core-kit';
 import { hasOwnProperty } from '@authup/kit';
-import type { OpenIDTokenPayload } from '@authup/specs';
+import type { OpenIDClaims, OpenIDTokenPayload } from '@authup/specs';
 import { OAuth2SubKind } from '@authup/specs';
 import type { ObjectLiteral } from 'validup';
 
@@ -19,10 +19,18 @@ type AttributeMapTuple<T> = {
     [K in keyof T]: [K, (value: unknown) => any]
 }[keyof T];
 
-type AttributeMap<T extends Record<string, any>> = Record<
-    keyof OpenIDTokenPayload,
+/**
+ * Keyed on `OpenIDClaims`, never on `OpenIDTokenPayload`: the latter inherits
+ * `JWTClaims`' `[key: string]: any`, so `keyof` collapses to `string | number`
+ * and the map accepts any claim name at all — a typo compiles and the claim is
+ * simply never emitted, which is the failure mode #3518 is about. `OpenIDClaims`
+ * carries no index signature, so a name that is not a claim fails the build.
+ * `Partial`, because a map declares only the claims its entity can supply.
+ */
+type AttributeMap<T extends Record<string, any>> = Partial<Record<
+    keyof OpenIDClaims,
 keyof T | AttributeMapTuple<T>
->;
+>>;
 
 export class OAuth2OpenIDClaimsBuilder {
     protected clientMap : AttributeMap<Client> = {
@@ -99,7 +107,7 @@ export class OAuth2OpenIDClaimsBuilder {
     ) : OpenIDTokenPayload {
         const result = {} as OpenIDTokenPayload;
 
-        const keys = Object.keys(attributeMap);
+        const keys = Object.keys(attributeMap) as (keyof OpenIDClaims)[];
         for (const key_ of keys) {
             const attribute = attributeMap[key_];
 
@@ -127,7 +135,10 @@ export class OAuth2OpenIDClaimsBuilder {
                 continue;
             }
 
-            result[key_] = value;
+            // Cast on the VALUE side only: which claim is written is checked by
+            // `AttributeMap`'s key type, while the value comes out of an entity
+            // column through an untyped transformer and never had a type here.
+            (result as Record<string, unknown>)[key_] = value;
         }
 
         return result;

--- a/apps/server-core/test/unit/adapters/http/middleware/built-in/authorization-cookie.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/middleware/built-in/authorization-cookie.spec.ts
@@ -45,6 +45,7 @@ function createUser(realmId: string) : User {
         lastName: null,
         displayName: null,
         email: 'jdoe@example.com',
+        emailVerified: false,
         password: null,
         avatar: null,
         cover: null,

--- a/apps/server-core/test/unit/adapters/http/middleware/built-in/authorization.spec.ts
+++ b/apps/server-core/test/unit/adapters/http/middleware/built-in/authorization.spec.ts
@@ -73,6 +73,7 @@ describe('src/adapters/http/middleware/built-in/authorization', () => {
             lastName: null,
             displayName: null,
             email: 'jdoe@example.com',
+            emailVerified: false,
             password: null,
             avatar: null,
             cover: null,

--- a/apps/server-core/test/unit/core/entities/user/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user/service.spec.ts
@@ -353,6 +353,9 @@ describe('core/entities/user/service', () => {
                 expect(result.emailVerified).toBe(false);
             });
 
+            // Resubmitting the SAME address is not a change, so the clear must
+            // not fire — the guard compares values, never mere presence of the
+            // `email` key.
             it('should keep it when the same address is resubmitted', async () => {
                 const entity = repository.seed(createFakeUser({
                     email: 'same@example.com',
@@ -368,6 +371,7 @@ describe('core/entities/user/service', () => {
                     createAllowAllActor(),
                 );
 
+                expect(result.displayName).toBe('New Display');
                 expect(result.emailVerified).toBe(true);
             });
 
@@ -388,7 +392,8 @@ describe('core/entities/user/service', () => {
 
             // So an admin can change the address and vouch for the new one in a
             // single request, rather than needing a second call to undo the
-            // clear.
+            // clear. The submitted value DIFFERS from the stored one, which is
+            // what makes it an assertion rather than an echo.
             it('should let an explicit value in the same payload win', async () => {
                 const entity = repository.seed(createFakeUser({
                     email: 'old@example.com',
@@ -406,6 +411,47 @@ describe('core/entities/user/service', () => {
 
                 expect(result.email).toBe('new@example.com');
                 expect(result.emailVerified).toBe(true);
+            });
+
+            // `AUserForm` posts its whole reactive state on every save, hydrated
+            // from the record it loaded, so an address change from the console
+            // always carries the stored `emailVerified` back with it. Reading
+            // that as a deliberate vouch made the rule above unreachable from
+            // the one UI that ships with the feature.
+            it('should clear it when a changed address carries a merely echoed value', async () => {
+                const entity = repository.seed(createFakeUser({
+                    email: 'old@example.com',
+                    emailVerified: true,
+                }));
+
+                const result = await service.update(
+                    entity.id,
+                    {
+                        email: 'new@example.com',
+                        emailVerified: true,
+                    },
+                    createAllowAllActor(),
+                );
+
+                expect(result.email).toBe('new@example.com');
+                expect(result.emailVerified).toBe(false);
+            });
+
+            // The mirror of the above: an admin may still explicitly REVOKE
+            // verification while leaving the address alone.
+            it('should honour an explicit revoke with no address change', async () => {
+                const entity = repository.seed(createFakeUser({
+                    email: 'kept@example.com',
+                    emailVerified: true,
+                }));
+
+                const result = await service.update(
+                    entity.id,
+                    { emailVerified: false },
+                    createAllowAllActor(),
+                );
+
+                expect(result.emailVerified).toBe(false);
             });
         });
 

--- a/apps/server-core/test/unit/core/entities/user/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/user/service.spec.ts
@@ -332,6 +332,83 @@ describe('core/entities/user/service', () => {
             ).rejects.toMatchObject({ code: ErrorCode.ENTITY_NOT_FOUND });
         });
 
+        // #3519. `email` is NOT on the self-manage denylist, so a user may
+        // change their own address. Without this the claim would keep asserting
+        // a verification that belonged to the PREVIOUS address, which is the
+        // email-based account-linking takeover the claim is read for.
+        describe('emailVerified', () => {
+            it('should clear it when the address changes', async () => {
+                const entity = repository.seed(createFakeUser({
+                    email: 'old@example.com',
+                    emailVerified: true,
+                }));
+
+                const result = await service.update(
+                    entity.id,
+                    { email: 'new@example.com' },
+                    createAllowAllActor(),
+                );
+
+                expect(result.email).toBe('new@example.com');
+                expect(result.emailVerified).toBe(false);
+            });
+
+            it('should keep it when the same address is resubmitted', async () => {
+                const entity = repository.seed(createFakeUser({
+                    email: 'same@example.com',
+                    emailVerified: true,
+                }));
+
+                const result = await service.update(
+                    entity.id,
+                    {
+                        email: 'same@example.com',
+                        displayName: 'New Display',
+                    },
+                    createAllowAllActor(),
+                );
+
+                expect(result.emailVerified).toBe(true);
+            });
+
+            it('should keep it when the payload does not carry an address', async () => {
+                const entity = repository.seed(createFakeUser({
+                    email: 'kept@example.com',
+                    emailVerified: true,
+                }));
+
+                const result = await service.update(
+                    entity.id,
+                    { displayName: 'New Display' },
+                    createAllowAllActor(),
+                );
+
+                expect(result.emailVerified).toBe(true);
+            });
+
+            // So an admin can change the address and vouch for the new one in a
+            // single request, rather than needing a second call to undo the
+            // clear.
+            it('should let an explicit value in the same payload win', async () => {
+                const entity = repository.seed(createFakeUser({
+                    email: 'old@example.com',
+                    emailVerified: false,
+                }));
+
+                const result = await service.update(
+                    entity.id,
+                    {
+                        email: 'new@example.com',
+                        emailVerified: true,
+                    },
+                    createAllowAllActor(),
+                );
+
+                expect(result.email).toBe('new@example.com');
+                expect(result.emailVerified).toBe(true);
+            });
+        });
+
         it('should hash password on update', async () => {
             const entity = repository.seed(createFakeUser());
 

--- a/apps/server-core/test/unit/core/identity/registration/service.spec.ts
+++ b/apps/server-core/test/unit/core/identity/registration/service.spec.ts
@@ -303,6 +303,9 @@ describe('core/identity/registration/service', () => {
             const user = await repository.findOneById(entity.id);
             expect(user!.active).toBe(true);
             expect(user!.activateHash).toBeNull();
+            // Following the mailed code is the only proof of address control
+            // authup obtains, so it is the only place the claim is stamped.
+            expect(user!.emailVerified).toBe(true);
         });
 
         it('should throw NotFoundError when token is invalid', async () => {

--- a/apps/server-core/test/unit/core/oauth2/authorization/code/issuer/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/code/issuer/module.spec.ts
@@ -50,6 +50,7 @@ describe('OAuth2AuthorizationCodeIssuer', () => {
             lastName: null,
             displayName: null,
             email: 'user@example.com',
+            emailVerified: false,
             password: null,
             avatar: null,
             cover: null,

--- a/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/authorization/module.spec.ts
@@ -65,6 +65,7 @@ describe('OAuth2Authorization prompt/max_age enforcement', () => {
             lastName: null,
             displayName: null,
             email: 'user@example.com',
+            emailVerified: false,
             password: null,
             avatar: null,
             cover: null,

--- a/apps/server-core/test/unit/core/oauth2/openid/claims.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/openid/claims.spec.ts
@@ -80,6 +80,7 @@ describe('OAuth2OpenIDClaimsBuilder', () => {
                 lastName: 'Doe',
                 displayName: 'John Doe',
                 email: 'john@example.com',
+                emailVerified: true,
                 active: true,
             } as User;
 
@@ -91,6 +92,44 @@ describe('OAuth2OpenIDClaimsBuilder', () => {
             expect(result.preferred_username).toBe('John Doe');
             expect(result.email).toBe('john@example.com');
             expect(result.email_verified).toBe(true);
+        });
+
+        // #3519: `active` is the account's enable flag. It is set true by
+        // registration with verification off (the default) and by every
+        // federated/provisioned create, so reading it as the email claim
+        // asserted a verification that never happened.
+        it('should derive email_verified from emailVerified, never from active', () => {
+            const user = {
+                name: 'jdoe',
+                email: 'john@example.com',
+                emailVerified: false,
+                active: true,
+            } as User;
+
+            const result = builder.fromUser(user);
+            expect(result.email_verified).toBe(false);
+        });
+
+        // #3518: OIDC models an unavailable claim as an omitted key. A nullable
+        // column passed through as `null` is not a claim value, and it landed in
+        // every id_token as one.
+        it('should omit a claim whose column is null rather than emitting null', () => {
+            const user = {
+                name: 'jdoe',
+                firstName: null,
+                lastName: null,
+                displayName: null,
+                email: 'john@example.com',
+                emailVerified: false,
+            } as unknown as User;
+
+            const result = builder.fromUser(user);
+            expect(result).not.toHaveProperty('given_name');
+            expect(result).not.toHaveProperty('family_name');
+            expect(result).not.toHaveProperty('nickname');
+            expect(result).not.toHaveProperty('preferred_username');
+            expect(result.name).toBe('jdoe');
+            expect(result.email_verified).toBe(false);
         });
 
         it('should transform string updated_at to unix timestamp in seconds per OIDC §5.1', () => {

--- a/apps/server-core/test/unit/core/oauth2/token/issuer/open-id/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/token/issuer/open-id/module.spec.ts
@@ -43,6 +43,7 @@ describe('OAuth2OpenIDTokenIssuer', () => {
         lastName: 'Doe',
         displayName: 'John Doe',
         email: 'john@example.com',
+        emailVerified: false,
         password: null,
         avatar: null,
         cover: null,

--- a/apps/server-core/test/unit/http/controllers/entities/user-self-manage.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user-self-manage.spec.ts
@@ -88,6 +88,12 @@ describe('http/controllers/user (self-manage)', () => {
         ).rejects.toThrow();
     });
 
+    it('should reject self-update of emailVerified (denylisted)', async () => {
+        await expect(
+            selfClient.user.update(entity.id, { emailVerified: true } as Partial<UserEntity>),
+        ).rejects.toThrow();
+    });
+
     it('should reject self-update of status (denylisted)', async () => {
         await expect(
             selfClient.user.update(entity.id, { status: 'banned' } as Partial<UserEntity>),

--- a/apps/server-core/test/unit/http/controllers/workflows/account/console-session.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/account/console-session.spec.ts
@@ -237,6 +237,10 @@ describe.each(CONSOLES)('$name console session', ({
         // through this endpoint's own `...subject.claims` spread rather than
         // through `POST /token/introspect`.
         expect(sessionBody.email).toEqual(userData.email);
+        // and the verification flag alongside it, for the same reason: this
+        // endpoint spreads the claims itself, so a pin on `/token/introspect`
+        // does not cover it (#3519).
+        expect(sessionBody.email_verified).toEqual(false);
 
         // 5) and the credential drives ordinary, identity-gated API routes —
         //    the same ones every other client reaches with a bearer.

--- a/apps/server-core/test/unit/http/controllers/workflows/token/introspect.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/token/introspect.spec.ts
@@ -128,6 +128,12 @@ describe('token-introspect', () => {
 
         expect(introspection.active).toBe(true);
         expect(introspection.email).toEqual(buildUserFakeEmail('admin'));
+        // #3519. The provisioned admin is `active: true` with a SYNTHESIZED
+        // `admin@example.com` that has never received anything, which is
+        // exactly the address the old `email_verified: 'active'` mapping
+        // asserted as verified. It is now the flag's own column, and nothing
+        // has verified this one.
+        expect(introspection.email_verified).toBe(false);
     });
 
     // Without the controller deriving `active` from `exp`, this is the

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -26,7 +26,8 @@ be proven verified.
 **Action required if a relying party reads the claim.** Anything gating on
 `email_verified: true` — account linking by email address is the usual case —
 stops matching until the addresses are verified again, or vouched for. The field
-is admin-settable (`PATCH /users/:id` with `{"emailVerified": true}`, and a
+is admin-settable (`POST /users/:id` with `{"emailVerified": true}` — the update verb
+authup serves is POST, not PATCH — and a
 switch in the admin console's user form), so an operator can restore it for
 addresses they trust. It is on the `system.user-names-self-manage` denylist, so a
 user cannot set it on themselves, and it is cleared automatically when a user's

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -7,6 +7,47 @@ either requires operator action or deliberately changes behavior.
 
 ## Next release (after v1.0.0-beta.62)
 
+### `email_verified` is a real column, and every existing user starts unverified
+
+The OIDC `email_verified` claim was mapped onto `auth_users.active`, the account
+enable flag, which says nothing about the address. It was wrong in both
+directions: registration sets `active` outright when `EMAIL_VERIFICATION_ENABLED`
+is off (the default), and a federated or provisioned user is created active with
+a synthesized `<name>@example.com`, so authup asserted a verified address that
+had never received anything; conversely, deactivating a user who *had* completed
+activation flipped the claim back to false.
+
+It now has its own column, `auth_users.email_verified`, set by the activation
+round-trip. The migration backfills **false for every existing row**, including
+users who genuinely activated: `activate_hash` is null both after a completed
+activation and for a user who was never asked to verify, so no existing row can
+be proven verified.
+
+**Action required if a relying party reads the claim.** Anything gating on
+`email_verified: true` — account linking by email address is the usual case —
+stops matching until the addresses are verified again, or vouched for. The field
+is admin-settable (`PATCH /users/:id` with `{"emailVerified": true}`, and a
+switch in the admin console's user form), so an operator can restore it for
+addresses they trust. It is on the `system.user-names-self-manage` denylist, so a
+user cannot set it on themselves, and it is cleared automatically when a user's
+email address changes.
+
+If you were relying on the old behaviour to mean anything, note that it did not:
+on a default deployment it read `true` for every self-registered user.
+
+### The introspection response omits a claim instead of answering `null`
+
+`POST /token/introspect`, `GET /sessions/@me/introspect` and every id_token
+mapped nullable user columns straight onto OIDC claims, so a user without a
+display name answered `nickname: null`. OIDC models an unavailable claim as an
+omitted key, so those claims are now absent rather than null. A consumer testing
+`payload.nickname === null` should test for absence (`== null` covers both).
+
+The claims are also declared on `OAuth2TokenIntrospectionResponse` now
+(`OpenIDClaims` in `@authup/specs`), so a TypeScript consumer reading `email`,
+`nickname`, `preferred_username`, `given_name`, `family_name` or `updated_at`
+gets a real type instead of `any`.
+
 ### The configuration file is `authup.yml`
 
 The `.conf` file family is retired. One file is discovered now, `authup.yml` (or

--- a/docs/src/sdks/javascript/core-kit/api-reference.md
+++ b/docs/src/sdks/javascript/core-kit/api-reference.md
@@ -524,6 +524,8 @@ interface User {
 
     email: string;
 
+    emailVerified: boolean;
+
     password: string | null;
 
     // ------------------------------------------------------------------

--- a/packages/client-web-kit/src/components/entities/user/AUserForm.vue
+++ b/packages/client-web-kit/src/components/entities/user/AUserForm.vue
@@ -42,7 +42,7 @@ import { IFieldValidation } from '@ilingo/validup-vue';
 // keys, so every `v.fields.<key>` degrades to `FieldState<any> | undefined`
 // (tada5hi/validup#455). Pinning the composable to an index-signature-free
 // projection restores typed field access.
-type UserFormState = Pick<User, 'active' | 'name' | 'nameLocked' | 'displayName' | 'email' | 'realmId'>;
+type UserFormState = Pick<User, 'active' | 'name' | 'nameLocked' | 'displayName' | 'email' | 'emailVerified' | 'realmId'>;
 
 export default defineComponent({
     components: {
@@ -80,6 +80,7 @@ export default defineComponent({
             nameLocked: false,
             displayName: '',
             email: '',
+            emailVerified: false,
             realmId: '',
         });
 
@@ -194,6 +195,14 @@ export default defineComponent({
                     key: TranslatorTranslationCommonKey.NOT_LOCKED, 
                 },
                 {
+                    namespace: TranslatorTranslationNamespace.COMMON,
+                    key: TranslatorTranslationCommonKey.EMAIL_VERIFIED,
+                },
+                {
+                    namespace: TranslatorTranslationNamespace.COMMON,
+                    key: TranslatorTranslationCommonKey.EMAIL_NOT_VERIFIED,
+                },
+                {
                     namespace: TranslatorTranslationNamespace.FIELD, 
                     key: TranslatorTranslationFieldKey.NAME, 
                 },
@@ -301,6 +310,21 @@ export default defineComponent({
                                         :class="[labelClass, form.nameLocked ? 'text-success-600' : 'text-warning-600']"
                                     >
                                         {{ form.nameLocked ? translationsDefault.locked : translationsDefault.notLocked }}
+                                    </label>
+                                </template>
+                            </VCFormSwitch>
+                        </div>
+                        <div class="flex-1 basis-0 px-2">
+                            <VCFormSwitch
+                                v-model="form.emailVerified"
+                                :label="true"
+                            >
+                                <template #label="{ id, class: labelClass }">
+                                    <label
+                                        :for="id"
+                                        :class="[labelClass, form.emailVerified ? 'text-success-600' : 'text-warning-600']"
+                                    >
+                                        {{ form.emailVerified ? translationsDefault.emailVerified : translationsDefault.emailNotVerified }}
                                     </label>
                                 </template>
                             </VCFormSwitch>

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -65,20 +65,6 @@ function createPromiseShareWrapperFn<F extends InputFn>(
 type RealmMinimal = Pick<Realm, 'id' | 'name'>;
 type UserMinimal = Pick<User, 'id' | 'name' | 'displayName' | 'email'>;
 
-/**
- * The subject claims the introspection endpoint answers with, alongside the
- * token payload it echoes. Declared here rather than on
- * `OAuth2TokenIntrospectionResponse`, because the endpoint maps entity columns
- * onto claim names and passes a nullable column through as `null` (a display
- * name arrives as `nickname: null`), where the OIDC claim types model an absent
- * claim as an omitted string.
- */
-type SubjectClaims = {
-    name?: string | null,
-    nickname?: string | null,
-    email?: string | null,
-};
-
 export function createStore(context: StoreCreateContext) {
     const client : IClient = context.httpClient ?? new Client({ baseURL: context.baseURL });
 
@@ -439,7 +425,7 @@ export function createStore(context: StoreCreateContext) {
             name,
             nickname,
             email,
-        } = introspection as SubjectClaims;
+        } = introspection;
 
         return {
             id: introspection.sub,

--- a/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
@@ -63,6 +63,7 @@ function seedLoggedIn(store: Store, realmId = REALM.id, withUser = true) {
         lastName: null,
         displayName: null,
         email: 'jdoe@example.com',
+        emailVerified: false,
         password: null,
         avatar: null,
         cover: null,

--- a/packages/client-web-kit/test/unit/components/workflows/end-session.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/end-session.spec.ts
@@ -35,6 +35,7 @@ function createUser(overrides: Pick<User, 'id'>): User {
         lastName: null,
         displayName: null,
         email: 'user@example.com',
+        emailVerified: false,
         password: null,
         avatar: null,
         cover: null,

--- a/packages/client-web-kit/test/unit/core/store/status.spec.ts
+++ b/packages/client-web-kit/test/unit/core/store/status.spec.ts
@@ -27,6 +27,7 @@ function buildUser() : User {
         lastName: null,
         displayName: null,
         email: 'admin@example.com',
+        emailVerified: false,
         password: null,
         avatar: null,
         cover: null,

--- a/packages/core-http-kit/src/domains/entities/user/types.ts
+++ b/packages/core-http-kit/src/domains/entities/user/types.ts
@@ -13,6 +13,7 @@ import type { User } from '@authup/core-kit';
 // `passwordRepeat` is NOT validator-mounted but is accepted by the controller for password
 // confirmation; it is only carried on update/save shapes.
 type UserOptionalFields = Pick<User, 'nameLocked' |
+    'emailVerified' |
     'firstName' |
     'lastName' |
     'displayName' |

--- a/packages/core-kit/src/domains/user/entity.ts
+++ b/packages/core-kit/src/domains/user/entity.ts
@@ -22,6 +22,13 @@ export interface User {
 
     email: string;
 
+    /**
+     * Whether control of `email` was proven, by following the code mailed
+     * to it. Deliberately NOT derived from `active`, which is the account's
+     * enable flag and says nothing about the address (#3519).
+     */
+    emailVerified: boolean;
+
     password: string | null;
 
     // ------------------------------------------------------------------

--- a/packages/core-kit/src/domains/user/validator.ts
+++ b/packages/core-kit/src/domains/user/validator.ts
@@ -139,6 +139,15 @@ export class UserValidator extends Container<User> {
             createValidator(z.boolean()),
         );
 
+        // Admin-settable, like `active`, so an operator can vouch for an address
+        // an activation round-trip never covered. Denied on the self-edit path
+        // by `system.user-names-self-manage` (#3519).
+        this.mount(
+            'emailVerified',
+            { optional: true },
+            createValidator(z.boolean()),
+        );
+
         this.mount(
             'nameLocked',
             { optional: true },

--- a/packages/i18n/src/catalogs/de/common.ts
+++ b/packages/i18n/src/catalogs/de/common.ts
@@ -17,6 +17,8 @@ export const TranslatorTranslationCommonGerman : NamespaceTranslations<`${Transl
     [TranslatorTranslationCommonKey.INACTIVE]: 'Inaktiv',
     [TranslatorTranslationCommonKey.LOCKED]: 'Gesperrt',
     [TranslatorTranslationCommonKey.NOT_LOCKED]: 'Nicht gesperrt',
+    [TranslatorTranslationCommonKey.EMAIL_VERIFIED]: 'E-Mail bestätigt',
+    [TranslatorTranslationCommonKey.EMAIL_NOT_VERIFIED]: 'E-Mail nicht bestätigt',
     [TranslatorTranslationCommonKey.APPLICATION]: 'Anwendung',
     [TranslatorTranslationCommonKey.SEARCH]: 'Suchen',
     [TranslatorTranslationCommonKey.NO_RESULTS]: 'Keine Ergebnisse gefunden.',

--- a/packages/i18n/src/catalogs/en/common.ts
+++ b/packages/i18n/src/catalogs/en/common.ts
@@ -17,6 +17,8 @@ export const TranslatorTranslationCommonEnglish : NamespaceTranslations<`${Trans
     [TranslatorTranslationCommonKey.INACTIVE]: 'Inactive',
     [TranslatorTranslationCommonKey.LOCKED]: 'Locked',
     [TranslatorTranslationCommonKey.NOT_LOCKED]: 'Not locked',
+    [TranslatorTranslationCommonKey.EMAIL_VERIFIED]: 'Email verified',
+    [TranslatorTranslationCommonKey.EMAIL_NOT_VERIFIED]: 'Email not verified',
     [TranslatorTranslationCommonKey.APPLICATION]: 'Application',
     [TranslatorTranslationCommonKey.SEARCH]: 'Search',
     [TranslatorTranslationCommonKey.NO_RESULTS]: 'No results found.',

--- a/packages/i18n/src/catalogs/es/common.ts
+++ b/packages/i18n/src/catalogs/es/common.ts
@@ -17,6 +17,8 @@ export const TranslatorTranslationCommonSpanish : NamespaceTranslations<`${Trans
     [TranslatorTranslationCommonKey.INACTIVE]: 'Inactivo',
     [TranslatorTranslationCommonKey.LOCKED]: 'Bloqueado',
     [TranslatorTranslationCommonKey.NOT_LOCKED]: 'No bloqueado',
+    [TranslatorTranslationCommonKey.EMAIL_VERIFIED]: 'Correo verificado',
+    [TranslatorTranslationCommonKey.EMAIL_NOT_VERIFIED]: 'Correo no verificado',
     [TranslatorTranslationCommonKey.APPLICATION]: 'Aplicación',
     [TranslatorTranslationCommonKey.SEARCH]: 'Buscar',
     [TranslatorTranslationCommonKey.NO_RESULTS]: 'No se encontraron resultados.',

--- a/packages/i18n/src/catalogs/fr/common.ts
+++ b/packages/i18n/src/catalogs/fr/common.ts
@@ -17,6 +17,8 @@ export const TranslatorTranslationCommonFrench : NamespaceTranslations<`${Transl
     [TranslatorTranslationCommonKey.INACTIVE]: 'Inactif',
     [TranslatorTranslationCommonKey.LOCKED]: 'Verrouillé',
     [TranslatorTranslationCommonKey.NOT_LOCKED]: 'Non verrouillé',
+    [TranslatorTranslationCommonKey.EMAIL_VERIFIED]: 'E-mail vérifié',
+    [TranslatorTranslationCommonKey.EMAIL_NOT_VERIFIED]: 'E-mail non vérifié',
     [TranslatorTranslationCommonKey.APPLICATION]: 'Application',
     [TranslatorTranslationCommonKey.SEARCH]: 'Rechercher',
     [TranslatorTranslationCommonKey.NO_RESULTS]: 'Aucun résultat trouvé.',

--- a/packages/i18n/src/constants.ts
+++ b/packages/i18n/src/constants.ts
@@ -475,6 +475,8 @@ export enum TranslatorTranslationCommonKey {
     INACTIVE = 'inactive',
     LOCKED = 'locked',
     NOT_LOCKED = 'notLocked',
+    EMAIL_VERIFIED = 'emailVerified',
+    EMAIL_NOT_VERIFIED = 'emailNotVerified',
     APPLICATION = 'application',
     SEARCH = 'search',
     NO_RESULTS = 'noResults',

--- a/packages/server-adapter-kit/test/data/token.ts
+++ b/packages/server-adapter-kit/test/data/token.ts
@@ -23,8 +23,6 @@ export const TokenPayload : OAuth2TokenIntrospectionResponse = {
     realm_name: 'master',
     scope: 'global',
     name: 'admin',
-    family_name: null,
-    given_name: null,
     nickname: 'admin',
     preferred_username: 'admin',
     email: 'admin@example.com',

--- a/packages/specs/src/oauth2/types.ts
+++ b/packages/specs/src/oauth2/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { JWTClaims } from '../json-web-token';
+import type { OpenIDClaims } from '../openid/claims';
 import type { OAuth2SubKind, OAuth2TokenKind } from './constants';
 
 export type OAuth2TokenGrantResponse = {
@@ -148,7 +149,16 @@ export type OAuth2TokenPermission = {
     realm_id?: string
 };
 
-export type OAuth2TokenIntrospectionResponse = OAuth2TokenPayload & {
+/**
+ * The endpoint answers with the token's own payload plus the subject's OpenID
+ * claims, so both are declared. Without the claim set they were reachable only
+ * through `JWTClaims`' index signature, which types every one of them `any`:
+ * a renamed or mistyped claim compiled and failed at runtime (#3518).
+ *
+ * `OpenIDClaims` rather than `OpenIDTokenPayload`, because that type lives in a
+ * module importing this one.
+ */
+export type OAuth2TokenIntrospectionResponse = OAuth2TokenPayload & OpenIDClaims & {
     active: boolean,
     permissions?: OAuth2TokenPermission[]
 };

--- a/packages/specs/src/openid/claims.ts
+++ b/packages/specs/src/openid/claims.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+/**
+ * The OpenID Connect Core §5.1 standard claims about a subject.
+ *
+ * Declared in a module of its own, importing nothing, so both the id_token
+ * payload (`OpenIDTokenPayload`) and the RFC 7662 introspection response
+ * (`OAuth2TokenIntrospectionResponse`) can intersect it. The latter lives in
+ * `../oauth2`, which `./type` already imports, so declaring the claims there
+ * would put the two modules in a cycle.
+ *
+ * Every claim is optional, and an absent one is an OMITTED key rather than a
+ * null: OIDC models an unavailable claim as one that is not returned, so a
+ * producer mapping a nullable column onto a claim must skip it rather than
+ * emit `null`.
+ */
+export type OpenIDClaims = {
+    // -----------------------------------------------------------------
+    // scope: email
+    // -----------------------------------------------------------------
+
+    email?: string,
+
+    email_verified?: boolean,
+
+    // -----------------------------------------------------------------
+    // scope: phone
+    // -----------------------------------------------------------------
+
+    phone_number?: string,
+
+    phone_number_verified?: boolean,
+
+    // -----------------------------------------------------------------
+    // scope: address
+    // -----------------------------------------------------------------
+
+    address?: Record<string, any>,
+
+    // -----------------------------------------------------------------
+    // scope: profile / identity
+    // -----------------------------------------------------------------
+
+    name?: string,
+
+    family_name?: string,
+
+    given_name?: string,
+
+    middle_name?: string,
+
+    nickname?: string,
+
+    preferred_username?: string,
+
+    profile?: string,
+
+    picture?: string,
+
+    website?: string,
+
+    gender?: string,
+
+    birthdate?: string,
+
+    roles?: string[],
+
+    zoneinfo?: string,
+
+    locale?: string,
+
+    /**
+     * UTC Date in seconds
+     */
+    updated_at?: number
+};

--- a/packages/specs/src/openid/index.ts
+++ b/packages/specs/src/openid/index.ts
@@ -5,5 +5,6 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+export * from './claims';
 export * from './type';
 export * from './utils';

--- a/packages/specs/src/openid/type.ts
+++ b/packages/specs/src/openid/type.ts
@@ -6,6 +6,7 @@
  */
 
 import type { OAuth2AuthorizationResponseType, OAuth2TokenPayload } from '../oauth2';
+import type { OpenIDClaims } from './claims';
 
 export type OpenIDProviderMetadata = {
     /**
@@ -106,62 +107,4 @@ export type OpenIDProviderMetadata = {
     userinfo_endpoint?: string
 };
 
-export type OpenIDTokenPayload = OAuth2TokenPayload & {
-    // -----------------------------------------------------------------
-    // scope: email
-    // -----------------------------------------------------------------
-
-    email?: string,
-
-    email_verified?: boolean,
-
-    // -----------------------------------------------------------------
-    // scope: phone
-    // -----------------------------------------------------------------
-
-    phone_number?: string,
-
-    phone_number_verified?: boolean,
-
-    // -----------------------------------------------------------------
-    // scope: address
-    // -----------------------------------------------------------------
-    address?: Record<string, any>,
-
-    // -----------------------------------------------------------------
-    // scope: profile / identity
-    // -----------------------------------------------------------------
-
-    name?: string,
-
-    family_name?: string,
-
-    given_name?: string,
-
-    middle_name?: string,
-
-    nickname?: string,
-
-    preferred_username?: string,
-
-    profile?: string,
-
-    picture?: string,
-
-    website?: string,
-
-    gender?: string,
-
-    birthdate?: string,
-
-    roles?: string[],
-
-    zoneinfo?: string,
-
-    locale?: string,
-
-    /**
-     * UTC Date in seconds
-     */
-    updated_at: number
-};
+export type OpenIDTokenPayload = OAuth2TokenPayload & OpenIDClaims;


### PR DESCRIPTION
Closes #3519, closes #3518. Both defects live in the same file, `OAuth2OpenIDClaimsBuilder`.

## #3519 — `email_verified` gets a column

The claim was mapped onto `User.active`, the account enable flag, which carries no statement about the address. Three facts from the code made the false positive routine rather than theoretical:

- `RegistrationService.register()` sets `active = true` outright when `EMAIL_VERIFICATION_ENABLED` is off, which is the **default**. Nothing was ever sent to that address.
- `IdentityProviderAccountManager` creates every federated user `active` and backfills `buildUserFakeEmail(name)` → `<name>@example.com` when the provider returns no email.
- The repo's own introspection spec asserted `email: admin@example.com` on a token that simultaneously claimed `email_verified: true`. That address does not exist.

The false negative was the mirror: deactivating a user who *had* completed activation flipped the claim back to false, though nothing about the address changed.

You chose to model it properly rather than drop the mapping:

| | |
|---|---|
| Column | `auth_users.email_verified`, `boolean NOT NULL DEFAULT false`, generated migration on both dialects |
| Set by | `RegistrationService.activate()` — following the mailed code is the only proof of address control authup obtains |
| Admin-settable | mounted in `UserValidator` like `active`; a switch in `AUserForm` inside the `canManage` gate; i18n in all four locales |
| Self-edit | denied via `system.user-names-self-manage` |
| Address change | cleared by `UserService.save()` |
| Backfill | `false` for every row |

**Backfill is `false` for everyone, including users who genuinely activated.** `activate_hash` is null both after a completed activation and for a user never asked to verify, so no existing row can be *proven* verified. The admin-settable field is the repair path, and the upgrade note says so.

**Clearing on address change is load-bearing, not tidiness.** `email` is deliberately *not* on the self-manage denylist, so a user may change their own address. Without the clear they verify their own, edit it to someone else's, and the claim keeps asserting it — the same takeover shape one layer in.

Two details worth review:

- The old address has to be **re-read** (`findOneByWithEmail`), because the entity the update path loads carries no `email` at all — the column is `select: false`. The read happens *before* the merge, which writes the new address onto that same entity; the clear is applied after both permission evaluations, since putting a denylisted key into the self-manage `ATTRIBUTES` bag would reject the edit outright.
- An `emailVerified` that **differs** from the stored value is a deliberate vouch and wins, so an admin can change the address and vouch for the new one in one request. One merely **echoed** back is not — see the audit section.

## #3518 — the OIDC claims get declared

The claims reached consumers only through `JWTClaims`' `[key: string]: any`, so every read of `email`, `nickname`, `preferred_username`, `given_name`, `family_name` or `updated_at` was `any`-typed. A rename compiled and failed at runtime, which had already cost a downstream consumer real time via the never-populated `OAuth2TokenPayload.sub_name`.

The OIDC Core §5.1 set is now `OpenIDClaims` in `@authup/specs`, intersected by both `OpenIDTokenPayload` and `OAuth2TokenIntrospectionResponse`. It sits in its own import-free module because `openid/type.ts` already imports `../oauth2`, so declaring it there would put the two in a cycle.

**The null-vs-absent question you flagged is fixed at the producer, not encoded in the types.** `extract()` now skips a nullish value, so an absent claim is an omitted key — which is what OIDC describes. Widening the claims to `string | null` would have made the deviation permanent and kept `client-web-kit`'s local `SubjectClaims` alias alive; instead the alias is deleted. It also stops every id_token carrying JSON `null` claim values.

Verified rather than assumed, with a `tsc` probe: a declared property **narrows** the index signature on read, unknown keys still resolve through it, and wrong literals fail on write.

## What the audit changed

I ran an adversarial review (5 dimensions, each finding refuted by two independent lenses before it counted). Three findings survived and are fixed in the second commit:

1. **The escape hatch swallowed the rule.** `AUserForm` posts its whole reactive state on every save, hydrated from the record it loaded, so every console address change carried the stored `emailVerified` back and the clear could never fire from the one UI that ships with the feature. The test passed because it posted the address alone, which no client does. An echoed value is now told from an assertion by comparing against the stored one. Reverting that comparison fails exactly one test (checked by mutation).
2. **`AttributeMap` was keyed on `OpenIDTokenPayload`**, so `keyof` collapsed through the index signature to `string | number` and the claims map accepted any name — declaring `OpenIDClaims` had fixed the *readers* only. Keying the map on `OpenIDClaims` makes a misspelled claim a build error: `email_verifed` now fails with TS2561 and a suggested correction. This is the producer half of the very bug #3518 is about.
3. **`UserOptionalFields`** documents itself as mirroring the validator mounts and had not been updated, so `client.user.update(id, { emailVerified: true })` was a TS2353 — the exact call the upgrade note tells operators to make. That note also named `PATCH /users/:id`, a verb the controller does not serve.

Plus three full `User` literals in the kit's own tests missing the new required property (nothing type-checks them — only `apps/server-core` runs `check:types` over its tests, and vitest transpiles through SWC), and the stale self-manage denylist table in `.agents/architecture.md`.

## Known residuals, deliberately not fixed here

- **`IdentityProviderAccountManager.saveUser` writes `user.email` directly**, bypassing the service, so a federated login with an operator-configured `email` attribute mapper can change the address without clearing the flag. Narrow (a federated user is never verified unless an admin said so) and it needs its own re-read against a `select: false` column.
- **`resetPassword` obtains the same proof of control** `activate()` does — the code is mailed to the address — and does not stamp the flag. A defensible follow-up; out of scope for what was agreed.
- **An outstanding `activateHash` survives an address change**, so an admin editing an inactive user's email leaves a code that would verify the new address. Clearing it would strand the user, since there is no resend endpoint.
- **`AUserForm` posts denylisted keys in self-service mode** (`active`, `nameLocked` already, now `emailVerified` too). Pre-existing shape, unchanged by this PR.
- On a default deployment nothing sets the flag true except an admin, because activation only runs when verification is enabled. That is correct — nothing verified anything — but worth knowing.

## Verification

- Full suite green: 2293 tests in server-core, all packages.
- `npm run build` and `npm run check:types -w apps/server-core` clean.
- Schema-drift gate clean on **both** mysql and postgres against a migrated database.
- Populated migration round-trip (`test:migration-latest`) **14/14 on both dialects** — the gate that actually exercises a `NOT NULL` column added to a table with rows.
- The mysql `tinyint` question checked empirically: the introspect spec's `expect(email_verified).toBe(false)` is a strict `toBe`, and it passes on mysql, so typeorm reads it back as a real boolean rather than `0`.
- Migration generated with `migration generate`, DDL committed as emitted (one statement per dialect), renamed and doc-headered per convention.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added email verification status to user records, APIs, user forms, and default user results.
  * Email verification is now reflected accurately in OpenID Connect tokens and introspection responses.
  * Added localized “Email verified” and “Email not verified” labels.

* **Bug Fixes**
  * Changing an email address clears its verified status.
  * Account activation marks the email address as verified.
  * Nullable OpenID claims are now omitted instead of returned as `null`.

* **Documentation**
  * Updated upgrade guidance and SDK API references for email verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->