### PR TITLE
feat: record an audit event per back-channel logout delivery

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -4034,7 +4034,7 @@ local-only — the round-trip is the chosen mechanism, **not** a
 `DELETE /sessions/@me` (which would collide with the #3191 interactive-login
 session reuse → self-DoS of fresh logins).
 
-### Back-channel logout (OIDC Back-Channel Logout 1.0, plan 064 Stages 1+2)
+### Back-channel logout (OIDC Back-Channel Logout 1.0, plan 064)
 
 `Client.backchannelLogoutUri` (`auth_clients.backchannel_logout_uri`, nullable
 `varchar(2000)`; one absolute http(s) URL of at most 2000 characters, no
@@ -4130,8 +4130,34 @@ other RP on that session that it ended.
   The URI is an `AClientForm` field, absent from `buildSystemClientAttributes`
   (a system client has no RP behind it) and from the anonymous
   `ClientSummary`.
-- **Deferred (plan 064 Stage 3):** a per-delivery audit event in
-  `auth_events`. Today the only trace of a failed push is the warn line.
+- **Every delivery leaves an `auth_events` row (plan 064 Stage 3).** The
+  notifier records `backchannelLogout` for a `2xx` and
+  `backchannelLogoutFailed` for anything else, one row per client, so an
+  operator can list which RPs actually received the push
+  (`GET /events?filter[name]=backchannelLogoutFailed`). The row is about the
+  CLIENT (`refType: client`, `refId` and `clientId` the RP's id), carries the
+  ended session under `sessionId`, is attributed to the session's subject
+  like the `logout` row, and is realm-scoped to the client's realm like the
+  token's `iss`. `data.jti` is the logout token's id, so the row can be
+  matched against the RP's own log of what it received; a failed row adds
+  `status` (the RP answered, with that code) or `errorCode` (it never
+  answered: the first `code` on the error's cause chain, `ECONNREFUSED`,
+  `ENOTFOUND`, `ERR_TLS_CERT_ALTNAME_INVALID`, else the error's name,
+  `TimeoutError` for the abort), and a signing failure carries no `jti`
+  because no token existed. **The row carries a CODE and never the rendered
+  error**: `describeCauseChain` renders the innermost message with its
+  `address=` and `port=`, a DNS failure names the RP hostname, a TLS failure
+  the certificate's altnames, and the row is attributed to the session's
+  subject, whom `EventService.getMany` answers with their own rows
+  self-service while `backchannelLogoutUri` itself is withheld from them
+  (absent from `ClientSummary`, gated by `CLIENT_READ`). The rendering stays
+  in the `warn` line, which is the log's. A client with
+  no `backchannelLogoutUri` never enters the audience, so nothing is recorded
+  for it: "skipped" would be one row per silent client per logout, which is
+  noise rather than a trace. The rows ride the default retention and are
+  recorded through the same `IEventService` every other OAuth2 emit uses,
+  handed to the notifier by the `AuthenticationModule`, so a `record()`
+  failure is swallowed there and never reaches the revoke.
 
 ## Application Access Policy (plan 052)
 
@@ -6073,8 +6099,11 @@ hub lacks: a **closed taxonomy** (`EventName`/`EventScope` enums in
   rather than a new key because `sanitizeEventData`'s allow-list is closed),
   `REFRESH_REPLAY_DETECTED` (`revokeFamily`), `AUTHORIZE`
   (`OAuth2Authorization.authorize()`, `data.reason: autoConsent|consent` from
-  `client.builtIn`), `LOGOUT` (end-session hint revoke), `REGISTER` /
-  `ACCOUNT_ACTIVATED`, `PASSWORD_RESET_REQUESTED/COMPLETED`, and the
+  `client.builtIn`), `LOGOUT` (end-session hint revoke),
+  `BACKCHANNEL_LOGOUT` / `BACKCHANNEL_LOGOUT_FAILED` (one per RP the
+  `OAuth2BackchannelLogoutNotifier` delivers a logout token to, `refType:
+  client`, `data.jti` plus `status` or `errorCode`; see *Back-channel logout*),
+  `REGISTER` / `ACCOUNT_ACTIVATED`, `PASSWORD_RESET_REQUESTED/COMPLETED`, and the
   **key / trust-anchor lifecycle** (issue #3269): `KeyService` /
   `TrustAnchorService` record ENTITY-scope `created`/`updated`/`deleted`
   rows themselves (both entities are deliberately subscriber-less, so the

--- a/apps/server-core/src/app/modules/authentication/module.ts
+++ b/apps/server-core/src/app/modules/authentication/module.ts
@@ -12,6 +12,7 @@ import type { IContainer } from 'eldin';
 import { OAuth2BackchannelLogoutNotifier, SessionManager } from '../../../core/index.ts';
 import { CacheInjectionKey } from '../cache/index.ts';
 import { ConfigInjectionKey } from '../config/index.ts';
+import { DatabaseInjectionKey } from '../database/index.ts';
 import { LoggerInjectionKey } from '../logger/index.ts';
 import { OAuth2InjectionToken } from '../oauth2/index.ts';
 
@@ -62,6 +63,7 @@ export class AuthenticationModule implements IModule {
                         sessionTokenRepository: c.resolve(OAuth2InjectionToken.SessionTokenRepository),
                         clientRepository: c.resolve(OAuth2InjectionToken.ClientRepository),
                         options: { issuer: config.publicUrl },
+                        eventService: c.resolve(DatabaseInjectionKey.EventService),
                         logger: c.resolve(LoggerInjectionKey),
                     }),
                 });

--- a/apps/server-core/src/core/oauth2/backchannel-logout/module.ts
+++ b/apps/server-core/src/core/oauth2/backchannel-logout/module.ts
@@ -6,12 +6,16 @@
  */
 
 import { randomUUID } from 'node:crypto';
-import type { Client, Session } from '@authup/core-kit';
+import type { Client, IdentityType, Session } from '@authup/core-kit';
+import { EventName, EventRefType, EventScope } from '@authup/core-kit';
 import type { Logger } from '@authup/server-kit';
 import type { OAuth2TokenPayload } from '@authup/specs';
 import { OAuth2TokenKind } from '@authup/specs';
+import { normalizeError } from '@authup/errors';
+import { isObject } from '@authup/kit';
 import { describeError } from '../../../utils/index.ts';
 import type { ISessionRevokeNotifier } from '../../authentication/session/types.ts';
+import type { IEventService } from '../../entities/event/types.ts';
 import type { IOAuth2ClientRepository } from '../client/types.ts';
 import type { ISessionTokenRepository } from '../session-token/types.ts';
 import type { IOAuth2TokenSigner } from '../token/signer/types.ts';
@@ -34,6 +38,8 @@ export class OAuth2BackchannelLogoutNotifier implements ISessionRevokeNotifier {
 
     protected options: OAuth2BackchannelLogoutNotifierOptions;
 
+    protected eventService?: IEventService;
+
     protected logger?: Logger;
 
     constructor(ctx: OAuth2BackchannelLogoutNotifierContext) {
@@ -41,6 +47,7 @@ export class OAuth2BackchannelLogoutNotifier implements ISessionRevokeNotifier {
         this.sessionTokenRepository = ctx.sessionTokenRepository;
         this.clientRepository = ctx.clientRepository;
         this.options = ctx.options;
+        this.eventService = ctx.eventService;
         this.logger = ctx.logger;
     }
 
@@ -74,8 +81,12 @@ export class OAuth2BackchannelLogoutNotifier implements ISessionRevokeNotifier {
             return;
         }
 
+        let jti: string | undefined;
+
         try {
-            const logoutToken = await this.signer.sign(this.buildPayload(session, client));
+            const payload = this.buildPayload(session, client);
+            const logoutToken = await this.signer.sign(payload);
+            jti = payload.jti;
 
             // `redirect: 'manual'`: a 3xx is the RP's refusal, not an
             // invitation to POST the token somewhere else.
@@ -94,10 +105,51 @@ export class OAuth2BackchannelLogoutNotifier implements ISessionRevokeNotifier {
                 this.logger?.warn(
                     `The back-channel logout of client ${client.id} was refused with status ${response.status}.`,
                 );
+                await this.record(session, client, { jti, status: response.status });
+                return;
             }
+
+            await this.record(session, client, { jti });
         } catch (e) {
             this.logger?.warn(describeError(e, `The back-channel logout of client ${client.id} failed.`));
+            await this.record(session, client, { jti, errorCode: describeFailureCode(e) });
         }
+    }
+
+    /**
+     * One audit row per delivery (plan 064 stage 3), so an operator can see
+     * which RPs actually received the push. The row is about the CLIENT
+     * (the RP told), attributed to the session's subject like the LOGOUT
+     * row, and realm-scoped like the token's `iss`. `jti` correlates it with
+     * the RP's own log of the logout token; a failed one carries the status
+     * the RP answered or the code of the failure that kept it from answering.
+     * A CODE and never the rendered error: the subject reads its own rows
+     * self-service, and the message names the RP's resolved address, which
+     * is the log's business (`describeError` above) and not theirs.
+     */
+    protected async record(
+        session: Session,
+        client: Client,
+        data: {
+            jti?: string, 
+            status?: number, 
+            errorCode?: string 
+        },
+    ): Promise<void> {
+        await this.eventService?.record({
+            scope: EventScope.OAUTH2,
+            name: data.status !== undefined || data.errorCode !== undefined ?
+                EventName.BACKCHANNEL_LOGOUT_FAILED :
+                EventName.BACKCHANNEL_LOGOUT,
+            refType: EventRefType.CLIENT,
+            refId: client.id,
+            clientId: client.id,
+            sessionId: session.id,
+            actorType: session.subKind as `${IdentityType}`,
+            actorId: session.sub,
+            realmId: client.realmId,
+            data,
+        });
     }
 
     protected buildPayload(session: Session, client: Client): OAuth2TokenPayload {
@@ -131,4 +183,23 @@ export class OAuth2BackchannelLogoutNotifier implements ISessionRevokeNotifier {
 
         return `${base}/realms/${client.realm.name}`;
     }
+}
+
+/**
+ * The first `code` on the error or its cause chain (`ECONNREFUSED`,
+ * `ENOTFOUND`, `ERR_TLS_CERT_ALTNAME_INVALID`, ...), else the error's name
+ * (`TimeoutError` for the abort, `Error` for a failed signing).
+ */
+function describeFailureCode(input: unknown): string {
+    let current: unknown = input;
+    // bounded like describeCauseChain: a cause chain can be cyclic
+    for (let depth = 0; isObject(current) && depth < 8; depth++) {
+        const { code, cause } = current as { code?: unknown, cause?: unknown };
+        if (typeof code === 'string') {
+            return code;
+        }
+        current = cause;
+    }
+
+    return normalizeError(input).name;
 }

--- a/apps/server-core/src/core/oauth2/backchannel-logout/types.ts
+++ b/apps/server-core/src/core/oauth2/backchannel-logout/types.ts
@@ -6,6 +6,7 @@
  */
 
 import type { Logger } from '@authup/server-kit';
+import type { IEventService } from '../../entities/event/types.ts';
 import type { IOAuth2ClientRepository } from '../client/types.ts';
 import type { ISessionTokenRepository } from '../session-token/types.ts';
 import type { IOAuth2TokenSigner } from '../token/signer/types.ts';
@@ -33,5 +34,10 @@ export type OAuth2BackchannelLogoutNotifierContext = {
     sessionTokenRepository: ISessionTokenRepository,
     clientRepository: IOAuth2ClientRepository,
     options: OAuth2BackchannelLogoutNotifierOptions,
+    /**
+     * Records one audit row per delivery (plan 064 stage 3): sent, or failed
+     * with the status or error the RP answered.
+     */
+    eventService?: IEventService,
     logger?: Logger,
 };

--- a/apps/server-core/test/unit/core/oauth2/backchannel-logout/module.spec.ts
+++ b/apps/server-core/test/unit/core/oauth2/backchannel-logout/module.spec.ts
@@ -7,7 +7,12 @@
 
 import { randomUUID } from 'node:crypto';
 import type { Client, Realm, Session } from '@authup/core-kit';
-import { IdentityType } from '@authup/core-kit';
+import { 
+    EventName, 
+    EventRefType, 
+    EventScope, 
+    IdentityType, 
+} from '@authup/core-kit';
 import { createNoopLogger } from '@authup/server-kit';
 import { OAuth2TokenKind } from '@authup/specs';
 import {
@@ -21,6 +26,7 @@ import {
 import { OAUTH2_BACKCHANNEL_LOGOUT_EVENT } from '../../../../../src/core/oauth2/backchannel-logout/constants.ts';
 import { OAuth2BackchannelLogoutNotifier } from '../../../../../src/core/oauth2/backchannel-logout/module.ts';
 import type { IOAuth2ClientRepository } from '../../../../../src/core/oauth2/client/types.ts';
+import { FakeEventService } from '../../helpers/fake-event-service.ts';
 import { FakeOAuth2TokenSigner } from '../../helpers/fake-oauth2-token-signer.ts';
 import { FakeSessionTokenRepository } from '../../helpers/fake-session-token-repository.ts';
 
@@ -107,6 +113,7 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
     const logger = createNoopLogger();
 
     let sessionTokenRepository: FakeSessionTokenRepository;
+    let eventService: FakeEventService;
     let fetchMock: ReturnType<typeof vi.fn>;
     let warn: ReturnType<typeof vi.spyOn>;
     let session: Session;
@@ -128,6 +135,7 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
             sessionTokenRepository,
             clientRepository,
             options: { issuer: 'https://auth.example.com/', ...options },
+            eventService,
             logger,
         });
 
@@ -137,6 +145,7 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
     beforeEach(() => {
         signer.signCalls = [];
         sessionTokenRepository = new FakeSessionTokenRepository();
+        eventService = new FakeEventService();
         session = createSession();
 
         fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
@@ -218,6 +227,31 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
             expect(warn).not.toHaveBeenCalled();
         });
 
+        it('records one audit row per delivered token, correlated by jti', async () => {
+            const a = createClient();
+            const b = createClient();
+            const { notifier } = buildNotifier([a, b]);
+
+            await notifier.notify(session, [a, b]);
+
+            expect(eventService.recordCalls).toHaveLength(2);
+            expect(eventService.recordCalls.map((call) => call.refId)).toEqual([a.id, b.id]);
+
+            const [row] = eventService.recordCalls;
+            expect(row).toMatchObject({
+                scope: EventScope.OAUTH2,
+                name: EventName.BACKCHANNEL_LOGOUT,
+                refType: EventRefType.CLIENT,
+                refId: a.id,
+                clientId: a.id,
+                sessionId: session.id,
+                actorType: IdentityType.USER,
+                actorId: session.sub,
+                realmId: a.realmId,
+            });
+            expect(row!.data).toEqual({ jti: signer.signCalls[0]!.jti });
+        });
+
         it('signs the claim set the specification requires and no nonce', async () => {
             const client = createClient();
             const { notifier } = buildNotifier([client], { issuer: 'https://auth.example.com/', maxAge: 120 });
@@ -273,6 +307,14 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
             expect(warn).toHaveBeenCalledTimes(1);
             expect(String(warn.mock.calls[0]![0])).toContain(client.id);
             expect(String(warn.mock.calls[0]![0])).toContain('500');
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            expect(eventService.recordCalls[0]).toMatchObject({
+                name: EventName.BACKCHANNEL_LOGOUT_FAILED,
+                refId: client.id,
+                sessionId: session.id,
+                data: { jti: signer.signCalls[0]!.jti, status: 500 },
+            });
         });
 
         it('logs and resolves when the delivery throws', async () => {
@@ -285,6 +327,35 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
             expect(warn).toHaveBeenCalledTimes(1);
             expect(String(warn.mock.calls[0]![0])).toContain(client.id);
             expect(String(warn.mock.calls[0]![0])).toContain('ECONNREFUSED');
+
+            expect(eventService.recordCalls).toHaveLength(1);
+            expect(eventService.recordCalls[0]).toMatchObject({
+                name: EventName.BACKCHANNEL_LOGOUT_FAILED,
+                refId: client.id,
+                // a plain Error carries no code, so the name stands in
+                data: { jti: signer.signCalls[0]!.jti, errorCode: 'Error' },
+            });
+        });
+
+        it('records the code of a delivery that never got an answer, never its message', async () => {
+            const client = createClient();
+            const { notifier } = buildNotifier([client]);
+            // what undici raises for a refused connection: the address rides
+            // the cause's message, and the row must carry the code alone
+            fetchMock.mockRejectedValueOnce(new TypeError('fetch failed', { cause: Object.assign(new Error('connect ECONNREFUSED 10.0.0.1:443'), { code: 'ECONNREFUSED' }) }));
+            fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted due to timeout', 'TimeoutError'));
+            const cyclic = new Error('loop');
+            cyclic.cause = cyclic;
+            fetchMock.mockRejectedValueOnce(cyclic);
+
+            await notifier.notify(session, [client]);
+            await notifier.notify(session, [client]);
+            await notifier.notify(session, [client]);
+
+            expect(eventService.recordCalls[0]!.data).toEqual({ jti: signer.signCalls[0]!.jti, errorCode: 'ECONNREFUSED' });
+            expect(eventService.recordCalls[1]!.data).toEqual({ jti: signer.signCalls[1]!.jti, errorCode: 'TimeoutError' });
+            expect(eventService.recordCalls[2]!.data).toEqual({ jti: signer.signCalls[2]!.jti, errorCode: 'Error' });
+            expect(JSON.stringify(eventService.recordCalls)).not.toContain('10.0.0.1');
         });
 
         it('still delivers to the other clients when one delivery fails', async () => {
@@ -316,6 +387,15 @@ describe('OAuth2BackchannelLogoutNotifier', () => {
             expect(fetchMock).not.toHaveBeenCalled();
             expect(warn).toHaveBeenCalledTimes(1);
             expect(String(warn.mock.calls[0]![0])).toContain(client.id);
+
+            // no token was signed, so there is no jti to correlate
+            expect(eventService.recordCalls).toHaveLength(1);
+            expect(eventService.recordCalls[0]).toMatchObject({
+                name: EventName.BACKCHANNEL_LOGOUT_FAILED,
+                refId: client.id,
+                data: { errorCode: 'Error' },
+            });
+            expect(eventService.recordCalls[0]!.data!.jti).toBeUndefined();
         });
     });
 });

--- a/apps/server-core/test/unit/http/controllers/workflows/logout/backchannel.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/workflows/logout/backchannel.spec.ts
@@ -17,7 +17,7 @@ import {
     it,
 } from 'vitest';
 import type { Client, Realm, User } from '@authup/core-kit';
-import { ScopeName } from '@authup/core-kit';
+import { EventName, EventRefType, ScopeName } from '@authup/core-kit';
 import { Client as HTTPClient } from '@authup/core-http-kit';
 import { verifyToken } from '@authup/server-kit';
 import type { OAuth2TokenGrantResponse, OAuth2TokenPayload } from '@authup/specs';
@@ -253,6 +253,18 @@ describe('back-channel logout', () => {
             iss: idToken.iss,
         });
         expect(idToken.iss).toEqual(`${publicUrl.replace(/\/+$/, '')}/realms/${realm.name}`);
+
+        // the delivery left its audit row, correlated with the token the RP got
+        const { data: events } = await suite.client.event.getMany({ filters: { name: EventName.BACKCHANNEL_LOGOUT, sessionId } });
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            refType: EventRefType.CLIENT,
+            refId: client.id,
+            clientId: client.id,
+            actorId: user.id,
+            realmId: realm.id,
+            data: { jti: decodeJwtSegment(deliveries[0]!.token, 1).jti },
+        });
     });
 
     it('pushes one logout token when a verified id_token_hint ends the session', async () => {
@@ -319,5 +331,12 @@ describe('back-channel logout', () => {
         expect(deliveries).toHaveLength(1);
         // the session is gone regardless of what the client answered
         await expect(suite.client.session.getOne(sessionId)).rejects.toBeDefined();
+
+        const { data: events } = await suite.client.event.getMany({ filters: { name: EventName.BACKCHANNEL_LOGOUT_FAILED, sessionId } });
+        expect(events).toHaveLength(1);
+        expect(events[0]).toMatchObject({
+            refId: client.id,
+            data: { jti: decodeJwtSegment(deliveries[0]!.token, 1).jti, status: 500 },
+        });
     });
 });

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -285,3 +285,16 @@ notified concurrently, each request times out after 5 seconds, and a client
 that is unreachable or answers a non-`2xx` status is logged on the server and
 otherwise ignored. The API call that ended the session succeeds regardless.
 Do not treat a missing push as proof that the session is still alive.
+
+Every delivery is recorded in the security event log
+(`GET /events?filter[name]=backchannelLogout` for the pushes that landed,
+`filter[name]=backchannelLogoutFailed` for the ones that did not). A row
+names the client and the ended session, and its `data.jti` is the `jti` of
+the logout token, so it can be matched against your application's own log of
+the tokens it received. A failed row carries the `status` your endpoint
+answered with, or the `errorCode` when no answer arrived (`ECONNREFUSED`,
+`ENOTFOUND`, `TimeoutError` after the 5 seconds). The rows are attributed to
+the user who was signed out, not to your client, so your own client
+credentials list none of them: reading another subject's rows takes the
+`EVENT_READ` permission, an administrator's. Clients without a
+`backchannelLogoutUri` are never contacted and leave no row.

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -293,8 +293,9 @@ names the client and the ended session, and its `data.jti` is the `jti` of
 the logout token, so it can be matched against your application's own log of
 the tokens it received. A failed row carries the `status` your endpoint
 answered with, or the `errorCode` when no answer arrived (`ECONNREFUSED`,
-`ENOTFOUND`, `TimeoutError` after the 5 seconds). The rows are attributed to
-the user who was signed out, not to your client, so your own client
-credentials list none of them: reading another subject's rows takes the
-`EVENT_READ` permission, an administrator's. Clients without a
-`backchannelLogoutUri` are never contacted and leave no row.
+`ENOTFOUND`, `TimeoutError` after the 5 seconds); one carrying no `jti` at
+all is a token that could never be signed, so nothing was sent to you. The
+rows are attributed to the user who was signed out, not to your client, so
+your own client credentials list none of them: reading another subject's
+rows takes the `EVENT_READ` permission, an administrator's. Clients without
+a `backchannelLogoutUri` are never contacted and leave no row.

--- a/packages/core-kit/src/domains/event/constants.ts
+++ b/packages/core-kit/src/domains/event/constants.ts
@@ -26,6 +26,8 @@ export enum EventName {
     MFA_CHALLENGE_FAILED = 'mfaChallengeFailed',
     IDENTITY_PROVIDER_LINKED = 'identityProviderLinked',
     IDENTITY_PROVIDER_UNLINKED = 'identityProviderUnlinked',
+    BACKCHANNEL_LOGOUT = 'backchannelLogout',
+    BACKCHANNEL_LOGOUT_FAILED = 'backchannelLogoutFailed',
     CREATED = 'created',
     UPDATED = 'updated',
     DELETED = 'deleted',


### PR DESCRIPTION
Closes plan 064 (OIDC back-channel logout) by delivering its last open item, stage 3: delivery outcomes become audit events, so an operator can see which relying parties actually received the push. Until now the only trace of one was a `warn` line on a failure.

## What it does

`OAuth2BackchannelLogoutNotifier` takes an optional `eventService` and records one `auth_events` row per delivery:

| | |
|---|---|
| `backchannelLogout` | the RP answered `2xx` |
| `backchannelLogoutFailed` | anything else |

The row is about the **client** (`refType: client`, `refId` and `clientId` the RP's id), carries the ended session under `sessionId`, is attributed to the session's subject like the sibling `logout` row, and is realm-scoped to the client's realm like the token's `iss`. `data.jti` is the logout token's id, so a row can be matched against the RP's own log of what it received; a failed row adds `status` (the RP answered, with that code) or `errorCode` (it never answered).

```
GET /events?filter[name]=backchannelLogoutFailed
```

## The failed row carries a code, never the rendered error

`describeCauseChain` is the log renderer: it appends `address=` and `port=`, a DNS failure names the RP hostname, a TLS failure the certificate's altnames. The row is attributed to the session's subject, whom `EventService.getMany` answers with their own rows self-service, while `backchannelLogoutUri` itself is withheld from that user (absent from `ClientSummary`, gated by `CLIENT_READ`). So the rendering stays in the `warn` line, which is the log's, and `describeFailureCode` walks the cause chain for the first `code` instead (`ECONNREFUSED`, `ENOTFOUND`, `ERR_TLS_CERT_ALTNAME_INVALID`, else the error's name, `TimeoutError` for the abort). A spec pins that the address never reaches the row.

## Deliberately not included

No `skipped-no-uri` event. A client without a logout URI never enters the audience, and a row per silent client per logout is noise rather than a trace.

## Scope

Two `EventName` members, an optional context field on the notifier, one `record()` method, one wiring line in `AuthenticationModule`. No new port and no per-site hooks: `SessionManager.revoke` was already the single chokepoint, and `IEventService.record` is contractually non-throwing, so a failed audit write can never reach the revoke. No migration: `auth_events.name` is a `varchar(64)` with no database enum.

## Verification

| Check | Result |
|---|---|
| server-core suite | 2357 passed, 7 skipped |
| notifier unit spec | 13 passed |
| HTTP back-channel spec | 5 passed, incl. two new end-to-end row assertions |
| `check:types`, eslint | clean |

Docs updated: the back-channel section of `.agents/architecture.md` and its emit-site list, plus the OAuth2 API guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added security event logging for OAuth 2.0 back-channel logout deliveries.
  - Successful deliveries and failed or refused deliveries now generate distinct audit events with relevant session, client, token, status, or failure details.
  - Documented access rules and behavior for back-channel logout audit records.

- **Tests**
  - Added coverage for successful deliveries, refusals, delivery errors, timeouts, and signing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->