### PR TITLE
fix(server-core,server-kit): write the entity audit row on the persist transaction

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -5898,13 +5898,37 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   (`@authup/server-kit` knows no persistence, hence `unknown`), the handler
   forwards it into `EventRecordInput.transaction`, and
   `EventRepositoryAdapter.save` writes through `manager.withRepository(...)`
-  when it recognizes an `EntityManager`. Three things follow. The row is
-  atomic with the write it describes: a rolled-back write leaves no row
-  (pinned by `event-repository.spec.ts`; the pin is only meaningful on
-  mysql/postgres, since sqlite shares one query runner and joined the
-  transaction anyway). Deferring the write to `afterTransactionCommit` was
-  NOT an option: TypeORM broadcasts it inside `commitTransaction()`, still
-  before the runner is released, so it would have deadlocked the same way.
+  when it recognizes an `EntityManager`, serialized per connection and with
+  `transaction: false` so it never opens one of its own. Both of those are
+  load-bearing. The hooks of one array save run concurrently (TypeORM awaits
+  them with `Promise.all`), so unserialized they put several statements in
+  flight on one client, which pg deprecates in 8.22 and removes in 9, and
+  which TypeORM itself avoids at every site it controls; the warning was
+  observed on `POST /identity-providers`, whose six extra-attribute rows fan
+  out that far. And a query-builder insert (the extra-attribute add path,
+  `Repository.insert`) broadcasts its hooks on a runner carrying NO
+  transaction, where each save would otherwise BEGIN and COMMIT one of its
+  own. Three things follow. The row is atomic with the write it describes
+  wherever the write runs through `Repository.save` / `.remove`, which is
+  every service path: a rolled-back write leaves no row (pinned by
+  `event-repository.spec.ts`; the pin is only meaningful on mysql/postgres,
+  since sqlite shares one query runner and joined the transaction anyway).
+  It is NOT atomic on that query-builder insert path, because the INSERT has
+  already committed before the first hook runs, so there the row is an
+  ordinary autocommitted write on the same connection. Deferring the write to
+  `afterTransactionCommit`, the issue's other candidate, does not fix this on
+  its own: `record()` would still go through the DataSource, and TypeORM
+  broadcasts that event inside `commitTransaction()`, before the executor
+  releases the runner, so the second connection is still taken while the first
+  is held. Deferring it AND riding the runner's manager WOULD work, and would
+  close the residual below, since at depth 1 the broadcast fires after `COMMIT`
+  with the transaction already closed and the connection still held (the event
+  carries `queryRunner` and `manager`). It was not taken because it needs a
+  stash keyed by the query runner, a transaction subscriber and a rollback
+  discard, and because a nested transaction broadcasts `AfterTransactionCommit`
+  at its inner `RELEASE SAVEPOINT` while the outer transaction is still open,
+  which would put the row back inside it. That is the escape hatch if the
+  residual ever bites.
   And the failed-save contract narrowed by one residual, stated exactly:
   `record()` still swallows a failed save, and on mysql and sqlite that is
   the whole story, but postgres aborts the WHOLE transaction on any failed
@@ -5914,14 +5938,20 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   line as a trace. It is infrastructure-only: `auth_events` carries no
   foreign key, every free-text column is truncated to its width and the four
   `uuid` columns only ever receive ids the server minted, so the INSERT has
-  no data-shaped way to fail while the write's own statements succeeded.
+  no data-shaped way to fail while the write's own statements succeeded. The
+  three columns that are neither truncated nor a foreign key (`scope`, `name`,
+  `actorType`) hold because they are closed enums, so a free-text value
+  admitted into one of them later would reopen this.
   A savepoint around the audit save was tried and REJECTED: savepoints are
-  a stack per connection and typeorm reads its depth before the awaited
-  `SAVEPOINT` statement, while the after-hooks of one array save (an
-  entity's attribute rows, a policy tree's cascade) run concurrently on one
-  runner, so two hooks both issue `SAVEPOINT typeorm_1` and the first
-  `RELEASE` names `typeorm_2`, which does not exist (the policy and
-  identity-provider update specs failed with exactly that). Making it
+  a stack per connection, and `startTransaction` issues
+  `SAVEPOINT typeorm_<depth>` and awaits it BEFORE incrementing
+  `transactionDepth`, while the after-hooks of one array save (an entity's
+  attribute rows, a policy tree's cascade) run concurrently on one runner.
+  So two hooks both read depth 1, both issue `SAVEPOINT typeorm_1`, the depth
+  lands at 3, and the first `RELEASE` names `typeorm_2`, which was never
+  created (the policy and identity-provider update specs failed with exactly
+  that). Naming the savepoints uniquely would not have helped either, since
+  rolling back to an earlier one discards every later one. Making it
   correct needs a per-runner mutex plus a sqlite bypass (the shared runner
   would leak the depth across requests), which is more mechanism than an
   infrastructure-only failure buys; revisit if a real deployment ever logs

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1081,8 +1081,11 @@ threads instances through constructor/context args:
   destination + one namespaced destination per non-null realm id); `cache.keys`
   returns the query-result-cache keys to drop on update/remove
   (`cache.onInsert: true` adds insert — used by junction/attribute subscribers
-  whose cache is keyed by the owner id). A subscriber without an injected
-  publisher publishes nothing (tests / migration CLI runs).
+  whose cache is keyed by the owner id). Every `after*` hook hands its
+  `event.manager` to the publish as the opaque `transaction`, because the
+  hooks run inside the persist transaction and a handler that persists must
+  ride it (#3539). A subscriber without an injected publisher publishes
+  nothing (tests / migration CLI runs).
 - **typeorm-extension's global registry is unused** — `setDataSource` /
   `useDataSource` / `unsetDataSource` have no call sites; repositories that
   need a `DataSource` (identity-provider mappers/account, `OAuth2KeyRepository`)
@@ -2709,11 +2712,12 @@ concurrent saves, reachable by any user with ten concurrent `POST /users/@me`.
 The concurrency spec carries a pool-exhaustion pin for exactly this (twelve
 concurrent updates on twelve different users, and twelve concurrent creates,
 all resolving inside the default timeout). The pin runs with the entity
-audit mirror OFF, because the mirror has the same hazard on its own and on
-master: every `EntitySubscriber.afterInsert` / `afterUpdate` awaits the audit
-row's save from INSIDE TypeORM's persist transaction, on a second pooled
-connection. That is issue #3539, and until it is fixed ten concurrent entity
-writes still hang a deployment with `eventLogEntityEnabled` on.
+audit mirror ON, its default, and that is deliberate: the mirror used to be
+the same hazard on its own. Every `EntitySubscriber.afterInsert` /
+`afterUpdate` awaited the audit row's save from INSIDE TypeORM's persist
+transaction, through the DataSource, on a second pooled connection (issue
+#3539). The row rides the write's own `event.manager` now (see *Entity-CRUD
+bridge* under *Security Event Log*), so the one pin covers both sites.
 
 On sqlite the seam is an unlocked passthrough that hands the callback the
 adapter itself, for the reason
@@ -5883,8 +5887,46 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   `created|updated|deleted` rows (`refType` = entity type, `refId` = id).
   The pre-update snapshot rides the publish **context** as `dataPrevious`
   (`afterUpdate` passes `event.databaseEntity`) — **never inside `content`**,
-  the shared realtime wire payload the redis/socket handlers ship. Actor +
-  request attribution comes from an AsyncLocalStorage request context
+  the shared realtime wire payload the redis/socket handlers ship.
+  **The audit row rides the write's own transaction** (issue #3539). The
+  subscriber hooks run inside TypeORM's persist transaction, before the
+  executor commits and releases the connection, so a save through the
+  DataSource waited for a SECOND pooled connection while the first was held,
+  and ten concurrent entity writes (ten `POST /users/@me`, any bulk import)
+  deadlocked the whole pool. `EntitySubscriber.publish` therefore hands
+  `event.manager` to the publish context as its opaque `transaction`
+  (`@authup/server-kit` knows no persistence, hence `unknown`), the handler
+  forwards it into `EventRecordInput.transaction`, and
+  `EventRepositoryAdapter.save` writes through `manager.withRepository(...)`
+  when it recognizes an `EntityManager`. Three things follow. The row is
+  atomic with the write it describes: a rolled-back write leaves no row
+  (pinned by `event-repository.spec.ts`; the pin is only meaningful on
+  mysql/postgres, since sqlite shares one query runner and joined the
+  transaction anyway). Deferring the write to `afterTransactionCommit` was
+  NOT an option: TypeORM broadcasts it inside `commitTransaction()`, still
+  before the runner is released, so it would have deadlocked the same way.
+  And the failed-save contract narrowed by one residual, stated exactly:
+  `record()` still swallows a failed save, and on mysql and sqlite that is
+  the whole story, but postgres aborts the WHOLE transaction on any failed
+  statement, so an audit INSERT that fails on the database's side dooms the
+  write and the executor's COMMIT answers ROLLBACK without raising, the API
+  answering 201 for a row that never landed with only the `record()` warn
+  line as a trace. It is infrastructure-only: `auth_events` carries no
+  foreign key, every free-text column is truncated to its width and the four
+  `uuid` columns only ever receive ids the server minted, so the INSERT has
+  no data-shaped way to fail while the write's own statements succeeded.
+  A savepoint around the audit save was tried and REJECTED: savepoints are
+  a stack per connection and typeorm reads its depth before the awaited
+  `SAVEPOINT` statement, while the after-hooks of one array save (an
+  entity's attribute rows, a policy tree's cascade) run concurrently on one
+  runner, so two hooks both issue `SAVEPOINT typeorm_1` and the first
+  `RELEASE` names `typeorm_2`, which does not exist (the policy and
+  identity-provider update specs failed with exactly that). Making it
+  correct needs a per-runner mutex plus a sqlite bypass (the shared runner
+  would leak the depth across requests), which is more mechanism than an
+  infrastructure-only failure buys; revisit if a real deployment ever logs
+  that warn line next to a lost write.
+  Actor + request attribution comes from an AsyncLocalStorage request context
   (`adapters/http/request/event-context.ts`; middleware mounted immediately
   after the authorization middleware — non-HTTP writes like
   provisioning/CLI/cron have no store → null actor = "system" semantics).

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -96,10 +96,10 @@ concurrent saves exhausted the pool and hung every later query. The same spec
 therefore carries a pool-exhaustion pin: twelve concurrent updates on twelve
 different users and twelve concurrent creates must all resolve within the
 default test timeout, which a regression turns into a hang and vitest into a
-failure. The spec boots with `eventLogEntityEnabled = false`: the entity
-audit mirror writes its row on a second pooled connection from inside the
-persist transaction (issue #3539, pre-existing), so with it on the pins hang
-against master too and would say nothing about the save shape.
+failure. The spec boots with the entity audit mirror on, its default: the
+mirror used to insert its row on a second pooled connection from inside the
+persist transaction (issue #3539), so the same pins are the regression test
+for that write too.
 
 ## Test Layers (server-core)
 

--- a/apps/server-core/src/adapters/database/domains/identity-provider-attribute/subscriber.ts
+++ b/apps/server-core/src/adapters/database/domains/identity-provider-attribute/subscriber.ts
@@ -8,6 +8,7 @@
 import type { EntityDefaultEventName, IdentityProviderAttribute } from '@authup/core-kit';
 import { EntityType } from '@authup/core-kit';
 import { buildRedisKeyPath } from '@authup/server-kit';
+import type { EntityManager } from 'typeorm';
 import { EventSubscriber } from 'typeorm';
 import { EntitySubscriber, buildEntityDestinations } from '../../subscriber/index.ts';
 import { IdentityProviderAttributeEntity } from './entity.ts';
@@ -41,11 +42,13 @@ export class IdentityProviderAttributeSubscriber extends EntitySubscriber<Identi
         event: `${EntityDefaultEventName}`,
         data: IdentityProviderAttribute,
         dataPrevious?: IdentityProviderAttribute,
+        transaction?: EntityManager,
     ): Promise<void> {
         await super.publish(
             event,
             { ...data, value: null },
             dataPrevious ? { ...dataPrevious, value: null } : undefined,
+            transaction,
         );
     }
 }

--- a/apps/server-core/src/adapters/database/subscriber/module.ts
+++ b/apps/server-core/src/adapters/database/subscriber/module.ts
@@ -14,6 +14,7 @@ import {
 import type { DomainEventDestinations, IDomainEventPublisher } from '@authup/server-kit';
 import type {
     DataSource,
+    EntityManager,
     EntitySubscriberInterface,
     InsertEvent,
     ObjectLiteral,
@@ -77,7 +78,7 @@ export class EntitySubscriber<T extends ObjectLiteral> implements EntitySubscrib
             await this.dropCacheKeys(event.connection, event.entity);
         }
 
-        await this.publish(EntityDefaultEventName.CREATED, event.entity);
+        await this.publish(EntityDefaultEventName.CREATED, event.entity, undefined, event.manager);
     }
 
     async afterUpdate(event: UpdateEvent<T>): Promise<any> {
@@ -87,7 +88,7 @@ export class EntitySubscriber<T extends ObjectLiteral> implements EntitySubscrib
 
         await this.dropCacheKeys(event.connection, event.entity as T);
 
-        await this.publish(EntityDefaultEventName.UPDATED, event.entity as T, event.databaseEntity);
+        await this.publish(EntityDefaultEventName.UPDATED, event.entity as T, event.databaseEntity, event.manager);
     }
 
     async afterRemove(event: RemoveEvent<T>): Promise<any> {
@@ -101,7 +102,7 @@ export class EntitySubscriber<T extends ObjectLiteral> implements EntitySubscrib
 
         await this.dropCacheKeys(event.connection, entity);
 
-        await this.publish(EntityDefaultEventName.DELETED, entity);
+        await this.publish(EntityDefaultEventName.DELETED, entity, undefined, event.manager);
     }
 
     protected async dropCacheKeys(connection: DataSource, data: T) : Promise<void> {
@@ -112,10 +113,15 @@ export class EntitySubscriber<T extends ObjectLiteral> implements EntitySubscrib
         await connection.queryResultCache.remove(this.ctx.cache.keys(data));
     }
 
+    /**
+     * `transaction` is the hook's `event.manager`: the after* hooks run inside
+     * the persist transaction, so a handler that persists rides it (#3539).
+     */
     protected async publish(
         event: `${EntityDefaultEventName}`,
         data: T,
         dataPrevious?: T,
+        transaction?: EntityManager,
     ) : Promise<void> {
         if (!this.publisher) {
             return;
@@ -129,6 +135,7 @@ export class EntitySubscriber<T extends ObjectLiteral> implements EntitySubscrib
             },
             destinations: this.ctx.destinations(data),
             ...(dataPrevious ? { dataPrevious } : {}),
+            transaction,
         });
     }
 }

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -24,8 +24,15 @@ import { applyRealmScopeSelect, deleteInBatches, resolveSweepBatchSize } from '.
 export class EventRepositoryAdapter implements IEventRepository {
     private readonly repository: Repository<Event>;
 
+    /**
+     * One pending audit save per caller connection, keyed by the manager the
+     * hook handed over (every hook of one broadcast gets the same object).
+     */
+    private readonly transactionQueue: WeakMap<EntityManager, Promise<unknown>>;
+
     constructor(repository: Repository<Event>) {
         this.repository = repository;
+        this.transactionQueue = new WeakMap();
     }
 
     create(data: Partial<Event>): Event {
@@ -33,26 +40,51 @@ export class EventRepositoryAdapter implements IEventRepository {
     }
 
     async save(entity: Event, options: EventSaveOptions = {}): Promise<Event> {
-        // An audit row written from inside a persist transaction rides it:
-        // the connection behind the write is still held while the subscriber
-        // hooks run, so a save through the DataSource would wait for a second
-        // pooled connection and ten concurrent writes deadlock (#3539).
-        // Deliberately no savepoint around it: savepoints are a stack per
-        // connection and typeorm reads its depth before the awaited SAVEPOINT
-        // statement, while the after-hooks of one array save (an entity's
-        // attribute rows) run concurrently on one runner, so the depth races
-        // and a RELEASE names a savepoint that does not exist. The residual is
-        // postgres-only: it aborts the whole transaction on a failed statement,
-        // so an INSERT that fails on the database's side (this row has no
-        // foreign key, its free-text columns are truncated and its uuid columns
-        // only receive ids the server minted, so nothing data-shaped fails it)
-        // dooms the write, and the executor's COMMIT then answers ROLLBACK
-        // without raising.
+        // An audit row written from inside a persist transaction rides it: the
+        // connection behind the write is still held while the subscriber hooks
+        // run, so a save through the DataSource would wait for a second pooled
+        // connection and ten concurrent writes deadlock (#3539).
         if (options.transaction instanceof EntityManager) {
-            return options.transaction.withRepository(this.repository).save(entity);
+            return this.saveOnCallerConnection(options.transaction, entity);
         }
 
         return this.repository.save(entity);
+    }
+
+    /**
+     * Writes the row on the connection the caller already holds.
+     *
+     * Serialized per connection, because the after-hooks of one array save run
+     * concurrently (typeorm awaits them with Promise.all) and would otherwise
+     * put several statements in flight on one client. pg deprecates that in
+     * 8.22 and removes it in 9, and typeorm avoids it everywhere it controls
+     * the fan-out.
+     *
+     * `transaction: false` keeps the nested save from opening a transaction of
+     * its own. Inside a persist transaction it would not have, but a
+     * query-builder insert (the extra-attribute add path) broadcasts its hooks
+     * on a runner carrying no transaction, and there each save would otherwise
+     * BEGIN and COMMIT one.
+     *
+     * Deliberately no savepoint: savepoints are a stack per connection, and
+     * `startTransaction` issues `SAVEPOINT typeorm_<depth>` and awaits it
+     * before incrementing the depth, so concurrent hooks raced it and a
+     * RELEASE named a savepoint that was never created. The residual is
+     * postgres-only and stated in .agents/architecture.md.
+     */
+    private saveOnCallerConnection(manager: EntityManager, entity: Event): Promise<Event> {
+        const pending = this.transactionQueue.get(manager) || Promise.resolve();
+        const next = pending
+            .catch(() => undefined)
+            .then(() => manager
+                .withRepository(this.repository)
+                .save(entity, { transaction: false }));
+
+        // the queue tail must never stay rejected, or it would fail every
+        // later row on this connection
+        this.transactionQueue.set(manager, next.catch(() => undefined));
+
+        return next;
     }
 
     async findOneById(id: string): Promise<Event | null> {

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -8,13 +8,14 @@
 import type { Event } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
-import { LessThan } from 'typeorm';
+import { EntityManager, LessThan } from 'typeorm';
 import { applyQuery, redactFieldConditions } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type {
     EventCountRecentFilter,
     EventDeleteExpiredOptions,
     EventFindManyOptions,
+    EventSaveOptions,
     IEventRepository,
 } from '../../../../../core/index.ts';
 import { EVENT_RETENTION_SWEEP_BATCH_SIZE } from '../../../../../core/index.ts';
@@ -31,7 +32,26 @@ export class EventRepositoryAdapter implements IEventRepository {
         return this.repository.create(data);
     }
 
-    async save(entity: Event): Promise<Event> {
+    async save(entity: Event, options: EventSaveOptions = {}): Promise<Event> {
+        // An audit row written from inside a persist transaction rides it:
+        // the connection behind the write is still held while the subscriber
+        // hooks run, so a save through the DataSource would wait for a second
+        // pooled connection and ten concurrent writes deadlock (#3539).
+        // Deliberately no savepoint around it: savepoints are a stack per
+        // connection and typeorm reads its depth before the awaited SAVEPOINT
+        // statement, while the after-hooks of one array save (an entity's
+        // attribute rows) run concurrently on one runner, so the depth races
+        // and a RELEASE names a savepoint that does not exist. The residual is
+        // postgres-only: it aborts the whole transaction on a failed statement,
+        // so an INSERT that fails on the database's side (this row has no
+        // foreign key, its free-text columns are truncated and its uuid columns
+        // only receive ids the server minted, so nothing data-shaped fails it)
+        // dooms the write, and the executor's COMMIT then answers ROLLBACK
+        // without raising.
+        if (options.transaction instanceof EntityManager) {
+            return options.transaction.withRepository(this.repository).save(entity);
+        }
+
         return this.repository.save(entity);
     }
 

--- a/apps/server-core/src/core/entities/event/entity-event-handler.ts
+++ b/apps/server-core/src/core/entities/event/entity-event-handler.ts
@@ -153,6 +153,7 @@ export class EntityEventHandler implements IDomainEventHandler {
                 requestUserAgent: requestContext?.requestUserAgent ?? null,
                 data,
                 retentionDays: this.options.retentionDays,
+                transaction: ctx.transaction,
             });
         } catch {
             // record() never throws, but the bridge itself must also never

--- a/apps/server-core/src/core/entities/event/entity-event-handler.ts
+++ b/apps/server-core/src/core/entities/event/entity-event-handler.ts
@@ -105,7 +105,7 @@ export class EntityEventHandler implements IDomainEventHandler {
             // recursion guard — no event subscriber exists today (the
             // auth_events entity is deliberately subscriber-less), so this is
             // defense in depth against an audit-write feedback loop.
-            if (ctx.content.type === 'event') {
+            if (ctx.content.type === EntityType.EVENT) {
                 return;
             }
 

--- a/apps/server-core/src/core/entities/event/service.ts
+++ b/apps/server-core/src/core/entities/event/service.ts
@@ -158,9 +158,11 @@ export class EventService extends AbstractEntityService implements IEventService
                     null,
             });
 
-            await this.repository.save(entity);
+            await this.repository.save(entity, { transaction: input.transaction });
         } catch {
             // an audit write failure must never fail the originating operation
+            // from here; a save that joined the write's transaction can still
+            // have doomed it on postgres, see EventRepositoryAdapter.save
             this.logger?.warn(`Recording the audit event ${input.scope}.${input.name} failed.`);
         }
     }

--- a/apps/server-core/src/core/entities/event/types.ts
+++ b/apps/server-core/src/core/entities/event/types.ts
@@ -50,10 +50,19 @@ export type EventCountRecentFilter = {
     since: string,
 };
 
+export type EventSaveOptions = {
+    /**
+     * The transaction the row rides, as the opaque handle the domain event
+     * carried. The adapter decides whether it recognizes the handle; without
+     * one the row saves on a connection of its own.
+     */
+    transaction?: unknown,
+};
+
 export interface IEventRepository {
     create(data: Partial<Event>): Event;
 
-    save(entity: Event): Promise<Event>;
+    save(entity: Event, options?: EventSaveOptions): Promise<Event>;
 
     findMany(
         query: IQuery,
@@ -104,6 +113,12 @@ export type EventRecordInput = {
      * effective value.
      */
     retentionDays?: number,
+    /**
+     * The transaction the originating write rides, when the caller is inside
+     * one (the entity-CRUD bridge). The row joins it instead of taking a
+     * second pooled connection (#3539).
+     */
+    transaction?: unknown,
 };
 
 export type EventServiceOptions = {

--- a/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
+++ b/apps/server-core/test/unit/app/modules/database/event-repository.spec.ts
@@ -67,6 +67,41 @@ describe('app/modules/database/repositories/event', () => {
         .getRepository<Event>(EventEntity)
         .countBy({ refId });
 
+    it('writes the row on the transaction it is handed, so a rollback takes it with it', async () => {
+        // the entity-CRUD bridge saves from inside the persist transaction
+        // (#3539); on mysql/postgres a save that ignored the handle would land
+        // on a second connection, autocommit, and survive this rollback.
+        const refId = `transaction-probe-${randomUUID()}`;
+
+        await expect(suite.dataSource.transaction(async (manager) => {
+            await repository.save(repository.create({
+                id: randomUUID(),
+                scope: EventScope.ENTITY,
+                name: EventName.CREATED,
+                refId,
+                expiring: false,
+            }), { transaction: manager });
+
+            throw new Error('rollback');
+        })).rejects.toThrow('rollback');
+
+        expect(await countByRef(refId)).toEqual(0);
+    });
+
+    it('saves on a connection of its own when the handle is not one it recognizes', async () => {
+        const refId = `handle-probe-${randomUUID()}`;
+
+        await repository.save(repository.create({
+            id: randomUUID(),
+            scope: EventScope.ENTITY,
+            name: EventName.CREATED,
+            refId,
+            expiring: false,
+        }), { transaction: {} });
+
+        expect(await countByRef(refId)).toEqual(1);
+    });
+
     it('counts a just-written row inside the window (host-timezone independent)', async () => {
         // the login-throttle window: the bound `since` must compare correctly
         // against the DB-clock-stamped created_at regardless of the HOST's

--- a/apps/server-core/test/unit/core/entities/event/entity-event-handler.spec.ts
+++ b/apps/server-core/test/unit/core/entities/event/entity-event-handler.spec.ts
@@ -314,6 +314,14 @@ describe('EntityEventHandler', () => {
         expect(eventService.recordCalls).toHaveLength(0);
     });
 
+    it('forwards the transaction handle the bus carried', async () => {
+        const transaction = {};
+
+        await buildHandler().handle({ ...buildPublishContext(), transaction });
+
+        expect(eventService.recordCalls[0].transaction).toBe(transaction);
+    });
+
     it('forwards the configured retention override', async () => {
         await buildHandler({ retentionDays: 7 }).handle(buildPublishContext());
 

--- a/apps/server-core/test/unit/http/controllers/entities/user-concurrency.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/user-concurrency.spec.ts
@@ -33,19 +33,10 @@ import { createFakeClient, createFakeUser } from '../../../../utils';
 const rowLockable = ['mysql', 'postgres'].includes(process.env.DB_TYPE ?? '');
 
 describe.skipIf(!rowLockable)('http/controllers/user (concurrency)', () => {
-    // `eventLogEntityEnabled` is off here on purpose. The entity audit mirror
-    // is a SECOND, pre-existing pinning site: `EntitySubscriber.afterInsert` /
-    // `afterUpdate` run inside TypeORM's own persist transaction, and the
-    // `EntityEventHandler` they await inserts the `auth_events` row through
-    // the DataSource, on a second pooled connection. Ten concurrent entity
-    // writes deadlock on that alone, with or without the #3526 seam, so the
-    // pool pin below could never settle with it on. That site is issue #3539;
-    // this file pins the save shape.
-    const suite = createTestApplication({
-        config: (config) => {
-            config.eventLogEntityEnabled = false;
-        },
-    });
+    // The entity audit mirror stays ON (its default): every entity write
+    // also inserts an `auth_events` row from inside TypeORM's persist
+    // transaction, so the pool pins below cover that write as well (#3539).
+    const suite = createTestApplication();
     const actor = createAllowAllActor();
 
     let realm: Realm;

--- a/packages/server-kit/src/domain-event/types.ts
+++ b/packages/server-kit/src/domain-event/types.ts
@@ -27,7 +27,14 @@ export type DomainEventPublishContext<
      * redis/socket consumers — only in-process handlers (e.g. the audit
      * entity-event bridge) may read it.
      */
-    dataPrevious?: Record<string, any>
+    dataPrevious?: Record<string, any>,
+    /**
+     * The transaction the publishing write rides, as an opaque handle (this
+     * package knows no persistence): an in-process handler that persists
+     * joins it instead of taking a second connection (#3539). Wire handlers
+     * ignore it.
+     */
+    transaction?: unknown
 };
 
 export interface IDomainEventHandler {


### PR DESCRIPTION
Closes #3539.

## The bug

Every `EntitySubscriber.afterInsert` / `afterUpdate` / `afterRemove` runs inside TypeORM's persist transaction (`SubjectExecutor` broadcasts the after-events, and awaits them, before `EntityPersistExecutor` commits and releases the query runner). The hook awaited `DomainEventPublisher.safePublish`, which reached `EntityEventHandler.handle`, `EventService.record` and `EventRepositoryAdapter.save`, and that save went through the DataSource: a SECOND pooled connection while the first was still held. The pool is ten with an unbounded wait on both drivers, so ten concurrent entity writes (ten `POST /users/@me`, any bulk import) held ten connections and each waited for an eleventh that never came. Every later request queued behind them until a restart.

## The fix

The audit row is written on the connection the originating write already holds:

- `DomainEventPublishContext` (`@authup/server-kit`, which knows no persistence) gains an opaque `transaction?: unknown`, next to `dataPrevious` and with the same "in-process handlers only" contract.
- `EntitySubscriber.publish` hands the hook's `event.manager` down as that handle. The one `publish` override, the identity-provider attribute subscriber, forwards it.
- `EntityEventHandler` forwards it into `EventRecordInput.transaction`, and `IEventRepository.save` takes it as `EventSaveOptions`.
- `EventRepositoryAdapter.save` writes through `manager.withRepository(...)` when the handle is an `EntityManager`. Anything else saves on a connection of its own, as before.

No typeorm type reaches core or `server-kit`. Two details of that write are load-bearing and are explained at the call site:

- **Serialized per connection.** The after-hooks of one array save run concurrently, so unserialized the audit saves put several statements in flight on one client. pg deprecates that in 8.22 and removes it in 9, and TypeORM avoids it at every site where it controls the fan-out. `POST /identity-providers`, whose six extra-attribute rows fan out that far, reproduced the warning on postgres while master does not emit it.
- **`transaction: false`.** The extra-attribute add path writes through `Repository.insert`, whose query builder starts no transaction, so its hooks fire on a runner carrying none and each audit save would otherwise open and commit one of its own.

## What was rejected, and why

- **Fire-and-forget**: fixes the deadlock, but `event-entity-bridge.spec.ts` asserts the audit row right after each API write, which becomes a race on mysql and postgres, and a row can be lost with the process.
- **A savepoint around the joined save**, to keep a failed audit INSERT from aborting the write's transaction on postgres: tried, and it broke the policy and identity-provider update specs with `no such savepoint: typeorm_2`. `startTransaction` issues `SAVEPOINT typeorm_<depth>` and awaits it before incrementing the depth, so two concurrent hooks both take depth 1, both issue `SAVEPOINT typeorm_1`, and the first `RELEASE` names one that was never created. Naming them uniquely would not help either, since rolling back to an earlier savepoint discards every later one.
- **Deferring to `afterTransactionCommit`**, the issue's other candidate: it does not fix the deadlock *on its own*, because `record()` would still go through the DataSource and the broadcast happens before the runner is released. Deferring it *and* riding the runner's manager would work, and would also close the residual below. It was not taken because it needs a stash keyed by the query runner, a transaction subscriber and a rollback discard, and because a nested transaction broadcasts `AfterTransactionCommit` at its inner `RELEASE SAVEPOINT` while the outer transaction is still open. It is the escape hatch if the residual ever bites.

## Behaviour change, stated

The audit row is now atomic with the write it describes wherever the write runs through `save` or `remove`, which is every service path: a rolled-back write leaves no row, where before the row autocommitted on its own connection and survived. It is deliberately not atomic on the query-builder insert path, because those rows are already committed before the first hook runs.

The residual is postgres-only. `record()` still swallows a failed audit save, and postgres aborts the whole transaction on any failed statement, so an audit INSERT that fails on the database's side dooms the write while the executor's COMMIT answers ROLLBACK without raising. It is infrastructure-only: `auth_events` carries no foreign key, its free-text columns are truncated to their widths, its uuid columns only receive server-minted ids, and the three remaining columns are closed enums. Authup sets no per-statement timeout, and boot fails on a pending migration or a schema mismatch, so a drifted table cannot reach this path.

## Tests

- `user-concurrency.spec.ts` drops its `eventLogEntityEnabled = false` override, so its twelve-concurrent create and update pins now cover the audit mirror. Both timed out at 30s on postgres before this change and pass in under a second after it.
- `event-repository.spec.ts` pins that the row rides the handed transaction and disappears with a rollback, and that an unrecognized handle still saves. The rollback pin was confirmed to fail with the fix disabled, so it discriminates.
- `entity-event-handler.spec.ts` pins that the handle is forwarded.
- Full server-core sqlite suite, plus the concurrency, event, bridge, policy and identity-provider specs on postgres and mysql, plus `check:types` for server-core and server-kit.

Note for anyone running the suites locally: do not run the sqlite suite concurrently with a `test:psql` or `test:mysql` run in the same workspace. Each run's global setup sweeps the per-worker sqlite copies, so an overlapping sqlite run fails across unrelated files.
