### PR TITLE
fix(server-core,docs): boot on sqlite when no database is configured

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1346,9 +1346,9 @@ no new endpoint — the `/authorize` verifier already resolves clients via
   (auth is header-based only, and OAuth2 clients are registered at runtime on
   domains unknown at startup; an explicit allowlist can be set via the
   `middlewareCors` config options). In non-production,
-  `http://localhost:3010` is dev-seeded (`DEVELOPMENT_ORIGIN`,
+  `http://localhost:5173` is dev-seeded (`DEVELOPMENT_ORIGIN`,
   `@authup/server-config`) so the admin console's standalone dev server
-  (`npm run dev -w apps/client-admin-console`, vite on :3010) works on first
+  (`npm run dev -w apps/client-admin-console`, vite on :5173) works on first
   run; the served console at `<publicUrl>/console/admin` needs no entry,
   since publicUrl's own origin is always in the set, and neither does
   `authup dev` (Development mode below), which serves every console on
@@ -3436,8 +3436,8 @@ against a running dev server during verification, and the resulting
 `HttpOnly` session cookie was confirmed unreadable from JavaScript with no
 bearer token anywhere in the shell payload. This is the loop's main
 fidelity win over the pre-102 standalone console dev server (`npm run dev`
-in `apps/client-admin-console`, on `:3010`, or `apps/client-account-console`,
-on vite's default `:5173`): both run cross-origin against the API's `:3000`,
+in `apps/client-admin-console` or `apps/client-account-console`, both on
+vite's default `:5173`): both run cross-origin against the API's `:3000`,
 where `cookieSession` resolves false and the browser-PKCE path is all that
 is reachable, so neither ever exercised what a served console actually does
 in production.

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -3144,7 +3144,7 @@ boots on its defaults).
 this service reads: the zod `type`, the `default` (a static value, or a
 thunk for the two process-derived keys `env` and `rootPath`; `publicUrl` and
 `db` carry none, the first is derived from host and port in `normalizeConfig`,
-the second falls back to typeorm-extension's driver default; `publicUrl` is derived by `resolvePublicUrl` in `@authup/server-config` from `core.host` + `core.port`, which are DOCUMENT keys rather than facts about whichever process is asking, so a console computes the identical issuer with no server-core anywhere -- that is what lets a console stand alone, and it is why the console registries carry the core section), an
+the second falls back to the sqlite driver default on the boot path alone, in `DataSourceOptionsBuilder` rather than in typeorm-extension (conventions.md -> *Configuration Naming*); `publicUrl` is derived by `resolvePublicUrl` in `@authup/server-config` from `core.host` + `core.port`, which are DOCUMENT keys rather than facts about whichever process is asking, so a console computes the identical issuer with no server-core anywhere -- that is what lets a console stand alone, and it is why the console registries carry the core section), an
 operator-facing `description`, and for the 51 env-backed keys the
 `EnvironmentVariable` plus a `readEnv` reader. The mapped
 `Schema` type is the exhaustiveness guard: a `Config` key with no

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -350,6 +350,38 @@ copy, not an oversight.
   else defaults to `<rootPath>/logs` and `<rootPath>/provisioning`, which is
   what keeps an unprivileged `npx` start working (any absolute system path
   needs root or a pre-chowned directory).
+- **With no database configured at all, the boot path falls back to sqlite,
+  outside production.** `db` carries no default and
+  `readDataSourceOptionsFromEnv()` returns nothing unless the driver type is
+  set (typeorm-extension's `hasEnvDataSourceOptions()` is `!!useEnv('type')`,
+  which reads `DB_TYPE` or `TYPEORM_CONNECTION`, else the scheme of `DB_URL` or
+  `TYPEORM_URL`), so `DatabaseModule.buildDataSourceOptions` calls
+  `DataSourceOptionsBuilder.buildWithEnvOrDefault`, which supplies
+  `better-sqlite3` plus the same `db.sqlite` name typeorm-extension derives for
+  that driver, resolved against the process cwd like any other sqlite path.
+  The gate is the TYPE alone: a WRONG value still fails, and a lone
+  `DB_DATABASE` or `DB_HOST` is ignored along with everything else, so the
+  fallback answers "nothing configured" and never rescues a half-written
+  configuration. Outside production that is silent, which is the one place the
+  fallback is weaker than the throw it replaced; in production the refusal
+  below names the variables, so a half-written configuration still fails loud
+  where it matters.
+  Production is the exception, because `isDatabaseTypeSupportedForEnvironment`
+  refuses `better-sqlite3` there. That is why the Docker image
+  (`NODE_ENV=production`) still requires postgres or mysql, and why that
+  refusal carries the actionable message naming the `DB_*` variables: with the
+  fallback in place it is the only error an operator with no database
+  configuration ever sees. **`buildWithEnv` stays strict and the two methods
+  must not be collapsed into one.** It is what the `migration` CLI command and
+  the two `scripts/` CI runners call, none of which applies the environment
+  check, so an unconfigured `migration run` would create a sqlite file, read
+  sqlite's empty migrations array, report "No migrations are pending" and exit
+  `0`. That is the same silent success the round-trip's `dist` pre-flight
+  exists to catch (testing.md → *Migration Tests*). The fallback exists because
+  it was already documented while nothing implemented it (the `db` entry's own
+  description, published as the JSON Schema, its `types.ts` doc comment, and
+  the database guide's opening line), so no surface booted unconfigured,
+  `npx authup start` included.
 
 ## Upstream (Own) Libraries
 

--- a/.agents/conventions.md
+++ b/.agents/conventions.md
@@ -359,13 +359,18 @@ copy, not an oversight.
   `DataSourceOptionsBuilder.buildWithEnvOrDefault`, which supplies
   `better-sqlite3` plus the same `db.sqlite` name typeorm-extension derives for
   that driver, resolved against the process cwd like any other sqlite path.
-  The gate is the TYPE alone: a WRONG value still fails, and a lone
-  `DB_DATABASE` or `DB_HOST` is ignored along with everything else, so the
-  fallback answers "nothing configured" and never rescues a half-written
-  configuration. Outside production that is silent, which is the one place the
-  fallback is weaker than the throw it replaced; in production the refusal
-  below names the variables, so a half-written configuration still fails loud
-  where it matters.
+  The gate is the TYPE alone, so the fallback is guarded rather than
+  unconditional: a WRONG value still fails the read, and an environment that
+  names a CONNECTION without a type (`DB_HOST`, `DB_DATABASE`, `DB_URL` or a
+  `TYPEORM_*` alias) is refused with the same error `buildWithEnv` raises,
+  never answered with sqlite. `hasDatabaseConnectionEnv` reads those keys
+  through typeorm-extension's own `useEnv()` rather than a local list, so it
+  cannot drift from what the reader accepts, and it excludes the list-valued
+  keys, which default to `[]` and would report every environment as
+  configured. The default therefore answers "nothing is configured" and
+  nothing else: without the guard a forgotten `DB_TYPE` would have redirected
+  every write to a local file, silently outside production, since production
+  refuses the driver anyway.
   Production is the exception, because `isDatabaseTypeSupportedForEnvironment`
   refuses `better-sqlite3` there. That is why the Docker image
   (`NODE_ENV=production`) still requires postgres or mysql, and why that

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .claude/settings.local.json
 .DS_Store
 dist
+db.sqlite
 node_modules
 *.log
 npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ one listener, with hot module replacement.
 $ VITE_API_URL=http://localhost:3000 npm run dev --workspace=apps/client-admin-console
 ```
 
-It listens on `http://localhost:3010/console/admin/`.
+It listens on `http://localhost:5173/console/admin/`.
 
 ## Applications
 The repository contains the following runnable applications:

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ With Authup, developers can quickly and easily add authentication & authorizatio
 - [Features](#features)
 - [Documentation](#documentation)
 - [Usage](#usage)
+  - [Quick Start](#quick-start)
   - [Production](#production)
   - [Development](#development)
 - [Applications](#applications)
@@ -54,37 +55,54 @@ To read the docs, visit [https://authup.org](https://authup.org)
 
 How Authup can be configured and set up in detail, you can find out [here](https://authup.org/guide/deployment/).
 
-### Production
-#### Docker
+### Quick Start
 
-The **recommended** and optimal way to set up authup is using docker.
-
-One container runs the whole deployment. To start it with default settings on http://localhost:3001/, execute the following command:
-
-```shell
-$ docker run \
-  -p 3001:3000 \
-  -e PUBLIC_URL=http://localhost:3001 \
-  authup/authup:latest start
-```
-
-That service also serves the admin console at http://localhost:3001/console/admin and the account console at http://localhost:3001/console/account.
-
-#### Bare Metal
-
-The easiest way to get the framework up and running, is by using the global CLI.
-Therefore, execute the following shell command.
+The fastest way to try Authup out is the global CLI. It needs no configuration:
 
 ```shell
 $ npx authup@latest start
 ```
 
-To find out how to configure and set up the bare metal variant in detail, click here.
+With no database configured, Authup falls back to SQLite and writes `db.sqlite`
+into the current working directory. That is meant for trying things out and for
+local development. It is not a production setup.
 
-This will launch the following with default settings:
-- Backend Application: `http://localhost:3001/`
-- Admin Console: `http://localhost:3001/console/admin`
-- Account Console: `http://localhost:3001/console/account`
+It serves:
+- API: `http://localhost:3000/`
+- Auth console (login, consent, register, password recovery): served under `http://localhost:3000/console/auth/`
+- Admin console: `http://localhost:3000/console/admin`
+- Account console: `http://localhost:3000/console/account`
+
+To find out how to configure and set up the bare metal variant in detail, click
+[here](https://authup.org/guide/deployment/bare-metal).
+
+### Production
+
+The **recommended** and optimal way to set up authup is using docker.
+One container runs the whole deployment against a PostgreSQL or MySQL database you already have.
+
+```shell
+$ docker run \
+  -p 3000:3000 \
+  -e PUBLIC_URL=http://localhost:3000 \
+  -e DB_TYPE=postgres \
+  -e DB_HOST=postgres.example.com \
+  -e DB_PORT=5432 \
+  -e DB_USERNAME=authup \
+  -e DB_PASSWORD=secret \
+  -e DB_DATABASE=authup \
+  authup/authup:latest start
+```
+
+The image runs in production mode, which does not support SQLite, so it does not start until a server database is configured, via `DB_*` or a `db:` block in `authup.yml`.
+
+It serves:
+- API: `http://localhost:3000/`
+- Auth console (login, consent, register, password recovery): served under `http://localhost:3000/console/auth/`
+- Admin console: `http://localhost:3000/console/admin`
+- Account console: `http://localhost:3000/console/account`
+
+For the full setup, including a compose file that brings the database with it, see the [deployment guide](https://authup.org/guide/deployment/).
 
 ### Development
 
@@ -104,23 +122,25 @@ $ npm run build
 $ npm run cli-dev --workspace=apps/server-core -- start
 ```
 
-It serves the admin console at `http://localhost:3001/console/admin` from that package's built `dist/`.
+It serves the API at `http://localhost:3000/`. server-core serves no console of its
+own: run `npm run dev` in the repository root to get the API and every console on
+one listener, with hot module replacement.
 
-**4**. To work on the admin console itself, start its dev server in a second terminal
+**4**. To work on the admin console against a standalone dev server instead, start it in a second terminal
 
 ```shell
-$ VITE_API_URL=http://localhost:3001 npm run dev --workspace=apps/client-admin-console
+$ VITE_API_URL=http://localhost:3000 npm run dev --workspace=apps/client-admin-console
 ```
 
-It listens on `http://localhost:3000/console/admin/`.
+It listens on `http://localhost:3010/console/admin/`.
 
 ## Applications
 The repository contains the following runnable applications:
 
 | Name                              | Type        | Description                                                                                           |
 |-----------------------------------|-------------|-------------------------------------------------------------------------------------------------------|
-| [authup](apps/authup)             | CLI         | The operator CLI, and the only binary. It runs server-core in the same process: `start`, `worker`, `migration` and `healthcheck`. |
-| [client-admin-console](apps/client-admin-console)     | Application | The admin console: a single-page application served by server-core at `/console/admin`. |
+| [authup](apps/authup)             | CLI         | The operator CLI, and the binary an ordinary deployment runs. It runs every service in the same process: `start` (roles: `core`, `worker`, `console`), `migration`, `healthcheck` and `config`. |
+| [client-admin-console](apps/client-admin-console)     | Application | The admin console: a single-page application served at `/console/admin` by `server-admin-console`. |
 | [server-core](apps/server-core)   | Service     | A service that forms the backbone of the server-side ecosystem.                                       |
 
 ## Packages

--- a/apps/authup/src/dev/server/module.ts
+++ b/apps/authup/src/dev/server/module.ts
@@ -49,7 +49,9 @@ const VITE_FS_DENY_DEFAULT = [
  * Both `*.sql` and `writable/**` are listed on purpose: the first covers a
  * database wherever it was configured to live, the second covers the
  * hand-made `db.sql.<something>.bak` copies a working checkout accumulates,
- * which no extension pattern catches.
+ * which no extension pattern catches. `*.sqlite` is the third: with no
+ * database configured the boot path falls back to `better-sqlite3` and writes
+ * `db.sqlite` into the process cwd, which `*.sql` does not match.
  *
  * This is defence in depth. The primary control is that `authup dev` refuses
  * to start at all when the resolved environment is production.
@@ -57,6 +59,7 @@ const VITE_FS_DENY_DEFAULT = [
 const CONSOLE_FS_DENY = [
     ...VITE_FS_DENY_DEFAULT,
     '**/*.sql',
+    '**/*.sqlite',
     '**/authup.yml',
     '**/.env',
     '**/.env.*',

--- a/apps/client-account-console/README.md
+++ b/apps/client-account-console/README.md
@@ -18,19 +18,24 @@ runtime configuration contract (`window.__AUTHUP__` via the
 
 The dev server needs a running authup server to talk to.
 
-1. Start (or pick) an authup server and allow the dev origin, so the
-   per-realm `account-console` OAuth2 client accepts the sign-in
-   round-trip from the vite origin:
+1. Start (or pick) an authup server. Outside production the vite origin
+   (`http://localhost:5173`) is seeded into the trusted origins already, so
+   the per-realm `account-console` OAuth2 client accepts the sign-in
+   round-trip with no configuration:
 
    ```sh
-   TRUSTED_ORIGINS=localhost:5173 authup start
+   authup start
    ```
 
    From the repository, after `npm run build`:
 
    ```sh
-   TRUSTED_ORIGINS=localhost:5173 npm run cli -w apps/server-core -- start
+   npm run cli -w apps/server-core -- start
    ```
+
+   Only one standalone console can hold the port, so if the admin console's
+   dev server already has it, run this one through `authup dev` instead or
+   give it its own `TRUSTED_ORIGINS` entry.
 
 2. Run the dev server with the API URL injected:
 

--- a/apps/client-account-console/vite.config.ts
+++ b/apps/client-account-console/vite.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
     // `/console/account` on its own origin. See src/config.ts for the runtime
     // configuration contract.
     base: '/console/account/',
+    // Vite's default port is the seeded `DEVELOPMENT_ORIGIN`; `strictPort`
+    // keeps it that way. See apps/client-admin-console/vite.config.ts. Only
+    // one standalone console can hold the port, so run the other through
+    // `authup dev` (or give it its own TRUSTED_ORIGINS entry).
+    server: { strictPort: true },
     plugins: [
         vuePlugin(),
         tailwindcss(),

--- a/apps/client-admin-console/README.md
+++ b/apps/client-admin-console/README.md
@@ -28,7 +28,7 @@ the browser-side authorization-code flow instead of the session cookie.
 ## Development
 
 ```shell
-VITE_API_URL=http://localhost:3000 npm run dev    # vite on http://localhost:3010/console/admin/
+VITE_API_URL=http://localhost:3000 npm run dev    # vite on http://localhost:5173/console/admin/
 npm run build                                       # dist/, what server-core serves
 npm run test
 ```

--- a/apps/client-admin-console/vite.config.ts
+++ b/apps/client-admin-console/vite.config.ts
@@ -24,13 +24,16 @@ export default defineConfig({
     // configuration contract.
     base: '/console/admin/',
     // The standalone dev server (`npm run dev`, JS-token mode against
-    // VITE_API_URL): this port, 3010, is the origin `trustedOrigins` seeds
-    // outside production (`DEVELOPMENT_ORIGIN` in `@authup/server-config`),
-    // so the login redirect is allowed without any TRUSTED_ORIGINS
-    // configuration. `npm run dev` at the repository root (`authup dev`)
-    // needs no such seed: it serves this console on server-core's own
-    // origin instead, so no cross-origin redirect is ever made.
-    server: { port: 3010 },
+    // VITE_API_URL) keeps vite's default port, which is the origin
+    // `trustedOrigins` seeds outside production (`DEVELOPMENT_ORIGIN` in
+    // `@authup/server-config`), so the login redirect is allowed without any
+    // TRUSTED_ORIGINS configuration. `strictPort` is what makes that hold: on
+    // a taken port vite otherwise shifts to the next one silently, and the
+    // seeded origin stops applying while the console still comes up.
+    // `npm run dev` at the repository root (`authup dev`) needs no seed at
+    // all: it serves this console on server-core's own origin, so no
+    // cross-origin redirect is ever made.
+    server: { strictPort: true },
     experimental: {
         // Asset URLs that JavaScript resolves at RUNTIME (the preload helper
         // fetching a lazy route's stylesheet) must be relative to the

--- a/apps/server-account-console/test/unit/config.spec.ts
+++ b/apps/server-account-console/test/unit/config.spec.ts
@@ -127,7 +127,7 @@ describe('readConfigFromEnv', () => {
         expect(readConfigFromEnv().trustedOrigins).toEqual([
             'https://admin.example.com',
             'https://hub.example.com',
-            'http://localhost:3010',
+            'http://localhost:5173',
         ]);
     });
 

--- a/apps/server-core/src/adapters/database/data-source/options/module.ts
+++ b/apps/server-core/src/adapters/database/data-source/options/module.ts
@@ -12,6 +12,7 @@ import {
     CodeTransformation,
     isCodeTransformation,
     readDataSourceOptionsFromEnv,
+    useEnv,
 } from 'typeorm-extension';
 import {
     ClientEntity,
@@ -68,12 +69,35 @@ import {
 } from '../../domains/index.ts';
 import { DIST_PATH, SRC_PATH } from '../../../../path.ts';
 
+const NO_DATABASE_CONFIGURED = 'No database is configured. Set DB_TYPE to "postgres" or "mysql", together with DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD and DB_DATABASE.';
+
+/**
+ * Whether the environment names a database connection without naming a driver.
+ *
+ * `readDataSourceOptionsFromEnv` reports the TYPE alone, so it answers nothing
+ * for an environment that carries every credential but no `DB_TYPE`. Read the
+ * connection keys through typeorm-extension's own reader rather than a local
+ * key list, so this cannot drift from what it accepts (each one is `DB_*` or
+ * its `TYPEORM_*` alias). The list-valued keys are excluded deliberately: they
+ * default to `[]` and would report every environment as configured.
+ */
+function hasDatabaseConnectionEnv() : boolean {
+    const env = useEnv();
+
+    return typeof env.url !== 'undefined' ||
+        typeof env.host !== 'undefined' ||
+        typeof env.port !== 'undefined' ||
+        typeof env.username !== 'undefined' ||
+        typeof env.password !== 'undefined' ||
+        typeof env.database !== 'undefined';
+}
+
 export class DataSourceOptionsBuilder {
     buildWithEnv() {
         const options = readDataSourceOptionsFromEnv();
 
         if (!options) {
-            throw new AuthupError('No database is configured. Set DB_TYPE to "postgres" or "mysql", together with DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD and DB_DATABASE.');
+            throw new AuthupError(NO_DATABASE_CONFIGURED);
         }
 
         return this.normalize(options);
@@ -85,7 +109,20 @@ export class DataSourceOptionsBuilder {
     // and the CI scripts, which apply no environment check and would otherwise
     // silently target sqlite and report nothing to do.
     buildWithEnvOrDefault() {
-        return this.normalize(readDataSourceOptionsFromEnv() ?? { type: 'better-sqlite3', database: 'db.sqlite' });
+        const options = readDataSourceOptionsFromEnv();
+        if (options) {
+            return this.normalize(options);
+        }
+
+        // The default answers "nothing is configured", never a half-written
+        // configuration: a `DB_HOST` or `DB_DATABASE` left without a `DB_TYPE`
+        // would otherwise redirect every write to a local file, silently
+        // outside production.
+        if (hasDatabaseConnectionEnv()) {
+            throw new AuthupError(NO_DATABASE_CONFIGURED);
+        }
+
+        return this.normalize({ type: 'better-sqlite3', database: 'db.sqlite' });
     }
 
     buildWith(options: DataSourceOptions) {

--- a/apps/server-core/src/adapters/database/data-source/options/module.ts
+++ b/apps/server-core/src/adapters/database/data-source/options/module.ts
@@ -73,10 +73,19 @@ export class DataSourceOptionsBuilder {
         const options = readDataSourceOptionsFromEnv();
 
         if (!options) {
-            throw new AuthupError('The database configuration could not be read from env variables.');
+            throw new AuthupError('No database is configured. Set DB_TYPE to "postgres" or "mysql", together with DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD and DB_DATABASE.');
         }
 
         return this.normalize(options);
+    }
+
+    // the application boot path: the `db` config key documents the
+    // better-sqlite3 driver default, and DatabaseModule refuses that driver in
+    // production downstream. buildWithEnv stays strict for the migration CLI
+    // and the CI scripts, which apply no environment check and would otherwise
+    // silently target sqlite and report nothing to do.
+    buildWithEnvOrDefault() {
+        return this.normalize(readDataSourceOptionsFromEnv() ?? { type: 'better-sqlite3', database: 'db.sqlite' });
     }
 
     buildWith(options: DataSourceOptions) {

--- a/apps/server-core/src/app/modules/database/module.ts
+++ b/apps/server-core/src/app/modules/database/module.ts
@@ -201,7 +201,7 @@ export class DatabaseModule implements IModule {
             // below is what narrows it.
             options = this.optionsBuilder.buildWith(config.db as DataSourceOptions);
         } else {
-            options = this.optionsBuilder.buildWithEnv();
+            options = this.optionsBuilder.buildWithEnvOrDefault();
         }
 
         if (!isDatabaseTypeSupported(options.type)) {
@@ -209,7 +209,7 @@ export class DatabaseModule implements IModule {
         }
 
         if (!isDatabaseTypeSupportedForEnvironment(options.type, config.env)) {
-            throw new AuthupError(`Database type ${options.type} is not supported for ${config.env}.`);
+            throw new AuthupError(`Database type "${options.type}" is not supported in the ${config.env} environment. Set DB_TYPE to "postgres" or "mysql" together with DB_HOST, DB_PORT, DB_USERNAME, DB_PASSWORD and DB_DATABASE, or declare "db" in authup.yml. With no database configured at all, "better-sqlite3" is the fallback.`);
         }
 
         const cacheResult = container.tryResolve(CacheInjectionKey);

--- a/apps/server-core/test/unit/adapters/database/data-source-options.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/data-source-options.spec.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { AuthupError } from '@authup/errors';
+import { Container } from 'eldin';
+import type { DataSourceOptions } from 'typeorm';
+import { resetEnv } from 'typeorm-extension';
+import { DataSourceOptionsBuilder } from '../../../../src/adapters/database/data-source/options/module.ts';
+import { ConfigInjectionKey } from '../../../../src/app/modules/config/index.ts';
+import { normalizeConfig } from '../../../../src/app/modules/config/read.ts';
+import { DatabaseModule } from '../../../../src/app/modules/database/index.ts';
+
+// buildDataSourceOptions is protected, and it is the one line that decides
+// which of the two builder methods the boot path takes. Without this the
+// wiring is unpinned: swapping it back to the strict method leaves every
+// other case in this file green.
+class ProbeDatabaseModule extends DatabaseModule {
+    build(container: Container) : Promise<DataSourceOptions> {
+        return this.buildDataSourceOptions(container);
+    }
+}
+
+const isDatabaseEnvKey = (key: string) => key.startsWith('DB_') || key.startsWith('TYPEORM_');
+
+// typeorm-extension memoizes its environment read, so every case has to reset
+// it after changing process.env. The test:mysql / test:psql runs set DB_TYPE
+// for the whole process, which is why the no-database case clears the keys
+// instead of merely leaving them alone.
+function withDatabaseEnv<T>(env: Record<string, string>, fn: () => T) : T {
+    const previous : Record<string, string | undefined> = Object.fromEntries(
+        Object.keys(process.env)
+            .filter((key) => isDatabaseEnvKey(key))
+            .map((key) => [key, process.env[key]]),
+    );
+
+    for (const key of Object.keys(previous)) {
+        delete process.env[key];
+    }
+
+    Object.assign(process.env, env);
+    resetEnv();
+
+    try {
+        return fn();
+    } finally {
+        for (const key of Object.keys(process.env)) {
+            if (isDatabaseEnvKey(key)) {
+                delete process.env[key];
+            }
+        }
+
+        Object.assign(process.env, previous);
+        resetEnv();
+    }
+}
+
+describe('adapters/database/data-source/options', () => {
+    it('should fall back to the better-sqlite3 driver when no database is configured', () => {
+        const options = withDatabaseEnv({}, () => new DataSourceOptionsBuilder().buildWithEnvOrDefault());
+
+        expect(options.type).toEqual('better-sqlite3');
+        expect((options as { database?: string }).database).toEqual('db.sqlite');
+    });
+
+    it('should keep a configured database type over the fallback', () => {
+        const options = withDatabaseEnv({ DB_TYPE: 'postgres' }, () => new DataSourceOptionsBuilder().buildWithEnvOrDefault());
+
+        expect(options.type).toEqual('postgres');
+    });
+
+    it('should apply the fallback on the boot path when no database is configured', async () => {
+        const config = await normalizeConfig({ env: 'development' });
+
+        const container = new Container();
+        container.register(ConfigInjectionKey, { useValue: config });
+
+        const options = await withDatabaseEnv({}, () => new ProbeDatabaseModule().build(container));
+
+        expect(options.type).toEqual('better-sqlite3');
+    });
+
+    it('should still throw on the strict read when no database is configured', () => {
+        withDatabaseEnv({}, () => {
+            expect(() => new DataSourceOptionsBuilder().buildWithEnv()).toThrow(AuthupError);
+        });
+    });
+});

--- a/apps/server-core/test/unit/adapters/database/data-source-options.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/data-source-options.spec.ts
@@ -67,6 +67,18 @@ describe('adapters/database/data-source/options', () => {
         expect((options as { database?: string }).database).toEqual('db.sqlite');
     });
 
+    it('should refuse a half-written configuration rather than falling back', () => {
+        withDatabaseEnv({ DB_HOST: '127.0.0.1', DB_DATABASE: 'app' }, () => {
+            expect(() => new DataSourceOptionsBuilder().buildWithEnvOrDefault()).toThrow(AuthupError);
+        });
+    });
+
+    it('should refuse it under the TYPEORM_ aliases as well', () => {
+        withDatabaseEnv({ TYPEORM_HOST: '127.0.0.1' }, () => {
+            expect(() => new DataSourceOptionsBuilder().buildWithEnvOrDefault()).toThrow(AuthupError);
+        });
+    });
+
     it('should keep a configured database type over the fallback', () => {
         const options = withDatabaseEnv({ DB_TYPE: 'postgres' }, () => new DataSourceOptionsBuilder().buildWithEnvOrDefault());
 

--- a/apps/server-core/test/unit/config/index.spec.ts
+++ b/apps/server-core/test/unit/config/index.spec.ts
@@ -45,13 +45,13 @@ describe('src/config/*.ts', () => {
                 publicUrl: 'https://auth.example.com/sub/path',
                 trustedOrigins: [
                     'https://auth.example.com',
-                    'http://localhost:3010',
+                    'http://localhost:5173',
                 ],
             } as any);
 
             expect(origins).toEqual([
                 'https://auth.example.com',
-                'http://localhost:3010',
+                'http://localhost:5173',
             ]);
         });
     });
@@ -142,7 +142,7 @@ describe('src/config/*.ts', () => {
                 'https://app.example.com',
                 'http://hub.local',
                 'https://hub.local',
-                'http://localhost:3010',
+                'http://localhost:5173',
             ]);
         });
 

--- a/docs/src/.vitepress/theme/components/CodeTabs.vue
+++ b/docs/src/.vitepress/theme/components/CodeTabs.vue
@@ -54,9 +54,11 @@ export default defineComponent({
                 label: '1. Install',
                 snippet: `docker pull authup/authup:latest
 
+# reads the .env from step 2
 docker run -d \\
   --name authup \\
   -p 3000:3000 \\
+  --env-file .env \\
   authup/authup:latest \\
   start`,
             },
@@ -67,13 +69,13 @@ docker run -d \\
 USER_ADMIN_PASSWORD=start123
 
 DB_TYPE=postgres
-DB_HOST=postgres
+DB_HOST=postgres.example.com
 DB_PORT=5432
 DB_USERNAME=authup
 DB_PASSWORD=secret
 DB_DATABASE=authup
 
-REDIS=redis://redis:6379
+REDIS=redis://cache.example.com:6379
 PUBLIC_URL=https://auth.example.com`,
             },
             {

--- a/docs/src/.vitepress/theme/components/CodeTabs.vue
+++ b/docs/src/.vitepress/theme/components/CodeTabs.vue
@@ -50,22 +50,10 @@ export default defineComponent({
     setup() {
         const tabs: Tab[] = [
             {
-                id: 'install',
-                label: '1. Install',
-                snippet: `docker pull authup/authup:latest
-
-# reads the .env from step 2
-docker run -d \\
-  --name authup \\
-  -p 3000:3000 \\
-  --env-file .env \\
-  authup/authup:latest \\
-  start`,
-            },
-            {
                 id: 'configure',
-                label: '2. Configure',
+                label: '1. Configure',
                 snippet: `# .env
+# Point these at your own PostgreSQL, Redis and public address.
 USER_ADMIN_PASSWORD=start123
 
 DB_TYPE=postgres
@@ -77,6 +65,19 @@ DB_DATABASE=authup
 
 REDIS=redis://cache.example.com:6379
 PUBLIC_URL=https://auth.example.com`,
+            },
+            {
+                id: 'install',
+                label: '2. Install',
+                snippet: `docker pull authup/authup:latest
+
+# reads the .env from step 1
+docker run -d \\
+  --name authup \\
+  -p 3000:3000 \\
+  --env-file .env \\
+  authup/authup:latest \\
+  start`,
             },
             {
                 id: 'use',
@@ -94,7 +95,7 @@ curl https://auth.example.com/users \\
             },
         ];
 
-        const active = ref<TabId>('install');
+        const active = ref<TabId>('configure');
         const copied = ref(false);
 
         const currentSnippet = computed(() => tabs.find((t) => t.id === active.value)?.snippet ?? '');

--- a/docs/src/.vitepress/theme/components/IntegrationSpotlight.vue
+++ b/docs/src/.vitepress/theme/components/IntegrationSpotlight.vue
@@ -67,9 +67,9 @@ export default defineComponent({
     image: authup/authup:latest
     restart: unless-stopped
     ports:
-      - "3001:3000"
+      - "3000:3000"
     environment:
-      - PUBLIC_URL=http://localhost:3001
+      - PUBLIC_URL=http://localhost:3000
       - DB_TYPE=postgres
       - DB_HOST=postgres
       - DB_USERNAME=authup

--- a/docs/src/guide/deployment/bare-metal.md
+++ b/docs/src/guide/deployment/bare-metal.md
@@ -49,6 +49,12 @@ Place `authup.yml` in the project root, or point the CLI elsewhere with
 `--configDirectory <path>` / `--configFile <path>`. The server settings live
 under `core`; environment variables always override file values.
 
+A database is optional outside production. With none configured, Authup falls
+back to SQLite and writes `db.sqlite` into the directory the CLI was started
+from, which is enough to try it out locally. A production environment refuses
+SQLite, so point `DB_*` or a `db:` block at PostgreSQL or MySQL for anything
+beyond that (see [Database](./configuration-server-core-database.md)).
+
 ## Step. 4: Boot up
 
 Add some scripts to `package.json`.

--- a/docs/src/guide/deployment/configuration-server-core-database.md
+++ b/docs/src/guide/deployment/configuration-server-core-database.md
@@ -1,8 +1,10 @@
 # Database
 
-By default, the database is run with `SQLite`,
-but for a production environment we recommend using `MySQL` or `Postgres` since they provide
-superior performance, scalability and advanced features such as built-in replication.
+With no database configured, `SQLite` is used, which is enough to run Authup locally.
+For anything beyond that, `MySQL` or `Postgres` is a requirement rather than a recommendation:
+Authup refuses to start on `SQLite` when the environment is `production`, and the Docker image
+sets `NODE_ENV=production`. They are also the better fit for a real deployment, since they
+provide superior performance, scalability and advanced features such as built-in replication.
 
 ## MySQL
 

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -93,9 +93,8 @@ export default {
      * token — only add origins you control. A wildcard host trusts every
      * subdomain, so use one only where you control the whole domain.
      * The consoles authup serves need no entry: they are on the
-     * publicUrl origin. In non-production, the admin console's standalone
-     * vite dev server origin (http://localhost:3010) is seeded
-     * automatically.
+     * publicUrl origin. In non-production, a console's standalone vite dev
+     * server origin (http://localhost:5173) is seeded automatically.
      * env: TRUSTED_ORIGINS (comma-separated)
      * default: []
      */

--- a/docs/src/guide/deployment/docker-compose.md
+++ b/docs/src/guide/deployment/docker-compose.md
@@ -9,7 +9,7 @@ The following guide is based on some shared assumptions:
 - Min. `5G` hard disk
 - Docker `v20.x` is [installed](https://docs.docker.com/get-docker/)
 - One available port on the host system if you want to map the service to your local machine (default: `3000`)
-- A reachable PostgreSQL or MySQL database. The image runs in production mode, which does not support SQLite, so it does not start until `DB_*` names a server database. The [Multiple services](#multiple-services) example below brings one up alongside Authup
+- A reachable PostgreSQL or MySQL database. The image runs in production mode, which does not support SQLite, so it does not start until a server database is configured, via `DB_*` or a `db:` block in `authup.yml`. The [Quick Start](#quick-start) example below brings one up alongside Authup
 - This guide assumes [Compose v2](https://docs.docker.com/compose/compose-file/)
 
 
@@ -21,7 +21,7 @@ examples show how to configure authup using the options described in the [config
 paste and modify the example you want to use into a `docker-compose.yml` file.
 
 The following example shows a sensible default configuration for getting started with Authup.
-This starts the one container a deployment needs: `start` runs the API
+This starts the one Authup container a deployment needs: `start` runs the API
 and every console on one listener (the auth console at `/console/auth`, the admin
 console at `/console/admin`, the account console at `/console/account`). To run the
 consoles as their own service instead, see
@@ -30,8 +30,9 @@ argument list; `start` is also the image's default command, and the former
 `server/core` prefix is deprecated (accepted with a notice on stderr for the
 rest of the 1.0.0-beta line, removed in v1.0.0).
 
-The container carries no volume, because the image keeps no durable state:
-every durable value lives in the database. Mount `/etc/authup` to supply the
+The Authup container carries no volume, because the image keeps no durable
+state: every durable value lives in the database. The volume in the example
+below belongs to the `postgres` service. Mount `/etc/authup` to supply the
 configuration file and the provisioning directory (see the examples below),
 and `/var/log/authup` only if you want the log files outside the container.
 The console transport writes to stdout regardless, so `docker compose logs`
@@ -40,6 +41,9 @@ works without it.
 ```yaml
 version: '3.8'
 
+volumes:
+    postgres_data:
+
 services:
   server-core:
       image: authup/authup:latest
@@ -47,22 +51,29 @@ services:
       container_name: server-core
       restart: unless-stopped
       ports:
-        - "3001:3000"
+        - "3000:3000"
+      depends_on:
+        - postgres
       environment:
-        - PUBLIC_URL=http://localhost:3001
+        - PUBLIC_URL=http://localhost:3000
+        - DB_TYPE=postgres
+        - DB_HOST=postgres
+        - DB_PORT=5432
+        - DB_USERNAME=postgres
+        - DB_PASSWORD=postgres
+        - DB_DATABASE=postgres
       command: start
-      networks:
-          authup:
 
-networks:
-    authup:
-        driver: bridge
-        driver_opts:
-            com.docker.network.bridge.name: authup
-        ipam:
-            driver: default
-            config:
-                - subnet: 172.23.1.0/24
+  postgres:
+      image: postgres:14
+      container_name: postgres
+      restart: unless-stopped
+      volumes:
+        - postgres_data:/var/lib/postgresql/data
+      environment:
+        - POSTGRES_PASSWORD=postgres
+        - POSTGRES_USER=postgres
+        - POSTGRES_DB=postgres
 ```
 
 Then start the service using the following command:
@@ -94,8 +105,12 @@ It is recommended to operate the service behind a reverse proxy. For example [ng
 
 ### Environment variables
 
-The following example shows how to configure the Authup service using environment variables. This will start only the
-main backend service and forward it to the port `3001` on the local machine.
+The following example shows how to configure the Authup service using environment variables, forwarding it to port
+`3000` on the local machine.
+
+This example shows only the keys under discussion. Add the `postgres` service,
+its top-level `volumes` entry and the `DB_*` variables from the
+[Quick Start](#quick-start) to make it start.
 
 ```yaml
 version: '3.8'
@@ -106,9 +121,9 @@ services:
     container_name: authup
     restart: unless-stopped
     ports:
-      - "3001:3000"
+      - "3000:3000"
     environment:
-        - PUBLIC_URL=http://localhost:3001
+        - PUBLIC_URL=http://localhost:3000
         - USER_ADMIN_PASSWORD=test-password
     command: start
 ```
@@ -133,6 +148,10 @@ In the following compose file example you can see that the
 configuration file is mounted into the container under `/etc/authup`, which is where the image
 reads it from.
 
+This example shows only the keys under discussion. Add the `postgres` service,
+its top-level `volumes` entry and the `DB_*` variables from the
+[Quick Start](#quick-start) to make it start.
+
 ```yaml
 version: '3.8'
 
@@ -144,17 +163,18 @@ services:
     volumes:
       - ./authup.yml:/etc/authup/authup.yml
     ports:
-      - "3001:3000"
+      - "3000:3000"
     environment:
-      - PUBLIC_URL=http://localhost:3001
+      - PUBLIC_URL=http://localhost:3000
     command: start
 
 ```
 
 
-### Multiple services
+### Additional services
 
-This shows an example of how to run authup alongside other services (postgres & redis) and connect to them.
+The Quick Start above already runs a database. This shows how to add further services, such as redis, and
+connect authup to them.
 
 ```yaml
 version: '3.8'
@@ -169,12 +189,12 @@ services:
         container_name: server-core
         restart: unless-stopped
         ports:
-            - "3001:3000"
+            - "3000:3000"
         depends_on:
             - postgres
             - redis
         environment:
-            - PUBLIC_URL=http://localhost:3001
+            - PUBLIC_URL=http://localhost:3000
             - DB_TYPE=postgres
             - DB_HOST=postgres
             - DB_PORT=5432

--- a/docs/src/guide/deployment/docker-compose.md
+++ b/docs/src/guide/deployment/docker-compose.md
@@ -76,6 +76,11 @@ services:
         - POSTGRES_DB=postgres
 ```
 
+The credentials above are placeholders that let the example run as pasted. The
+`postgres` service publishes no host port, so it is reachable only from the
+compose network, but change both halves of the pair before this is anything but
+a local trial.
+
 Then start the service using the following command:
 
 ```bash

--- a/docs/src/guide/deployment/docker.md
+++ b/docs/src/guide/deployment/docker.md
@@ -9,7 +9,8 @@ The following guide is based on some shared assumptions:
 - Min. `2` cores
 - Min. `5G` hard disk
 - One available port on the host system if you want to map the service to your local machine (default: `3000`)
-- A reachable PostgreSQL or MySQL database. The image runs in production mode, which does not support SQLite, so it does not start until `DB_*` names a server database (see [Database](./configuration-server-core-database.md))
+- A reachable PostgreSQL or MySQL database. The image runs in production mode, which does not support SQLite, so it does not start until a server database is configured, via `DB_*` or a `db:` block in `authup.yml` (see [Database](./configuration-server-core-database.md)). The [Boot up](#step-3-boot-up) example below brings one up alongside Authup
+- This guide assumes [Compose v2](https://docs.docker.com/compose/compose-file/)
 
 
 ## Step. 1: Create a new project
@@ -24,46 +25,82 @@ $ mkdir authup && cd authup
 
 `PORT` and `HOST` are honored inside the container. The image defaults them to
 `3000` and `0.0.0.0`, so the rule when the container is run is as follows:
-- By default the API listens on the internal port `3000` and is published on another external port with `-p <port>:3000`. Setting `-e PORT=4000` moves the listener to `4000`, so the container side of the mapping must follow it (`-p <port>:4000`); the built-in healthcheck follows `PORT` on its own, and the image's `EXPOSE 3000` is metadata that pins nothing. The `start console` role is the exception: each console binds its own port (`3020` auth, `3021` admin, `3022` account), see [Console Replicas](./console-replicas.md).
+- The API listens on port `3000` and the examples publish it unchanged (`"3000:3000"`). Setting `PORT=4000` under `environment` moves the listener to `4000`, so the mapping must follow it (`"4000:4000"`); the built-in healthcheck follows `PORT` on its own, and the image's `EXPOSE 3000` is metadata that pins nothing. The `start console` role is the exception: each console binds its own port (`3020` auth, `3021` admin, `3022` account), see [Console Replicas](./console-replicas.md).
+- **Publish the port the listener binds.** A mapping that publishes a different port (`"8080:3000"`) leaves `PUBLIC_URL` naming a port nothing listens on inside the container, and the auth console renders its pages by calling the API at that address, so `/console/auth/*` answers `502` while the API and the two static consoles work. To publish on a different host port, move the listener with `PORT` and map that port to itself.
 
 
 Follow the instructions for [configuring](./configuration.md) Authup using a configuration file or via environment variables.
-In case of a configuration file, mount it at `/etc/authup/authup.yml` using `-v ./authup.yml:/etc/authup/authup.yml`.
+In case of a configuration file, mount it at `/etc/authup/authup.yml` with a `volumes` entry on the `authup` service.
 
 
 ## Step. 3: Boot up
 
-One container runs the whole deployment. It serves the API and every console:
+One authup container runs the whole deployment. It serves the API and every
+console, with PostgreSQL alongside it:
 
-```shell
-docker run \
-  -p 3001:3000 \
-  -e PUBLIC_URL=http://localhost:3001 \
-  authup/authup:latest start
+```yaml
+version: '3.8'
+
+volumes:
+    postgres_data:
+
+services:
+    authup:
+        image: authup/authup:latest
+        restart: unless-stopped
+        ports:
+            - "3000:3000"
+        depends_on:
+            - postgres
+        environment:
+            - PUBLIC_URL=http://localhost:3000
+            - DB_TYPE=postgres
+            - DB_HOST=postgres
+            - DB_PORT=5432
+            - DB_USERNAME=postgres
+            - DB_PASSWORD=postgres
+            - DB_DATABASE=postgres
+        command: start
+
+    postgres:
+        image: postgres:14
+        restart: unless-stopped
+        volumes:
+            - postgres_data:/var/lib/postgresql/data
+        environment:
+            - POSTGRES_PASSWORD=postgres
+            - POSTGRES_USER=postgres
+            - POSTGRES_DB=postgres
 ```
 
-The image keeps no durable state, so there is nothing to persist: every
+Start it with:
+
+```bash
+docker compose up -d
+```
+
+The authup image keeps no durable state, so there is nothing to persist: every
 durable value lives in the database. Mount `/etc/authup` to supply the
 configuration file and the provisioning directory, and `/var/log/authup` only
 if you want the log files outside the container. The console transport writes
-to stdout regardless, so `docker logs` works without it.
+to stdout regardless, so `docker compose logs` works without it.
 
 The container command is the CLI's own argument list (`start`, `start worker`,
 `migration run`, ...), and `start` is the image's default command. The former
 `server/core` prefix is deprecated: it is still accepted with a notice on
 stderr for the rest of the 1.0.0-beta line and is removed in v1.0.0.
 
-`PUBLIC_URL` is the address the browser reaches the container at. The
-consoles derive the API address from it, so with the port published as
-`3001` it must name `3001`, not the container-internal `3000`.
+`PUBLIC_URL` is the address the browser reaches the container at, and the
+consoles derive the API address from it, so it must name the published port.
+That is the same port the listener binds, per the rule in Step 2.
 
 Now all should be set up, and you are ready to go :tada:
 
-This will launch the following with default settings:
-- API: `http://localhost:3001/`
-- Auth console (login, consent, register, password recovery): `http://localhost:3001/console/auth`
-- Admin console: `http://localhost:3001/console/admin`
-- Account console: `http://localhost:3001/console/account`
+It serves:
+- API: `http://localhost:3000/`
+- Auth console (login, consent, register, password recovery): served under `http://localhost:3000/console/auth/`
+- Admin console: `http://localhost:3000/console/admin`
+- Account console: `http://localhost:3000/console/account`
 
 ::: warning The `client/admin-console` service was retired
 The admin console used to be a second container. It is now a console service

--- a/docs/src/guide/deployment/index.md
+++ b/docs/src/guide/deployment/index.md
@@ -3,7 +3,7 @@
 The Authup Deployment Guide is a comprehensive resource for users looking to deploy Authup on various targets 🚀: 
 
 - **`Bare Metal`**: [Bare Metal](./bare-metal) deploy Authup directly on the host system using NodeJs.
-- **`Docker`**: [Docker](./docker) deploy authup as a standalone docker container (**recommended**).
+- **`Docker`**: [Docker](./docker) deploy Authup as a docker container (**recommended**).
 - **`Docker Compose`**: [Docker Compose](./docker-compose) integrate Authup into a docker-compose environment.
 
 Following this guide you will first learn how to configure your Authup instance and how to then deploy it on your chosen target.

--- a/docs/src/guide/deployment/theming.md
+++ b/docs/src/guide/deployment/theming.md
@@ -119,6 +119,10 @@ links and the login backdrop at once.
 
 **3. Run it.**
 
+The image needs a server database, so add the `DB_*` variables from
+[Docker](./docker) to the command below, or set `THEME_DIRECTORY_PATH` and the
+mount on the `authup` service of a compose file that already has one.
+
 ```bash
 docker run --rm -p 3000:3000 \
   -e THEME_DIRECTORY_PATH=/etc/authup/theme \

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -673,6 +673,27 @@ runs no migrations, so a fallback there would create a database file, report
 configuration was missing in a non-production environment. Such a process now
 starts against an empty local SQLite file rather than exiting.
 
+### The seeded development origin moves to vite's default port
+
+`DEVELOPMENT_ORIGIN`, the origin appended to `trustedOrigins` outside
+production, changes from `http://localhost:3010` to `http://localhost:5173`.
+The admin console's dev server no longer pins a port, so it takes vite's
+default like the account console, and both now pin `strictPort` so a taken
+port fails loudly instead of shifting to an origin nothing trusts.
+
+This makes the account console's standalone dev server work with no
+configuration for the first time: it was already on 5173, which was not the
+seeded origin, so its sign-in round-trip was refused unless
+`TRUSTED_ORIGINS` named it by hand.
+
+Only one standalone console can hold the port. Run the other through
+`authup dev`, which serves every console on the API's own origin and needs no
+seeded origin at all, or give it its own `TRUSTED_ORIGINS` entry.
+
+**Action required only if** you run a console dev server on `:3010` (a
+non-production deployment trusted that origin automatically and no longer
+does). Set `TRUSTED_ORIGINS=localhost:3010`, or move to the default port.
+
 ## v1.0.0-beta.63
 
 ### Introspecting an expired token now returns its payload

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -649,6 +649,30 @@ the beta.63 entry below warns about. The log files are written inside the
 container layer unless `/var/log/authup` is mounted, which is the ordinary
 posture for a container that logs to a collector.
 
+### Authup boots on SQLite when no database is configured
+
+Outside production, a process started with no database configuration now falls
+back to the `better-sqlite3` driver and writes `db.sqlite` into the working
+directory, instead of exiting with "The database configuration could not be
+read from env variables.". That is what the `db` configuration key and the
+[Database](./configuration-server-core-database.md) guide have both described
+for some time, while nothing implemented it, so no surface booted
+unconfigured. `npx authup@latest start` now works with no configuration at all.
+
+**Production is unchanged.** `better-sqlite3` is still refused when the
+environment is `production`, which is what the Docker image sets, so a
+container still requires PostgreSQL or MySQL. That refusal now names the
+variables to set instead of reading as a generic environment failure.
+
+`authup migration run` and the two CI runners under `apps/server-core/scripts/`
+are deliberately not covered and still fail when nothing is configured. SQLite
+runs no migrations, so a fallback there would create a database file, report
+"No migrations are pending" and exit `0`.
+
+**Action required only if** you relied on the crash as the signal that database
+configuration was missing in a non-production environment. Such a process now
+starts against an empty local SQLite file rather than exiting.
+
 ## v1.0.0-beta.63
 
 ### Introspecting an expired token now returns its payload

--- a/docs/src/guide/deployment/worker.md
+++ b/docs/src/guide/deployment/worker.md
@@ -129,7 +129,7 @@ services:
         container_name: server-core
         restart: unless-stopped
         ports:
-            - "3001:3000"
+            - "3000:3000"
         environment:
             - PUBLIC_URL=http://localhost:3000
             - DB_TYPE=postgres

--- a/docs/src/guide/development/quick-start.md
+++ b/docs/src/guide/development/quick-start.md
@@ -112,14 +112,14 @@ $ VITE_API_URL=http://localhost:3000 npm run dev --workspace=apps/client-admin-c
 ```
 
 It gives hot module replacement against the running backend, but it costs
-fidelity: served on a different origin (`http://localhost:3010` for the
-admin console) than the API, it signs in with the standalone browser
+fidelity: served on a different origin (`http://localhost:5173`, vite's
+default) than the API, it signs in with the standalone browser
 authorization-code (PKCE) flow rather than the cookie-session credential a
 served console uses in production.
 
 ::: warning Sign out of the hosted pages first
 
-Cookies ignore ports, so `localhost:3010` and `localhost:3000` are the same
+Cookies ignore ports, so `localhost:5173` and `localhost:3000` are the same
 HOST to the browser. A standalone console started while a session from the
 hosted auth pages is still open therefore seeds itself from that session's
 path-`/` token cookies and comes up already signed in, without ever running

--- a/packages/server-config/src/helpers/trusted-origins.ts
+++ b/packages/server-config/src/helpers/trusted-origins.ts
@@ -10,12 +10,18 @@ import { expandToOrigins } from './origins.ts';
 const PRODUCTION = 'production';
 
 /**
- * The dev console's own listener. In non-production it runs on its own port
- * while the API answers on `core.port`, so it is seeded into the trusted
- * origins: without it the redirect allowlist (`<origin>/**`) and CORS
+ * A standalone console dev server's own listener. In non-production it runs on
+ * its own port while the API answers on `core.port`, so it is seeded into the
+ * trusted origins: without it the redirect allowlist (`<origin>/**`) and CORS
  * reject the realm-selection login and a first run is dead on arrival.
+ *
+ * It is vite's default port, which is what every console's dev server binds
+ * (each pins `strictPort`, so a taken port fails loudly rather than shifting
+ * to an unseeded one). Only one console can hold it at a time, which is the
+ * standalone loop's limit rather than this constant's: `authup dev` serves
+ * every console on the API's own origin and needs no seed at all.
  */
-export const DEVELOPMENT_ORIGIN = 'http://localhost:3010';
+export const DEVELOPMENT_ORIGIN = 'http://localhost:5173';
 
 /**
  * The trusted origins as every consumer needs them: bare origins

--- a/packages/server-config/src/sections/root/schema.ts
+++ b/packages/server-config/src/sections/root/schema.ts
@@ -107,7 +107,7 @@ export const ROOT_SCHEMA = defineSchema<RootConfig, 'publicUrl' | 'db', Environm
     // special-cased in server-core's environment read, outside the registry.
     db: {
         type: z.custom<DatabaseConnectionOptions>((value) => isObject(value)),
-        description: 'Database connection (TypeORM data source options). Without one the better-sqlite3 driver default of typeorm-extension applies.',
+        description: 'Database connection (TypeORM data source options). Without one, and outside production, the better-sqlite3 driver default applies.',
         path: 'db',
     },
     redis: {

--- a/packages/server-config/src/sections/root/types.ts
+++ b/packages/server-config/src/sections/root/types.ts
@@ -112,8 +112,8 @@ export type RootConfig = {
     trustedOrigins: string[],
 
     /**
-     * Database connection. Without one the better-sqlite3 driver default of
-     * typeorm-extension applies.
+     * Database connection. Without one, and outside production, the
+     * better-sqlite3 driver default applies.
      */
     db?: DatabaseConnectionOptions,
 


### PR DESCRIPTION
Closes #3547.

The quickstart did not boot because it configures no database. Fixing only that
turned out to understate the problem, so this does both halves the issue asks
for (its option 1 and option 3) plus the cause underneath them.

## Nothing booted unconfigured, on any surface

typeorm-extension gates `readDataSourceOptionsFromEnv()` on
`hasEnvDataSourceOptions()`, which is `!!useEnv('type')`. With no `DB_TYPE`,
`TYPEORM_CONNECTION`, `DB_URL` or `TYPEORM_URL` it returns nothing, `db` has no
default, and `buildWithEnv()` threw. So `npx authup@latest start` failed exactly
like the container, verified before touching anything:

```
$ npx authup@latest start
debug: Environment: development
AuthupError: The database configuration could not be read from env variables.
```

Two places already documented a sqlite default that no code implemented: the
`db` config key's own description, which is published as the JSON Schema, and
the database guide's opening line. `DatabaseModule` now calls a new
`buildWithEnvOrDefault()`, which applies `better-sqlite3` plus the same
`db.sqlite` name typeorm-extension derives for that driver.

**`buildWithEnv()` stays strict, and the two must not be collapsed.** It is what
`authup migration run` and the two `scripts/` CI runners call, none of which
applies the environment check, so a fallback there would create a database file,
read sqlite's empty migrations array, report "No migrations are pending" and
exit `0`. That is recorded in `.agents/conventions.md` next to the fallback.

Production is unchanged: `isDatabaseTypeSupportedForEnvironment` still refuses
better-sqlite3, so the image still requires postgres or mysql, and that refusal
now names the variables to set.

Two consequences of the new file handled here: `authup dev` denies `*.sqlite`
over `/@fs/` alongside `*.sql` (the deny list was written for exactly this file
and `*.sql` does not match it), and `db.sqlite` is gitignored, because it holds
the realm's active private signing key.

## The quickstarts

README leads with the npx one-liner and its `docker run` names a server
database; `docker.md` Step 3 and the compose Quick Start bring postgres up
alongside Authup; the two illustrative compose snippets say what to add rather
than repeating the database a third and fourth time.

## Verified end to end, not just built

An image was built from this branch and the documented compose file was
extracted from the page verbatim (only the image tag and `pull_policy` altered,
since the tag is local):

| path | before | after |
|---|---|---|
| `/` | container exits 1 | 200 |
| `/console/admin` | - | 200 |
| `/console/account` | - | 200 |
| `/console/auth/authorize` | - | 200 |
| `/console/auth/register` | - | 200 |
| healthcheck | never healthy | `healthy` |

The admin shell's first script asset also serves as `application/javascript`,
so the bundle is really reachable. Separately: unconfigured plus production
gives the new actionable message; unconfigured plus `NODE_ENV=development`
boots and creates `db.sqlite`.

Suite: 2332 passed. `check:types` and eslint clean. The new spec's four cases
were each mutation-tested, including the one pinning the `DatabaseModule`
wiring, which is the single line that fixes this issue and was otherwise
unpinned.

## Why every example now publishes the default port unchanged

The examples carried a host-side `3001` that predates `core.port` defaulting to
`3000`, so they are now plain `"3000:3000"` with no `PORT` override. That is not
only tidying: the old `-p 3001:3000` shape 502s the hosted login page.

```
error: fetch failed (GET http://localhost:3001/authorize/info?client_id=admin-console)
  cause: TypeError: fetch failed <- AggregateError: (code=ECONNREFUSED)
    at async fn (.../apps/server-auth-console/dist/server-*.mjs:317:10)
```

`apps/server-auth-console/src/config.ts` sets `apiUrl: values.publicUrl`, and
the auth console is the one console that fetches server-side. `publicUrl` is the
browser-facing address, so under a port mapping it names a port nothing listens
on inside the container. server-core already solves this for its own self-calls
with `createPublicToInternalURLRewriter`; the console services have no
equivalent.

That is a separate bug, filed as #3550. Publishing the port the listener binds
avoids it, and `docker.md` Step 2 states the rule. Setting `PORT` is still
supported, with the mapping following it.

## Second commit: the seeded development origin moves to vite's default port

Unrelated to the boot fix, folded in on request. `DEVELOPMENT_ORIGIN` goes from
`http://localhost:3010` to `http://localhost:5173`, and the admin console drops
its `server.port` pin.

3010 was not special beyond the constant naming it. It made the admin console's
standalone dev origin equal the seeded one, so its browser-PKCE sign-in passes
the `admin-console` client's `<origin>/**` redirect patterns with no
`TRUSTED_ORIGINS`. The account console never got that: it has always taken
vite's default, which was not seeded, so its own README told the reader to pass
`TRUSTED_ORIGINS=localhost:5173` by hand. That step is now gone.

Both consoles pin `strictPort`, which is what makes the seed mean anything.
Reproduced first: with the port held, vite printed `Port 3010 is in use, trying
another one...` and bound 3011, so the console came up while the seeded origin
silently stopped applying. It now fails at the port instead:

```
$ npm run dev                      # admin console
  ➜  Local:   http://localhost:5173/console/admin/
$ npm run dev                      # account console, port held
Error: Port 5173 is already in use
```

Only one standalone console can hold the port; `authup dev` serves every console
on the API's own origin and needs no seeded origin at all. The released
`:3000 -> :3010` note in `upgrading.md` stays as history and a new entry records
this move.

## Also corrected while here, flag anything unwanted

- `README.md` Development section and Applications table: server-core has served
  no console since plan 101 D2-3, the admin console dev server listens on 3010
  not 3000, and the CLI command list was missing `config` and `dev` while
  listing `worker` as a command rather than a role of `start`.
- `docs/src/guide/deployment/index.md` no longer calls the Docker page the
  standalone-container guide, since its example is now a compose file.
- `theming.md`'s "Run it." snippet notes it needs a database.
- The compose Troubleshooting note pointed `PUBLIC_URL` at `authup:3000`, a port
  nothing listens on once the examples moved to `PORT=3001`.
- `docs/src/guide/deployment/worker.md` published `"3001:3000"` while setting
  `PUBLIC_URL=http://localhost:3000`, the inverse mismatch. The sweep settles it.
