### PR TITLE
feat(client-web-nuxt): allow namespacing the session cookies

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -3139,12 +3139,28 @@ needs next to it (`CLI_CONFIG_ARGS`, `applyCLIConfigArgs`,
 `createCLIConfigModule`, `assertNoStrayPositionals`, `describeConfigError`)
 and no config command of its own.
 
-**Unsupported:** sharing one cookie domain between a standalone-hosted
+**Partly unsupported:** sharing one cookie domain between a standalone-hosted
 console (or a downstream kit app on its own origin) and the hosted auth
-pages — both surfaces embed the kit store under identical cookie names, so a
+pages. Both surfaces embed the kit store under identical cookie names, so a
 widened cookie domain has the two apps clobbering each other's session
-cookies. The served consoles are same-origin and hold no token cookies at
-all (cookie mode), so the question does not arise for them. The same-ORIGIN variant of this collision — a host
+cookies. A downstream app on `@authup/client-web-nuxt` has a way out since
+issue #3527: `cookiePrefix` prepends a namespace to every store cookie name
+inside that plugin's own `cookieGet` / `cookieSet` / `cookieUnset`, which is
+total because `installStore` routes all cookie I/O through those three, and
+the kit therefore needs no option of its own. Only a consumer supplying its
+own `cookieSet` can set a `Domain` at all (the kit assigns one nowhere), so
+in every cross-host collision the widening side IS the side that can prefix,
+and breaking name equality on one side is enough. Two things stay
+unsupported. A prefix is a contract across the adopting app's OWN services:
+a resource server of theirs reading the access token out of the cookie (a
+file download is a top-level navigation, so it carries no `Authorization`
+header) must read the prefixed name. And two kit-DEFAULT consumers on ONE
+host still collide with no widening involved, since both take the host-only
+`useCookies()` default and a console builds its install from
+`window.__AUTHUP__`, which carries no such key; that is what a kit-level
+option would be for (PR #3403, parked). The served consoles are
+same-origin and hold no token cookies at all (cookie mode), so the question
+does not arise for them. The same-ORIGIN variant of this collision — a host
 application at `/` embedding authup under a sub-path — is defused by the
 consoles scoping their cookies to the base path (see *Account Console →
 Session cookies are scoped to the deployment base path*); the residual

--- a/docs/src/sdks/javascript/client-web-nuxt/index.md
+++ b/docs/src/sdks/javascript/client-web-nuxt/index.md
@@ -75,6 +75,14 @@ export type RuntimeOptions = {
     cookieDomainRuntimeKey?: string,
 
     /**
+     * Prefix prepended to every session cookie name
+     * (client-side & server-side)
+     *
+     * See "Namespacing the session cookies" below.
+     */
+    cookiePrefix?: string,
+
+    /**
      * Path of the home route
      * Default: /
      */
@@ -88,4 +96,47 @@ export type RuntimeOptions = {
 };
 ```
 
+## Namespacing the session cookies
 
+The session cookies are written under fixed names (`access_token`,
+`refresh_token`, `id_token`, `realm`, ...). Widening `cookieDomain` delivers
+those names to every host under that domain, so any other authup client
+reachable there writes the same names and the browser ends up holding two
+records under one name. A read takes the first, which can be the older one,
+and each side then drives on, refreshes and revokes the other's tokens. It
+surfaces as being signed out on the next page load.
+
+Set `cookiePrefix` to keep them apart:
+
+```typescript
+export default defineNuxtConfig({
+    // ...
+    modules: [
+        [
+            '@authup/client-web-nuxt',
+            {
+                apiURLRuntimeKey: 'authupUrl',
+                cookieDomainRuntimeKey: 'cookieDomain',
+                cookiePrefix: 'flame_'
+            }
+        ]
+    ]
+    // ...
+});
+```
+
+The value is prepended verbatim, so `access_token` becomes
+`flame_access_token`. Use cookie name characters only: letters, digits, `_`,
+`-` and `.`, never `:` or a space.
+
+Two consequences to plan for:
+
+- **The prefix applies to everything that reads these cookies**, not only the
+  Nuxt app. A resource server of your own that reads the access token out of
+  the cookie, because a file download is a top-level navigation and cannot
+  carry an `Authorization` header, must read the prefixed name.
+- **Cookies written before the prefix was set are afterwards neither read nor
+  cleared.** Only `access_token` and `access_token_expire_date` carry a
+  lifetime; the rest are session cookies that go away when the browser
+  closes. Sign out and close the browser once after the change, or clear the
+  cookies for the domain by hand.

--- a/docs/src/sdks/javascript/client-web-nuxt/index.md
+++ b/docs/src/sdks/javascript/client-web-nuxt/index.md
@@ -136,7 +136,10 @@ Two consequences to plan for:
   the cookie, because a file download is a top-level navigation and cannot
   carry an `Authorization` header, must read the prefixed name.
 - **Cookies written before the prefix was set are afterwards neither read nor
-  cleared.** Only `access_token` and `access_token_expire_date` carry a
-  lifetime; the rest are session cookies that go away when the browser
-  closes. Sign out and close the browser once after the change, or clear the
-  cookies for the domain by hand.
+  cleared**, because signing out only clears the prefixed names. So sign out
+  *before* you set the prefix, and nothing is left behind. If you have already
+  switched, the leftovers still clear themselves: `refresh_token`, `id_token`,
+  `realm` and `realm_management` are session cookies that go away when the
+  browser closes, and the bare `access_token` pair carries the access token's
+  own lifetime, 15 minutes by default. Clear them for the domain by hand if
+  you would rather not wait.

--- a/packages/client-web-nuxt/src/module.ts
+++ b/packages/client-web-nuxt/src/module.ts
@@ -33,16 +33,10 @@ export default defineNuxtModule<ModuleOptions>({
 
         const resolver = createResolver(import.meta.url);
 
-        const runtimeOptions : RuntimeOptions = {
-            apiURL: options.apiURL,
-            apiURLRuntimeKey: options.apiURLRuntimeKey,
-
-            cookieDomain: options.cookieDomain,
-            cookieDomainRuntimeKey: options.cookieDomainRuntimeKey,
-
-            homeRoute: options.homeRoute,
-            loginRoute: options.loginRoute,
-        };
+        // Spread rather than enumerate: `ModuleOptions` IS `RuntimeOptions`, so a
+        // hand-written list can only ever fall behind the type. `serverApiURL`
+        // already had, and the plugin read a value that never reached it.
+        const runtimeOptions : RuntimeOptions = { ...options };
 
         nuxt.options.runtimeConfig.public = nuxt.options.runtimeConfig.public || {};
         if (nuxt.options.runtimeConfig.public.authup) {

--- a/packages/client-web-nuxt/src/runtime/plugins/kit.ts
+++ b/packages/client-web-nuxt/src/runtime/plugins/kit.ts
@@ -45,6 +45,16 @@ function buildCookieOptions(runtimeConfig: RuntimeConfig) : CookieOptions {
     return cookieOptions;
 }
 
+function buildCookieName(runtimeConfig: RuntimeConfig) : (key: string) => string {
+    const options = runtimeConfig.public.authup as RuntimeOptions;
+
+    if (!options.cookiePrefix) {
+        return (key) => key;
+    }
+
+    return (key) => `${options.cookiePrefix}${key}`;
+}
+
 function buildApiUrl(runtimeConfig: RuntimeConfig) : string {
     const options = runtimeConfig.public.authup as RuntimeOptions;
 
@@ -87,6 +97,9 @@ export default defineNuxtPlugin({
 
         const baseURL = buildApiUrl(runtimeConfig);
         const cookieOptions = buildCookieOptions(runtimeConfig);
+        // One function for all three, because a prefix on the write but not on
+        // the read is a session the app can never hydrate again.
+        const cookieName = buildCookieName(runtimeConfig);
 
         install(ctx.vueApp, {
             pinia: ctx.$pinia as Pinia,
@@ -94,7 +107,7 @@ export default defineNuxtPlugin({
             cookieSet: (key, value, options) => {
                 const app = tryUseNuxtApp();
                 if (app) {
-                    const cookie = useCookie(key, {
+                    const cookie = useCookie(cookieName(key), {
                         ...cookieOptions,
                         ...(options || {}),
                     });
@@ -104,7 +117,7 @@ export default defineNuxtPlugin({
             cookieUnset: (key, options) => {
                 const app = tryUseNuxtApp();
                 if (app) {
-                    const cookie = useCookie(key, {
+                    const cookie = useCookie(cookieName(key), {
                         ...cookieOptions,
                         ...(options || {}),
                     });
@@ -114,7 +127,7 @@ export default defineNuxtPlugin({
             cookieGet: (key) => {
                 const app = tryUseNuxtApp();
                 if (app) {
-                    const cookie = useCookie(key);
+                    const cookie = useCookie(cookieName(key));
                     return cookie.value;
                 }
 

--- a/packages/client-web-nuxt/src/runtime/types.ts
+++ b/packages/client-web-nuxt/src/runtime/types.ts
@@ -35,6 +35,22 @@ export type RuntimeOptions = {
     cookieDomainRuntimeKey?: string,
 
     /**
+     * Prefix prepended to every session cookie name
+     * (client-side & server-side)
+     *
+     * The session cookies are written under fixed names (`access_token`,
+     * `refresh_token`, ...). Widening `cookieDomain` delivers those names to
+     * every host under that domain, so any other authup client there writes
+     * the same names and the browser ends up holding two records under one.
+     * A prefix keeps them apart.
+     *
+     * Prepended verbatim, so `flame_` writes `flame_access_token`. Use cookie
+     * name characters only: letters, digits, `_`, `-`, `.`, never `:` or a
+     * space.
+     */
+    cookiePrefix?: string,
+
+    /**
      * Path of the home route
      * Default: /
      */


### PR DESCRIPTION
Closes #3527.

## What

`cookiePrefix` on `@authup/client-web-nuxt`, prepended verbatim to every store
cookie name, so an embedding app that widens `cookieDomain` no longer writes
the same names as another authup client reachable under that domain.

```typescript
modules: [
    [
        '@authup/client-web-nuxt',
        {
            apiURLRuntimeKey: 'authupUrl',
            cookieDomainRuntimeKey: 'cookieDomain',
            cookiePrefix: 'flame_'
        }
    ]
]
```

`flame_access_token`, `flame_refresh_token`, and so on. Unset keeps today's
bare names, so nothing changes for an existing consumer.

## Why it lands in the plugin and not in the kit

The reporter's read of the seam is exactly right.
`packages/client-web-kit/src/core/store/install.ts` is the only source file in
the repo that names `CookieName` outside the enum and the tests, and all 16
touches inside it go through the caller-supplied `cookieGet` / `cookieSet` /
`cookieUnset`, which this plugin supplies all three of. So a prefix applied
here is total, not partial. The two cleanup sweeps (`dropShadowingCookies`
and the legacy `user` sweep) inherit it for free, which is the desirable
narrowing: today, under a widened domain, the sweep deletes BARE names at
`Domain=example.com` on every ancestor path, meaning a sibling app's or the
IdP's own cookies.

Nothing server-side reads any of these names. The complete set of cookies read
server-side is `vc-locale`, `vc-color-mode`, `authup_session`,
`authup_console_login` and `authup_federated_login`, and the three server
adapters parse no cookies at all, so the rename crosses no server contract
inside authup.

Only a consumer that supplies its own `cookieSet` can set a `Domain`, since
the kit assigns one nowhere. So in every cross-host collision the widening side
IS the side that can prefix, and breaking name equality on one side is enough
to dissolve it.

This deliberately does not revive the parked kit-level `cookiePrefix` of #3403.
That one was about authup's own consoles sharing the IdP origin, where a second
cookie set roughly doubles header weight on every request including assets, and
that reasoning still stands. It says nothing about a downstream app widening
its domain across sibling hosts, which is what this is.

## What is deliberately not here

- **No automatic sweep of the pre-prefix cookies.** Tempting and wrong: under a
  widened domain it would delete a not-yet-migrated sibling's cookies, and on
  the IdP origin it would clear the hosted auth pages' own SSO cookies, signing
  the visitor out as a side effect of loading an app. Documented instead. The
  stranding is bounded: only `access_token` and `access_token_expire_date`
  carry a lifetime, the rest are session cookies.
- **No `cookiePrefixRuntimeKey` twin.** `cookieDomain` has one because the
  domain varies per deployment. A prefix is the application's identity.
- **No charset validation, no imposed separator.** #3403 joined with `.`; this
  concatenates verbatim, matching the issue's `flame_`. The value is authored
  in build config and a bad one fails on first login. The constraint is stated
  in the docs.
- **No new spec.** `buildApiUrl` and `buildCookieOptions` in the same file are
  untested for the same reason: `plugins/kit.ts` imports `#imports` at module
  scope, which the package's vitest config cannot resolve, so a spec would cost
  a stub module and an alias to cover one ternary. Verified instead by running
  the built plugin against a stubbed `useCookie`: with a prefix set, all seven
  names touched carry it, none leak bare, and a prefixed install does not read
  a seeded bare `access_token`, which is the adoption that produces the
  reported sign-out loop.

Still unsupported, and now written down in `.agents/architecture.md`: two
kit-DEFAULT consumers colliding on ONE host with no widening involved. Both
take the host-only `useCookies()` default, and a console builds its install
from `window.__AUTHUP__`, which carries no such key. That is what a kit-level
option would be for.

## Second commit

`fix(client-web-nuxt): forward every declared module option` is a one-line
prerequisite, split out. `runtimeOptions` was a hand-written list of six fields
annotated as `RuntimeOptions` itself, so it could only fall behind, and it
already had: `serverApiURL` is declared and read by the plugin, yet never
reached `runtimeConfig`. Spreading removes the class rather than adding a
seventh line to it.

## Verification

- `npm run build -w packages/client-web-nuxt`
- `npm run test -w packages/client-web-nuxt` (15 passed)
- `npm run test -w packages/client-web-kit` (247 passed, the suite that pins
  the seam this relies on)
- `npx eslint packages/client-web-nuxt/src`
- The stubbed-`useCookie` run described above, against `dist/`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional cookie prefix setting for Nuxt clients.
  * Session cookies now consistently use the configured prefix, helping prevent collisions when multiple clients share a cookie domain.
  * Runtime configuration now supports additional module options, including the server API URL.

* **Documentation**
  * Added configuration guidance, naming rules, migration considerations, and coordination requirements for prefixed cookies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->