### PR TITLE
fix(authup): subtract the deployment path prefix from the console mount

### DIFF
--- a/apps/authup/src/commands/application.ts
+++ b/apps/authup/src/commands/application.ts
@@ -61,6 +61,7 @@ export function defineApplicationCommand(
 
                         consoles.push(...await buildConsoleApplications(
                             await readConsoleConfigs(configFs),
+                            config.publicUrl,
                         ));
 
                         for (const mount of consoles) {

--- a/apps/authup/src/commands/dev.ts
+++ b/apps/authup/src/commands/dev.ts
@@ -75,12 +75,12 @@ export function defineCLIDevCommand(configFs: ConfigReadFsOptions = {}) {
             // console lives, and read BEFORE the application is built because
             // the exemption has to be on the config by the time server-core
             // registers the middleware.
-            const authPath = assertConsolePath('auth', consoles.auth.url);
+            const authPath = assertConsolePath('auth', consoles.auth.url, config.publicUrl);
             const adminPath = consoles.admin.enabled ?
-                assertConsolePath('admin', consoles.admin.url) :
+                assertConsolePath('admin', consoles.admin.url, config.publicUrl) :
                 undefined;
             const accountPath = consoles.account.enabled ?
-                assertConsolePath('account', consoles.account.url) :
+                assertConsolePath('account', consoles.account.url, config.publicUrl) :
                 undefined;
 
             config.middlewareRateLimit = withConsoleRateLimitSkip(

--- a/apps/authup/src/console/applications.ts
+++ b/apps/authup/src/console/applications.ts
@@ -23,12 +23,16 @@ import type { ConsoleApplication, ConsoleConfigs } from './types.ts';
  * that only resembles the two supported ones. A console owns its listener
  * everywhere except here, and here it is composed rather than reduced.
  *
- * The mount PATH is the path component of the console's url, never the url
- * itself. A console url is where a BROWSER reaches the console, so it carries
- * the origin the proxy publishes; the listener only ever sees the path.
+ * The mount PATH is derived from the console's url, never the url itself, and
+ * never the whole path either. A console url is where a BROWSER reaches the
+ * console, so it carries both the origin the proxy publishes and the path
+ * prefix authup is published under; the listener sees neither, because the
+ * proxy strips the prefix before the request arrives. `assertConsolePath`
+ * takes publicUrl for exactly that subtraction.
  */
 export async function buildConsoleApplications(
     consoles: ConsoleConfigs,
+    publicUrl: string,
 ) : Promise<ConsoleApplication[]> {
     const candidates : {
         name: string,
@@ -64,7 +68,7 @@ export async function buildConsoleApplications(
     const applications : ConsoleApplication[] = [];
 
     for (const candidate of candidates) {
-        const path = assertConsolePath(candidate.name, candidate.url);
+        const path = assertConsolePath(candidate.name, candidate.url, publicUrl);
 
         const application = candidate.create();
 

--- a/apps/authup/src/console/path.ts
+++ b/apps/authup/src/console/path.ts
@@ -8,8 +8,28 @@
 import { AuthupError } from '@authup/errors';
 import { getURLBasePath } from '@authup/kit';
 
-export function assertConsolePath(name: string, url: string) : string {
-    const value = getURLBasePath(url);
+export function assertConsolePath(name: string, url: string, publicUrl: string) : string {
+    const base = getURLBasePath(publicUrl);
+    const publicPath = getURLBasePath(url);
+
+    if (base && publicPath !== base && !publicPath.startsWith(`${base}/`)) {
+        // Only reachable when a console url names a path outside the one
+        // authup is published under, which the proxy routes nothing to: the
+        // rule that reaches this listener is publicUrl's own. Refuse it
+        // rather than mount where no request can arrive.
+        throw new AuthupError(
+            `The ${name} console url is ${url}, which is outside ${publicUrl}, the path this deployment is published under. ` +
+            'A console shares the deployment\'s path prefix; the defaults are under /console.',
+        );
+    }
+
+    // The mount is the console path RELATIVE to what the listener sees. A
+    // console url is where a BROWSER reaches the console, so under a sub-path
+    // deployment it carries publicUrl's own prefix, and the proxy strips that
+    // prefix before the request arrives, exactly as it does for every
+    // server-core route (all of which are mounted root-relative). Mounting the
+    // browser-facing path would put the console where nothing can reach it.
+    const value = publicPath.slice(base.length);
     if (!value) {
         // A console with no path of its own would have to own the API's
         // root, where it would shadow the protocol routes and the page
@@ -18,7 +38,7 @@ export function assertConsolePath(name: string, url: string) : string {
         // here: every console url is already refused unless it is
         // publicUrl's own origin, by the key that resolves it.
         throw new AuthupError(
-            `The ${name} console url is ${url}, which is this deployment's own origin root. ` +
+            `The ${name} console url is ${url}, which is this deployment's own root. ` +
             'A console needs a path of its own; the defaults are under /console.',
         );
     }

--- a/apps/authup/test/unit/console-path.spec.ts
+++ b/apps/authup/test/unit/console-path.spec.ts
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { assertConsolePath } from '../../src/console/path';
+
+const PUBLIC_URL = 'https://idp.example.com';
+const PUBLIC_URL_SUB_PATH = 'https://example.com/auth';
+
+describe('assertConsolePath', () => {
+    it('should mount a console at its own path when the deployment owns the origin root', () => {
+        expect(assertConsolePath('admin', `${PUBLIC_URL}/console/admin`, PUBLIC_URL))
+            .toEqual('/console/admin');
+    });
+
+    /**
+     * The regression behind #3531: under a sub-path deployment the proxy
+     * strips publicUrl's prefix before the request reaches the listener, the
+     * way it does for every server-core route, so the mount must not carry it.
+     * Mounting the browser-facing path answered 404 for every console page.
+     */
+    it('should subtract the deployment path prefix, because the listener never sees it', () => {
+        expect(assertConsolePath('admin', `${PUBLIC_URL_SUB_PATH}/console/admin`, PUBLIC_URL_SUB_PATH))
+            .toEqual('/console/admin');
+    });
+
+    it('should subtract the prefix from a console published under a path of its own', () => {
+        expect(assertConsolePath('auth', `${PUBLIC_URL_SUB_PATH}/login`, PUBLIC_URL_SUB_PATH))
+            .toEqual('/login');
+    });
+
+    it('should refuse a console url outside the deployment path prefix', () => {
+        expect(() => assertConsolePath('admin', 'https://example.com/elsewhere', PUBLIC_URL_SUB_PATH))
+            .toThrow(/outside/);
+    });
+
+    it('should refuse a console url that is the deployment root', () => {
+        expect(() => assertConsolePath('admin', PUBLIC_URL, PUBLIC_URL))
+            .toThrow(/deployment's own root/);
+    });
+
+    it('should refuse a console url that is the deployment prefix itself', () => {
+        expect(() => assertConsolePath('admin', PUBLIC_URL_SUB_PATH, PUBLIC_URL_SUB_PATH))
+            .toThrow(/deployment's own root/);
+    });
+});

--- a/docs/src/guide/deployment/nginx.md
+++ b/docs/src/guide/deployment/nginx.md
@@ -79,15 +79,18 @@ PUBLIC_URL=https://[DOMAIN]/auth
 The API is then reachable under the prefix, and session cookies are scoped to
 it, so an application of your own on the same origin is left alone.
 
-::: warning The consoles do not work under a prefix yet
+The consoles are reachable under the prefix as well
+(`https://[DOMAIN]/auth/console/admin`), because the rule above strips it for
+them exactly as it does for the API: a console's url carries the prefix, since
+that is where a browser reaches it, and the mount subtracts it, since that is
+what the listener sees.
 
-`authup start` mounts each console at the path component of its own url, which
-carries the prefix, while the proxy has just stripped it: every console page
-answers 404 (authup/authup#3531). The API, the token endpoint and the
-management API are unaffected. Until it is fixed, deploy authup at the origin
-root, or publish the consoles from their own replica set
-([Console Replicas](./console-replicas.md)), where each console listener is
-addressed directly.
+::: warning Keep the console urls under the prefix
+
+A console url may name a path of its own (`AUTH_CONSOLE_URL=https://[DOMAIN]/auth/login`),
+but it has to stay under the prefix authup is published at, because the proxy
+routes nothing else here. A url outside it is refused at startup, naming both
+values.
 
 :::
 

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -223,11 +223,11 @@ published; the path may differ from `publicUrl`, the origin may not), `port`
 deployment that runs a console without the CLI; `authup console` is the
 supported route.
 
-**Known limitation.** Under a sub-path deployment (`PUBLIC_URL` carrying a path
-behind a prefix-stripping proxy), `authup start` mounts the consoles at a path
-the listener never sees, so console pages answer `404`
-([#3531](https://github.com/authup/authup/issues/3531)). The API is unaffected.
-Deploy at the origin root, or serve the consoles from their own replica set.
+**Sub-path deployments.** A console url carries the path prefix authup is
+published under, and the mount subtracts it, so a prefix-stripping proxy
+reaches the consoles the same way it reaches the API. A console url outside
+that prefix is refused at startup rather than mounted where no request can
+arrive.
 
 ### A console derives its own configuration, and refuses a foreign origin
 


### PR DESCRIPTION
Closes #3531.

## The bug

A console url is where a **browser** reaches the console, so under a sub-path deployment (`PUBLIC_URL=https://example.com/auth` behind a prefix-stripping proxy, the shape `nginx.md` documents) it resolves to `https://example.com/auth/console/admin`. `authup start` mounted the console at that path's full path component, `/auth/console/admin`. The listener never sees that prefix: the proxy strips it before the request arrives, exactly as it does for every server-core route, which are all mounted root-relative. So the request arrived as `/console/admin`, nothing was mounted there, and every console page answered 404 while the API, the token endpoint and the management API kept working.

Regression from plan 101 D2-3: server-core used to mount the consoles at a constant segment (`ADMIN_CONSOLE_SEGMENT`), which carries no prefix and is therefore correct under the strip.

## The fix

`assertConsolePath(name, url, publicUrl)` returns the console path **relative to what the listener sees**, i.e. with `getURLBasePath(publicUrl)` subtracted. Both callers pass it: `buildConsoleApplications` (`start`) and `dev`, where the same value also drives the vite middleware mounts and the rate-limit exemption, so all three agree by construction.

A console url on the right origin but outside publicUrl's path prefix is now **refused at startup**, naming both values, rather than mounted where no request can arrive. Under `authup start` the only proxy rule reaching this listener is publicUrl's own, and such a console's cookie path would not cover it either. `authup console` is unaffected: each console owns its listener there and the proxy may map whatever it likes.

The origin rule is unchanged and untouched — `assertConsoleOrigin` already refuses a console url on a foreign domain when the config resolves.

## Verification

- `apps/authup/test/unit/console-path.spec.ts` (new, 6 cases). Confirmed **red before, green after**: with the fix reverted, 4 of the 6 fail (the two subtraction cases and both new refusals); with it, 6 pass.
- Full `apps/authup` suite: 45 passed.
- `npm run check:types -w apps/authup`: clean. This is what caught the three `dev.ts` call sites, which the vitest run could not — vitest transpiles through SWC.
- `npm run test:smoke -w apps/authup`: both scenarios pass, so the composed and split topologies without a prefix are unchanged.
- Docs: the two passages added in #3532 that described this as a live limitation (`nginx.md`, `upgrading.md`) now describe the behaviour instead.

## Not included

**A smoke scenario with a path-carrying `PUBLIC_URL`.** The issue proposed one, and it remains the only end-to-end proof of the mount. It needs `executeScenario` and the three assert helpers threaded with a public-path parameter (the redirect target carries the prefix while the dial must not), plus a third server boot in CI, for a regression the new unit spec already fails on. Left as a follow-up rather than folded in here; say the word if you would rather have it in this PR.
