### PR TITLE
docs(development): warn that a standalone console dev server inherits the hosted session

### DIFF
--- a/docs/src/guide/development/quick-start.md
+++ b/docs/src/guide/development/quick-start.md
@@ -117,4 +117,19 @@ admin console) than the API, it signs in with the standalone browser
 authorization-code (PKCE) flow rather than the cookie-session credential a
 served console uses in production.
 
+::: warning Sign out of the hosted pages first
+
+Cookies ignore ports, so `localhost:3010` and `localhost:3000` are the same
+HOST to the browser. A standalone console started while a session from the
+hosted auth pages is still open therefore seeds itself from that session's
+path-`/` token cookies and comes up already signed in, without ever running
+the flow you are trying to test. Sign out at `http://localhost:3000/logout`
+(or clear the `localhost` cookies) before you start.
+
+This is a same-host development artefact only. A real deployment serves the
+consoles on the API's own origin, where they hold no token cookies at all,
+and a standalone-hosted console runs on a domain of its own.
+
+:::
+
 You can start working with the application or begin making contributions to the project!


### PR DESCRIPTION
The last open half of plan 098 D1. The #3403 half is closed as parked, because both served consoles hold no JWT cookies since 088; this is the artefact that made the question look bigger than it was.

Cookies ignore ports, so `localhost:3010` and `localhost:3000` are the same host to the browser. Running `npm run dev -w apps/client-admin-console` while a session from the hosted auth pages is still open means the console seeds its store from that session's path-`/` token cookies and comes up already signed in, without ever running the sign-in flow the standalone origin is meant to exercise. Sign out first.

Scoped as the development artefact it is: a real deployment serves the consoles on the API's own origin, where they hold no token cookies at all, and a standalone-hosted console runs on a domain of its own.

Docs-only, one file.