### PR TITLE
refactor(client-web-kit): declare the store's minimal user and realm shapes once

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -5877,7 +5877,10 @@ base64-decodable, on every same-path request. What the ref adds on the wire is
 nothing, and for a Nuxt consumer one more field in an SSR payload that already
 carries the access and refresh tokens off the same store.
 
-**`UserMinimal` is spelled in THREE places and only two of them are guarded.**
+**`UserMinimal` is declared once and re-picked at two sinks.** The alias, and
+`RealmMinimal` beside it, lives in `core/store/types.ts` and is imported by
+`core/store/create.ts` and `core/store/dispatcher/types.ts`, so widening the
+pick reaches the refs and the `USER_UPDATED` payload type in one edit.
 `buildUser` returns the shape and `setUser` re-picks it again at the sink,
 deliberately (callers hand over whole entity rows, and the ref is what a Nuxt
 consumer's SSR payload carries). Both are contextually typed against the alias
@@ -5885,13 +5888,13 @@ and a pure `Pick` makes every member required, so omitting a newly picked field
 at either site is a compile error, TS2741 in `buildUser` and TS2322 at the sink,
 never a silent drop. Note the guard is `build:types` alone: vitest transpiles
 through SWC, so the suite runs an un-type-checked tree and reports the omission
-as a runtime absence instead. The genuinely unguarded site is the alias ITSELF,
-declared independently in `core/store/create.ts` and
-`core/store/dispatcher/types.ts` with nothing tying the two together. Widening
-one and not the other compiles clean, and the `USER_UPDATED` payload type then
-understates what is emitted. They stay separate because both are private
-aliases, so sharing one would mean exporting it and growing the published
-surface to fix a documentation problem.
+as a runtime absence instead. The DECLARATION carried no such guard until issue
+#3520: it was spelled independently in both files with nothing tying the two
+together, so widening one and leaving the other narrow compiled clean and the
+dispatcher payload type silently understated what was emitted. Sharing it
+publishes it through the store barrel, which is not the cost it reads as: that
+barrel already re-exports `create.ts` wholesale, so an alias exported from
+either file lands in the package's public `.d.ts` just the same.
 
 The server half is droppable once per SURFACE. The claim maps from a
 `select: false` column that survives only because `UserIdentityRepository.find()`

--- a/packages/client-web-kit/src/core/store/create.ts
+++ b/packages/client-web-kit/src/core/store/create.ts
@@ -17,15 +17,17 @@ import type {
     OAuth2TokenGrantResponse,
     OAuth2TokenIntrospectionResponse,
 } from '@authup/specs';
-import type {
-    Realm,
-    User,
-} from '@authup/core-kit';
 import { REALM_MASTER_NAME } from '@authup/core-kit';
 import { Client } from '@authup/core-http-kit';
 import { StoreAuthOrigin, StoreAuthStatus } from './constants';
 import { StoreDispatcherEventName } from './dispatcher';
-import type { StoreCreateContext, StoreLoginContext, StoreLogoutOptions } from './types';
+import type {
+    RealmMinimal,
+    StoreCreateContext,
+    StoreLoginContext,
+    StoreLogoutOptions,
+    UserMinimal,
+} from './types';
 
 type InputFn = (...args: any[]) => Promise<any>;
 type OutputFn<F extends InputFn> = (...args: Parameters<F>) => Promise<Awaited<ReturnType<F>>>;
@@ -61,9 +63,6 @@ function createPromiseShareWrapperFn<F extends InputFn>(
         return promise;
     };
 }
-
-type RealmMinimal = Pick<Realm, 'id' | 'name'>;
-type UserMinimal = Pick<User, 'id' | 'name' | 'displayName' | 'email'>;
 
 export function createStore(context: StoreCreateContext) {
     const client : IClient = context.httpClient ?? new Client({ baseURL: context.baseURL });

--- a/packages/client-web-kit/src/core/store/dispatcher/types.ts
+++ b/packages/client-web-kit/src/core/store/dispatcher/types.ts
@@ -5,12 +5,9 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
-import type { Realm, User } from '@authup/core-kit';
+import type { RealmMinimal, UserMinimal } from '../types';
 import type { EventEmitter } from '@posva/event-emitter';
 import type { StoreDispatcherEventName } from './constants';
-
-type RealmMinimal = Pick<Realm, 'id' | 'name'>;
-type UserMinimal = Pick<User, 'id' | 'name' | 'displayName' | 'email'>;
 
 export type StoreDispatcherEvents = {
     [StoreDispatcherEventName.LOGGING_IN]: [],

--- a/packages/client-web-kit/src/core/store/types.ts
+++ b/packages/client-web-kit/src/core/store/types.ts
@@ -13,10 +13,14 @@ import type {
     _ExtractGettersFromSetupStore, 
     _ExtractStateFromSetupStore,
 } from 'pinia';
+import type { Realm, User } from '@authup/core-kit';
 import type { IClient } from '@authup/core-http-kit';
 import type { CookieGetFn, CookieSetFn, CookieUnsetFn } from '../../types';
 import type { createStore } from './create';
 import type { StoreDispatcher } from './dispatcher';
+
+export type RealmMinimal = Pick<Realm, 'id' | 'name'>;
+export type UserMinimal = Pick<User, 'id' | 'name' | 'displayName' | 'email'>;
 
 type StoreData = ReturnType<typeof createStore>;
 export type Store = BaseStore<


### PR DESCRIPTION
Closes #3520.

`UserMinimal` and `RealmMinimal` were declared independently in
`core/store/create.ts` and `core/store/dispatcher/types.ts`. The two narrowing
SITES are compile-guarded (a pure `Pick` makes every member required, so a
missing field is TS2741 in `buildUser` and TS2322 at the `setUser` sink); the
DECLARATION was not. Widening one copy and leaving the other narrow builds
clean, and the `USER_UPDATED` payload type then understates what is emitted.

Both aliases now live in `core/store/types.ts` and are imported by both files.

## On the published surface

The issue weighed option 2 (export from `create.ts`) against option 3 (a
private module) on the assumption that only the former grows the public
surface. That premise does not hold: `core/store/index.ts:9` is
`export * from './create'`, so an alias exported from `create.ts` reaches
`dist/index.d.ts` exactly as one exported from `types.ts` does. The two options
cost the same, and keeping them private would have required a module
deliberately left out of the barrel.

Publishing them is right on its own terms anyway. They are the type of
`store.user` and `store.realm`; a consumer should be able to name them. And
`types.ts` is where the repo's own convention puts an exported alias, it is a
file `create.ts` already imports from, and moving there lets both files drop a
now-unused `import type { Realm, User } from '@authup/core-kit'`.

## Verified

- `npm run build -w packages/client-web-kit` clean; `dist/core/store/types.d.ts`
  carries both exports.
- `grep -c Minimal dist/index.mjs` -> 0. Type-only throughout, so the new
  `dispatcher/types.ts -> ../types` edge adds no runtime cycle. (It does close a
  new type-level cycle through the dispatcher barrel; the pre-existing
  `create.ts <-> types.ts` one already proves the toolchain tolerates it.)
- `build:types` clean for all three consoles, which type-check kit SOURCE via
  the root `paths` map, plus a clean `client-web-nuxt` build.
- Kit suite: 34 files, 247 tests, all passing.
- No collision: neither name existed anywhere else in the monorepo, no workspace
  re-exports the kit wholesale, and all 113 kit import sites are named imports.

## Deliberately not here

The adjacent gap the issue notes, that `packages/client-web-kit` has no
`check:types` script so `build:types` (at `strict: false`) is its only type
guard, stays its own issue. No test either: vitest transpiles through SWC and
cannot observe a type-alias divergence at all.

`.agents/architecture.md` is updated in place, since its paragraph documented
the duplication as a deliberate state.
