### PR TITLE
docs(deployment): rewrite for the console services and the core/console roles

### DIFF
--- a/docs/src/guide/deployment/account-console.md
+++ b/docs/src/guide/deployment/account-console.md
@@ -2,8 +2,11 @@
 
 The account console is the end-user self-service surface. It is a
 client-side single-page application (the `@authup/client-account-console`
-package) that `server-core` serves on the IdP origin at
-`<publicUrl>/console/account` by default. It works in every deployment, including
+package) served by `@authup/server-account-console` on the IdP origin at
+`<publicUrl>/console/account` by default. `authup start` runs that service
+alongside the API on one listener; `authup console account` runs it alone, on
+its own port, for a [split deployment](./console-replicas.md).
+It works in every deployment, including
 ones that run with the admin console disabled, and gives each of your
 applications a stable "Manage account" link target.
 
@@ -20,11 +23,27 @@ It covers:
 
 ## Sign-in
 
-The surface authenticates through a regular authorization-code + PKCE flow
-against the per-realm `account-console` system client (see
-[Provisioning](./provisioning.md#per-realm-system-clients)). A user visiting
-`/console/account` without a session picks a realm (a single-realm deployment skips
-the picker) and is redirected to the hosted login. An existing session on the
+Served on the IdP origin, the console signs in **through the server** and never
+holds an OAuth2 token in JavaScript. A user visiting `/console/account` without
+a session picks a realm (a single-realm deployment skips the picker), and the
+page navigates to `GET /console/account/login/start`. The server mints the PKCE
+verifier and the `state`, parks them behind a short-lived cookie and redirects
+to the hosted login; `GET /console/account/callback` then redeems the code,
+revokes the tokens it received and hands the browser an opaque, `HttpOnly`
+session cookie naming the session row. Those two routes are the only
+`/console/account` paths the API answers; everything else under it is the
+console service. The admin console signs in the same way, and both surfaces
+share the single session on that origin.
+
+The flow is an authorization-code flow with PKCE either way, against the
+per-realm `account-console` system client (see
+[Provisioning](./provisioning.md#per-realm-system-clients)). What the
+server-side variant changes is who holds the credential. A bundle hosted
+standalone on a foreign origin cannot present a `SameSite=Strict` cookie, so it
+runs the same flow in the browser and keeps its tokens there; that is decided
+at runtime, not configured.
+
+An existing session on the
 IdP origin is reused, so no second session row is created. Attribution is per
 token (`auth_session_tokens.client_id`), so the tokens the account console
 obtains name the `account-console` client. The session row itself records no

--- a/docs/src/guide/deployment/bare-metal.md
+++ b/docs/src/guide/deployment/bare-metal.md
@@ -89,18 +89,19 @@ i Server: Started http server.
 
 Now all should be set up, and you are ready to go :tada:
 
-This will launch one service with default settings:
+This will launch the API with default settings:
 - Backend (server/core): `http://127.0.0.1:3000/`
 
-The consoles are served by that same process:
+The consoles run in that same process, on the same listener:
+- Auth console (login, consent, register, password recovery): `http://127.0.0.1:3000/console/auth`
 - Admin console: `http://127.0.0.1:3000/console/admin`
 - Account console: `http://127.0.0.1:3000/console/account`
 
 ## Process behavior
 
-`authup start` runs `server/core` **in the process you started**. There is no
-child process and no supervisor, so there is nothing between you and the
-service:
+`authup start` runs `server/core` and every enabled console **in the process
+you started**. There is no child process and no supervisor, so there is nothing
+between you and the service:
 
 - **Environment**: the process environment is the server's environment. Every
   [server](./configuration-server-core) variable can be set on the `authup`
@@ -115,23 +116,32 @@ service:
   restart it.
 
 The service cannot be named as an argument. `authup start server.core` and
-`authup start server/core` are refused: `start` and `worker` take no
-positional argument, because the CLI starts exactly one service.
+`authup start server/core` are refused: `start`, `core` and `worker` take no
+positional argument. The one command that takes a name is `console`, and it
+names a console to serve, not a package to select.
 
 ::: warning `client.admin-console` no longer exists
-The admin console is served by `server/core` at `<publicUrl>/console/admin`.
+The admin console is served by `@authup/server-admin-console` at
+`<publicUrl>/console/admin`, composed into `authup start`.
 `authup start client.admin-console` is refused as an unexpected argument, and a
 `client.admin-console` section in the configuration file is not read. Remove
-both. See
-[Upgrading](./upgrading.md#the-admin-console-is-served-by-server-core).
+both. See [Upgrading](./upgrading.md).
 :::
 
 ## Other commands
 
-The CLI carries three more commands, all against the same `server/core`
-service:
+The CLI carries more commands. `core` and `console` split what `start` does
+into two processes (see [Console Replicas](./console-replicas.md)); the rest
+act on the same deployment:
 
 ```shell
+# the API and the IdP alone, mounting no console
+$ authup core
+
+# one console service, or every enabled one, each on its own port
+$ authup console
+$ authup console admin
+
 # run the background sweeps alone, with no HTTP listener
 $ authup worker
 

--- a/docs/src/guide/deployment/configuration-client-admin-console.md
+++ b/docs/src/guide/deployment/configuration-client-admin-console.md
@@ -3,23 +3,28 @@
 The admin console is the administration surface: realms, clients, users,
 roles, permissions, policies, keys, sessions and the audit event log. It is a
 client-side single-page application (the `@authup/client-admin-console`
-package) that `server-core` serves on the IdP origin at `<publicUrl>/console/admin`
-by default, the same way it serves the
-[account console](./account-console.md) at `<publicUrl>/console/account`.
+package) served by `@authup/server-admin-console` on the IdP origin at
+`<publicUrl>/console/admin` by default, the same way the
+[account console](./account-console.md) is served at
+`<publicUrl>/console/account`.
 
-It is no longer a service of its own. Earlier releases shipped it as a
-separate Nuxt server with its own port and its own environment variables; a
-deployment now runs `server/core` alone. See
-[Upgrading](./upgrading.md#the-admin-console-is-served-by-server-core) for what
-to remove from an existing setup.
+The bundle and the service that serves it are two packages. `authup start`
+runs that service in its own process alongside the API, on the API's listener,
+so a default deployment is still one container and one port; `authup console
+admin` runs it alone, on its own port, for a
+[split deployment](./console-replicas.md). Earlier releases shipped the console
+as a Nuxt server with its own environment variables, all of which are gone; see
+[Upgrading](./upgrading.md) for what to remove from an existing setup.
 
 ## Sign-in
 
 The console shares an origin with the API, so it signs in through the server.
-`GET /console/admin/login` starts an authorization-code flow with PKCE against the
-per-realm `admin-console` system client (see
+`GET /console/admin/login/start` starts an authorization-code flow with PKCE against
+the per-realm `admin-console` system client (see
 [Provisioning](./provisioning.md#per-realm-system-clients)) and
-`GET /console/admin/callback` redeems the code. The browser keeps an opaque,
+`GET /console/admin/callback` redeems the code. Those two are the only
+`/console/admin` paths the API answers; everything else under it is the console
+service. The browser keeps an opaque,
 `HttpOnly` session cookie; no OAuth2 token is handed to the page's
 JavaScript. The account console authenticates the same way, and both surfaces
 share the single session on that origin.
@@ -32,8 +37,10 @@ were already issued. See the tip in
 
 ## Configuration
 
-The console reads no configuration of its own. Two `server-core` options
-control it:
+The console has its own section, `server.adminConsole`, in the one
+[configuration file](./configuration.md). Two of its options are the ones a
+single-container deployment ever needs; `url`, `port` and `host` matter for a
+[split deployment](./console-replicas.md) and are documented there.
 
 ::: code-group
 ````dotenv [.env]
@@ -52,17 +59,20 @@ server:
 :::
 
 `server.adminConsole.enabled` / `ADMIN_CONSOLE_ENABLED` (default `true`) turns the
-surface off. The routes then
-serve a localized "not enabled" notice instead of the console, so stale links
-do not dead-end, and the sign-in routes (`/console/admin/login`, `/console/admin/callback`)
-answer the same notice instead of starting a login. The flag is also reported
-in the `features` block of the public status endpoint (`GET /`).
+surface off. Both sides read it: `authup start` then mounts no admin console at
+all, and the API's two sign-in routes (`/console/admin/login/start`,
+`/console/admin/callback`) answer `404` rather than minting a session for a
+console nothing serves. `authup console admin` refuses to start for the same
+reason. The flag is also reported in the `features` block of the public status
+endpoint (`GET /`).
 
 `server.adminConsole.path` / `ADMIN_CONSOLE_PATH` replaces the served package. It
 points at a directory
 holding a built `dist/`, whose `index.html` must carry the
-`<!--admin-config-->` marker; the marker is checked at boot for a package you
-actually substituted. Empty resolves `@authup/client-admin-console` from
+`<!--admin-config-->` marker and whose assets must be built for the
+`/console/admin/` vite base. Neither is verified at boot: a shell without the
+marker still answers `200`, and the console silently falls back to deriving its
+API URL from its own origin. Empty resolves `@authup/client-admin-console` from
 `node_modules`. See
 [Replacing a console](./theming.md#replacing-a-console). For branding alone,
 use the [theme directory](./theming.md) instead: it needs no build.
@@ -119,10 +129,10 @@ of the following is read any more, and none has a successor:
 | Variable | Why it is gone |
 |---|---|
 | `NUXT_PUBLIC_API_URL`, `API_URL`, `API_URL_SERVER` | The API is the serving origin, or `window.__AUTHUP__.apiUrl` when hosted standalone. |
-| `NUXT_PUBLIC_PUBLIC_URL` | The console has no public URL of its own. It lives at `<publicUrl>/console/admin`. |
+| `NUXT_PUBLIC_PUBLIC_URL` | `ADMIN_CONSOLE_URL`, which defaults to `<publicUrl>/console/admin` and may change the path but not the origin. |
 | `NUXT_PUBLIC_COOKIE_DOMAIN` | The console is same-origin with the API, so there is no cookie domain to widen. |
 | `NUXT_PUBLIC_CLIENT_ID` | The client is `admin-console`. A fork injects `clientId` in `window.__AUTHUP__`. |
-| `NUXT_HOST`, `NUXT_PORT` | There is no second process to bind. |
+| `NUXT_HOST`, `NUXT_PORT` | `ADMIN_CONSOLE_HOST` / `ADMIN_CONSOLE_PORT`, the listener `authup console` binds. |
 
 The plain build-time names `PUBLIC_URL`, `COOKIE_DOMAIN` and `CLIENT_ID` are
 gone with them. Note that `PUBLIC_URL` is unrelated to the console and stays a
@@ -130,5 +140,6 @@ gone with them. Note that `PUBLIC_URL` is unrelated to the console and stays a
 the server, and the console's own address derives from it.
 
 The `client.admin-console` section of the configuration file is no longer read
-either, and `authup start client.admin-console` is refused: `authup start` takes
-no positional argument, because it starts exactly one service.
+either, and `authup start client.admin-console` is refused: `start` takes no
+positional argument. The command that does is `authup console [admin|account|auth]`,
+which serves a console rather than selecting a package.

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -8,11 +8,18 @@ Most options can also be provided as environment variables (shown in the `.env` 
 **An environment variable always overrides the file value** for the same option.
 A few options are file-only and have no environment variable — they are marked as such.
 
-Not every option below sits under `server.core`. `env`, `rootPath`, `publicUrl` and
-`trustedOrigins` are top-level, the two theme options are `theme.directoryPath` and
-`theme.fragmentsEnabled`, and the console options are `server.adminConsole.*`,
-`server.accountConsole.*` and `server.authConsole.*`. The `authup.yml` tab shows each
-one at its place.
+Not every option below sits under `server.core`. `env`, `host`, `rootPath`,
+`publicUrl` and `trustedOrigins` are top-level, the two theme options are
+`theme.directoryPath` and `theme.fragmentsEnabled`, and the console options are
+`server.adminConsole.*`, `server.accountConsole.*` and `server.authConsole.*`. The
+`authup.yml` tab shows each one at its place.
+
+Of those, server-core itself reads only `enabled` and `url` per console: `enabled`
+gates the console's two sign-in routes, `url` is where it sends the browser. The rest
+of a console's section, and the whole `theme` section, are read by the **console
+service** that serves the console, so setting them on an API-only process
+(`authup core`) does nothing. See [Console Replicas](./console-replicas.md) for the
+full per-console option list.
 
 ::: danger Security
 The admin password and the `system` client secret both default to `start123`.
@@ -80,8 +87,9 @@ export default {
      * token — only add origins you control. A wildcard host trusts every
      * subdomain, so use one only where you control the whole domain.
      * The consoles authup serves need no entry: they are on the
-     * publicUrl origin. In non-production, the admin console's vite dev
-     * server origin (http://localhost:3000) is seeded automatically.
+     * publicUrl origin. In non-production, the admin console's standalone
+     * vite dev server origin (http://localhost:3010) is seeded
+     * automatically.
      * env: TRUSTED_ORIGINS (comma-separated)
      * default: []
      */
@@ -91,6 +99,8 @@ export default {
         /**
          * EXPERIMENTAL (may change in a minor release; see the Theming guide).
          * Directory holding the operator theme applied to the served consoles.
+         * Read by the console services, not by server-core: in a split
+         * deployment it must be mounted into the console containers.
          * Relative paths are resolved against rootPath. Empty disables theming.
          * See the Theming guide.
          * env: THEME_DIRECTORY_PATH
@@ -101,7 +111,7 @@ export default {
         /**
          * EXPERIMENTAL, alongside directoryPath.
          * Read fragments/head.html from the theme directory and splice it
-         * into the head of both served consoles. Raw, unsanitized markup on
+         * into the head of every served console. Raw, unsanitized markup on
          * the identity provider origin, so it is opt-in.
          * env: THEME_FRAGMENTS_ENABLED
          * default: false
@@ -111,6 +121,18 @@ export default {
 
     server: {
         adminConsole: {
+            /**
+             * Where the admin console is published. server-core sends the browser
+             * there once a sign-in is complete; the console service rebases its
+             * asset URLs and links onto it. Only the path may differ from
+             * publicUrl, never the origin. `port` and `host` (the console's own
+             * listener, used by `authup console`) are documented in the
+             * Console Replicas guide.
+             * env: ADMIN_CONSOLE_URL
+             * default: '' (derived: <publicUrl>/console/admin)
+             */
+            url: '',
+
             /**
              * Serve the admin console at `<publicUrl>/console/admin` (realms, clients,
              * users, roles, permissions, policies, keys, sessions, events).
@@ -135,6 +157,14 @@ export default {
 
         accountConsole: {
             /**
+             * Where the account console is published, same rules as
+             * adminConsole.url above.
+             * env: ACCOUNT_CONSOLE_URL
+             * default: '' (derived: <publicUrl>/console/account)
+             */
+            url: '',
+
+            /**
              * Serve the account self-service surface at `<publicUrl>/console/account`
              * (profile, password, authenticators, sessions, applications).
              * Disable it when you run your own self-service portal.
@@ -157,6 +187,16 @@ export default {
         },
 
         authConsole: {
+            /**
+             * Where the hosted login, consent and workflow pages are published.
+             * The six page GETs on this server redirect there, carrying the
+             * request's own query. Same rules as adminConsole.url above; there is
+             * no `enabled`, because those pages are the issuance surface.
+             * env: AUTH_CONSOLE_URL
+             * default: '' (derived: <publicUrl>/console/auth)
+             */
+            url: '',
+
             /**
              * EXPERIMENTAL. Package directory replacing the served auth console. It
              * points at a directory holding the built dist/. Empty resolves the
@@ -219,9 +259,10 @@ export default {
             port: 3000,
 
             /**
-             * Address the HTTP server binds to.
-             * env: HOST
-             * default: 0.0.0.0 (all interfaces)
+             * Address the HTTP server binds to. Has no environment variable of
+             * its own: HOST sets the top-level `host`, which this listener and
+             * every console listener inherit unless they name their own.
+             * default: the top-level host (0.0.0.0, all interfaces)
              */
             host: '0.0.0.0',
 
@@ -273,7 +314,8 @@ export default {
 
             /**
              * Built-in HTTP middlewares. Each accepts a boolean or an options
-             * object (options objects require the js/ts file variant).
+             * object (options objects require the js/ts file variant), except
+             * middlewareSwagger, which is boolean-only.
              * File-only (no environment variables).
              * default: true (each)
              */

--- a/docs/src/guide/deployment/configuration.md
+++ b/docs/src/guide/deployment/configuration.md
@@ -21,9 +21,9 @@ service off, say so: `REDIS=false`, not `REDIS=`.
 ## Configuration File
 
 One file holds the configuration: `authup.yml`, discovered in the **current working
-directory** of the process. Every CLI command (`start`, `worker`, `migration`,
-`healthcheck`, `config`) honors it, and the lookup can be redirected with two global
-CLI flags:
+directory** of the process. Every CLI command (`start`, `core`, `console`, `worker`,
+`migration`, `healthcheck`, `config`) honors it, and the lookup can be redirected with
+two global CLI flags:
 
 - `--configDirectory <path>`: directory to search instead of the cwd.
 - `--configFile <path>`: load one (or more) explicit file(s) instead of discovering.
@@ -36,7 +36,10 @@ The extensions discovered are `yml`, `yaml`, `json`, `js`, `mjs`, `cjs`, `ts` an
 cannot be expressed in YAML: use the `js`/`ts` variant for those.
 
 Deployment-wide options sit at the top level, and everything a single service reads
-sits in that service's own section. `server/core` reads `server.core`:
+sits in that service's own section. `server/core` reads `server.core`; each console
+service reads `server.authConsole`, `server.adminConsole` or `server.accountConsole`,
+plus the top level and `theme`. One document configures all of them, whether they run
+in one process (`authup start`) or in several:
 
 ```yaml
 # yaml-language-server: $schema=https://authup.org/schema/config.json
@@ -74,8 +77,8 @@ document is printed by `authup config schema`.
 Every option not documented as living elsewhere belongs under `server.core`. The
 [server/core page](./configuration-server-core) shows each option at its place.
 
-A `client.admin-console` section is no longer read: the admin console is served by
-`server/core` and has no configuration of its own. See
+A `client.admin-console` section is no longer read. The admin console is served by
+`@authup/server-admin-console` and configured under `server.adminConsole`; see
 [Admin Console](./configuration-client-admin-console).
 
 ::: warning YAML has teeth
@@ -120,5 +123,5 @@ line above names.
 ## Component-Wise
 
 - [server/core](./configuration-server-core) This page describes the configuration of the main backend service.
-- [Admin Console](./configuration-client-admin-console) This page describes the surface `server/core` serves at `/console/admin`, and how to host it standalone.
-- [Account Console](./account-console) This page describes the self-service surface `server/core` serves at `/console/account`.
+- [Admin Console](./configuration-client-admin-console) This page describes the administration console service, published at `/console/admin`, and how to host its bundle standalone.
+- [Account Console](./account-console) This page describes the self-service console service, published at `/console/account`.

--- a/docs/src/guide/deployment/console-replicas.md
+++ b/docs/src/guide/deployment/console-replicas.md
@@ -1,79 +1,106 @@
 # Console Replicas
 
-`server-core` serves the API and the consoles from one process. Every console
-lives under the `/console` prefix, so the two can be split across two replica
-sets on the ONE origin: an API set that answers the protocol and the
-management API, and a console set that serves the admin and account console
-shells. Same image, same binary, same `PUBLIC_URL`, same database, one shared
-Redis.
+Authup is a family of services that ship in one image and one npm package.
+`authup start` (container: `server/core start`) runs all of them in one
+process: the API and the IdP, plus every enabled console, on one listener.
+That is the default and it stays supported.
 
-This page is the flag-only shape of that split. A dedicated
-`authup console [admin|account]` role, which additionally leaves the
-management API unmounted on the console set, is planned and builds on exactly
-this recipe.
+This page is the other shape. Two replica sets on the ONE origin: an API set
+running `authup core`, which answers the protocol and the management API and
+mounts no console at all, and a console set running `authup console`, which
+serves the console pages and nothing else. Same image, same `PUBLIC_URL`; only
+the API set reaches the database and the cache.
 
-## The two sets
+## The two roles
 
-Both sets run `server/core start`. What differs is the console flags:
+| | API set | Console set |
+|---|---|---|
+| Command | `server/core core` | `server/core console` |
+| Serves | the protocol, the management API, the two sign-in routes per static console | the auth, admin and account console pages |
+| Listens on | `3000` | `3020` (auth), `3021` (admin), `3022` (account) |
+| Database | required | none |
+| Redis | required (see below) | none |
+| Runs migrations / cron sweeps | per `MIGRATION_ENABLED` / `COMPONENTS_ENABLED` | never, by construction |
 
-| Setting | API set | Console set |
-|---------|---------|-------------|
-| `ADMIN_CONSOLE_ENABLED` | `false` | `true` |
-| `ACCOUNT_CONSOLE_ENABLED` | `false` | `true` |
-| `COMPONENTS_ENABLED` | `false` | `false` |
-| `MIGRATION_ENABLED` | `false` | `false` |
+`authup console` starts every enabled console in one process, each on its own
+port, because each console is its own service: its own package, its own
+config section, its own deployment. Name one to serve only that one
+(`server/core console admin`).
 
-The console flags decide which set renders the console shells and answers
-their sign-in routes (`/console/admin/login`, `/console/admin/callback` and
-the account console's pair). With a flag off those routes answer a "not
-enabled" notice, so a console request that reaches the API set by mistake
-fails visibly rather than signing someone in on the wrong set.
+A console process holds no credential, opens no database or cache connection
+and mounts no controller. `COMPONENTS_ENABLED` and `MIGRATION_ENABLED` are
+server-core options and do nothing on it, so run `authup migration run`
+(container: `server/core migration run`) once before either set starts and let
+a single [worker](./worker.md) own the sweeps, exactly as for any multi-replica
+deployment.
 
-The other two flags are the [worker](./worker.md) rules applied to both sets.
-A console replica is a plain `start` process: with the defaults every console
-replica would run the cron sweeps and race its siblings for the DDL. So run
-`authup migration run` (container: `server/core migration run`) once,
-before either set starts, and let a single [worker](./worker.md) own the
-sweeps.
+## The console flags stay on
+
+`ADMIN_CONSOLE_ENABLED` and `ACCOUNT_CONSOLE_ENABLED` are **not** how the split
+is made. `core` mounts no console whatever they say, and turning one off on the
+API set disables the only console routes that set still owns, so every sign-in
+would 404. Leave them at their default (`true`) on both sets and use the roles.
+
+Turn a flag off only to remove that console from the deployment altogether: the
+console set then serves no shell for it and the API set answers 404 for its
+sign-in.
 
 ## Routing
 
-The proxy sends `/console/**` to the console set and everything else to the
-API set. If you use the [theme directory](./theming.md), route `/theme/**` to
-the console set as well and mount the directory on both sets: the API set
-renders the auth pages, which reference the theme's files, and the console set
-serves them.
+Two rules, in this order:
 
-Nginx, with two upstreams:
+1. **`/console/<name>/login/start` and `/console/<name>/callback` go to the API
+   set** (admin and account; the auth console has no such pair). Those two are
+   the cookie-mode sign-in and they are still server-core routes: the
+   pending-login cookie has to be issued by the origin that reads it back.
+2. **Everything else under `/console/**` goes to the console set**, per console
+   port. Everything outside `/console` goes to the API set.
+
+A console service serves its handler at the ROOT of its own listener (`/`,
+`/assets/**`, `/theme/**`, `/healthy`) while the browser addresses it under the
+console's public path, so **the proxy must strip that prefix**.
+
+Nginx, with one upstream per listener:
 
 ```nginx
-upstream authup_api {
-    server 10.0.0.11:3000;
-    server 10.0.0.12:3000;
-}
-
-upstream authup_console {
-    server 10.0.0.21:3000;
-}
+upstream authup_api          { server 10.0.0.11:3000; server 10.0.0.12:3000; }
+upstream authup_auth_console { server 10.0.0.21:3020; }
+upstream authup_admin_console   { server 10.0.0.21:3021; }
+upstream authup_account_console { server 10.0.0.21:3022; }
 
 server {
     server_name [DOMAIN];
     listen 80;
 
-    location /console/ {
+    # The sign-in pair stays on the API set. Exact matches, so they win over
+    # the prefix rules below.
+    location = /console/admin/login/start   { proxy_pass http://authup_api; }
+    location = /console/admin/callback      { proxy_pass http://authup_api; }
+    location = /console/account/login/start { proxy_pass http://authup_api; }
+    location = /console/account/callback    { proxy_pass http://authup_api; }
+
+    location /console/auth/ {
+        rewrite ^/console/auth(/.*)$ $1 break;
         proxy_set_header Host               $host;
-        proxy_set_header X-Real-IP          $remote_addr;
-        proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto  $scheme;
         proxy_set_header X-Forwarded-Tls-Client-Cert "";
-        proxy_pass                          http://authup_console;
+        proxy_pass                          http://authup_auth_console;
     }
 
-    location /theme/ {
+    location /console/admin/ {
+        rewrite ^/console/admin(/.*)$ $1 break;
         proxy_set_header Host               $host;
         proxy_set_header X-Forwarded-Proto  $scheme;
         proxy_set_header X-Forwarded-Tls-Client-Cert "";
-        proxy_pass                          http://authup_console;
+        proxy_pass                          http://authup_admin_console;
+    }
+
+    location /console/account/ {
+        rewrite ^/console/account(/.*)$ $1 break;
+        proxy_set_header Host               $host;
+        proxy_set_header X-Forwarded-Proto  $scheme;
+        proxy_set_header X-Forwarded-Tls-Client-Cert "";
+        proxy_pass                          http://authup_account_console;
     }
 
     location / {
@@ -87,106 +114,114 @@ server {
 }
 ```
 
-The same rule as a Kubernetes `Ingress`, with one `Service` per set:
+The same rules as a Kubernetes `Ingress`. `Exact` paths are matched before
+`Prefix` ones, and the prefix rewrite is the controller's own (shown for
+ingress-nginx):
 
 ```yaml
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-    name: authup
+    name: authup-console
+    annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /$2
 spec:
     rules:
         - host: auth.example.com
           http:
               paths:
-                  - path: /console
-                    pathType: Prefix
+                  - path: /console/admin(/|$)(.*)
+                    pathType: ImplementationSpecific
                     backend:
                         service:
                             name: authup-console
                             port:
-                                number: 3000
-                  - path: /theme
-                    pathType: Prefix
+                                number: 3021
+                  - path: /console/account(/|$)(.*)
+                    pathType: ImplementationSpecific
                     backend:
                         service:
                             name: authup-console
                             port:
-                                number: 3000
-                  - path: /
-                    pathType: Prefix
+                                number: 3022
+                  - path: /console/auth(/|$)(.*)
+                    pathType: ImplementationSpecific
                     backend:
                         service:
-                            name: authup-api
+                            name: authup-console
                             port:
-                                number: 3000
+                                number: 3020
 ```
 
+plus a second `Ingress` (no rewrite annotation) carrying the four `Exact`
+sign-in paths and the `/` catch-all, both backed by the API `Service` on port
+`3000`.
+
 `/authorize`, `/token`, `/logout`, `/sessions/@me`, `/userinfo`, the identity
-provider callbacks and the entity routes all land on the API set. That is the
-whole routing table: one prefix for the consoles, the root for everything
-else.
+provider callbacks and the entity routes all land on the API set. The six
+hosted page GETs (`/authorize`, `/register`, `/activate`, `/password-forgot`,
+`/password-reset`, `/logout`) are answered there with a redirect to the auth
+console, which the browser then follows into the console set.
+
+## Console options
+
+Every console has the same section, `server.authConsole`, `server.adminConsole`
+or `server.accountConsole`, and the same environment prefix (`AUTH_CONSOLE_`,
+`ADMIN_CONSOLE_`, `ACCOUNT_CONSOLE_`):
+
+| Option | Env | Default | Read by |
+|---|---|---|---|
+| `url` | `*_CONSOLE_URL` | `<publicUrl>/console/<name>` | the console service and server-core |
+| `enabled` | `*_CONSOLE_ENABLED` | `true` (the auth console has none) | the console service and server-core |
+| `port` | `*_CONSOLE_PORT` | `3020` / `3021` / `3022` | the console service |
+| `host` | `*_CONSOLE_HOST` | the deployment-wide `host` (`HOST`) | the console service |
+| `path` | `*_CONSOLE_PATH` | the installed bundle package | the console service |
+
+`path` points at a substituted console bundle, consulted before the
+`node_modules` lookup. `theme.directoryPath` and `theme.fragmentsEnabled`
+([Theming](./theming.md)) are read by the console services too, so in a split
+deployment the theme directory has to be mounted into the console containers,
+not the API ones.
+
+`url` is where a browser reaches that console. Change it to
+publish a console under another path, and the service rebases its asset URLs
+and links onto it while server-core redirects and lands sign-ins there. The
+ORIGIN must stay `PUBLIC_URL`'s own: the consoles authenticate with a
+`SameSite=Strict` cookie that is re-checked against `Sec-Fetch-Site:
+same-origin`, and the auth console holds the browser session every
+`prompt=none` decision reads. A foreign origin is refused when the
+configuration resolves.
 
 ## Redis is required
 
-The split needs a shared cache, so [`REDIS`](./configuration-server-core-redis.md)
-must point both sets at the same server. The reason is the sign-in round-trip.
-The hosted login page posts the consent to `POST /authorize`, which the proxy
-sends to the API set; the authorization code it mints is a cache entry, not a
-database row. The browser is then redirected to `/console/<name>/callback`,
-which the proxy sends to the console set, and the console replica that
-answers it redeems the code through its own `/token`, popping that entry. With
-the default per-process memory cache the entry exists only in the API replica
-that minted it, and every console sign-in fails.
+The console sign-in crosses two API replicas. `GET
+/console/<name>/login/start` parks a pending login in the cache and redirects
+to `/authorize`; the consent POST mints an authorization code, also a cache
+entry; `GET /console/<name>/callback` then redeems it. Nothing pins those
+requests to one replica, so with the default per-process memory cache the
+entry exists only in the replica that wrote it and sign-in fails. Point both
+sets at the same [Redis](./configuration-server-core-redis.md).
 
-Sticky sessions do not help. The two requests are on different paths and land
-on different sets by design, so no affinity rule can keep them on one
-process. The pending-login entry the console's `/login` parks and the token
-blocklist ride the same cache and have the same requirement.
+The token blocklist rides the same cache and has the same requirement. The
+console set needs no cache configuration at all.
 
 ## SQLite cannot split
 
 The split is for the server databases (MySQL and Postgres). A SQLite
 deployment keeps one database file per container, the same caveat the
-[worker](./worker.md) page states: a console container would sign users into a
-database the API set never sees. Keep a SQLite deployment in one process.
+[worker](./worker.md) page states. Keep it in one process.
 
-## What the flags do not do
+## Health checks
 
-- **The asset mounts stay.** The console flags gate the shells and the sign-in
-  routes, not `/console/admin/assets/*` and `/console/account/assets/*`. A
-  replica that has a console's `dist/` installed serves them whatever the
-  flag says. That is harmless (hashed, immutable files) and means an asset
-  request that reaches the API set is still answered.
-- **The auth pages ride every replica.** `/authorize`, `/logout`,
-  `/register`, `/activate`, `/password-forgot`, `/password-reset` and their
-  assets under `/console/auth/assets/*` are served by every replica of both
-  sets. There is no flag for them, by design: they are the identity
-  provider's own surface (`authorization_endpoint`, `end_session_endpoint`,
-  the mail deep links), not a console. The `/console/**` rule sends the auth
-  console's assets to the console set while the API set renders its pages;
-  both sets carry the bundle, so both answer.
-- **`GET /` reports per replica.** The `features` block of the status
-  endpoint reflects the console flags of the replica that answered. Through
-  the proxy `GET /` lands on the API set and reports `adminConsole: false`
-  and `accountConsole: false`; a console replica probed directly (the image
-  healthcheck does) reports `true`. Harmless, and a quick way to check which
-  set a process belongs to.
-- **The management API stays mounted on the console set.** A request for
-  `/users` that reaches a console replica is answered like on the API set.
-  The planned console role is what removes it.
+The image's own `HEALTHCHECK` probes `127.0.0.1:3000`, which a console
+container does not bind. Override it per console listener; each answers `GET
+/healthy` on its own port.
 
 ## Docker Compose
 
-Two services from the same image and the same configuration, differing only
-in the two console flags, behind the proxy above. Redis and the database are
-shared:
-
 ```yaml
-version: '3.8'
-
 services:
-    server-core:
+    authup-api:
         image: authup/authup:latest
         restart: unless-stopped
         environment:
@@ -198,29 +233,23 @@ services:
             - DB_PASSWORD=postgres
             - DB_DATABASE=postgres
             - REDIS=redis://redis:6379
-            - ADMIN_CONSOLE_ENABLED=false
-            - ACCOUNT_CONSOLE_ENABLED=false
             - COMPONENTS_ENABLED=false
             - MIGRATION_ENABLED=false
-        command: server/core start
+        command: server/core core
 
-    server-core-console:
+    authup-console:
         image: authup/authup:latest
         restart: unless-stopped
         environment:
             - PUBLIC_URL=https://auth.example.com
-            - DB_TYPE=postgres
-            - DB_HOST=postgres
-            - DB_PORT=5432
-            - DB_USERNAME=postgres
-            - DB_PASSWORD=postgres
-            - DB_DATABASE=postgres
-            - REDIS=redis://redis:6379
-            - COMPONENTS_ENABLED=false
-            - MIGRATION_ENABLED=false
-        command: server/core start
+        command: server/core console
+        healthcheck:
+            test: ["CMD", "wget", "--spider", "--proxy", "off", "http://127.0.0.1:3021/healthy"]
+            interval: 10s
 ```
 
-Run `server/core migration run` once before starting either service, and add
-a [worker](./worker.md) for the sweeps. Both services keep the image
-healthcheck: each opens an HTTP port and answers `GET /`.
+Run `server/core migration run` once before starting either service, and add a
+[worker](./worker.md) for the sweeps. The console service takes no `DB_*` and
+no `REDIS`: it reads `PUBLIC_URL` (to derive its own url and the API address
+it injects into the console), its own section, and the
+[theme](./theming.md) directory when one is configured.

--- a/docs/src/guide/deployment/docker-compose.md
+++ b/docs/src/guide/deployment/docker-compose.md
@@ -20,8 +20,11 @@ examples show how to configure authup using the options described in the [config
 paste and modify the example you want to use into a `docker-compose.yml` file.
 
 The following example shows a sensible default configuration for getting started with Authup.
-This starts the one service a deployment needs: `server/core` serves the API and both consoles
-(the admin console at `/console/admin`, the account console at `/console/account`).
+This starts the one container a deployment needs: `server/core start` runs the API
+and every console on one listener (the auth console at `/console/auth`, the admin
+console at `/console/admin`, the account console at `/console/account`). To run the
+consoles as their own service instead, see
+[Console Replicas](./console-replicas.md).
 
 ```yaml
 version: '3.8'
@@ -43,7 +46,7 @@ services:
       ports:
         - "3001:3000"
       environment:
-        - PUBLIC_URL=http://localhost:3000
+        - PUBLIC_URL=http://localhost:3001
       command: server/core start
       networks:
           authup:
@@ -74,8 +77,7 @@ docker compose logs -f
 ::: warning The `client/admin-console` service was retired
 Earlier versions of this example ran a second container for the admin
 console. That service no longer exists: remove it, and remove its
-`NUXT_PUBLIC_*` environment variables. See
-[Upgrading](./upgrading.md#the-admin-console-is-served-by-server-core).
+`NUXT_PUBLIC_*` environment variables. See [Upgrading](./upgrading.md).
 :::
 
 ## Configuration
@@ -108,7 +110,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-        - PUBLIC_URL=http://localhost:3000
+        - PUBLIC_URL=http://localhost:3001
         - USER_ADMIN_PASSWORD=test-password
     command: server/core start
 ```
@@ -147,7 +149,7 @@ services:
     ports:
       - "3001:3000"
     environment:
-      - PUBLIC_URL=http://localhost:3000
+      - PUBLIC_URL=http://localhost:3001
     command: server/core start
 
 ```
@@ -178,7 +180,7 @@ services:
             - postgres
             - redis
         environment:
-            - PUBLIC_URL=http://localhost:3000
+            - PUBLIC_URL=http://localhost:3001
             - DB_TYPE=postgres
             - DB_HOST=postgres
             - DB_PORT=5432

--- a/docs/src/guide/deployment/docker.md
+++ b/docs/src/guide/deployment/docker.md
@@ -26,7 +26,7 @@ It is important to mention that in the docker environment the configuration for 
 :::
 
 So when the authup container is run, the rule is as follows:
-- The service always runs on the internal port `3000` and can be mounted on another external port (`-p <port>:3000`)
+- The API always runs on the internal port `3000` and can be mounted on another external port (`-p <port>:3000`). The `console` role is the exception: each console binds its own port (`3020` auth, `3021` admin, `3022` account), see [Console Replicas](./console-replicas.md).
 
 
 Follow the instructions for [configuring](./configuration.md) Authup using a configuration file or via environment variables.
@@ -35,13 +35,13 @@ In case of a configuration file, mount it into the container's working directory
 
 ## Step. 3: Boot up
 
-One container runs the whole deployment. It serves the API and both consoles:
+One container runs the whole deployment. It serves the API and every console:
 
 ```shell
 docker run \
   -v authup:/var/lib/authup \
   -p 3001:3000 \
-  -e PUBLIC_URL=http://localhost:3000 \
+  -e PUBLIC_URL=http://localhost:3001 \
   authup/authup:latest server/core start
 ```
 
@@ -52,15 +52,15 @@ consoles derive the API address from it, so with the port published as
 Now all should be set up, and you are ready to go :tada:
 
 This will launch the following with default settings:
-- API: `http://localhost:3000/`
-- Admin console: `http://localhost:3000/console/admin`
-- Account console: `http://localhost:3000/console/account`
+- API: `http://localhost:3001/`
+- Auth console (login, consent, register, password recovery): `http://localhost:3001/console/auth`
+- Admin console: `http://localhost:3001/console/admin`
+- Account console: `http://localhost:3001/console/account`
 
 ::: warning The `client/admin-console` service was retired
-The admin console used to be a second container. It is now served by
-`server/core`, and `client/admin-console start` exits with an error naming
-the replacement. See
-[Upgrading](./upgrading.md#the-admin-console-is-served-by-server-core).
+The admin console used to be a second container. It is now a console service
+composed into `server/core start`, and `client/admin-console start` exits with
+an error naming the replacement. See [Upgrading](./upgrading.md).
 :::
 
 It is recommended to operate the service behind a reverse proxy. For example [nginx](./nginx.md).

--- a/docs/src/guide/deployment/nginx.md
+++ b/docs/src/guide/deployment/nginx.md
@@ -8,9 +8,14 @@ Don't forget to replace the placeholders with the actual values:
 - `[SERVER_CORE_PORT]`: Port of the server core application.
 :::
 
-There is one upstream. `server/core` serves the API and both consoles (the
-admin console at `/console/admin`, the account console at `/console/account`), so nothing has
-to be routed by path.
+There is one upstream. `server/core start` runs the API and every console in
+one process, on one listener: the auth console at `/console/auth` (the hosted
+login, consent and workflow pages), the admin console at `/console/admin` and
+the account console at `/console/account`. Nothing has to be routed by path.
+
+To run the consoles as their own replica set instead, see
+[Console Replicas](./console-replicas.md); that is the only shape that needs
+per-path rules.
 
 ```txt
 map $sent_http_content_type $expires {
@@ -71,9 +76,20 @@ location /auth/ {
 PUBLIC_URL=https://[DOMAIN]/auth
 ```
 
-The consoles are then reachable at `https://[DOMAIN]/auth/console/admin` and
-`https://[DOMAIN]/auth/console/account`. Session cookies are scoped to the prefix, so
-an application of your own on the same origin is left alone.
+The API is then reachable under the prefix, and session cookies are scoped to
+it, so an application of your own on the same origin is left alone.
+
+::: warning The consoles do not work under a prefix yet
+
+`authup start` mounts each console at the path component of its own url, which
+carries the prefix, while the proxy has just stripped it: every console page
+answers 404 (authup/authup#3531). The API, the token endpoint and the
+management API are unaffected. Until it is fixed, deploy authup at the origin
+root, or publish the consoles from their own replica set
+([Console Replicas](./console-replicas.md)), where each console listener is
+addressed directly.
+
+:::
 
 ## Certificate
 

--- a/docs/src/guide/deployment/theming.md
+++ b/docs/src/guide/deployment/theming.md
@@ -59,6 +59,12 @@ Deployment itself.
 Point `theme.directoryPath` (`THEME_DIRECTORY_PATH`) at the directory. Empty is
 the default and disables theming entirely.
 
+The option is read by the **console services**, not by the API. In a
+single-container deployment (`authup start`) they are the same process and
+there is nothing to think about. In a [split deployment](./console-replicas.md)
+the directory has to be mounted into the console containers; on an API-only
+process (`authup core`) the option does nothing.
+
 ```bash
 docker run \
   -e THEME_DIRECTORY_PATH=/etc/authup/theme \
@@ -225,7 +231,8 @@ The rest of this page is the reference for what you just used.
 ```
 /etc/authup/theme/
   theme.json          design tokens, title, favicon, logo, stylesheet
-  assets/             the only directory served over HTTP, at /theme
+  assets/             the only directory served over HTTP, under each
+                      console's own base (e.g. /console/admin/theme)
     theme.css
     logo.svg
     logo-dark.svg
@@ -340,8 +347,8 @@ for the things tokens cannot express.
 
 ```css
 /* Relative to theme.css, not root-absolute. Authup rebases the hrefs it
-   generates, but your stylesheet is served verbatim, so "/theme/..." would
-   break when authup runs under a public URL prefix. */
+   generates, but your stylesheet is served verbatim, and the assets live
+   under each console's own base, so "/theme/..." never resolves. */
 @font-face {
   font-family: Inter;
   src: url("./inter.woff2") format("woff2");
@@ -467,17 +474,20 @@ different flow.
 
 - `dist/client/index.html` containing the `<!--preload-links-->` and
   `<!--app-html-->` markers, built with vite `base: '/console/auth/'` (the
-  assets then resolve under `/console/auth/assets/`, which is what server-core
-  mounts)
+  service rebases those hrefs onto the path it serves the bundle under, and
+  mounts the bundle's assets at its own `/assets`)
 - `dist/client/.vite/ssr-manifest.json` (`{}` is valid)
 - `dist/server/server.js` exporting `render(ctx)`, plus `CONTRACT_VERSION`
   once the contract moves past version 1 (omitting it means version 1)
 
-`CONTRACT_VERSION` is checked at boot against the version this authup
-implements, and a mismatch **stops the container** with a message naming both
-versions. That is deliberate: you replaced security-relevant code, so a drift
-must not surface as subtly wrong auth pages. A bundle without the export counts
-as version 1.
+::: warning Nothing verifies this at boot
+`CONTRACT_VERSION` is exported but not read: the serving service loads
+`render` and calls it. A bundle written against an older contract therefore
+produces subtly wrong auth pages rather than a failed start. Version 3 is
+current; a version 2 bundle strands every federated login on the login form,
+because it does not know it has to redeem the login handle. Check the version
+yourself when you substitute the package.
+:::
 
 The types are published in the package's `src/contract.ts`
 (`HydrationPayload`, `RenderContext`, `RenderResult`, `RenderFunction`).
@@ -493,8 +503,9 @@ absolute, so a bundle built for another base is served but loads nothing.
 | account console | `<!--account-config-->` |
 | admin console | `<!--admin-config-->` |
 
-The marker is checked at boot; without it the injected `window.__AUTHUP__`
-never lands and the SPA would silently fall back to deriving its API URL from
-the origin.
-
-Every check only runs for a package you actually substituted.
+The marker is not verified either. Without it the shell is still served, the
+injected `window.__AUTHUP__` never lands, and the SPA silently falls back to
+deriving its API URL from its own origin. The same goes for the vite base: a
+bundle built for another one is served and loads nothing. Both failures answer
+`200`, so verify a substituted bundle by loading it and following the first
+script the shell references.

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -102,12 +102,14 @@ JSON Schema your editor can validate against while you type.
 variable name changed, so a `docker run -e`, a Compose `environment:` block, a Helm
 values file and a `.env` are all unaffected.
 
-### `authup` is the only binary, and it runs the server in process
+### `authup` is the operator binary, and it runs the server in process
 
 The `authup-server` binary is retired. The `@authup/server-core` package ships
 no binary at all now; the `authup` package (`npm install authup`) carries the
-one command and runs the server **inside its own process**, where it used to
-start it as a child and supervise it.
+operator commands and runs the server **inside its own process**, where it used
+to start it as a child and supervise it. (Each console service ships an
+`authup-<name>-console` binary as well, for a deployment that runs one console
+without the CLI; see the console entries below.)
 
 | Was | Is |
 |---|---|
@@ -174,6 +176,59 @@ The admin console's development server moves from `:3000` to `:3010` so it no
 longer collides with the API, and the trusted origin seeded in non-production
 follows it. That affects `npm run dev` in this repository only.
 
+### The consoles are their own services
+
+`server-core` serves no console any more. Each console is a service package of
+its own (`@authup/server-auth-console` for the hosted login, consent, register,
+activate and password pages, plus `@authup/server-admin-console` and
+`@authup/server-account-console`), and `server-core` is the protocol surface
+and the management API. What it keeps under `/console` is two routes per static
+console, `GET /console/<name>/login/start` and `GET /console/<name>/callback`:
+they are the cookie-mode sign-in, and the pending-login cookie has to be issued
+by the origin that reads it back. The six hosted page GETs answer a redirect to
+the auth console, carrying the request's own query.
+
+The CLI gained two roles for it:
+
+| Command | Runs |
+|---|---|
+| `authup start` (unchanged default) | the API and every enabled console on one listener |
+| `authup core` | the API and the IdP alone, mounting no console |
+| `authup console [admin\|account\|auth]` | one console service, or every enabled one, each on its own port (`3020` auth, `3021` admin, `3022` account) |
+
+**No action** for a deployment running `server/core start`: the process, the
+port, the paths and the container command are all unchanged, and the consoles
+now run as separate services inside it.
+
+**Action required** for:
+
+- **A split deployment.** The flag-only recipe (both sets running `start` with
+  the console flags inverted) no longer produces the intended split, and the
+  flags must now stay `true` on both sets. Use `core` and `console` instead;
+  [Console Replicas](./console-replicas.md) is rewritten around them, including
+  the two sign-in paths that must keep reaching the API set.
+- **A themed deployment.** `theme.directoryPath` and `theme.fragmentsEnabled`
+  are read by the console services now. In one container nothing changes; in a
+  split one, mount the theme directory into the console containers.
+- **A substituted console.** `server.<name>Console.path` moved to the console
+  services with the serving. Setting it on an API-only process does nothing.
+  The auth console is themed as well since this release, which is what closes
+  the one window in which the hosted auth pages rendered unthemed.
+
+**New options**, all per console: `url` (`*_CONSOLE_URL`, where the console is
+published; the path may differ from `publicUrl`, the origin may not), `port`
+(`*_CONSOLE_PORT`) and `host` (`*_CONSOLE_HOST`, inheriting the deployment-wide
+`HOST`). Each console service also ships a binary of its own
+(`authup-auth-console`, `authup-admin-console`, `authup-account-console`) for a
+deployment that runs a console without the CLI; `authup console` is the
+supported route.
+
+**Known limitation.** Under a sub-path deployment (`PUBLIC_URL` carrying a path
+behind a prefix-stripping proxy), `authup start` mounts the consoles at a path
+the listener never sees, so console pages answer `404`
+([#3531](https://github.com/authup/authup/issues/3531)). The API is unaffected.
+Deploy at the origin root, or serve the consoles from their own replica set.
+
 ### A console derives its own configuration, and refuses a foreign origin
 
 Every value a console service used to be handed by the CLI is now computed
@@ -209,11 +264,12 @@ the IdP origin:
 | Account console | `<publicUrl>/account` | `<publicUrl>/console/account` |
 | Auth console assets (the scripts and styles behind `/authorize`, `/logout`, `/register`, ...) | `<publicUrl>/public/` | `<publicUrl>/console/auth/assets/` |
 
-The auth pages themselves (`/authorize`, `/logout`, `/register`, `/activate`,
+The auth page URLs (`/authorize`, `/logout`, `/register`, `/activate`,
 `/password-forgot`, `/password-reset`) and every API route are unchanged.
 They are the protocol surface (`authorization_endpoint`,
-`end_session_endpoint`, the mail deep links) and stay at the root. `/console`
-and `/console/auth` themselves serve nothing.
+`end_session_endpoint`, the mail deep links) and stay at the root; a `GET` on
+one of them now redirects to the auth console at `/console/auth`, which
+renders it (see the next entries). `/console` itself serves nothing.
 
 **Action required.**
 
@@ -229,13 +285,16 @@ and `/console/auth` themselves serve nothing.
   vite base (`/console/admin/`, `/console/account/`, `/console/auth/`).
 - **Links, bookmarks and proxy rules** naming `/account`, `/admin` or
   `/public` must name the new paths. That includes the sign-in routes
-  (`/console/account/login`, `/console/account/callback` and the admin pair)
-  and every page below a console (`/console/account/authenticators`, ...).
-  Update the "Manage account" link your own applications render.
+  (`/console/account/login/start`, `/console/account/callback` and the admin
+  pair) and every page below a console (`/console/account/authenticators`,
+  ...). Update the "Manage account" link your own applications render.
 - **No redirect is served for the old paths.** `/account/**`, `/admin/**` and
   `/public/**` answer `404`.
 - **`@authup/client-web-kit` and the server must be on the same release.** The
-  kit's `buildConsoleLoginURL` now emits `<baseURL>/console/<console>/login`.
+  kit's `buildConsoleLoginURL` now emits
+  `<baseURL>/console/<console>/login/start`, a path of its own: the bare
+  `/console/<console>/login` is the console's own login PAGE, served by the
+  console service.
   A newer kit against an older server kicks to a route that does not exist,
   and an older kit (or an older standalone-hosted console bundle) against
   this server does the same the other way round; a `404` on a top-level
@@ -251,18 +310,19 @@ One prefix is what makes serving the consoles from their own replica set a
 single proxy rule; see [Console Replicas](./console-replicas.md).
 
 Also in this release, `ACCOUNT_CONSOLE_ENABLED=false` applies to the account
-console's sign-in routes as well: `GET /console/account/login` and
-`GET /console/account/callback` answer the "not enabled" notice instead of
-starting a login, the way the admin console's routes did already. Before, a
-disabled account console still minted a pending login and a session cookie
-on a direct hit. No action needed.
+console's sign-in routes as well: `GET /console/account/login/start` and
+`GET /console/account/callback` answer `404` instead of starting a login, the
+way the admin console's routes did already. Before, a disabled account console
+still minted a pending login and a session cookie on a direct hit. No action
+needed.
 
-### The admin console is served by server-core
+### The admin console is no longer a Nuxt server
 
-The admin console is no longer a separate Nuxt server. It is a static
-single-page bundle that `server-core` serves at `<publicUrl>/console/admin`,
-the way it serves the account console at `<publicUrl>/console/account` (the
-`/console` prefix is the entry above). A deployment runs one process.
+The admin console is a static single-page bundle, served at
+`<publicUrl>/console/admin` the way the account console is served at
+`<publicUrl>/console/account` (the `/console` prefix is the entry above). A
+default deployment still runs one container: `authup start` runs the API and
+every console on one listener (see the next entry for what serves what).
 
 **Action required.**
 
@@ -281,10 +341,10 @@ the way it serves the account console at `<publicUrl>/console/account` (the
 - **`TRUSTED_ORIGINS`**: drop the console's former origin. It serves nothing
   now, but the provisioner keeps re-asserting every listed origin into the
   system clients' redirect allowlists on each boot.
-- **Reverse proxy**: collapse the two upstreams into one. The API and both
-  consoles are served by the same listener, so a rule that routed `/` to the
-  console port and `/api/` to the server port routes `/` to the server port
-  now. See [Nginx](./nginx).
+- **Reverse proxy**: collapse the two upstreams into one. Under `authup start`
+  the API and every console are served by the same listener, so a rule that
+  routed `/` to the console port and `/api/` to the server port routes `/` to
+  the server port now. See [Nginx](./nginx).
 - **Links and bookmarks**: the console moved from the root of its own origin
   to `<publicUrl>/console/admin`.
 
@@ -297,14 +357,15 @@ the API, so there is nothing to widen. Note that `PUBLIC_URL` is unaffected as
 a [`server/core` option](./configuration-server-core); it is the server's own
 public URL, and the console's address derives from it.
 
-**New `server/core` options.** `ADMIN_CONSOLE_ENABLED` / `adminConsoleEnabled`
-(default `true`) serves the console; with it off the routes render a "not
-enabled" notice (and the sign-in routes start no login), so stale links do
-not dead-end. `ADMIN_CONSOLE_PATH` /
-`adminConsolePath` substitutes the console package, the same contract as
-`ACCOUNT_CONSOLE_PATH`: a directory holding a built `dist/` whose
-`index.html` carries the `<!--admin-config-->` marker. The `features` block of
-the public status endpoint (`GET /`) gains `adminConsole`.
+**New options.** `ADMIN_CONSOLE_ENABLED` / `server.adminConsole.enabled`
+(default `true`) serves the console; with it off nothing mounts it and the
+API's two sign-in routes answer `404`. `ADMIN_CONSOLE_PATH` /
+`server.adminConsole.path` substitutes the console package, the same contract
+as `ACCOUNT_CONSOLE_PATH`: a directory holding a built `dist/` whose
+`index.html` carries the `<!--admin-config-->` marker. `enabled` is read by
+both server-core and the console service; `path` only by the console service.
+The `features` block of the public status endpoint (`GET /`) gains
+`adminConsole`.
 
 **Deliberately gone**: the `authup-admin-console` binary and the published
 Nuxt server bundle. `@authup/client-admin-console` ships `dist/` only. The
@@ -313,10 +374,10 @@ bundle stays hostable on a static host of your own, on its own origin; see
 
 Sign-in changed as well and needs no action. Served from the API's origin, the
 console authenticates with the same opaque `HttpOnly` session cookie the
-account console uses (`GET /console/admin/login` and `GET /console/admin/callback` against the
-per-realm `admin-console` client), so no OAuth2 token reaches the browser's
-JavaScript. Hosted standalone on a foreign origin it keeps the browser-side
-authorization-code flow with PKCE.
+account console uses (`GET /console/admin/login/start` and
+`GET /console/admin/callback` against the per-realm `admin-console` client), so
+no OAuth2 token reaches the browser's JavaScript. Hosted standalone on a
+foreign origin it keeps the browser-side authorization-code flow with PKCE.
 
 ### Token introspection requires authorization
 

--- a/docs/src/guide/deployment/worker.md
+++ b/docs/src/guide/deployment/worker.md
@@ -1,9 +1,11 @@
 # Worker
 
-`server-core` normally runs everything in one process: it serves the API and
-the consoles, and it also runs a set of cron sweeps in the background. Those
-sweeps can be moved into a separate process, the **worker**, so the API
-replicas only serve requests.
+`authup start` normally runs everything in one process: `server-core` answers
+the API, the console services serve their pages on the same listener, and a set
+of cron sweeps runs in the background. Those sweeps can be moved into a
+separate process, the **worker**, so the API replicas only serve requests. The
+consoles can be moved out the same way; see
+[Console Replicas](./console-replicas.md).
 
 The worker is the same image and the same binary, started with a different
 subcommand:


### PR DESCRIPTION
The docs half of plan 101 D2-4. `server-core` stopped serving the consoles in #3513, and the deployment guide still described the shape before it: one process serving both consoles, a flag-only replica split, a root `/theme` mount, boot-time checks for a substituted console that never existed after the extraction.

Every claim in `docs/src/guide/deployment/` was checked against the tree (seven parallel readers, one per page cluster, each verifying against the source rather than the prose). 45 statements came back false or misleading; this fixes them.

## The substantive corrections

- **`console-replicas.md` is rewritten.** It documented a flag-only split of two `start` processes, which does not produce the intended topology any more and, worse, told operators to turn the console flags *off* on the API set, which is exactly what disables the only console routes that set still owns. It is now built on `authup core` and `authup console`: the per-console ports (3020/3021/3022), the four exact sign-in paths that must keep reaching the API set, the prefix-stripping the console listeners need, and the fact that a console process reaches no database and no cache at all.
- **The account console's sign-in section** described the browser-side authorization-code + PKCE flow. A served console has signed in through the server-side cookie session since #3498; the PKCE path is the standalone fallback. This is plan 098 B1.
- **Theming**: `theme.directoryPath` is read by the console services, not by server-core, so a split deployment must mount the directory into the console containers. Theme assets are served under each console's own base, never at a root `/theme`. The page also promised two boot-time checks (`CONTRACT_VERSION` and the config marker) that do not exist; both failures are silent, so the text now says so and says how to check by hand.
- **Config pages**: each console owns a section (`url`, `enabled`, `path`, `port`, `host`) rather than "no configuration of its own"; server-core reads only `enabled` and `url`; `HOST` sets the deployment-wide `host`, not `server.core.host`; `middlewareSwagger` is boolean-only; the seeded dev origin is `:3010`, not `:3000`.
- **The auth console is a console.** `docker`, `docker-compose` and `bare-metal` listed two consoles and omitted the one that renders every login, consent, register and password page.
- **`docker` / `docker-compose`**: every example published the container on host port 3001 while naming 3000 as `PUBLIC_URL`, so the consoles' injected `apiUrl`, the issuer and the hosted-page redirects all pointed at a port the browser cannot reach. The prose two lines below already said what the value should be.
- **`upgrading.md`** gains one entry for the service family (what moved, the two new roles, what needs action and what does not), and the neighbouring unreleased entries are corrected: the kick is `/console/<name>/login/start`, a disabled console answers `404` rather than a notice, and `*_CONSOLE_PATH` is no longer a server-core option.

## Found on the way, not fixed here

#3531: under a sub-path deployment (`PUBLIC_URL` carrying a path behind a prefix-stripping proxy) `authup start` mounts the consoles at the prefixed path, which the listener never sees, so every console page 404s. The API is unaffected. It is a code regression from D2-3, not a docs bug, so it is filed rather than papered over; `nginx.md` and the new upgrade entry name the limitation and the workaround.

The chart work is authup/helm#26 (a major: the ConfigMap still writes the retired `authup.server.core.conf`, the `adminConsole` workload still crash-loops, and the split topology needs a workload of its own). It supersedes the topology half of authup/helm#25.

## Verification

Docs-only. Every relative link and anchor in the changed files resolves; the vitepress build runs in this PR's own `Deploy` workflow, which triggers on `docs/**`.
