### PR TITLE
fix(server-core): serialize provisioning across replicas with an advisory lock

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1250,9 +1250,10 @@ own, and a client in the same realm block may bind them via `realmScopes`.
 Every write in the provisioner is find-then-insert with no guard between the
 two statements, so two replicas booting against an unprovisioned database
 interleave. `ProvisionerModule.setup` therefore holds a deployment-wide mutex
-around the whole pass (`withProvisioningLock`,
-`adapters/database/helpers/advisory-lock.ts`) and calls the untouched body as
-`provision()`. Nothing else changed: no write site is guarded, no port grew a
+around the whole pass (`withDatabaseLock`,
+`adapters/database/helpers/advisory-lock.ts`, holding the
+`PROVISIONING_DATABASE_LOCK` identity the provisioning module owns) and calls
+the untouched body as `provision()`. Nothing else changed: no write site is guarded, no port grew a
 method, and boot stays fatal.
 
 **One mutex rather than a guard per write site, because half the failures

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -1245,6 +1245,87 @@ one into every realm would fight the system MERGE on every boot).
 Scopes run first because they are leaf entities carrying no relations of their
 own, and a client in the same realm block may bind them via `realmScopes`.
 
+### Concurrent boots: the provisioning lock (issue #3356)
+
+Every write in the provisioner is find-then-insert with no guard between the
+two statements, so two replicas booting against an unprovisioned database
+interleave. `ProvisionerModule.setup` therefore holds a deployment-wide mutex
+around the whole pass (`withProvisioningLock`,
+`adapters/database/helpers/advisory-lock.ts`) and calls the untouched body as
+`provision()`. Nothing else changed: no write site is guarded, no port grew a
+method, and boot stays fatal.
+
+**One mutex rather than a guard per write site, because half the failures
+cannot raise an error to catch.** The insert sites split into two groups with
+opposite failure modes, and the issue text describes only the first:
+
+- `auth_realms` (unique on `name`), `auth_clients` and `auth_users` (unique on
+  `name, realm_id` with `realm_id` NOT NULL) and every junction (each unique
+  over its two id columns, both NOT NULL; the nullable `*_realm_id` and
+  `policy_id` companions are not part of the key) genuinely collide. The loser gets a driver-level unique violation
+  out of `save`, and since provisioning is a boot module that replica fails to
+  start. This is the reported crash, and the first statement that can reach it
+  is the master-realm insert, since the graph runs policies, permissions,
+  roles and scopes before realms.
+- `auth_permissions` and `auth_roles` (unique on `name, client_id, realm_id`)
+  and `auth_scopes` / `auth_policies` (unique on `name, realm_id`) are unique
+  over a tuple containing a NULLABLE column, and every row the default source
+  declares for them is global, so both columns are null. All three dialects
+  treat nulls as distinct in a unique index (postgres defaults to `NULLS
+  DISTINCT`, mysql and sqlite permit repeated nulls), so nothing raises and
+  both replicas simply insert. Nothing cleans them up afterwards
+  (`PolicyProvisioningSynchronizer.cleanupStaleTopLevel` only prunes names
+  absent from the declared set, so a duplicate of a declared name survives).
+
+The second group is why the issue's own options 1 and 2, which catch the
+duplicate-key error and re-read, were not taken: there is no error to catch
+for the entire global permission catalogue, both global roles, every global
+scope and every system policy. Serialization does not care whether the
+database refuses the second insert, so it is the only shape that closes both
+halves. Making the second group structurally safe needs `NULLS NOT DISTINCT`
+or an expression index over coalesced sentinels, which TypeORM cannot express
+in entity metadata; that is tracked separately and is a schema change, not a
+behaviour one.
+
+**Mechanics that are load-bearing.** The lock is SESSION-scoped in both
+dialects, so it takes a dedicated query runner for its whole lifetime:
+`dataSource.query()` would acquire and release on different pooled
+connections. It is also COUNTED in both, so it is acquired exactly once, and
+it is released explicitly in a `finally` before the runner goes back to the
+pool. Skipping that release leaks the lock onto a pooled connection for the
+lifetime of the process, and a second `setup()` in that process then
+deadlocks against itself. The acquisition answer is normalized rather than
+tested for truthiness: postgres returns a JS boolean, and mysql2 returns the
+STRING `'1'` or `'0'` (verified against a live server), so a truthiness check
+reads a lock held by another session as acquired and makes the whole mechanism
+inert on mysql.
+
+`better-sqlite3` is a passthrough that creates no runner at all, the same
+shape and the same reasoning as `isDatabaseTypeRowLockable`: one database file
+per container means a second replica cannot reach it, and the driver hands out
+ONE shared query runner (`this.queryRunner ??= ...`), so holding one here
+would nest inside whatever else is running.
+
+**On timeout it throws rather than proceeding unlocked.** Proceeding is the
+pre-fix behaviour, which is the thing being removed; failing the boot is what
+today's losing replica does anyway, and the deployment restarts it, by which
+point the winner has finished and the pass is a no-op. Boot stays fatal for
+the same reason it always was: provisioning seeds the authorization graph, and
+a replica that comes up without the master realm, the admin user or the
+permission catalogue passes a container health check while being useless.
+
+**Two residuals, stated rather than papered over.** The lock serializes boot
+against boot; it does not serialize a booting replica against a live one
+serving `POST /realms`, which calls the same three realm provisioners. The two
+sides of that race are not symmetric, which is worth being exact about:
+`RealmService.save` wraps each provisioner and logs, so the request side
+degrades to a warn line, while the boot side's own backfill loop has no catch
+and can still abort on the client the request just created. That window is a
+realm created in the seconds a replica takes to boot, and the restart
+reconciles it. And `RealmService.save` itself runs no `checkUniqueness`, so
+two concurrent `POST /realms` with one name give the loser an unmapped 500
+rather than a 409.
+
 ### Wildcard Realm Entry (`realms[].attributes.name: "*"`, plan 082)
 
 A `realms[]` entry whose name is the literal `*` (`REALM_WILDCARD_NAME`,

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -111,15 +111,17 @@ each for a global permission, role, scope and policy. It is
 `describe.skipIf`-gated to mysql/postgres because the provisioning lock is a
 deliberate passthrough on better-sqlite3 (one database file per container, so
 a second replica cannot exist). Confirm it is honest by making
-`withProvisioningLock` an unconditional passthrough: without the lock it fails
+`withDatabaseLock` an unconditional passthrough: without the lock it fails
 with `duplicate key value violates unique constraint
 "UQ_9b95dc8c08d8b11a80a6798a640"`, the `auth_realms(name)` collision issue
 #3356 reports. One DataSource is enough to model two replicas, because each
 `setup()` takes its own query runner and the lock is arbitrated per session.
 The lock's own unit spec
 (`test/unit/adapters/database/advisory-lock.spec.ts`) runs on every dialect
-over a fake DataSource and pins the mysql answer shape: mysql2 returns the
-STRING `'1'`/`'0'`, so a truthiness check would make the lock inert there.
+over a fake DataSource and pins two things a broken implementation would
+otherwise pass silently: the mysql answer shape (mysql2 returns the STRING
+`'1'`/`'0'`, so a truthiness check makes the lock inert there), and that the
+caller's lock identity is BOUND into both statements rather than interpolated.
 
 ## Test Layers (server-core)
 

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -101,6 +101,26 @@ mirror used to insert its row on a second pooled connection from inside the
 persist transaction (issue #3539), so the same pins are the regression test
 for that write too.
 
+**Provisioning concurrency is gated the same way.**
+`test/unit/modules/provisioning-concurrency.spec.ts` boots two
+`ProvisionerModule` instances concurrently against one empty database
+(`createTestDatabaseModuleForSecondaryInstance`, since the per-worker sqlite
+copy is a provisioned template and this race exists only on a first boot) and
+asserts one master realm, one `system` client, one `admin` user, and one row
+each for a global permission, role, scope and policy. It is
+`describe.skipIf`-gated to mysql/postgres because the provisioning lock is a
+deliberate passthrough on better-sqlite3 (one database file per container, so
+a second replica cannot exist). Confirm it is honest by making
+`withProvisioningLock` an unconditional passthrough: without the lock it fails
+with `duplicate key value violates unique constraint
+"UQ_9b95dc8c08d8b11a80a6798a640"`, the `auth_realms(name)` collision issue
+#3356 reports. One DataSource is enough to model two replicas, because each
+`setup()` takes its own query runner and the lock is arbitrated per session.
+The lock's own unit spec
+(`test/unit/adapters/database/advisory-lock.spec.ts`) runs on every dialect
+over a fake DataSource and pins the mysql answer shape: mysql2 returns the
+STRING `'1'`/`'0'`, so a truthiness check would make the lock inert there.
+
 ## Test Layers (server-core)
 
 ### Service-Level Tests

--- a/.agents/testing.md
+++ b/.agents/testing.md
@@ -113,8 +113,8 @@ deliberate passthrough on better-sqlite3 (one database file per container, so
 a second replica cannot exist). Confirm it is honest by making
 `withDatabaseLock` an unconditional passthrough: without the lock it fails
 with `duplicate key value violates unique constraint
-"UQ_9b95dc8c08d8b11a80a6798a640"`, the `auth_realms(name)` collision issue
-#3356 reports. One DataSource is enough to model two replicas, because each
+"UQ_9b95dc8c08d8b11a80a6798a640"`, the `auth_realms(name)` collision
+issue #3356 reports. One DataSource is enough to model two replicas, because each
 `setup()` takes its own query runner and the lock is arbitrated per session.
 The lock's own unit spec
 (`test/unit/adapters/database/advisory-lock.spec.ts`) runs on every dialect

--- a/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
+++ b/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+import { InternalError } from '@authup/errors';
+import { isObject } from '@authup/kit';
+import type { Logger } from '@authup/server-kit';
+import type { DataSource, DatabaseType } from 'typeorm';
+
+/**
+ * The mutex identity. Arbitrary, but it must stay STABLE across releases: a
+ * changed key is a different mutex, so during a rolling deploy the outgoing
+ * and the incoming replica would each hold their own and provision at once.
+ *
+ * postgres takes two int4 keys, mysql one string of at most 64 characters.
+ *
+ * The two are not scoped alike, which is confirmed rather than assumed: a
+ * postgres advisory lock carries the database OID, so two databases in one
+ * cluster do not contend, while a mysql named lock is scoped to the mysqld
+ * INSTANCE, so two authup databases on one server share this mutex. That is
+ * left as it is. The consequence is that one deployment's first boot delays
+ * the other's rather than corrupting it, and both are bounded by the wait
+ * budget below.
+ */
+const LOCK_KEY_NAMESPACE = 16725;
+const LOCK_KEY_ID = 1;
+const LOCK_NAME = 'authup:provisioning';
+
+export const PROVISIONING_LOCK_WAIT_TIMEOUT = 60_000;
+export const PROVISIONING_LOCK_POLL_INTERVAL = 500;
+
+type AdvisoryLockStatements = {
+    acquire: string,
+    release: string
+};
+
+/**
+ * The statements for a session-scoped advisory lock, or undefined for a driver
+ * that has none.
+ *
+ * The keys are inlined rather than bound, so the two dialects' placeholder
+ * syntaxes never enter the picture; both values are compile-time constants.
+ *
+ * better-sqlite3 falls through deliberately. One database file per container
+ * means a second replica cannot reach it, so there is nothing to serialize.
+ * `BetterSqlite3Driver.createQueryRunner` also returns ONE shared runner
+ * (`this.queryRunner ??= ...`), so holding a runner here would nest inside
+ * whatever else is running. Same shape and same reasoning as
+ * `isDatabaseTypeRowLockable`.
+ */
+function statementsFor(type: DatabaseType): AdvisoryLockStatements | undefined {
+    switch (type) {
+        case 'postgres':
+            return {
+                acquire: `SELECT pg_try_advisory_lock(${LOCK_KEY_NAMESPACE}, ${LOCK_KEY_ID}) AS acquired`,
+                release: `SELECT pg_advisory_unlock(${LOCK_KEY_NAMESPACE}, ${LOCK_KEY_ID})`,
+            };
+        case 'mysql':
+            return {
+                acquire: `SELECT GET_LOCK('${LOCK_NAME}', 0) AS acquired`,
+                release: `SELECT RELEASE_LOCK('${LOCK_NAME}')`,
+            };
+        default:
+            return undefined;
+    }
+}
+
+/**
+ * Whether the try-lock reports success.
+ *
+ * postgres answers with a JS boolean, mysql2 with the string `'1'` (or the
+ * number 1), and mysql answers NULL on error. A truthiness check would read
+ * mysql's `'0'` (a lock held by another session) as acquired.
+ */
+function isAcquired(rows: unknown): boolean {
+    const row = Array.isArray(rows) ? rows[0] : undefined;
+    if (!isObject(row)) {
+        return false;
+    }
+
+    const value = (row as Record<string, unknown>).acquired;
+    return value === true || value === 1 || value === '1';
+}
+
+export type ProvisioningLockOptions = {
+    logger?: Logger,
+    /** Total time to wait for the lock before giving up. */
+    waitTimeout?: number,
+    /** Delay between try-lock attempts. */
+    pollInterval?: number,
+    /** Test seam. */
+    wait?: (ms: number) => Promise<void>
+};
+
+/**
+ * Run `fn` while holding the deployment-wide provisioning mutex.
+ *
+ * Provisioning is a reconciliation pass built out of find-then-insert pairs
+ * with no guard between the two statements, so two replicas booting against an
+ * unprovisioned database interleave. One mutex around the whole pass is what
+ * closes that, rather than a guard per write site, and it is the only shape
+ * that closes BOTH halves of the failure. Half the tables carry a unique key
+ * that raises on the loser (`auth_realms`, `auth_clients`, `auth_users`, every
+ * junction), and half carry one that cannot: `auth_permissions`,
+ * `auth_roles`, `auth_scopes` and `auth_policies` are unique over a tuple
+ * containing a NULLABLE column, and every row the default source declares for
+ * them is global, so the duplicates are simply written and nothing raises. A
+ * duplicate-key guard is unreachable there by construction (issue #3356).
+ *
+ * The lock is SESSION-scoped in both dialects, so it needs a dedicated query
+ * runner for its whole lifetime: `dataSource.query()` would acquire and
+ * release on different pooled connections. It is also COUNTED in both, so it
+ * is acquired exactly once. Not releasing it explicitly would leak it onto a
+ * pooled connection for the lifetime of the process, and a second `setup()`
+ * in the same process would then deadlock against itself.
+ *
+ * On timeout this THROWS rather than proceeding unlocked. Proceeding is the
+ * pre-fix behaviour, which is the thing being removed; failing the boot is
+ * what today's losing replica does anyway, and the deployment already restarts
+ * it, by which point the winner has finished and the pass is a no-op.
+ */
+export async function withProvisioningLock<R>(
+    dataSource: DataSource,
+    fn: () => Promise<R>,
+    options: ProvisioningLockOptions = {},
+): Promise<R> {
+    const statements = statementsFor(dataSource.options.type);
+    if (!statements) {
+        return fn();
+    }
+
+    const waitTimeout = options.waitTimeout ?? PROVISIONING_LOCK_WAIT_TIMEOUT;
+    const pollInterval = options.pollInterval ?? PROVISIONING_LOCK_POLL_INTERVAL;
+    const wait = options.wait ?? ((ms: number) => new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+    }));
+
+    const queryRunner = dataSource.createQueryRunner();
+    await queryRunner.connect();
+
+    let acquired = false;
+
+    try {
+        // The elapsed budget is counted in poll intervals rather than read off
+        // the clock, so an injected `wait` makes the timeout branch instant.
+        // A real wait therefore over-runs the budget by the round-trip time of
+        // each attempt, which is the right direction to be wrong in.
+        let waited = 0;
+
+        for (;;) {
+            acquired = isAcquired(await queryRunner.query(statements.acquire));
+            if (acquired) {
+                break;
+            }
+
+            if (waited >= waitTimeout) {
+                throw new InternalError(
+                    `Timed out after ${waitTimeout}ms waiting for the provisioning lock. ` +
+                    'Another replica is provisioning this database; this one will reconcile on restart.',
+                );
+            }
+
+            if (waited === 0) {
+                options.logger?.info('Another replica holds the provisioning lock. Waiting for it to finish.');
+            }
+
+            await wait(pollInterval);
+            waited += pollInterval;
+        }
+
+        return await fn();
+    } finally {
+        if (acquired) {
+            try {
+                await queryRunner.query(statements.release);
+            } catch {
+                // A leaked lock self-releases when the session ends, so this
+                // must never displace whatever the caller is already throwing.
+                options.logger?.warn('Could not release the provisioning lock.');
+            }
+        }
+
+        await queryRunner.release();
+    }
+}

--- a/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
+++ b/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
@@ -10,6 +10,16 @@ import type { Logger } from '@authup/server-kit';
 import type { DataSource, DatabaseType } from 'typeorm';
 
 /**
+ * REMOVAL TRIGGER: this is a deliberate local fallback, not a permanent home.
+ * The mechanism is dialect knowledge and belongs upstream, next to its exact
+ * structural sibling `withForeignKeyChecksDisabled`; proposed as
+ * tada5hi/typeorm-extension#1441. When that lands, delete this file and call
+ * the library, keeping the spec as the conformance check that it treats
+ * mysql's string answer and the sqlite passthrough the way this deployment
+ * needs. The one call site is `ProvisionerModule.setup`.
+ */
+
+/**
  * A mutex identity. The two dialects address a lock differently, so a lock
  * carries both spellings and the caller owns the values.
  *

--- a/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
+++ b/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
@@ -128,13 +128,25 @@ export async function withDatabaseLock<R>(
     fn: () => Promise<R>,
     options: DatabaseLockOptions = {},
 ): Promise<R> {
+    const waitTimeout = options.waitTimeout ?? DATABASE_LOCK_WAIT_TIMEOUT;
+    const pollInterval = options.pollInterval ?? DATABASE_LOCK_POLL_INTERVAL;
+
+    // The budget below is counted in poll intervals, so an interval that does
+    // not advance it (zero, negative, NaN) or a budget it can never reach (NaN)
+    // turns the wait into an unbounded loop that hammers the database with
+    // try-lock queries and never times out. Checked before the dialect gate, so
+    // a caller does not discover it only on the dialect that takes the lock.
+    if (!(pollInterval > 0) || !(waitTimeout >= 0)) {
+        throw new InternalError(
+            'The database lock needs a non-negative wait budget and a positive poll interval.',
+        );
+    }
+
     const statements = statementsFor(dataSource.options.type, lock);
     if (!statements) {
         return fn();
     }
 
-    const waitTimeout = options.waitTimeout ?? DATABASE_LOCK_WAIT_TIMEOUT;
-    const pollInterval = options.pollInterval ?? DATABASE_LOCK_POLL_INTERVAL;
     const wait = options.wait ?? ((ms: number) => new Promise<void>((resolve) => {
         setTimeout(resolve, ms);
     }));

--- a/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
+++ b/apps/server-core/src/adapters/database/helpers/advisory-lock.ts
@@ -10,38 +10,36 @@ import type { Logger } from '@authup/server-kit';
 import type { DataSource, DatabaseType } from 'typeorm';
 
 /**
- * The mutex identity. Arbitrary, but it must stay STABLE across releases: a
- * changed key is a different mutex, so during a rolling deploy the outgoing
- * and the incoming replica would each hold their own and provision at once.
+ * A mutex identity. The two dialects address a lock differently, so a lock
+ * carries both spellings and the caller owns the values.
  *
- * postgres takes two int4 keys, mysql one string of at most 64 characters.
- *
- * The two are not scoped alike, which is confirmed rather than assumed: a
+ * The two are also not scoped alike, which is confirmed rather than assumed: a
  * postgres advisory lock carries the database OID, so two databases in one
  * cluster do not contend, while a mysql named lock is scoped to the mysqld
- * INSTANCE, so two authup databases on one server share this mutex. That is
- * left as it is. The consequence is that one deployment's first boot delays
- * the other's rather than corrupting it, and both are bounded by the wait
- * budget below.
+ * INSTANCE, so two databases on one server share the lock.
  */
-const LOCK_KEY_NAMESPACE = 16725;
-const LOCK_KEY_ID = 1;
-const LOCK_NAME = 'authup:provisioning';
+export type DatabaseLock = {
+    /** mysql: the `GET_LOCK` name, at most 64 characters. */
+    name: string,
+    /** postgres: the two int4 keys `pg_try_advisory_lock` takes. */
+    key: [number, number]
+};
 
-export const PROVISIONING_LOCK_WAIT_TIMEOUT = 60_000;
-export const PROVISIONING_LOCK_POLL_INTERVAL = 500;
+export const DATABASE_LOCK_WAIT_TIMEOUT = 60_000;
+export const DATABASE_LOCK_POLL_INTERVAL = 500;
 
-type AdvisoryLockStatements = {
+type DatabaseLockStatements = {
     acquire: string,
-    release: string
+    release: string,
+    parameters: unknown[]
 };
 
 /**
  * The statements for a session-scoped advisory lock, or undefined for a driver
  * that has none.
  *
- * The keys are inlined rather than bound, so the two dialects' placeholder
- * syntaxes never enter the picture; both values are compile-time constants.
+ * The identity is BOUND rather than interpolated, so a lock name never reaches
+ * the statement text. Both statements of a dialect take the same parameters.
  *
  * better-sqlite3 falls through deliberately. One database file per container
  * means a second replica cannot reach it, so there is nothing to serialize.
@@ -50,17 +48,19 @@ type AdvisoryLockStatements = {
  * whatever else is running. Same shape and same reasoning as
  * `isDatabaseTypeRowLockable`.
  */
-function statementsFor(type: DatabaseType): AdvisoryLockStatements | undefined {
+function statementsFor(type: DatabaseType, lock: DatabaseLock): DatabaseLockStatements | undefined {
     switch (type) {
         case 'postgres':
             return {
-                acquire: `SELECT pg_try_advisory_lock(${LOCK_KEY_NAMESPACE}, ${LOCK_KEY_ID}) AS acquired`,
-                release: `SELECT pg_advisory_unlock(${LOCK_KEY_NAMESPACE}, ${LOCK_KEY_ID})`,
+                acquire: 'SELECT pg_try_advisory_lock($1, $2) AS acquired',
+                release: 'SELECT pg_advisory_unlock($1, $2)',
+                parameters: [lock.key[0], lock.key[1]],
             };
         case 'mysql':
             return {
-                acquire: `SELECT GET_LOCK('${LOCK_NAME}', 0) AS acquired`,
-                release: `SELECT RELEASE_LOCK('${LOCK_NAME}')`,
+                acquire: 'SELECT GET_LOCK(?, 0) AS acquired',
+                release: 'SELECT RELEASE_LOCK(?)',
+                parameters: [lock.name],
             };
         default:
             return undefined;
@@ -84,7 +84,7 @@ function isAcquired(rows: unknown): boolean {
     return value === true || value === 1 || value === '1';
 }
 
-export type ProvisioningLockOptions = {
+export type DatabaseLockOptions = {
     logger?: Logger,
     /** Total time to wait for the lock before giving up. */
     waitTimeout?: number,
@@ -95,44 +95,36 @@ export type ProvisioningLockOptions = {
 };
 
 /**
- * Run `fn` while holding the deployment-wide provisioning mutex.
+ * Run `fn` while holding a database-wide advisory lock, for work that must not
+ * run on two connections at once.
  *
- * Provisioning is a reconciliation pass built out of find-then-insert pairs
- * with no guard between the two statements, so two replicas booting against an
- * unprovisioned database interleave. One mutex around the whole pass is what
- * closes that, rather than a guard per write site, and it is the only shape
- * that closes BOTH halves of the failure. Half the tables carry a unique key
- * that raises on the loser (`auth_realms`, `auth_clients`, `auth_users`, every
- * junction), and half carry one that cannot: `auth_permissions`,
- * `auth_roles`, `auth_scopes` and `auth_policies` are unique over a tuple
- * containing a NULLABLE column, and every row the default source declares for
- * them is global, so the duplicates are simply written and nothing raises. A
- * duplicate-key guard is unreachable there by construction (issue #3356).
+ * Three mechanics are load-bearing, and each is a way this can be broken
+ * without any visible symptom:
  *
- * The lock is SESSION-scoped in both dialects, so it needs a dedicated query
- * runner for its whole lifetime: `dataSource.query()` would acquire and
- * release on different pooled connections. It is also COUNTED in both, so it
- * is acquired exactly once. Not releasing it explicitly would leak it onto a
- * pooled connection for the lifetime of the process, and a second `setup()`
- * in the same process would then deadlock against itself.
+ * - The lock is SESSION-scoped in both dialects, so it takes a dedicated query
+ *   runner for its whole lifetime. `dataSource.query()` would acquire and
+ *   release on different pooled connections.
+ * - It is COUNTED in both, so it is acquired exactly once.
+ * - It is released explicitly before the runner goes back to the pool. Skipping
+ *   that leaks the lock onto a pooled connection for the lifetime of the
+ *   process, and the next call in that process deadlocks against itself.
  *
- * On timeout this THROWS rather than proceeding unlocked. Proceeding is the
- * pre-fix behaviour, which is the thing being removed; failing the boot is
- * what today's losing replica does anyway, and the deployment already restarts
- * it, by which point the winner has finished and the pass is a no-op.
+ * On timeout this THROWS rather than running `fn` unlocked, so a caller that
+ * cannot tolerate an unserialized run does not silently get one.
  */
-export async function withProvisioningLock<R>(
+export async function withDatabaseLock<R>(
     dataSource: DataSource,
+    lock: DatabaseLock,
     fn: () => Promise<R>,
-    options: ProvisioningLockOptions = {},
+    options: DatabaseLockOptions = {},
 ): Promise<R> {
-    const statements = statementsFor(dataSource.options.type);
+    const statements = statementsFor(dataSource.options.type, lock);
     if (!statements) {
         return fn();
     }
 
-    const waitTimeout = options.waitTimeout ?? PROVISIONING_LOCK_WAIT_TIMEOUT;
-    const pollInterval = options.pollInterval ?? PROVISIONING_LOCK_POLL_INTERVAL;
+    const waitTimeout = options.waitTimeout ?? DATABASE_LOCK_WAIT_TIMEOUT;
+    const pollInterval = options.pollInterval ?? DATABASE_LOCK_POLL_INTERVAL;
     const wait = options.wait ?? ((ms: number) => new Promise<void>((resolve) => {
         setTimeout(resolve, ms);
     }));
@@ -150,20 +142,20 @@ export async function withProvisioningLock<R>(
         let waited = 0;
 
         for (;;) {
-            acquired = isAcquired(await queryRunner.query(statements.acquire));
+            acquired = isAcquired(await queryRunner.query(statements.acquire, statements.parameters));
             if (acquired) {
                 break;
             }
 
             if (waited >= waitTimeout) {
                 throw new InternalError(
-                    `Timed out after ${waitTimeout}ms waiting for the provisioning lock. ` +
-                    'Another replica is provisioning this database; this one will reconcile on restart.',
+                    `Timed out after ${waitTimeout}ms waiting for the database lock "${lock.name}". ` +
+                    'Another process holds it.',
                 );
             }
 
             if (waited === 0) {
-                options.logger?.info('Another replica holds the provisioning lock. Waiting for it to finish.');
+                options.logger?.info(`Another process holds the database lock "${lock.name}". Waiting for it to finish.`);
             }
 
             await wait(pollInterval);
@@ -174,11 +166,11 @@ export async function withProvisioningLock<R>(
     } finally {
         if (acquired) {
             try {
-                await queryRunner.query(statements.release);
+                await queryRunner.query(statements.release, statements.parameters);
             } catch {
                 // A leaked lock self-releases when the session ends, so this
                 // must never displace whatever the caller is already throwing.
-                options.logger?.warn('Could not release the provisioning lock.');
+                options.logger?.warn(`Could not release the database lock "${lock.name}".`);
             }
         }
 

--- a/apps/server-core/src/adapters/database/helpers/index.ts
+++ b/apps/server-core/src/adapters/database/helpers/index.ts
@@ -6,4 +6,5 @@
  */
 
 export * from './date.ts';
+export * from './advisory-lock.ts';
 export * from './is-supported.ts';

--- a/apps/server-core/src/app/modules/provisioning/constants.ts
+++ b/apps/server-core/src/app/modules/provisioning/constants.ts
@@ -6,7 +6,19 @@
  */
 
 import { TypedToken } from 'eldin';
+import type { DatabaseLock } from '../../../adapters/database/helpers/index.ts';
 import type { IRealmProvisioner } from '../../../core/index.ts';
+
+/**
+ * The mutex one provisioning pass holds against every other. The values are
+ * arbitrary, but they must stay STABLE across releases: a changed key is a
+ * different mutex, so during a rolling deploy the outgoing and the incoming
+ * replica would each hold their own and provision at the same time.
+ */
+export const PROVISIONING_DATABASE_LOCK: DatabaseLock = {
+    name: 'authup:provisioning',
+    key: [16725, 1],
+};
 
 export const ProvisioningInjectionKey = {
     /**

--- a/apps/server-core/src/app/modules/provisioning/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/module.ts
@@ -31,6 +31,7 @@ import {
     UserPermissionEntity,
     UserRoleEntity,
 } from '../../../adapters/database/index.ts';
+import { withProvisioningLock } from '../../../adapters/database/helpers/index.ts';
 import { SystemPolicyName } from '@authup/access';
 import {
     PermissionPolicyEntity,
@@ -99,7 +100,25 @@ export class ProvisionerModule implements IModule {
         this.sources = sources;
     }
 
+    /**
+     * Provisioning is a reconciliation pass of find-then-insert pairs with no
+     * guard between the two statements, so two replicas booting against an
+     * unprovisioned database interleave and either collide on a unique key or,
+     * for the four entity types whose unique tuple contains a nullable column,
+     * silently write duplicate rows. One mutex around the whole pass
+     * closes both halves; see `withProvisioningLock` (issue #3356).
+     */
     async setup(container: IContainer): Promise<void> {
+        const dataSource = container.resolve(DatabaseInjectionKey.DataSource);
+
+        await withProvisioningLock(
+            dataSource,
+            () => this.provision(container),
+            { logger: container.resolve(LoggerInjectionKey) },
+        );
+    }
+
+    protected async provision(container: IContainer): Promise<void> {
         const sources = [...this.sources];
 
         const config = container.resolve(ConfigInjectionKey);

--- a/apps/server-core/src/app/modules/provisioning/module.ts
+++ b/apps/server-core/src/app/modules/provisioning/module.ts
@@ -31,7 +31,7 @@ import {
     UserPermissionEntity,
     UserRoleEntity,
 } from '../../../adapters/database/index.ts';
-import { withProvisioningLock } from '../../../adapters/database/helpers/index.ts';
+import { withDatabaseLock } from '../../../adapters/database/helpers/index.ts';
 import { SystemPolicyName } from '@authup/access';
 import {
     PermissionPolicyEntity,
@@ -56,7 +56,7 @@ import {
     extractWildcardRealmEntry,
 } from '../../../core/provisioning/wildcard/index.ts';
 import type { IProvisioningSource } from '../../../core/provisioning/types.ts';
-import { ProvisioningInjectionKey } from './constants.ts';
+import { PROVISIONING_DATABASE_LOCK, ProvisioningInjectionKey } from './constants.ts';
 import {
     ClientPermissionRepositoryAdapter,
     ClientRepositoryAdapter,
@@ -106,13 +106,14 @@ export class ProvisionerModule implements IModule {
      * unprovisioned database interleave and either collide on a unique key or,
      * for the four entity types whose unique tuple contains a nullable column,
      * silently write duplicate rows. One mutex around the whole pass
-     * closes both halves; see `withProvisioningLock` (issue #3356).
+     * closes both halves; see `withDatabaseLock` (issue #3356).
      */
     async setup(container: IContainer): Promise<void> {
         const dataSource = container.resolve(DatabaseInjectionKey.DataSource);
 
-        await withProvisioningLock(
+        await withDatabaseLock(
             dataSource,
+            PROVISIONING_DATABASE_LOCK,
             () => this.provision(container),
             { logger: container.resolve(LoggerInjectionKey) },
         );

--- a/apps/server-core/test/unit/adapters/database/advisory-lock.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/advisory-lock.spec.ts
@@ -216,6 +216,29 @@ describe('adapters/database/helpers/advisory-lock', () => {
         expect(fake.state.runnersReleased).toEqual(1);
     });
 
+    // A poll interval that never advances the budget, or a budget the budget
+    // can never reach, would loop forever hammering the try-lock. Refused
+    // before the dialect gate, so sqlite reports it too rather than passing a
+    // call the lock-taking dialects reject.
+    it.each([
+        ['a zero poll interval', 'postgres' as DatabaseType, { pollInterval: 0 }],
+        ['a negative poll interval', 'postgres' as DatabaseType, { pollInterval: -1 }],
+        ['a NaN poll interval', 'postgres' as DatabaseType, { pollInterval: NaN }],
+        ['a NaN wait budget', 'postgres' as DatabaseType, { waitTimeout: NaN }],
+        ['a negative wait budget', 'postgres' as DatabaseType, { waitTimeout: -1 }],
+        ['a zero poll interval on sqlite', 'better-sqlite3' as DatabaseType, { pollInterval: 0 }],
+    ])('should refuse %s', async (_label, type, overrides) => {
+        const fake = createFakeDataSource(type, [[{ acquired: true }]]);
+
+        let ran = false;
+        await expect(withDatabaseLock(fake.dataSource, LOCK, async () => {
+            ran = true;
+        }, { wait: noWait, ...overrides })).rejects.toThrow(/poll interval|wait budget/);
+
+        expect(ran).toBeFalsy();
+        expect(fake.state.runnersCreated).toEqual(0);
+    });
+
     it('should release the lock and rethrow untouched when the callback fails', async () => {
         const fake = createFakeDataSource('postgres', [[{ acquired: true }]]);
         const error = new Error('provisioning blew up');

--- a/apps/server-core/test/unit/adapters/database/advisory-lock.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/advisory-lock.spec.ts
@@ -1,0 +1,223 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { DataSource, DatabaseType } from 'typeorm';
+import { describe, expect, it } from 'vitest';
+import { withProvisioningLock } from '../../../../src/adapters/database/helpers/index.ts';
+
+type QueryAnswer = unknown | ((sql: string) => unknown);
+
+type FakeDataSourceState = {
+    statements: string[],
+    runnersCreated: number,
+    runnersReleased: number
+};
+
+function isReleaseStatement(sql: string): boolean {
+    return sql.includes('pg_advisory_unlock') || sql.includes('RELEASE_LOCK');
+}
+
+/**
+ * A DataSource whose query runner records every statement and answers from a
+ * queue, so an interleaving can be written out exactly. A queued function is
+ * invoked (to make a statement throw); anything else is returned verbatim.
+ */
+function createFakeDataSource(
+    type: DatabaseType,
+    answers: QueryAnswer[] = [],
+): { dataSource: DataSource, state: FakeDataSourceState } {
+    const state: FakeDataSourceState = {
+        statements: [],
+        runnersCreated: 0,
+        runnersReleased: 0,
+    };
+
+    const queue = [...answers];
+
+    const dataSource = {
+        options: { type },
+        createQueryRunner() {
+            state.runnersCreated += 1;
+
+            return {
+                connect: async () => undefined,
+                release: async () => {
+                    state.runnersReleased += 1;
+                },
+                query: async (sql: string) => {
+                    state.statements.push(sql);
+
+                    if (queue.length > 0) {
+                        const answer = queue.shift();
+                        if (typeof answer === 'function') {
+                            return (answer as (input: string) => unknown)(sql);
+                        }
+
+                        return answer;
+                    }
+
+                    return isReleaseStatement(sql) ? [{}] : [{ acquired: true }];
+                },
+            };
+        },
+    } as unknown as DataSource;
+
+    return { dataSource, state };
+}
+
+const noWait = async () => undefined;
+
+describe('adapters/database/helpers/advisory-lock', () => {
+    it('should pass through without a query runner on better-sqlite3', async () => {
+        const fake = createFakeDataSource('better-sqlite3');
+
+        const output = await withProvisioningLock(fake.dataSource, async () => 'done');
+
+        expect(output).toEqual('done');
+        // One database file per container, so there is nothing to serialize,
+        // and the driver hands out ONE shared runner that must not be held.
+        expect(fake.state.runnersCreated).toEqual(0);
+        expect(fake.state.statements).toEqual([]);
+    });
+
+    it('should acquire and release around the callback on postgres', async () => {
+        const fake = createFakeDataSource('postgres', [[{ acquired: true }]]);
+        const order: string[] = [];
+
+        await withProvisioningLock(fake.dataSource, async () => {
+            order.push(`callback after ${fake.state.statements.length} statement(s)`);
+        });
+
+        expect(fake.state.statements).toHaveLength(2);
+        expect(fake.state.statements[0]).toContain('pg_try_advisory_lock');
+        expect(fake.state.statements[1]).toContain('pg_advisory_unlock');
+        expect(order).toEqual(['callback after 1 statement(s)']);
+        expect(fake.state.runnersReleased).toEqual(1);
+    });
+
+    it('should acquire and release around the callback on mysql', async () => {
+        const fake = createFakeDataSource('mysql', [[{ acquired: 1 }]]);
+
+        await withProvisioningLock(fake.dataSource, async () => undefined);
+
+        expect(fake.state.statements[0]).toContain('GET_LOCK');
+        expect(fake.state.statements[1]).toContain('RELEASE_LOCK');
+        expect(fake.state.runnersReleased).toEqual(1);
+    });
+
+    // mysql2 answers the string '1', pg a JS boolean. A truthiness check would
+    // read mysql's '0' as acquired and run the pass unserialized.
+    it.each([
+        ['mysql string', 'mysql' as DatabaseType, '1'],
+        ['mysql number', 'mysql' as DatabaseType, 1],
+        ['postgres boolean', 'postgres' as DatabaseType, true],
+    ])('should treat a %s answer as acquired', async (_label, type, value) => {
+        const fake = createFakeDataSource(type, [[{ acquired: value }]]);
+
+        let ran = false;
+        await withProvisioningLock(fake.dataSource, async () => {
+            ran = true;
+        });
+
+        expect(ran).toBeTruthy();
+        expect(fake.state.statements).toHaveLength(2);
+    });
+
+    it.each([
+        ['mysql zero string', 'mysql' as DatabaseType, '0'],
+        ['mysql zero number', 'mysql' as DatabaseType, 0],
+        ['mysql null (error)', 'mysql' as DatabaseType, null],
+        ['postgres false', 'postgres' as DatabaseType, false],
+    ])('should not treat a %s answer as acquired', async (_label, type, value) => {
+        const fake = createFakeDataSource(type, [[{ acquired: value }]]);
+
+        let ran = false;
+        await expect(withProvisioningLock(fake.dataSource, async () => {
+            ran = true;
+        }, { waitTimeout: 0, wait: noWait })).rejects.toThrow(/provisioning lock/);
+
+        expect(ran).toBeFalsy();
+    });
+
+    it('should poll until the lock frees up', async () => {
+        const fake = createFakeDataSource('postgres', [
+            [{ acquired: false }],
+            [{ acquired: false }],
+            [{ acquired: true }],
+        ]);
+
+        const waits: number[] = [];
+        let ran = false;
+
+        await withProvisioningLock(fake.dataSource, async () => {
+            ran = true;
+        }, {
+            waitTimeout: 1_000,
+            pollInterval: 100,
+            wait: async (ms) => {
+                waits.push(ms);
+            },
+        });
+
+        expect(ran).toBeTruthy();
+        expect(waits).toEqual([100, 100]);
+        expect(fake.state.statements).toHaveLength(4);
+    });
+
+    it('should fail the boot rather than provision unserialized when the wait runs out', async () => {
+        const fake = createFakeDataSource('postgres', [
+            [{ acquired: false }],
+            [{ acquired: false }],
+            [{ acquired: false }],
+        ]);
+
+        let ran = false;
+
+        await expect(withProvisioningLock(fake.dataSource, async () => {
+            ran = true;
+        }, {
+            waitTimeout: 200, 
+            pollInterval: 100, 
+            wait: noWait, 
+        }))
+            .rejects.toThrow(/Timed out after 200ms waiting for the provisioning lock/);
+
+        expect(ran).toBeFalsy();
+        // Nothing was acquired, so nothing is unlocked, but the runner is
+        // handed back either way.
+        expect(fake.state.statements.every((statement) => statement.includes('pg_try_advisory_lock'))).toBeTruthy();
+        expect(fake.state.runnersReleased).toEqual(1);
+    });
+
+    it('should release the lock and rethrow untouched when the callback fails', async () => {
+        const fake = createFakeDataSource('postgres', [[{ acquired: true }]]);
+        const error = new Error('provisioning blew up');
+
+        await expect(withProvisioningLock(fake.dataSource, async () => {
+            throw error;
+        })).rejects.toBe(error);
+
+        expect(fake.state.statements[1]).toContain('pg_advisory_unlock');
+        expect(fake.state.runnersReleased).toEqual(1);
+    });
+
+    it('should not let a failing release displace the callback error', async () => {
+        const fake = createFakeDataSource('postgres', [
+            [{ acquired: true }],
+            () => {
+                throw new Error('connection reset');
+            },
+        ]);
+        const error = new Error('provisioning blew up');
+
+        await expect(withProvisioningLock(fake.dataSource, async () => {
+            throw error;
+        })).rejects.toBe(error);
+
+        expect(fake.state.runnersReleased).toEqual(1);
+    });
+});

--- a/apps/server-core/test/unit/adapters/database/advisory-lock.spec.ts
+++ b/apps/server-core/test/unit/adapters/database/advisory-lock.spec.ts
@@ -7,12 +7,19 @@
 
 import type { DataSource, DatabaseType } from 'typeorm';
 import { describe, expect, it } from 'vitest';
-import { withProvisioningLock } from '../../../../src/adapters/database/helpers/index.ts';
+import type { DatabaseLock } from '../../../../src/adapters/database/helpers/index.ts';
+import { withDatabaseLock } from '../../../../src/adapters/database/helpers/index.ts';
+
+const LOCK: DatabaseLock = {
+    name: 'authup:test',
+    key: [4711, 2],
+};
 
 type QueryAnswer = unknown | ((sql: string) => unknown);
 
 type FakeDataSourceState = {
     statements: string[],
+    parameters: unknown[][],
     runnersCreated: number,
     runnersReleased: number
 };
@@ -32,6 +39,7 @@ function createFakeDataSource(
 ): { dataSource: DataSource, state: FakeDataSourceState } {
     const state: FakeDataSourceState = {
         statements: [],
+        parameters: [],
         runnersCreated: 0,
         runnersReleased: 0,
     };
@@ -48,8 +56,9 @@ function createFakeDataSource(
                 release: async () => {
                     state.runnersReleased += 1;
                 },
-                query: async (sql: string) => {
+                query: async (sql: string, parameters: unknown[] = []) => {
                     state.statements.push(sql);
+                    state.parameters.push(parameters);
 
                     if (queue.length > 0) {
                         const answer = queue.shift();
@@ -75,7 +84,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
     it('should pass through without a query runner on better-sqlite3', async () => {
         const fake = createFakeDataSource('better-sqlite3');
 
-        const output = await withProvisioningLock(fake.dataSource, async () => 'done');
+        const output = await withDatabaseLock(fake.dataSource, LOCK, async () => 'done');
 
         expect(output).toEqual('done');
         // One database file per container, so there is nothing to serialize,
@@ -88,7 +97,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
         const fake = createFakeDataSource('postgres', [[{ acquired: true }]]);
         const order: string[] = [];
 
-        await withProvisioningLock(fake.dataSource, async () => {
+        await withDatabaseLock(fake.dataSource, LOCK, async () => {
             order.push(`callback after ${fake.state.statements.length} statement(s)`);
         });
 
@@ -99,10 +108,24 @@ describe('adapters/database/helpers/advisory-lock', () => {
         expect(fake.state.runnersReleased).toEqual(1);
     });
 
+    it.each([
+        ['postgres', 'postgres' as DatabaseType, [4711, 2]],
+        ['mysql', 'mysql' as DatabaseType, ['authup:test']],
+    ])('should bind the caller lock identity on %s', async (_label, type, expected) => {
+        const fake = createFakeDataSource(type, [[{ acquired: true }]]);
+
+        await withDatabaseLock(fake.dataSource, LOCK, async () => undefined);
+
+        // Bound, never interpolated, so a lock name never reaches the
+        // statement text, and both statements address the same lock.
+        expect(fake.state.parameters).toEqual([expected, expected]);
+        expect(fake.state.statements.every((statement) => !statement.includes('authup:test'))).toBeTruthy();
+    });
+
     it('should acquire and release around the callback on mysql', async () => {
         const fake = createFakeDataSource('mysql', [[{ acquired: 1 }]]);
 
-        await withProvisioningLock(fake.dataSource, async () => undefined);
+        await withDatabaseLock(fake.dataSource, LOCK, async () => undefined);
 
         expect(fake.state.statements[0]).toContain('GET_LOCK');
         expect(fake.state.statements[1]).toContain('RELEASE_LOCK');
@@ -119,7 +142,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
         const fake = createFakeDataSource(type, [[{ acquired: value }]]);
 
         let ran = false;
-        await withProvisioningLock(fake.dataSource, async () => {
+        await withDatabaseLock(fake.dataSource, LOCK, async () => {
             ran = true;
         });
 
@@ -136,9 +159,9 @@ describe('adapters/database/helpers/advisory-lock', () => {
         const fake = createFakeDataSource(type, [[{ acquired: value }]]);
 
         let ran = false;
-        await expect(withProvisioningLock(fake.dataSource, async () => {
+        await expect(withDatabaseLock(fake.dataSource, LOCK, async () => {
             ran = true;
-        }, { waitTimeout: 0, wait: noWait })).rejects.toThrow(/provisioning lock/);
+        }, { waitTimeout: 0, wait: noWait })).rejects.toThrow(/database lock/);
 
         expect(ran).toBeFalsy();
     });
@@ -153,7 +176,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
         const waits: number[] = [];
         let ran = false;
 
-        await withProvisioningLock(fake.dataSource, async () => {
+        await withDatabaseLock(fake.dataSource, LOCK, async () => {
             ran = true;
         }, {
             waitTimeout: 1_000,
@@ -168,7 +191,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
         expect(fake.state.statements).toHaveLength(4);
     });
 
-    it('should fail the boot rather than provision unserialized when the wait runs out', async () => {
+    it('should fail rather than run the callback unserialized when the wait runs out', async () => {
         const fake = createFakeDataSource('postgres', [
             [{ acquired: false }],
             [{ acquired: false }],
@@ -177,14 +200,14 @@ describe('adapters/database/helpers/advisory-lock', () => {
 
         let ran = false;
 
-        await expect(withProvisioningLock(fake.dataSource, async () => {
+        await expect(withDatabaseLock(fake.dataSource, LOCK, async () => {
             ran = true;
         }, {
             waitTimeout: 200, 
             pollInterval: 100, 
             wait: noWait, 
         }))
-            .rejects.toThrow(/Timed out after 200ms waiting for the provisioning lock/);
+            .rejects.toThrow(/Timed out after 200ms waiting for the database lock "authup:test"/);
 
         expect(ran).toBeFalsy();
         // Nothing was acquired, so nothing is unlocked, but the runner is
@@ -197,7 +220,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
         const fake = createFakeDataSource('postgres', [[{ acquired: true }]]);
         const error = new Error('provisioning blew up');
 
-        await expect(withProvisioningLock(fake.dataSource, async () => {
+        await expect(withDatabaseLock(fake.dataSource, LOCK, async () => {
             throw error;
         })).rejects.toBe(error);
 
@@ -214,7 +237,7 @@ describe('adapters/database/helpers/advisory-lock', () => {
         ]);
         const error = new Error('provisioning blew up');
 
-        await expect(withProvisioningLock(fake.dataSource, async () => {
+        await expect(withDatabaseLock(fake.dataSource, LOCK, async () => {
             throw error;
         })).rejects.toBe(error);
 

--- a/apps/server-core/test/unit/modules/provisioning-concurrency.spec.ts
+++ b/apps/server-core/test/unit/modules/provisioning-concurrency.spec.ts
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import {
+    CLIENT_SYSTEM_NAME,
+    PermissionName,
+    REALM_MASTER_NAME,
+    ROLE_ADMIN_NAME,
+    ScopeName,
+} from '@authup/core-kit';
+import type {
+    Client,
+    Permission,
+    Policy,
+    Realm,
+    Role,
+    Scope,
+    User,
+} from '@authup/core-kit';
+import { SystemPolicyName } from '@authup/access';
+import { Container } from 'eldin';
+import type { IContainer } from 'eldin';
+import type { Repository } from 'typeorm';
+import { IsNull } from 'typeorm';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import {
+    CacheModule,
+    ConfigModule,
+    DefaultProvisioningSource,
+    LoggerModule,
+    ProvisionerModule,
+} from '../../../src/index.ts';
+import {
+    ClientEntity,
+    PermissionEntity,
+    PolicyEntity,
+    RealmEntity,
+    RoleEntity,
+    ScopeEntity,
+    UserEntity,
+} from '../../../src/adapters/database/domains/index.ts';
+import { DatabaseInjectionKey } from '../../../src/app/modules/database/index.ts';
+import { createTestDatabaseModuleForSecondaryInstance } from '../../app/index.ts';
+
+// The provisioning lock is a no-op on better-sqlite3: one database file per
+// container means a second replica cannot reach it, so there is nothing to
+// serialize and this race does not exist in that topology.
+const lockable = ['mysql', 'postgres'].includes(process.env.DB_TYPE ?? '');
+
+// Schema synchronize plus two full provisioning passes, both before the first
+// assertion runs.
+const HOOK_TIMEOUT = 120_000;
+
+describe.skipIf(!lockable)('app/modules/provisioning (concurrency)', () => {
+    let di: IContainer;
+
+    const config = new ConfigModule();
+    const logger = new LoggerModule();
+    const cache = new CacheModule();
+    // An EMPTY database: the per-worker sqlite copy is a provisioned template,
+    // and this race only exists on the first boot.
+    const database = createTestDatabaseModuleForSecondaryInstance('provisioning-race');
+
+    beforeAll(async () => {
+        di = new Container();
+
+        await config.setup(di);
+        await logger.setup(di);
+        await cache.setup(di);
+        await database.setup(di);
+
+        // Two replicas booting at once. One DataSource is enough to model
+        // them: each setup() takes its own query runner, so the two contend
+        // on separate pooled connections, which is what the session-scoped
+        // advisory lock is arbitrated by.
+        await Promise.all([
+            new ProvisionerModule([new DefaultProvisioningSource()]).setup(di),
+            new ProvisionerModule([new DefaultProvisioningSource()]).setup(di),
+        ]);
+    }, HOOK_TIMEOUT);
+
+    afterAll(async () => {
+        await database.teardown(di);
+    });
+
+    it('should not crash the losing replica on a unique constraint', () => {
+        // Reaching the assertions at all is the assertion: an unserialized
+        // second pass loses the master-realm insert to
+        // `UQ auth_realms(name)`, and ProvisionerModule.setup has no catch.
+        expect(di.resolve(DatabaseInjectionKey.DataSource)).toBeDefined();
+    });
+
+    it('should provision the realm-bound rows exactly once', async () => {
+        const realmRepository = di.resolve<Repository<Realm>>(RealmEntity);
+        const clientRepository = di.resolve<Repository<Client>>(ClientEntity);
+        const userRepository = di.resolve<Repository<User>>(UserEntity);
+
+        expect(await realmRepository.countBy({ name: REALM_MASTER_NAME })).toEqual(1);
+        expect(await clientRepository.countBy({ name: CLIENT_SYSTEM_NAME })).toEqual(1);
+        expect(await userRepository.countBy({ name: 'admin' })).toEqual(1);
+    });
+
+    // The half no duplicate-key guard can reach. auth_permissions, auth_roles,
+    // auth_scopes and auth_policies are unique over a tuple carrying a
+    // nullable column, and every row the default source declares for them is
+    // global, so all three dialects treat the two inserts as distinct and
+    // write both. Nothing raises, and no cleanup pass removes them.
+    it('should provision the global rows exactly once', async () => {
+        const permissionRepository = di.resolve<Repository<Permission>>(PermissionEntity);
+        const roleRepository = di.resolve<Repository<Role>>(RoleEntity);
+        const scopeRepository = di.resolve<Repository<Scope>>(ScopeEntity);
+        const policyRepository = di.resolve<Repository<Policy>>(PolicyEntity);
+
+        expect(await permissionRepository.countBy({
+            name: PermissionName.REALM_READ,
+            realmId: IsNull(),
+            clientId: IsNull(),
+        })).toEqual(1);
+
+        expect(await roleRepository.countBy({
+            name: ROLE_ADMIN_NAME,
+            realmId: IsNull(),
+            clientId: IsNull(),
+        })).toEqual(1);
+
+        expect(await scopeRepository.countBy({
+            name: ScopeName.GLOBAL,
+            realmId: IsNull(),
+        })).toEqual(1);
+
+        expect(await policyRepository.countBy({
+            name: SystemPolicyName.DEFAULT,
+            realmId: IsNull(),
+        })).toEqual(1);
+    });
+});


### PR DESCRIPTION
Closes #3356.

## What the issue gets right, and what it misses

The issue reports a crash: two replicas booting against an unprovisioned database both take the "absent" branch of a find-then-insert pair, and the loser gets a driver-level unique violation out of `save`. That is real. `auth_realms(name)`, `auth_clients(name, realm_id)`, `auth_users(name, realm_id)` and every junction (each unique over its two id columns, both NOT NULL) genuinely collide, and the first statement in the boot graph that can reach it is the master-realm insert.

But that is only half of what happens, and the quieter half is worse:

| table | unique key | on a concurrent second insert |
|---|---|---|
| `auth_realms`, `auth_clients`, `auth_users`, junctions | NOT NULL columns | raises, replica fails to boot |
| `auth_permissions`, `auth_roles` | `name, client_id, realm_id`, **both nullable** | silently duplicates |
| `auth_scopes`, `auth_policies` | `name, realm_id`, **nullable** | silently duplicates |

`DefaultProvisioningSource` declares every permission, role, scope and policy as global, so `client_id` and `realm_id` are null. All three supported dialects treat nulls as distinct in a unique index, so nothing raises: both replicas insert the entire global permission catalogue, both global roles, every global scope and every system policy. Nothing cleans them up afterwards — `PolicyProvisioningSynchronizer.cleanupStaleTopLevel` only prunes names absent from the declared set, so a duplicate of a *declared* name survives.

This is why the issue's preferred options 1 and 2 were not taken. Both catch the duplicate-key error and re-read; for those four types there is no error to catch. Serialization does not care whether the database refuses the second insert, so it is the only shape that closes both halves.

## The change

`ProvisionerModule.setup` is renamed to `protected provision(container)`, body untouched, and a new `setup()` wraps it in `withDatabaseLock` (`adapters/database/helpers/advisory-lock.ts`): `pg_try_advisory_lock` on postgres, `GET_LOCK` on mysql, a passthrough on better-sqlite3. The helper is generic mechanism and the lock identity is a parameter, so the provisioning-specific `PROVISIONING_DATABASE_LOCK` lives with the provisioning module rather than in the database layer; the identity is bound, never interpolated into the statement. No write site is guarded, no repository port grew a method, boot stays fatal.

That last point is deliberate. Provisioning seeds the authorization graph, so a replica that comes up without the master realm, the admin user or the permission catalogue passes a container health check while being useless. On lock timeout the helper throws rather than proceeding unlocked, because proceeding *is* the pre-fix behaviour: failing is what today's losing replica does anyway, and the deployment restarts it, by which point the winner has finished and the pass is a no-op.

Four mechanics are load-bearing rather than incidental, and each is a way this could have shipped silently broken:

- The lock is **session-scoped**, so it takes a dedicated query runner. `dataSource.query()` would acquire and release on different pooled connections.
- It is **counted** in both dialects, so it is acquired exactly once.
- It is **released explicitly** before the runner goes back to the pool. Skipping that leaks it for the process lifetime, and a second `setup()` then deadlocks against itself.
- The acquisition answer is **normalized, not tested for truthiness**. Traced against a live server: postgres returns `[{"acquired":true}]` and mysql2 returns the *string* `[{"acquired":"1"}]` / `[{"acquired":"0"}]`. A truthiness check reads a lock held by another session as acquired and makes the entire mechanism inert on mysql.

better-sqlite3 creates no runner at all: one database file per container means a second replica cannot reach it, and `BetterSqlite3Driver.createQueryRunner` hands out one shared runner (`this.queryRunner ??= ...`), so holding one would nest inside whatever else is running. Same shape and same reasoning as `isDatabaseTypeRowLockable`.

## Verification

- `test/unit/adapters/database/advisory-lock.spec.ts`, 16 cases over a fake DataSource, runs on every dialect. Neutering `withDatabaseLock` to an unconditional passthrough fails 15 of them (the survivor is the sqlite case, a passthrough either way).
- `test/unit/modules/provisioning-concurrency.spec.ts` boots two `ProvisionerModule` instances concurrently against one empty database and asserts single rows for the realm/client/user **and** for a global permission, role, scope and policy — the assertions no catch-based design could pass. Gated to mysql/postgres. Neutered, it fails with `duplicate key value violates unique constraint "UQ_9b95dc8c08d8b11a80a6798a640"`, the `auth_realms(name)` collision the issue reports.
- Passes on postgres and mysql. Traced under the lock: one replica acquires immediately, the other polls (`false,false,true` on pg, `"0","0","0","1"` on mysql) and then provisions.
- Full server-core suite on sqlite: 2371 passed, 10 skipped, 0 failed. `tsc -p tsconfig.test.json` and eslint clean.

## Residuals, stated rather than papered over

- **The schema hole stays open.** The lock prevents boot-vs-boot duplication in those four tables; it does not make it structurally impossible. That needs `NULLS NOT DISTINCT` or an expression index over coalesced sentinels, which TypeORM cannot express in entity metadata, plus a dedupe migration for clusters that already raced. Filed separately.
- **Boot vs a live `POST /realms` is not serialized**, and the two sides are not symmetric: `RealmService.save` wraps each provisioner and logs, while the boot backfill loop has no catch and can still abort. The window is a realm created in the seconds a replica takes to boot, and the restart reconciles it.
- **`RealmService.save` runs no `checkUniqueness`**, so two concurrent `POST /realms` with one name give the loser an unmapped 500 rather than a 409.
- **On mysql the mutex is instance-wide**, not per-database, since a named lock is scoped to the mysqld instance while a postgres advisory lock carries the database OID. Two authup databases on one server delay each other's first boot rather than corrupting it. Confirmed by probing, and recorded in the code comment.

Docs: a `Concurrent boots: the provisioning lock` subsection in `.agents/architecture.md` and a paragraph in `.agents/testing.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added deployment-wide locking during database provisioning to prevent duplicate records and startup failures when multiple instances initialize concurrently.
  * Provisioning now waits for an available lock and reports a failure if it cannot be acquired within the timeout.

* **Documentation**
  * Added documentation describing provisioning concurrency behavior, locking mechanics, and related test coverage.

* **Tests**
  * Added coverage for lock acquisition, polling, timeouts, cleanup, and concurrent provisioning across supported databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
