### PR TITLE
fix(server-core): read-gate hashed client secrets like plaintext ones

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -213,11 +213,14 @@ usable at the service level and nothing in core depends on TypeORM:
   with `null`, so a negated leg — or an `ownOrNull` reach's
   null-inclusive realm leg — would match an unfetched column.
   Today's only gated column is `client.secret`: `allow` verdict →
-  ungated; otherwise visible iff the stored value discloses nothing
-  (`secret` null / hashed) OR covered by the compiled
-  `CLIENT_READ/UPDATE/DELETE` condition OR the actor's own client row
-  (self leg — preserves the service-level isMe contract in list
-  shape). `secretEncrypted` is deliberately NOT a leg (plan 105): the
+  ungated; otherwise visible iff `secret` is null OR covered by the
+  compiled `CLIENT_READ/UPDATE/DELETE` condition OR the actor's own
+  client row (self leg — preserves the service-level isMe contract in
+  list shape). A hashed value took no gate until #3328 (it stayed
+  visible to any pre-gated reader, foreign realms included): a bcrypt
+  hash of an admin-chosen secret is offline-crackable and no reader
+  needs another realm's, so it is gated like a plaintext, and
+  `ClientService.getOne` denies a foreign hashed row the same way. `secretEncrypted` is deliberately NOT a leg (plan 105): the
   flag encrypted nothing before the mode existed (#3351), and now that
   it does, the stored value is a realm cipher blob that
   `ClientService.revealSecret` decrypts AFTER the redaction has run, so

--- a/apps/server-core/src/core/entities/client/schema.ts
+++ b/apps/server-core/src/core/entities/client/schema.ts
@@ -29,15 +29,16 @@ const schemaMapping = { realm: EntityType.REALM, accessPolicy: EntityType.POLICY
  * client-permission / client-role / client-scope, which never run
  * `ClientService`'s read path.
  *
- * Only rows exposing a READABLE secret are guarded: `null` and hashed
- * values stay visible to any actor that passed the read pre-gate (the
- * historical service semantics). A plaintext value is additionally
- * visible on the actor's OWN client row (the `getOne` isMe bypass,
- * list-shaped) and on rows the compiled permission condition covers.
- * `secretEncrypted` is deliberately NOT a leg: the flag never encrypted
- * anything (#3351), and once it does (plan 105 PR 2) the value is
- * decrypted for exactly the readers a plaintext value reaches. A non-expressible (`post`) or settled-deny compile
- * yields no permission leg — fail closed for plaintext rows rather
+ * Only a `null` value is visible to every actor that passed the read
+ * pre-gate. Every stored form takes the gate: a plaintext is the secret
+ * itself, an encrypted value is decrypted for exactly the readers a
+ * plaintext reaches (plan 105), and a hashed value, visible to any
+ * pre-gated reader until #3328, is a bcrypt hash of an admin-chosen
+ * secret and therefore offline-crackable, with no reader-facing reason
+ * to ship it across realms. A gated value is visible on the actor's OWN
+ * client row (the `getOne` isMe bypass, list-shaped) and on rows the
+ * compiled permission condition covers. A non-expressible (`post`) or
+ * settled-deny compile yields no permission leg — fail closed rather
  * than falling back to per-row evaluation.
  *
  * The outer `ne('realmId', null)` guard is semantically inert (clients
@@ -55,7 +56,6 @@ async function secretReadGate(actor: ActorContext) : Promise<KeyValidationVerdic
 
     const visible : ICondition[] = [
         eq('secret', null),
-        eq('secretHashed', true),
     ];
 
     if (compiled.verdict === 'conditional') {

--- a/apps/server-core/src/core/entities/client/service.ts
+++ b/apps/server-core/src/core/entities/client/service.ts
@@ -126,14 +126,11 @@ export class ClientService extends AbstractEntityService implements IClientServi
             await actor.permissionEvaluator.preEvaluateOneOf({ name: CLIENT_READ_PERMISSIONS });
         }
 
-        // A hashed value discloses nothing; every other stored form is the
-        // secret itself (encrypted rows are decrypted for a permitted reader
-        // from plan 105 PR 2 on), so it takes the reach evaluate.
-        if (
-            !isMe &&
-            entity.secret &&
-            !entity.secretHashed
-        ) {
+        // Every stored form takes the reach evaluate: a plaintext is the
+        // secret itself, an encrypted value is decrypted for a permitted
+        // reader (plan 105), and a hash is offline-crackable and has no
+        // reader-facing reason to cross realms (#3328).
+        if (!isMe && entity.secret) {
             await actor.permissionEvaluator.evaluateOneOf({
                 name: CLIENT_READ_PERMISSIONS,
                 data: definePolicyData({ [BuiltInPolicyType.ATTRIBUTES]: entity, ...this.resourceRealmMatch(entity) }),

--- a/apps/server-core/test/unit/core/entities/client/service.spec.ts
+++ b/apps/server-core/test/unit/core/entities/client/service.spec.ts
@@ -135,7 +135,7 @@ describe('core/entities/client/service', () => {
             expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 
-        it('redacts uncovered plaintext secrets instead of dropping rows when the projection selects secret', async () => {
+        it('redacts uncovered plaintext and hashed secrets instead of dropping rows when the projection selects secret', async () => {
             const realmA = randomUUID();
             const realmB = randomUUID();
             const rows = repository.seed([
@@ -178,8 +178,8 @@ describe('core/entities/client/service', () => {
 
             // the schema gate rides the decoded query as a field visibility
             // condition — replaying it drops the uncovered PLAINTEXT value
-            // while every row keeps listing; hashed / secret-less rows keep
-            // their value regardless of the compiled condition
+            // while every row keeps listing; a secret-less row keeps its null,
+            // and a foreign HASHED value is redacted like a plaintext (#3328)
             const query = spy.mock.calls[0]![0];
             const applied = applyQuery(query, rows);
             expect(applied.data.map((row) => row.name).sort())
@@ -189,7 +189,7 @@ describe('core/entities/client/service', () => {
             expect(byName.get('safe')).toHaveProperty('secret', null);
             expect(byName.get('plain-covered')).toHaveProperty('secret', 'mysecret');
             expect(byName.get('plain-foreign')).not.toHaveProperty('secret');
-            expect(byName.get('hashed-foreign')).toHaveProperty('secret', '$2b$10$hash');
+            expect(byName.get('hashed-foreign')).not.toHaveProperty('secret');
             expect(actor.permissionEvaluator.evaluateOneOfCalls).toHaveLength(0);
         });
 

--- a/apps/server-core/test/unit/core/query/module.spec.ts
+++ b/apps/server-core/test/unit/core/query/module.spec.ts
@@ -270,11 +270,10 @@ describe('core/query', () => {
 
             const field = findField(parsed, 'secret');
             expect(field!.condition).toBeDefined();
-            // realm presence guard, non-plaintext legs, then the compiled leg
+            // realm presence guard, the null leg, then the compiled leg
             expect(collectFieldConditions(field!.condition!)).toEqual([
                 ['realmId', null],
                 ['secret', null],
-                ['secretHashed', true],
                 ['realmId', 'realm-a'],
             ]);
         });
@@ -291,7 +290,6 @@ describe('core/query', () => {
             expect(collectFieldConditions(field!.condition!)).toEqual([
                 ['realmId', null],
                 ['secret', null],
-                ['secretHashed', true],
             ]);
         });
 
@@ -317,7 +315,6 @@ describe('core/query', () => {
             expect(collectFieldConditions(field!.condition!)).toEqual([
                 ['realmId', null],
                 ['secret', null],
-                ['secretHashed', true],
                 ['id', selfId],
             ]);
         });

--- a/apps/server-core/test/unit/http/controllers/entities/client-secret-projection.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/client-secret-projection.spec.ts
@@ -49,12 +49,14 @@ describe('http/controllers (client secret projection)', () => {
     let foreignHashedClientId: string;
     let ownEncryptedClientId: string;
     let foreignEncryptedClientId: string;
+    let ownHashedClientId: string;
 
     const ownClientSecret = 'secret-projection-own';
     const foreignClientSecret = 'secret-projection-foreign';
     // a plaintext the server hashes at create; the projection then carries
     // the bcrypt form, never this value
     const foreignHashedSecret = 'secret-projection-hashed';
+    const ownHashedSecret = 'secret-projection-own-hashed';
     const ownEncryptedSecret = 'secret-projection-own-encrypted';
     const foreignEncryptedSecret = 'secret-projection-foreign-encrypted';
     const restrictedActorSecret = 'secret-projection-actor';
@@ -89,6 +91,14 @@ describe('http/controllers (client secret projection)', () => {
             secretEncrypted: false,
         });
         foreignHashedClientId = foreignHashedClient.id;
+
+        const { data: ownHashedClient } = await suite.client.client.create({
+            ...createFakeClient(),
+            secret: ownHashedSecret,
+            secretHashed: true,
+            secretEncrypted: false,
+        });
+        ownHashedClientId = ownHashedClient.id;
 
         // encrypted secrets follow the plaintext rule: decrypted for a reader
         // whose reach covers the row, redacted otherwise
@@ -205,15 +215,31 @@ describe('http/controllers (client secret projection)', () => {
         expect(byId.get(foreignClientId)!.secret).toBeUndefined();
     });
 
-    it('keeps a foreign HASHED secret visible to a permitted reader', async () => {
+    it('keeps an own-realm HASHED secret visible and redacts a foreign one', async () => {
         const response = await restrictedActor.client.getMany({
             fields: ['+secret'],
-            filters: { id: [foreignHashedClientId] },
+            filters: { id: [ownHashedClientId, foreignHashedClientId] },
         });
 
-        expect(response.data).toHaveLength(1);
-        expect(isBCryptHash(response.data[0].secret!)).toBe(true);
-        expect(response.data[0].secret).not.toEqual(foreignHashedSecret);
+        expect(response.data).toHaveLength(2);
+        const byId = new Map(response.data.map((row) => [row.id, row]));
+        // a covered reader gets the hash, never the plaintext; a foreign
+        // realm's hash is offline-crackable and is redacted (#3328)
+        expect(isBCryptHash(byId.get(ownHashedClientId)!.secret!)).toBe(true);
+        expect(byId.get(ownHashedClientId)!.secret).not.toEqual(ownHashedSecret);
+        expect(byId.get(foreignHashedClientId)!.secret).toBeUndefined();
+    });
+
+    it('serves an own-realm hashed secret on a single read and denies a foreign one', async () => {
+        const own = await restrictedActor.client.getOne(ownHashedClientId, { fields: ['+secret'] });
+        expect(isBCryptHash(own.data.secret!)).toBe(true);
+
+        // the single read has no field to redact, so a foreign hashed row is
+        // refused outright, exactly as a foreign plaintext row already was
+        await expectClientError(
+            () => restrictedActor.client.getOne(foreignHashedClientId, { fields: ['+secret'] }),
+            { status: 403 },
+        );
     });
 
     it('decrypts an own encrypted secret and redacts a foreign one', async () => {
@@ -247,15 +273,15 @@ describe('http/controllers (client secret projection)', () => {
         expect(foreignRow.client!.secret).toBeUndefined();
     });
 
-    it('keeps a hashed secret visible on the client-permission fields[client] projection', async () => {
+    it('redacts a foreign hashed secret on the client-permission fields[client] projection', async () => {
         const response = await restrictedActor.clientPermission.getMany({
             fields: { client: ['id', 'secret'] },
             filters: { clientId: [foreignHashedClientId] },
         });
 
         expect(response.data).toHaveLength(1);
-        expect(isBCryptHash(response.data[0].client!.secret!)).toBe(true);
-        expect(response.data[0].client!.secret).not.toEqual(foreignHashedSecret);
+        expect(response.data[0].client).toBeDefined();
+        expect(response.data[0].client!.secret).toBeUndefined();
     });
 
     it('gates the client-role fields[client] projection', async () => {

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -7,6 +7,20 @@ either requires operator action or deliberately changes behavior.
 
 ## Next release (after v1.0.0-beta.64)
 
+### A hashed client secret is read-gated like a plaintext one
+
+A reader projecting `secret` (`?fields=+secret` on `/clients`, or
+`fields[client]` on the client-permission, client-role and client-scope
+collections) used to receive the bcrypt hash of every client that passed the
+read pre-gate, foreign realms included; only plaintext values were gated per
+row. A hash of an admin-chosen secret is offline-crackable and no reader needs
+another realm's, so a hashed value now takes the same gate a plaintext or an
+encrypted one does: it is projected on the reader's own client row and on rows
+the reader's permissions cover, and redacted elsewhere. `GET /clients/:id`
+with `?fields=+secret` answers `403` for a foreign hashed row, as it already did
+for a foreign plaintext one. A `realm_admin` listing clients with the field
+projected sees the change; an `admin` does not.
+
 ### Global permissions, roles, scopes and policies are unique by name
 
 The unique key of `auth_permissions`, `auth_roles`, `auth_scopes` and

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -37,6 +37,11 @@ modes. The mode is chosen when the client is created, through the two flags
 | `hashed` | `secretHashed: true` | a bcrypt hash | no |
 | `encrypted` | `secretEncrypted: true` | a cipher blob under the realm's encryption key | yes, by a reader whose permissions cover the client |
 
+Whatever the mode, the stored value is projected only to a reader whose
+permissions cover the client, or to the client itself; the hash of a `hashed`
+secret is no exception, since a hash of an admin-chosen value is
+offline-crackable. A reader outside that reach gets the row without the field.
+
 `encrypted` is the recoverable mode that keeps the plaintext out of the
 database. The value is encrypted at rest (AES-256-GCM) under the client
 realm's encryption key, the same automatically generated per-realm key that


### PR DESCRIPTION
Closes #3328.

## Summary

- The client `secret` read gate kept two legs open to every actor that passed the read pre-gate: `secret IS NULL` and `secretHashed = true`. #3562 already closed the encrypted case (the blob is decrypted for exactly the readers a plaintext reaches), so the hashed leg was the one left from the issue. It is gone: a hashed value is now projected on the reader's own client row and on rows the compiled `CLIENT_READ/UPDATE/DELETE` condition covers, and redacted elsewhere, exactly like a plaintext. A bcrypt hash of an admin-chosen secret is offline-crackable, and no reader needs another realm's.
- `ClientService.getOne` takes the same step: its post-fetch reach evaluate fired for plaintext only and now fires for every non-null stored form, so `GET /clients/:id?fields=+secret` on a foreign hashed row answers `403`, as it already did for a foreign plaintext row.
- Behaviour change called out in `upgrading.md`: a `realm_admin` listing clients with `fields=+secret` (root, or `fields[client]` on the client-permission / client-role / client-scope collections) no longer receives foreign realms' hashes. An `admin` sees no difference.

## Verification

- `client-secret-projection.spec.ts`: the two cases that pinned the old rule are flipped and gained an own-realm hashed fixture, so the change is proven a gate rather than a blanket hide (a covered reader still gets the hash, never the plaintext; a foreign one is redacted on the root and on `fields[client]`), plus a single-read case (own hashed served, foreign hashed `403`).
- `core/query/module.spec.ts` verdict matrix and the client service spec updated for the dropped leg.
- Full server-core sqlite suite, `check:types`, docs build green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Hashed client secrets now follow the same access controls as plaintext and encrypted secrets.
  * Unauthorized readers receive redacted secrets in listings, while direct access to foreign secrets returns `403`.
  * Authorized readers can still access secrets for permitted clients and their own client records.

* **Documentation**
  * Updated deployment and OAuth2 guidance to explain the revised hashed-secret visibility rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->