### PR TITLE
ci: move the floating semver tags with the beta line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,12 +52,16 @@ jobs:
 
                     # latest deliberately follows prereleases while no stable line exists (docs reference authup/authup:latest)
                     TAGS="latest"
+                    IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION%%-*}"
+                    TAGS+=$'\n'"$MAJOR"$'\n'"$MAJOR.$MINOR"
                     if [[ "$VERSION" == *-* ]]; then
                         PRERELEASE="${VERSION#*-}"
-                        TAGS+=$'\n'"${PRERELEASE%%.*}"
-                    else
-                        IFS='.' read -r MAJOR MINOR _ <<< "$VERSION"
-                        TAGS+=$'\n'"$MAJOR"$'\n'"$MAJOR.$MINOR"
+                        # The floating semver tags follow the beta line too. They cannot be
+                        # removed from the registry, so leaving them on the last release that
+                        # published them (1.0.0-beta.53) would keep serving a stale image to
+                        # every deployment pinning 1 / 1.0 / 1.0.0. Drop the MAJOR.MINOR.PATCH
+                        # line below once stable v1.0.0 ships and the tags mean what they say.
+                        TAGS+=$'\n'"$MAJOR.$MINOR.$PATCH"$'\n'"${PRERELEASE%%.*}"
                     fi
                     TAGS+=$'\n'"$VERSION"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,15 @@ jobs:
                     VERSION="${VERSION#v}"
                     echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
+                    # A malformed version would publish malformed tags and, worse, move the
+                    # floating 1 / 1.0 / 1.0.0 tags onto whatever the dispatched ref builds.
+                    # workflow_dispatch takes the value from a human; the release path leaves
+                    # it empty when release-please cut nothing, and then publishes nothing.
+                    if [[ -n "$VERSION" && ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+                        echo "::error::Invalid version '$VERSION'. Expected MAJOR.MINOR.PATCH or MAJOR.MINOR.PATCH-PRERELEASE."
+                        exit 1
+                    fi
+
                     # latest deliberately follows prereleases while no stable line exists (docs reference authup/authup:latest)
                     TAGS="latest"
                     IFS='.' read -r MAJOR MINOR PATCH <<< "${VERSION%%-*}"


### PR DESCRIPTION
## Problem

`d3043c5a3` (beta.54) split the docker tag set so that `1`, `1.0` and `1.0.0` are published for stable releases only. That was the right call in isolation — the old workflow rebuilt the version from release-please's `major`/`minor`/`patch` outputs, which drop the prerelease suffix, so every beta was silently overwriting a `1.0.0` tag that was not 1.0.0.

The side effect is that those three tags froze at `1.0.0-beta.53` (2026-07-17, the last release cut before the split) and stay there until a stable 1.0.0 ships. They cannot be removed from the registry, so every deployment pinning one of them keeps pulling that image indefinitely, with no error and no signal. `pull_policy: always` does not help — the tag simply never moves.

This is not hypothetical: `dnpm-dip/deployment` pins `authup/authup:1` and is therefore stuck 11 releases back.

Serving a stale image forever is worse than the naming impurity the split avoided.

## Change

Publish `MAJOR`, `MAJOR.MINOR` and `MAJOR.MINOR.PATCH` for prereleases as well, alongside the channel tag and the full version, so the floating tags track the beta line.

| Version | Tags published |
|---|---|
| `1.0.0-beta.65` | `latest` `1` `1.0` `1.0.0` `beta` `1.0.0-beta.65` |
| `1.0.0` (stable) | `latest` `1` `1.0` `1.0.0` |
| `1.2.3` | `latest` `1` `1.2` `1.2.3` |
| `2.0.0-rc.1` | `latest` `2` `2.0` `2.0.0` `rc` `2.0.0-rc.1` |

Stable output is unchanged and carries no duplicate. This mirrors the posture `latest` already has — it deliberately follows prereleases while no stable line exists.

The prerelease branch is marked to be removed at stable v1.0.0, at which point the tags mean what they say again.

## Note

The tags start moving with the next release. `workflow_dispatch` is not a backfill route: the checkout step pins no `ref`, so a dispatched run builds the default branch and would publish master content under the given version label.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Version handling now rejects invalid non-empty versions that do not follow the supported `MAJOR.MINOR.PATCH` format, including optional prerelease suffixes.

- **Release Improvements**
  - Docker images now consistently receive major and major-minor tags.
  - Prerelease builds also receive precise version and prerelease identifier tags for easier image selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->