### PR TITLE
fix(server-core): make the field-condition redaction structural on every findMany

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -201,13 +201,18 @@ usable at the service level and nothing in core depends on TypeORM:
   traversal itself). Enforcement is two-part: the rapiq SQL adapter
   force-selects every column a condition reads (operand projection —
   the condition cannot go into the statement, a TypeORM selection must
-  stay a bare column for hydration), and EVERY `findMany` adapter runs
-  its fetched rows through `redactFieldConditions(query, entities)`
-  (`app/modules/database/repositories/query.ts`, wrapping
+  stay a bare column for hydration), and EVERY `findMany` adapter reads
+  its rows through `fetchMany(qb, query)`
+  (`app/modules/database/repositories/query.ts`), which executes the
+  builder and runs the module-private `redactFieldConditions` (wrapping
   `@rapiq/adapter-memory`'s `applyFieldConditions`) — failing values are
-  REDACTED, rows never drop, totals stay exact. The sweep is universal
-  because enforcement is fail-open by construction: a `findMany` that
-  skips the call ships the value. Author conditions FAIL-CLOSED over
+  REDACTED, rows never drop, totals stay exact. Enforcement is fail-open
+  by construction (a fetch that skips the redaction ships the value), so
+  it is structural rather than a convention (#3329): `fetchMany` is the
+  only exported fetch, and the root eslint config refuses a bare
+  `getManyAndCount` under every `repositories/` directory except that
+  file, so a new adapter cannot fetch a collection without redacting.
+  Author conditions FAIL-CLOSED over
   missing columns (positive legs + a presence guard like
   `ne('realmId', null)`): `@rapiq/adapter-memory` unifies a missing column
   with `null`, so a negated leg — or an `ownOrNull` reach's

--- a/apps/server-core/src/app/modules/authentication/repositories/session.ts
+++ b/apps/server-core/src/app/modules/authentication/repositories/session.ts
@@ -11,7 +11,7 @@ import type { EntityRepositoryFindManyResult, ICache } from '@authup/server-kit'
 import { buildCacheKey } from '@authup/server-kit';
 import type { Repository } from 'typeorm';
 import { LessThan } from 'typeorm';
-import { applyQuery, redactFieldConditions } from '../../database/repositories/query.ts';
+import { applyQuery, fetchMany } from '../../database/repositories/query.ts';
 import { SESSION_EXPIRY_SWEEP_BATCH_SIZE, hashSessionSecret } from '../../../../core/index.ts';
 import type {
     ISessionRepository,
@@ -103,10 +103,10 @@ export class SessionRepository implements ISessionRepository {
             });
         }
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client-permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client-permission/repository.ts
@@ -9,7 +9,7 @@ import type { ClientPermission } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientPermissionRepository } from '../../../../../core/entities/client-permission/types.ts';
 import { ClientPermissionEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class ClientPermissionRepositoryAdapter implements IClientPermissionRepos
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client-role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client-role/repository.ts
@@ -9,7 +9,7 @@ import type { ClientRole } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientRoleRepository } from '../../../../../core/entities/client-role/types.ts';
 import { ClientRoleEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class ClientRoleRepositoryAdapter implements IClientRoleRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client-scope/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client-scope/repository.ts
@@ -9,7 +9,7 @@ import type { ClientScope } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientScopeRepository } from '../../../../../core/entities/client-scope/types.ts';
 import { ClientScopeEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class ClientScopeRepositoryAdapter implements IClientScopeRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/client/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/client/repository.ts
@@ -12,7 +12,7 @@ import { buildRedisKeyPath } from '@authup/server-kit';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IClientRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -56,10 +56,10 @@ export class ClientRepositoryAdapter implements IClientRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/event/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/event/repository.ts
@@ -9,7 +9,7 @@ import type { Event } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { EntityManager, LessThan } from 'typeorm';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type {
     EventCountRecentFilter,
@@ -135,10 +135,10 @@ export class EventRepositoryAdapter implements IEventRepository {
             qb.andWhere(`(${constraints.length > 0 ? constraints.join(' OR ') : '1 = 0'})`, parameters);
         }
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider-account/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider-account/repository.ts
@@ -14,7 +14,7 @@ import type {
     DeepPartial, 
     Repository,
 } from 'typeorm';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import { IdentityProviderAccountEntity } from '../../../../../adapters/database/domains/index.ts';
 import { isUniqueConstraintDatabaseError } from '../../../../../adapters/database/errors/index.ts';
 import { isDatabaseTypeRowLockable } from '../../../../../adapters/database/helpers/index.ts';
@@ -65,10 +65,10 @@ export class IdentityProviderAccountRepositoryAdapter implements IIdentityProvid
             qb.andWhere('identityProviderAccount.userRealmId = :ownerRealmId', { ownerRealmId: options.realmId });
         }
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider-role-mapping/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider-role-mapping/repository.ts
@@ -9,7 +9,7 @@ import type { IdentityProviderRoleMapping } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IIdentityProviderRoleMappingRepository } from '../../../../../core/index.ts';
 import { IdentityProviderRoleMappingEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class IdentityProviderRoleMappingRepositoryAdapter implements IIdentityPr
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IIdentityProviderRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -40,10 +40,10 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/key/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/key/repository.ts
@@ -22,7 +22,7 @@ import { JWKType, JWKUse, JWTAlgorithm } from '@authup/specs';
 import type { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { Like } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import { getRandomValues } from 'uncrypto';
 import {
     ClientEntity,
@@ -330,10 +330,10 @@ export class KeyRepositoryAdapter implements IKeyRepository, IKeyStore {
 
         applyRealmScopeSelect(qb, 'keyEntity');
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/permission-policy/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/permission-policy/repository.ts
@@ -9,7 +9,7 @@ import type { PermissionPolicy } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IPermissionPolicyRepository } from '../../../../../core/index.ts';
 import { PermissionPolicyEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class PermissionPolicyRepositoryAdapter implements IPermissionPolicyRepos
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/permission/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IPermissionRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -39,10 +39,10 @@ export class PermissionRepositoryAdapter implements IPermissionRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/policy/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IPolicyRepository, IRealmRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -40,11 +40,11 @@ export class PolicyRepositoryAdapter implements IPolicyRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
         await this.repository.extendManyWithEA(entities);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/query.ts
+++ b/apps/server-core/src/app/modules/database/repositories/query.ts
@@ -9,7 +9,7 @@ import type { IQuery } from '@rapiq/core';
 import { Query, hasFieldConditions } from '@rapiq/core';
 import { applyFieldConditions } from '@rapiq/adapter-memory';
 import { TypeormAdapter } from '@rapiq/adapter-typeorm';
-import type { SelectQueryBuilder } from 'typeorm';
+import type { ObjectLiteral, SelectQueryBuilder } from 'typeorm';
 import type { EntityRepositoryPaginationMeta } from '@authup/server-kit';
 
 /**
@@ -30,8 +30,8 @@ import type { EntityRepositoryPaginationMeta } from '@authup/server-kit';
  * force-selects every column its condition reads (rapiq#830's operand
  * projection — the SQL counterpart of the plan-039 force-select
  * discipline, so a sparse replace-projection can neither over-redact
- * nor fail open on missing operands); the fetching adapter MUST then
- * run the rows through `redactFieldConditions` before returning them.
+ * nor fail open on missing operands); the fetching adapter then reads
+ * the rows through `fetchMany`, which is what runs the redaction.
  */
 export function applyQuery(
     queryBuilder: SelectQueryBuilder<any>,
@@ -54,15 +54,37 @@ export function applyQuery(
 }
 
 /**
+ * Execute a builder that `applyQuery` prepared and hand back the rows
+ * with the field visibility conditions enforced, plus the total the
+ * response meta needs. This is the ONE way a collection leaves the
+ * repository layer: the SQL path projects a gated column
+ * unconditionally, so a fetch that bypasses the redaction ships the
+ * value, which is why `getManyAndCount` is refused by lint under every
+ * repositories directory except this file (#3329). Post-processing
+ * that adds to the rows (the extra-attribute extension) runs on what
+ * this returns; the redaction touches gated columns alone.
+ */
+export async function fetchMany<T extends ObjectLiteral>(
+    queryBuilder: SelectQueryBuilder<T>,
+    query?: IQuery,
+) : Promise<{ data: T[], total: number }> {
+    const [entities, total] = await queryBuilder.getManyAndCount();
+
+    return {
+        data: redactFieldConditions(query, entities),
+        total,
+    };
+}
+
+/**
  * Enforce the field visibility conditions of a decoded query on
  * already-fetched rows: a gated column is dropped from every row that
- * fails its condition; no row is ever removed. The SQL execution path
- * projects gated columns unconditionally, so EVERY `findMany` adapter
- * must pass its fetched entities through this before returning them —
- * enforcement is fail-open by construction (a skipped call ships the
- * value). Condition-less queries pass through untouched.
+ * fails its condition; no row is ever removed. Condition-less queries
+ * pass through untouched. Module-private on purpose: `fetchMany` is the
+ * only exported fetch, so an adapter cannot obtain rows without passing
+ * through here.
  */
-export function redactFieldConditions<T>(query: IQuery | undefined, data: T[]) : T[] {
+function redactFieldConditions<T>(query: IQuery | undefined, data: T[]) : T[] {
     if (!query || !hasFieldConditions(query.fields)) {
         return data;
     }

--- a/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/realm/repository.ts
@@ -12,7 +12,7 @@ import { InternalError } from '@authup/errors';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import { buildRedisKeyPath } from '@authup/server-kit';
 import type { IRealmRepository } from '../../../../../core/index.ts';
@@ -53,10 +53,10 @@ export class RealmRepositoryAdapter implements IRealmRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/role-attribute/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role-attribute/repository.ts
@@ -9,7 +9,7 @@ import type { RoleAttribute } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRoleAttributeRepository } from '../../../../../core/index.ts';
 import { RoleAttributeEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -30,10 +30,10 @@ export class RoleAttributeRepositoryAdapter implements IRoleAttributeRepository 
 
         applyRealmScopeSelect(qb, 'roleAttribute');
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/role-permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role-permission/repository.ts
@@ -9,7 +9,7 @@ import type { RolePermission } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRolePermissionRepository } from '../../../../../core/index.ts';
 import { RolePermissionEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class RolePermissionRepositoryAdapter implements IRolePermissionRepositor
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/role/repository.ts
@@ -11,7 +11,7 @@ import type { PermissionPolicyBinding } from '@authup/access';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRealmRepository, IRoleRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -45,10 +45,10 @@ export class RoleRepositoryAdapter implements IRoleRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/scope/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRealmRepository, IScopeRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -39,10 +39,10 @@ export class ScopeRepositoryAdapter implements IScopeRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/trust-anchor/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/trust-anchor/repository.ts
@@ -11,7 +11,7 @@ import { isUUID } from '@authup/kit';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { DataSource, FindOptionsWhere, Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import { DatabaseConflictError, RealmEntity, TrustAnchorEntity } from '../../../../../adapters/database/index.ts';
 import type { IRealmRepository, ITrustAnchorRepository } from '../../../../../core/index.ts';
 import { applyRealmScopeSelect, isEntityUnique, translateWhereConditions } from '../helpers.ts';
@@ -39,10 +39,10 @@ export class TrustAnchorRepositoryAdapter implements ITrustAnchorRepository {
 
         applyRealmScopeSelect(qb, 'trustAnchor');
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-attribute/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-attribute/repository.ts
@@ -9,7 +9,7 @@ import type { UserAttribute } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IUserAttributeRepository } from '../../../../../core/index.ts';
 import { UserAttributeEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -30,10 +30,10 @@ export class UserAttributeRepositoryAdapter implements IUserAttributeRepository 
 
         applyRealmScopeSelect(qb, 'userAttribute', ['userId']);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-authenticator/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-authenticator/repository.ts
@@ -8,7 +8,7 @@
 import type { UserAuthenticator, UserAuthenticatorKind } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type {
     IUserAuthenticatorRepository,
@@ -94,10 +94,10 @@ export class UserAuthenticatorRepositoryAdapter implements IUserAuthenticatorRep
             qb.andWhere('userAuthenticator.userId = :ownerUserId', { ownerUserId: options.owner.userId });
         }
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-permission/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-permission/repository.ts
@@ -9,7 +9,7 @@ import type { UserPermission } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IUserPermissionRepository } from '../../../../../core/index.ts';
 import { UserPermissionEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class UserPermissionRepositoryAdapter implements IUserPermissionRepositor
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user-role/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user-role/repository.ts
@@ -9,7 +9,7 @@ import type { UserRole } from '@authup/core-kit';
 import type { IQuery } from '@rapiq/core';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IUserRoleRepository } from '../../../../../core/index.ts';
 import { UserRoleEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -28,10 +28,10 @@ export class UserRoleRepositoryAdapter implements IUserRoleRepository {
 
         const { pagination } = applyQuery(qb, query);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/database/repositories/user/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/user/repository.ts
@@ -12,7 +12,7 @@ import { buildRedisKeyPath } from '@authup/server-kit';
 import { isUUID } from '@authup/kit';
 import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
-import { applyQuery, redactFieldConditions } from '../query.ts';
+import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { IRealmRepository, IUserRepository } from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
@@ -59,12 +59,12 @@ export class UserRepositoryAdapter implements IUserRepository {
 
         applyRealmScopeSelect(qb, 'user', ['id']);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         await this.repository.extendManyWithEA(entities);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/oauth2/repositories/consent/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/consent/repository.ts
@@ -11,7 +11,7 @@ import { IdentityType  } from '@authup/core-kit';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import { buildRedisKeyPath } from '@authup/server-kit';
 import type { DataSource, Repository } from 'typeorm';
-import { applyQuery, redactFieldConditions } from '../../../database/repositories/query.ts';
+import { applyQuery, fetchMany } from '../../../database/repositories/query.ts';
 import { CachePrefix, ConsentEntity } from '../../../../../adapters/database/domains/index.ts';
 import { isUniqueConstraintDatabaseError } from '../../../../../adapters/database/errors/index.ts';
 import type {
@@ -69,10 +69,10 @@ export class ConsentRepositoryAdapter implements IConsentRepository {
             qb.andWhere('consent.realmId = :realmId', { realmId: options.realmId });
         }
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
+++ b/apps/server-core/src/app/modules/oauth2/repositories/session-token/repository.ts
@@ -10,7 +10,7 @@ import type { IQuery } from '@rapiq/core';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
 import type { DataSource, Repository, SelectQueryBuilder } from 'typeorm';
 import { In, LessThan } from 'typeorm';
-import { applyQuery, redactFieldConditions } from '../../../database/repositories/query.ts';
+import { applyQuery, fetchMany } from '../../../database/repositories/query.ts';
 import { deleteInBatches, resolveSweepBatchSize } from '../../../database/repositories/helpers.ts';
 import { SessionTokenEntity } from '../../../../../adapters/database/domains/index.ts';
 import { isForeignKeyConstraintDatabaseError } from '../../../../../adapters/database/errors/index.ts';
@@ -179,10 +179,10 @@ export class SessionTokenRepositoryAdapter implements ISessionTokenRepository {
         this.joinSessionForGate(qb);
         this.joinClientSummary(qb);
 
-        const [entities, total] = await qb.getManyAndCount();
+        const { data: entities, total } = await fetchMany(qb, query);
 
         return {
-            data: redactFieldConditions(query, entities),
+            data: entities,
             meta: {
                 total,
                 ...pagination,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,6 +25,16 @@ export default eslintConfig(
         },
     },
     {
+        files: ['apps/server-core/src/app/modules/**/repositories/**/*.ts'],
+        ignores: ['apps/server-core/src/app/modules/database/repositories/query.ts'],
+        rules: {
+            'no-restricted-properties': ['error', {
+                property: 'getManyAndCount',
+                message: 'Read collections through fetchMany (app/modules/database/repositories/query.ts): it enforces the field visibility conditions, a bare getManyAndCount ships the gated columns (#3329).',
+            }],
+        },
+    },
+    {
         files: ['**/*.vue'],
         languageOptions: { globals: { NodeJS: 'readonly' } },
     },


### PR DESCRIPTION
Closes #3329.

## Summary

Option 1 from the issue, with the lint rule as the guard that makes it structural rather than the next convention.

- `fetchMany(qb, query)` in `app/modules/database/repositories/query.ts` executes a builder `applyQuery` prepared and returns the rows with the field visibility conditions enforced, plus the total. `redactFieldConditions` is module-private now, so `fetchMany` is the only exported way to obtain a collection from that module.
- All 26 `findMany` adapters (the 23 under `database/repositories`, plus session, consent and session-token) read through it. Each lost its own `getManyAndCount` and its own redaction call; nothing else about them changed, and post-processing that adds to the rows (the extra-attribute extension on user and policy) keeps running after the fetch, since the redaction touches gated columns alone.
- The root eslint config refuses a bare `getManyAndCount` under every `apps/server-core/src/app/modules/**/repositories/**` path except `query.ts`, with a message naming `fetchMany`. `lint Packages` runs in CI, so a future adapter that fetches around the redaction fails the build rather than shipping the gated value. `getMany()` is deliberately not restricted: its eight call sites are the unpaginated internal reads (`findAllByQuery`, `findByClientId` and siblings) that return rows to services, not to a projection.
- `.agents/architecture.md` (*Query IR flow → Field authorization*) now describes the structural rule instead of the sweep.

## Verification

- The lint rule was checked negatively: a probe file with a bare `getManyAndCount` under a repositories directory fails `eslint` with the rule's message, and `query.ts` itself passes.
- Full server-core sqlite suite, `check:types` and `eslint` over the three repository directories green.
