### PR TITLE
ci: type-check test files in every workspace, not 5 of 29

### DIFF
--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -55,6 +55,33 @@
   in, transitive ones included: an unaliased package is bundled from its
   built dist while `vue-tsc` checks the source, so the two silently disagree
   until a rebuild.
+- **`check:types` (`tsc -p tsconfig.test.json`, `vue-tsc` in the Vue
+  workspaces) is the only thing that type-checks `test/**`.** `build:types`
+  compiles `src` alone, and vitest transpiles through SWC, which strips types
+  without checking them. So a type error in a spec (or in `src`, exercised
+  only by a spec) otherwise ships green and surfaces as a RUNTIME assertion
+  failure, which reads as a different class of bug and gets diagnosed as one.
+  That happened in #3517. Every workspace declares the script, so CI's
+  `npm run check:types --workspaces --if-present` is a real gate rather than
+  a hand-kept list; adding a workspace means adding its `tsconfig.test.json`
+  too. The three client console BUNDLES are the exception and carry none:
+  their `build:types` is already `vue-tsc --noEmit -p tsconfig.json` and that
+  config's `include` lists `test/**/*.ts`, so their tests are gated by the
+  build job instead, and a second script there would run vue-tsc twice for no
+  coverage. `packages/client-web-nuxt` is the one config that deviates, in
+  three ways: its script is prefixed with `nuxt-module-build prepare` because
+  its tsconfig extends the generated, gitignored `.nuxt/tsconfig.json` (on a
+  warm nx cache the lint job's build step is skipped and `.nuxt` never
+  exists); it runs `vue-tsc` because Nuxt's generated config aliases
+  `@authup/client-web-kit` to source, which imports `.vue`; and it omits
+  `"ignoreDeprecations": "6.0"`, because that chain never reaches the repo
+  root, whose deprecated `baseUrl` is the whole reason the other configs
+  carry it. That generated config is also STRICTER than the root (it sets
+  `noUncheckedIndexedAccess`), which is why two genuine `src` errors surfaced
+  there and nowhere else. The gate stops at the include globs
+  (`src/**/*.ts` + `test/**/*.ts`), so root-level build files
+  (`tsdown.config.ts`, `vite.config.ts`, `test/vitest.config.ts`) stay
+  unchecked.
 - The auth console emits both halves of its SSR output from one
   `vite build`, declared as `environments: { client, ssr }` plus
   `builder: {}` rather than two invocations with CLI flags. The output

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -55,6 +55,7 @@ npm run build                                  # required before testing
 npm run test                                   # test all apps/packages
 npm run test --workspace=apps/server-core      # test a single app/package
 npm run test --workspace=apps/server-core -- test/unit/core/entities/role/service.spec.ts  # run a specific test file
+npm run check:types --workspace=apps/server-core  # type-check src + test (vitest's SWC does not)
 ```
 
 ### Database-Specific Tests (server-core)

--- a/apps/client-auth-console/tsconfig.json
+++ b/apps/client-auth-console/tsconfig.json
@@ -13,6 +13,7 @@
     },
     "include": [
         "src/**/*.ts",
-        "src/**/*.vue"
+        "src/**/*.vue",
+        "test/**/*.ts"
     ]
 }

--- a/packages/access/package.json
+++ b/packages/access/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/access/test/unit/permission/checker.spec.ts
+++ b/packages/access/test/unit/permission/checker.spec.ts
@@ -8,7 +8,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ErrorCode } from '@authup/errors';
-import type { AttributeNamesPolicy, PermissionPolicyBinding } from '../../../src';
+import type { PermissionPolicyBinding } from '../../../src';
 import { 
     BuiltInPolicyType, 
     PermissionError, 
@@ -17,16 +17,14 @@ import {
     PolicyDefaultEvaluators, 
     PolicyEngine, 
     definePolicyData, 
+    definePolicyWithType,
 } from '../../../src';
 
 const abilities : PermissionPolicyBinding[] = [
     {
         permission: { name: 'user_edit' },
         policies: [
-            {
-                type: BuiltInPolicyType.ATTRIBUTE_NAMES,
-                names: ['name'],
-            } satisfies AttributeNamesPolicy,
+            definePolicyWithType(BuiltInPolicyType.ATTRIBUTE_NAMES, { names: ['name'] }),
         ],
     },
     { permission: { name: 'user_add' } },

--- a/packages/access/test/unit/permission/escalation.spec.ts
+++ b/packages/access/test/unit/permission/escalation.spec.ts
@@ -122,16 +122,19 @@ describe('escalation prevention', () => {
     });
 
     it('should allow: same policy by id even as distinct objects (identity, not reference)', () => {
+        const parentPolicy = { type: BuiltInPolicyType.ATTRIBUTES, id: 'realm-bound-id' };
+        const childPolicy = { type: BuiltInPolicyType.ATTRIBUTES, id: 'realm-bound-id' };
+
         const parent: PermissionPolicyBinding[] = [
             {
                 permission: { name: 'user_read' },
-                policies: [{ type: BuiltInPolicyType.ATTRIBUTES, id: 'realm-bound-id' }],
+                policies: [parentPolicy],
             },
         ];
         const child: PermissionPolicyBinding[] = [
             {
                 permission: { name: 'user_read' },
-                policies: [{ type: BuiltInPolicyType.ATTRIBUTES, id: 'realm-bound-id' }],
+                policies: [childPolicy],
             },
         ];
 
@@ -182,24 +185,27 @@ describe('escalation prevention', () => {
     it('should allow: distinct policy rows with identical configuration (value-compare, different id)', () => {
         // Two SEPARATE policy rows (different id) encoding the same restriction = same predicate,
         // so the actor genuinely holds what it confers. id differs; structural config is identical.
+        const policyRow1 = {
+            type: BuiltInPolicyType.ATTRIBUTES,
+            id: 'row-1',
+            query: { department: 'x' },
+        };
+        const policyRow2 = {
+            type: BuiltInPolicyType.ATTRIBUTES,
+            id: 'row-2',
+            query: { department: 'x' },
+        };
+
         const parent: PermissionPolicyBinding[] = [
             {
                 permission: { name: 'user_update' },
-                policies: [{
-                    type: BuiltInPolicyType.ATTRIBUTES, 
-                    id: 'row-1', 
-                    query: { department: 'x' }, 
-                }],
+                policies: [policyRow1],
             },
         ];
         const child: PermissionPolicyBinding[] = [
             {
                 permission: { name: 'user_update' },
-                policies: [{
-                    type: BuiltInPolicyType.ATTRIBUTES, 
-                    id: 'row-2', 
-                    query: { department: 'x' }, 
-                }],
+                policies: [policyRow2],
             },
         ];
 

--- a/packages/access/test/unit/policy/attribute-names.spec.ts
+++ b/packages/access/test/unit/policy/attribute-names.spec.ts
@@ -49,10 +49,11 @@ describe('src/policy/attribute-names', () => {
 
     it('should parse options with unknown', async () => {
         const validator = new AttributeNamesPolicyValidator();
-        const output = await validator.run({
+        const input : AttributeNamesPolicy & { foo?: string } = {
             names: ['foo', 'bar'],
             foo: 'bar',
-        } satisfies AttributeNamesPolicy & { foo?: string }) as Partial<AttributeNamesPolicy> & { foo?: string };
+        };
+        const output = await validator.run(input) as Partial<AttributeNamesPolicy> & { foo?: string };
 
         expect(output.names).toBeDefined();
         expect(output.foo).toBeUndefined();

--- a/packages/access/test/unit/policy/attributes.spec.ts
+++ b/packages/access/test/unit/policy/attributes.spec.ts
@@ -54,10 +54,11 @@ describe('src/policy/attributes', () => {
 
     it('should parse options with unknown', async () => {
         const validator = new AttributesPolicyValidator();
-        const output = await validator.run({
+        const input : AttributesPolicy & { foo?: string } = {
             query: { name: { $eq: 'admin' } },
             foo: 'bar',
-        } satisfies AttributesPolicy & { foo?: string }) as Partial<AttributesPolicy> & { foo?: string };
+        };
+        const output = await validator.run(input) as Partial<AttributesPolicy> & { foo?: string };
 
         expect(output.query).toBeDefined();
         expect(output.foo).toBeUndefined();

--- a/packages/access/test/unit/policy/date.spec.ts
+++ b/packages/access/test/unit/policy/date.spec.ts
@@ -54,11 +54,12 @@ describe('src/policy/date', () => {
 
     it('should parse options with unknown', async () => {
         const validator = new DatePolicyValidator();
-        const output = await validator.run({
+        const input : DatePolicy & { foo?: string } = {
             start: '2024-01-01',
             end: '2024-05-01',
             foo: 'bar',
-        } satisfies DatePolicy & { foo?: string }) as Partial<DatePolicy> & { foo?: string };
+        };
+        const output = await validator.run(input) as Partial<DatePolicy> & { foo?: string };
 
         expect(output.start).toEqual('2024-01-01');
         expect(output.end).toEqual('2024-05-01');

--- a/packages/access/test/unit/policy/time.spec.ts
+++ b/packages/access/test/unit/policy/time.spec.ts
@@ -69,10 +69,11 @@ describe('src/policy/time', () => {
 
     it('should parse options with unknown', async () => {
         const validator = new TimePolicyValidator();
-        const output = await validator.run({
+        const input: TimePolicy & { foo?: string } = {
             start: '08:00:00',
             foo: 'bar',
-        } satisfies TimePolicy & { foo?: string }) as Partial<TimePolicy> & { foo?: string };
+        };
+        const output = await validator.run(input) as Partial<TimePolicy> & { foo?: string };
 
         expect(output.start)
             .toEqual('08:00:00');

--- a/packages/access/tsconfig.test.json
+++ b/packages/access/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/client-web-kit-theme/package.json
+++ b/packages/client-web-kit-theme/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
     "build:js": "tsdown",
-    "build": "rimraf ./dist && npm run build:js && npm run build:types"
+    "build": "rimraf ./dist && npm run build:js && npm run build:types",
+    "check:types": "tsc -p tsconfig.test.json"
   },
   "engines": {
     "node": "^22.13.0 || ^23.5.0 || >=24.0.0"

--- a/packages/client-web-kit-theme/tsconfig.test.json
+++ b/packages/client-web-kit-theme/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/client-web-kit/package.json
+++ b/packages/client-web-kit/package.json
@@ -21,6 +21,7 @@
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
         "build:watch": "npm run build -- --watch",
+        "check:types": "vue-tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
         "test:coverage": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts --coverage"
     },

--- a/packages/client-web-kit/test/unit/components/workflows/authorize-form-silent.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize-form-silent.spec.ts
@@ -63,6 +63,8 @@ const client: Client = {
         createdAt: new Date(0).toISOString(),
         updatedAt: new Date(0).toISOString(),
     },
+    accessPolicyId: null,
+    accessPolicy: null,
 };
 
 // a non-login_required failure (transient 500 / network blip)

--- a/packages/client-web-kit/test/unit/components/workflows/authorize-form.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize-form.spec.ts
@@ -67,6 +67,8 @@ const client: Client = {
     updatedAt: now,
     realmId: 'realm-x',
     realm,
+    accessPolicyId: null,
+    accessPolicy: null,
 };
 
 type FormProps = {

--- a/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/authorize.spec.ts
@@ -9,6 +9,7 @@ import type {
     Client, 
     Consent, 
     OAuth2AuthorizationCodeRequest, 
+    Realm,
     User,
 } from '@authup/core-kit';
 import { IDENTITY_PROVIDER_LOGIN_NOT_PENDING } from '@authup/core-http-kit';
@@ -94,10 +95,46 @@ function seedLoggedIn(store: Store, realmId = REALM.id, withUser = true) {
 // lowercase scope token, mirroring the server's persisted shape.
 function consentRow(scope: string, expiresAt: string | null = null): Consent {
     const now = new Date(0).toISOString();
+    const realm: Realm = {
+        id: REALM.id,
+        name: REALM.name,
+        displayName: null,
+        description: null,
+        builtIn: false,
+        createdAt: now,
+        updatedAt: now,
+    };
+
     return {
         id: `consent-${scope}`,
         clientId: 'client-1',
+        client: {
+            id: 'client-1',
+            active: true,
+            builtIn: false,
+            authMethod: 'none',
+            tokenBindingMethod: 'none',
+            name: 'web',
+            displayName: 'Web',
+            description: null,
+            secret: null,
+            secretHashed: false,
+            secretEncrypted: false,
+            redirectUri: null,
+            postLogoutRedirectUri: null,
+            grantTypes: null,
+            scope: null,
+            baseUrl: null,
+            rootUrl: null,
+            createdAt: now,
+            updatedAt: now,
+            realmId: REALM.id,
+            realm,
+            accessPolicyId: null,
+            accessPolicy: null,
+        },
         realmId: REALM.id,
+        realm,
         userId: 'user-1',
         sub: 'user-1',
         subKind: 'user',
@@ -223,6 +260,8 @@ function mountAuthorize(overrides: MountOverrides = {}) {
             createdAt: clientTimestamp,
             updatedAt: clientTimestamp,
         },
+        accessPolicyId: null,
+        accessPolicy: null,
     };
 
     let store!: Store;

--- a/packages/client-web-kit/test/unit/components/workflows/mfa-challenge.spec.ts
+++ b/packages/client-web-kit/test/unit/components/workflows/mfa-challenge.spec.ts
@@ -77,9 +77,10 @@ describe('AMfaChallengeForm', () => {
                 new URL(r.url, 'http://localhost').pathname === '/authenticators/challenge',
         );
         expect(verifyRequest).toBeDefined();
-        expect(verifyRequest!.body.kind).toEqual('webauthn');
+        const verifyBody = verifyRequest!.body as Record<string, string>;
+        expect(verifyBody.kind).toEqual('webauthn');
         // the assertion is forwarded as a JSON string
-        expect(JSON.parse(verifyRequest!.body.response).id).toEqual('cred-1');
+        expect(JSON.parse(verifyBody.response).id).toEqual('cred-1');
         expect(wrapper.emitted('done')).toBeTruthy();
     });
 

--- a/packages/client-web-kit/tsconfig.test.json
+++ b/packages/client-web-kit/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "types/**/*.d.ts",
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/client-web-nuxt/package.json
+++ b/packages/client-web-nuxt/package.json
@@ -24,6 +24,7 @@
         "build": "nuxt-module-build prepare && nuxt-module-build build",
         "prepack": "nuxt-module-build prepare && nuxt-module-build build",
         "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
+        "check:types": "nuxt-module-build prepare && vue-tsc -p tsconfig.test.json",
         "lint": "eslint .",
         "test": "nuxt-module-build prepare && cross-env NODE_ENV=test vitest run --config test/vitest.config.ts"
     },

--- a/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
+++ b/packages/client-web-nuxt/src/runtime/helpers/routing-interceptor.ts
@@ -16,6 +16,7 @@ import {
 } from '@authup/client-web-kit';
 import { hasOwnProperty, omitRecord } from '@authup/kit';
 import type { RouteLocationAsPathGeneric, RouteLocationNormalized } from 'vue-router';
+import type { Pinia } from 'pinia';
 import { BuiltInPolicyType, type IdentityPolicyData, definePolicyData } from '@authup/access';
 import type { NuxtApp } from '#app';
 import { RouteMetaKey } from '../constants';
@@ -37,7 +38,7 @@ export class RoutingInterceptor {
     protected loginRoute : string;
 
     constructor(nuxtApp: NuxtApp) {
-        this.store = injectStore(nuxtApp.$pinia, nuxtApp.vueApp);
+        this.store = injectStore(nuxtApp.$pinia as Pinia | undefined, nuxtApp.vueApp);
         this.storeRefs = storeToRefs(this.store);
 
         const runtimeOptions = nuxtApp.$config.public.authup as RuntimeOptions;
@@ -114,7 +115,7 @@ export class RoutingInterceptor {
                     const query : Record<string, string | string[]> = {};
                     for (const key of new Set(destination.searchParams.keys())) {
                         const values = destination.searchParams.getAll(key);
-                        query[key] = values.length > 1 ? values : values[0];
+                        query[key] = values.length > 1 ? values : values[0]!;
                     }
 
                     return {

--- a/packages/client-web-nuxt/tsconfig.test.json
+++ b/packages/client-web-nuxt/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+    "extends": "./tsconfig.json",
+    // No `ignoreDeprecations` here: this chain extends the Nuxt-generated .nuxt/tsconfig.json,
+    // not the repo root, whose deprecated `baseUrl` is what the sibling configs suppress.
+    "compilerOptions": {
+        "noEmit": true
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/client-web-theme/package.json
+++ b/packages/client-web-theme/package.json
@@ -22,7 +22,8 @@
   "scripts": {
     "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
     "build:js": "tsdown",
-    "build": "rimraf ./dist && npm run build:js && npm run build:types"
+    "build": "rimraf ./dist && npm run build:js && npm run build:types",
+    "check:types": "tsc -p tsconfig.test.json"
   },
   "engines": {
     "node": "^22.13.0 || ^23.5.0 || >=24.0.0"

--- a/packages/client-web-theme/tsconfig.test.json
+++ b/packages/client-web-theme/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/core-http-kit/package.json
+++ b/packages/core-http-kit/package.json
@@ -24,6 +24,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/core-http-kit/test/unit/fake-client.spec.ts
+++ b/packages/core-http-kit/test/unit/fake-client.spec.ts
@@ -24,6 +24,7 @@ describe('src/testing/matcher', () => {
             method: 'GET', 
             url: 'clients', 
             params: {},
+            headers: {},
         })).toEqual('many');
     });
 
@@ -39,6 +40,7 @@ describe('src/testing/matcher', () => {
             method: 'POST', 
             url: 'clients', 
             params: {},
+            headers: {},
         })).toEqual('created');
     });
 
@@ -53,6 +55,7 @@ describe('src/testing/matcher', () => {
             method: 'GET', 
             url: '', 
             params: {},
+            headers: {},
         })).toEqual('fallthrough');
     });
 
@@ -65,6 +68,7 @@ describe('src/testing/matcher', () => {
             method: 'GET', 
             url: '', 
             params: {},
+            headers: {},
         })).toEqual('one');
     });
 

--- a/packages/core-http-kit/tsconfig.test.json
+++ b/packages/core-http-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/core-kit/package.json
+++ b/packages/core-kit/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/core-kit/tsconfig.test.json
+++ b/packages/core-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/core-realtime-kit/package.json
+++ b/packages/core-realtime-kit/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/core-realtime-kit/tsconfig.test.json
+++ b/packages/core-realtime-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit"
     },
     "engines": {

--- a/packages/errors/test/unit/check.spec.ts
+++ b/packages/errors/test/unit/check.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import type { Issue } from '@ebec/core';
 import { BaseError, isBaseError, markInstanceof } from '@ebec/core';
 import { describe, expect, it } from 'vitest';
 import {
@@ -147,7 +148,7 @@ describe('duck-type guards (JSON-rehydrated)', () => {
         // and the shape heuristic must not run.
         const FOREIGN_MARKER = Symbol.for('@foreign/ForeignError');
         class ForeignError extends BaseError {
-            issues: unknown[] = [];
+            readonly issues: readonly Issue[] = [];
 
             constructor() {
                 super({ message: 'foo', code: 'inputRejected' });

--- a/packages/errors/tsconfig.test.json
+++ b/packages/errors/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/i18n/tsconfig.test.json
+++ b/packages/i18n/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/kit/package.json
+++ b/packages/kit/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/kit/tsconfig.test.json
+++ b/packages/kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-adapter-kit/package.json
+++ b/packages/server-adapter-kit/package.json
@@ -22,6 +22,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-adapter-kit/tsconfig.test.json
+++ b/packages/server-adapter-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-adapter-node/package.json
+++ b/packages/server-adapter-node/package.json
@@ -22,6 +22,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-adapter-node/tsconfig.test.json
+++ b/packages/server-adapter-node/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-adapter-socket-io/package.json
+++ b/packages/server-adapter-socket-io/package.json
@@ -19,6 +19,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-adapter-socket-io/tsconfig.test.json
+++ b/packages/server-adapter-socket-io/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-adapter-web/package.json
+++ b/packages/server-adapter-web/package.json
@@ -22,6 +22,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-adapter-web/tsconfig.test.json
+++ b/packages/server-adapter-web/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-config-kit/package.json
+++ b/packages/server-config-kit/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-config-kit/test/unit/schema.spec.ts
+++ b/packages/server-config-kit/test/unit/schema.spec.ts
@@ -288,7 +288,7 @@ describe('mergeSchemaData', () => {
             publicUrl: 'https://idp.example.com',
             server: { core: { host: '10.0.0.1' } },
         }, SCHEMA);
-        const env = { core: { port: 4001 } };
+        const env = { core: { port: 4001 } } as Partial<Fixture>;
 
         expect(mergeSchemaData(SCHEMA, defaults, file, env)).toEqual({
             publicUrl: 'https://idp.example.com',
@@ -313,7 +313,7 @@ describe('mergeSchemaData', () => {
 describe('mountSchema', () => {
     it('should validate a section rather than drop it', async () => {
         const container = new Container<Record<string, any>>();
-        mountSchema(container, SCHEMA);
+        mountSchema(container, SCHEMA as SchemaInput<Record<string, any>>);
 
         await expect(container.run({
             publicUrl: 'https://idp.example.com',

--- a/packages/server-config-kit/test/unit/schema.spec.ts
+++ b/packages/server-config-kit/test/unit/schema.spec.ts
@@ -288,7 +288,9 @@ describe('mergeSchemaData', () => {
             publicUrl: 'https://idp.example.com',
             server: { core: { host: '10.0.0.1' } },
         }, SCHEMA);
-        const env = { core: { port: 4001 } } as Partial<Fixture>;
+        // a section arrives partial, which validup's own shallow
+        // `ContainerInput<T> = Partial<T>` cannot express.
+        const env : Record<string, any> = { core: { port: 4001 } };
 
         expect(mergeSchemaData(SCHEMA, defaults, file, env)).toEqual({
             publicUrl: 'https://idp.example.com',
@@ -312,20 +314,25 @@ describe('mergeSchemaData', () => {
 
 describe('mountSchema', () => {
     it('should validate a section rather than drop it', async () => {
-        const container = new Container<Record<string, any>>();
-        mountSchema(container, SCHEMA as SchemaInput<Record<string, any>>);
+        const container = new Container<Fixture>();
+        mountSchema(container, SCHEMA);
 
-        await expect(container.run({
+        // what a parsed document actually carries: untrusted, and a section
+        // arrives partial, which validup's own shallow `ContainerInput<T> =
+        // Partial<T>` cannot express.
+        const invalid : Record<string, any> = {
             publicUrl: 'https://idp.example.com',
             core: { port: 'not-a-port' },
-        })).rejects.toThrow();
+        };
+        await expect(container.run(invalid)).rejects.toThrow();
 
         // a mounted section is also what carries the value over: validup
         // strips whatever nothing claims.
-        expect(await container.run({
+        const valid : Record<string, any> = {
             publicUrl: 'https://idp.example.com',
             core: { port: 4001 },
-        })).toEqual({
+        };
+        expect(await container.run(valid)).toEqual({
             publicUrl: 'https://idp.example.com',
             core: { port: 4001 },
         });

--- a/packages/server-config-kit/tsconfig.test.json
+++ b/packages/server-config-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-config/package.json
+++ b/packages/server-config/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-config/test/unit/schema.spec.ts
+++ b/packages/server-config/test/unit/schema.spec.ts
@@ -17,6 +17,7 @@ import {
 } from '@authup/server-config-kit';
 import { describe, expect, it } from 'vitest';
 import {
+    CORE_SCHEMA,
     EnvironmentVariable,
     SCHEMA,
     expandToOrigins,
@@ -34,8 +35,8 @@ type Declaration = {
  * shaped like the configuration object, so a key of a section is only
  * reachable through it.
  */
-function collectDeclarations(
-    schema: SchemaInput<any>,
+function collectDeclarations<T>(
+    schema: SchemaInput<T>,
     prefix = '',
     declarations: Declaration[] = [],
 ) : Declaration[] {
@@ -49,14 +50,14 @@ function collectDeclarations(
         }
 
         if (isSchemaInput(entry)) {
-            collectDeclarations(entry as SchemaInput<any>, key, declarations);
+            collectDeclarations<any>(entry, key, declarations);
         }
     }
 
     return declarations;
 }
 
-const DECLARATIONS = collectDeclarations(SCHEMA);
+const DECLARATIONS = collectDeclarations<AuthupConfig>(SCHEMA);
 
 describe('SCHEMA', () => {
     /**
@@ -222,7 +223,7 @@ describe('SCHEMA', () => {
     });
 
     it('rejects a mis-typed trustProxy allowlist entry', () => {
-        const { type } = SCHEMA.core.trustProxy;
+        const { type } = CORE_SCHEMA.trustProxy;
 
         expect(type.safeParse(['10.0.0.0/8', 'loopback']).success).toBe(true);
         // proxy-addr would compile '1' to the address 0.0.0.1

--- a/packages/server-config/tsconfig.test.json
+++ b/packages/server-config/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-console-kit/package.json
+++ b/packages/server-console-kit/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run --config test/vitest.config.ts",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-console-kit/tsconfig.test.json
+++ b/packages/server-console-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-kit/package.json
+++ b/packages/server-kit/package.json
@@ -21,6 +21,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-kit/tsconfig.test.json
+++ b/packages/server-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/server-test-kit/package.json
+++ b/packages/server-test-kit/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/server-test-kit/test/unit/index.spec.ts
+++ b/packages/server-test-kit/test/unit/index.spec.ts
@@ -5,6 +5,7 @@
  * view the LICENSE file that was distributed with this source code.
  */
 
+import { Query } from '@rapiq/core';
 import { describe, expect, it } from 'vitest';
 import {
     FakeEntityRepository,
@@ -40,7 +41,7 @@ describe('FakeEntityRepository', () => {
     it('paginates findMany with total count', async () => {
         const repo = new FakeEntityRepository<{ id: string }>();
         repo.seed([{ id: '1' }, { id: '2' }, { id: '3' }]);
-        const { data, meta } = await repo.findMany({});
+        const { data, meta } = await repo.findMany(new Query({}));
         expect(data).toHaveLength(3);
         expect(meta.total).toBe(3);
     });

--- a/packages/server-test-kit/tsconfig.test.json
+++ b/packages/server-test-kit/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}

--- a/packages/specs/package.json
+++ b/packages/specs/package.json
@@ -20,6 +20,7 @@
         "build:types": "tsc --emitDeclarationOnly -p tsconfig.build.json",
         "build:js": "tsdown",
         "build": "rimraf ./dist && npm run build:js && npm run build:types",
+        "check:types": "tsc -p tsconfig.test.json",
         "test": "cross-env NODE_ENV=test vitest run test/unit",
         "test:coverage": "cross-env NODE_ENV=test vitest run --coverage"
     },

--- a/packages/specs/tsconfig.test.json
+++ b/packages/specs/tsconfig.test.json
@@ -1,0 +1,11 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "noEmit": true,
+        "ignoreDeprecations": "6.0"
+    },
+    "include": [
+        "src/**/*.ts",
+        "test/**/*.ts"
+    ]
+}


### PR DESCRIPTION
Closes #3521.

`npm run check:types --workspaces --if-present` silently covered only the 5 workspaces that declared the script. Everywhere else nothing type-checked `test/**`: `build:types` compiles `src` alone, and vitest transpiles through SWC, which strips types without checking them.

As the issue argues, the cost is not only broken tests. A type error in `src` that a spec exercises surfaces as a **runtime** assertion failure, which reads as a different class of bug and gets diagnosed as one, the way it did in #3517.

## What changed

**21 packages** gain a `tsconfig.test.json` + `"check:types"`, mirroring `apps/server-core` verbatim.

**`apps/client-auth-console` needed one line instead**, and this is worth knowing before reviewing the rest. Its `build:types` is already `vue-tsc --noEmit -p tsconfig.json`, and its two console siblings already list `test/**/*.ts` in that config's `include`, which is why their tests were the only client-console tests being checked at all. Verified by planting `const x: string = 42` in `apps/client-admin-console/test/unit/` and watching `build:types` fail with `TS2322`. So this app only needed the missing `include` entry. A `check:types` script there would run `vue-tsc` twice in CI for no coverage.

CI needs no change: `--if-present` picks each new script up.

## What turning it on found

**27 pre-existing type errors**, all fixed, none by weakening a type. No `as any`, no `@ts-ignore`/`@ts-expect-error`, no deleted assertion, no skipped test. Test counts are provably unchanged (zero added or removed `it()`/`describe()` lines across the whole spec diff).

**Two are real `src` bugs**, both in `client-web-nuxt`, both only visible because its Nuxt-generated config is stricter than the repo root:

- `nuxtApp.$pinia` is typed `unknown` where the module itself compiles. The `$pinia` injection is declared only by Nuxt's generated `plugins.d.ts` in a *consuming* app, and `@pinia/nuxt` ships no augmentation of its own, so the module's runtime code depends on a type that does not exist where the module is built.
- `noUncheckedIndexedAccess` flags an unguarded `values[0]` in the routing interceptor.

Both are fixed with narrowing assertions rather than widened types, and both are type-erased.

## Deliberate deviations

`packages/client-web-nuxt` is the one config that differs, in three ways, each verified rather than assumed:

- the script is prefixed with `nuxt-module-build prepare`, because its tsconfig extends the generated, gitignored `.nuxt/tsconfig.json`. On a warm nx cache the lint job's build step is skipped and `.nuxt` never exists, so a bare `vue-tsc` would die on a missing `extends` target.
- it runs `vue-tsc`, because Nuxt's generated config aliases `@authup/client-web-kit` to *source*, which imports `.vue` (plain `tsc` gives ~60 `TS2307`s).
- it omits `"ignoreDeprecations": "6.0"`, because that chain never reaches the root config whose deprecated `baseUrl` is the reason the other 20 carry it. The file carries a comment saying so, since it is the only one that differs.

`packages/client-web-kit` keeps its `types/**/*.d.ts` glob, since a child `include` replaces the parent's rather than extending it. It also stayed on `strict: true` (its `tsconfig.json`, not the `strict: false` its build uses): that produced only 6 errors, all genuine and all in tests, so the bar was not lowered.

The two theme packages have no `test/` yet and get the script anyway. A gate that is uniform is a gate; one with two undocumented holes is the thing this issue is about.

## Verification

- `npm run check:types --workspaces --if-present` → exit 0 across **26/26** declaring workspaces.
- `npm run lint` → exit 0.
- `npm run build` → exit 0.
- Every touched workspace's suite passes: access 157, client-web-kit 247, core-http-kit 24, errors 29, server-config 15, server-config-kit 32, server-test-kit 11.
- **Each gate is differentially proven.** A check that cannot fail reads as coverage without being any, so every workspace had a deliberate `const probe: string = 42` planted, confirmed to fail with `TS2322` naming the file, and removed. Three were re-planted against the aggregate `--workspaces` run to confirm a single workspace's failure propagates, which is what CI depends on.

## Known limits, stated so they are not mistaken for coverage

- The include globs are `src/**/*.ts` + `test/**/*.ts`, so root-level build files (`tsdown.config.ts`, `vite.config.ts`, `test/vitest.config.ts`) stay unchecked. This matches the pre-existing pattern in the 5 workspaces that already had it.
- One cast in `packages/server-config-kit/test/unit/schema.spec.ts` asserts a shape the value lacks, because `Partial<T>` is shallow. It papers over a genuine understatement in `mergeSchemaData`'s own signature: the source passes produce *partial sections*, which the parameter type cannot express. Left alone here because fixing it changes five exported signatures and ripples into `@authup/server-config`, `apps/server-core` and `apps/authup`, and because `validup`'s own `ContainerInput<T> = Partial<T>` carries the identical understatement upstream. Worth its own issue.
- `.agents/architecture.md` documents `PermissionPolicyBinding.policies?: PolicyWithType[]` while src declares `BasePolicy[]`. src is right: `PolicyWithType` resolves to `Record<string, any> & BasePolicy`, so adopting it would forfeit exactly the checking this PR buys. The doc line is stale; not corrected here to keep the diff to its subject.

`.agents/conventions.md` and `.agents/testing.md` record the contract.
