### PR TITLE
feat(server-core): encrypt identity-provider secrets at rest

### DIFF
--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -6548,10 +6548,17 @@ must be visible in `auth_events`). The table was folded into migration
   the LDAP bind `password`) inside `saveWithEA` and decrypts them after
   every extra-attribute extension, so the protocol factories and the
   admin form see plaintext while `auth_identity_provider_attributes`
-  holds blobs. A legacy plaintext passes through a read untouched and is
-  encrypted by the next save; a blob the cipher cannot open (unknown,
-  disabled or foreign key) is DROPPED from the entity, so a login through
-  that provider fails closed instead of presenting ciphertext upstream.
+  holds blobs. The write side never sniffs its input, the plan-105
+  `protect()` rule: every value a caller writes is encrypted, a secret
+  that starts with `v1.` included, because a read reveals and so nothing
+  legitimately echoes a blob back, and keeping a prefix-matched value raw
+  would let a caller bypass the encryption while a genuine `v1.` secret
+  could never round-trip (stored raw, dropped by the next read). The
+  prefix stays the discriminator on the READ side only: a legacy plaintext
+  passes through a read untouched and is encrypted by the next save; a
+  blob the cipher cannot open (malformed, unknown, disabled or foreign
+  key) is DROPPED from the entity, so a login through that provider fails
+  closed instead of presenting ciphertext upstream.
   The adapter is registered under `IdentityInjectionKey.ProviderRepository`
   as a lazy factory, because the identity module is set up before the
   oauth2 module that registers the cipher; `countBlobReferences` counts

--- a/.agents/architecture.md
+++ b/.agents/architecture.md
@@ -6540,12 +6540,24 @@ must be visible in `auth_events`). The table was folded into migration
   both methods — shape-aligned with `ISymmetricCipher.encrypt(plain)` plus a
   scope argument; every consumer knows its entity's realm, so a skippable
   assert would only invite forgetting it). Two consumers today: the MFA
-  seed cipher (`UserAuthenticatorService` ctx) and, since plan 105, client
+  seed cipher (`UserAuthenticatorService` ctx), since plan 105 client
   secrets in encrypted mode (`secretEncrypted`, see *Client secret storage
-  and rotation*), both resolving the one instance registered under
-  `OAuth2InjectionToken.RealmCipher`; plan 070 Stage 2 adds the IdP
-  `clientSecret` and the LDAP bind password over the same token, blob
-  discriminator and reveal rule.
+  and rotation*), and since plan 070 Stage 2 the identity-provider secrets:
+  `IdentityProviderRepositoryAdapter` encrypts exactly the attribute names
+  in `IDENTITY_PROVIDER_SECRET_ATTRIBUTES` (the OAuth2/OIDC `clientSecret`,
+  the LDAP bind `password`) inside `saveWithEA` and decrypts them after
+  every extra-attribute extension, so the protocol factories and the
+  admin form see plaintext while `auth_identity_provider_attributes`
+  holds blobs. A legacy plaintext passes through a read untouched and is
+  encrypted by the next save; a blob the cipher cannot open (unknown,
+  disabled or foreign key) is DROPPED from the entity, so a login through
+  that provider fails closed instead of presenting ciphertext upstream.
+  The adapter is registered under `IdentityInjectionKey.ProviderRepository`
+  as a lazy factory, because the identity module is set up before the
+  oauth2 module that registers the cipher; `countBlobReferences` counts
+  the attribute rows, so `DELETE /keys/:id` answers 409 while a provider
+  depends on the key. All three consumers resolve the one instance
+  registered under `OAuth2InjectionToken.RealmCipher`.
 - **Optional KEK — config `secretsEncryptionKey` (`SECRETS_ENCRYPTION_KEY`,
   base64 32 bytes, boot-validated when set):** the adapter persists
   `decryptionKey` material (RSA private keys AND oct material — never the

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -208,12 +208,15 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
     }
 
     /**
-     * Encrypt a secret for storage. A value that already is a blob is
-     * kept (a caller echoing what it read), and without a cipher the value
-     * is stored as given, which is the pre-plan-070 behaviour.
+     * Encrypt a secret for storage. The input is never sniffed: every
+     * value a caller writes is a plaintext (a read reveals, so nothing
+     * echoes a blob back), and a secret that happens to start with the
+     * blob prefix must round-trip like any other rather than be stored
+     * raw and dropped by the next read. Without a cipher the value is
+     * stored as given, which is the pre-plan-070 behaviour.
      */
     private async protect(value: string, realmId: string): Promise<string> {
-        if (!this.cipher || isRealmCipherBlob(value)) {
+        if (!this.cipher) {
             return value;
         }
 

--- a/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/identity-provider/repository.ts
@@ -12,7 +12,12 @@ import type { Repository } from 'typeorm';
 import { validateEntityJoinColumns } from 'typeorm-extension';
 import { applyQuery, fetchMany } from '../query.ts';
 import type { EntityRepositoryFindManyResult } from '@authup/server-kit';
-import type { IIdentityProviderRepository, IRealmRepository } from '../../../../../core/index.ts';
+import type { IIdentityProviderRepository, IRealmCipher, IRealmRepository } from '../../../../../core/index.ts';
+import {
+    IDENTITY_PROVIDER_SECRET_ATTRIBUTES,
+    isRealmCipherBlob,
+    isRealmCipherBlobError,
+} from '../../../../../core/index.ts';
 import { DatabaseConflictError } from '../../../../../adapters/database/index.ts';
 import type { IdentityProviderRepository } from '../../../../../adapters/database/domains/index.ts';
 import { IdentityProviderEntity } from '../../../../../adapters/database/domains/index.ts';
@@ -22,6 +27,13 @@ import { RealmRepositoryAdapter } from '../realm/repository.ts';
 export type IdentityProviderRepositoryAdapterContext = {
     repository: IdentityProviderRepository,
     realmRepository: Repository<Realm>,
+    /**
+     * Encrypts the secret-bearing attributes
+     * (`IDENTITY_PROVIDER_SECRET_ATTRIBUTES`) at rest under the provider
+     * realm's encryption key. Without it the adapter writes them as given
+     * and drops a stored blob it cannot decrypt.
+     */
+    cipher?: IRealmCipher,
 };
 
 export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepository {
@@ -29,9 +41,12 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
 
     private readonly realmRepository: IRealmRepository;
 
+    private readonly cipher?: IRealmCipher;
+
     constructor(ctx: IdentityProviderRepositoryAdapterContext) {
         this.repository = ctx.repository;
         this.realmRepository = new RealmRepositoryAdapter(ctx.realmRepository);
+        this.cipher = ctx.cipher;
     }
 
     async findMany(query: IQuery): Promise<EntityRepositoryFindManyResult<IdentityProvider>> {
@@ -54,7 +69,7 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
     async findOneById(id: string): Promise<IdentityProvider | null> {
         const entity = await this.findOneBy({ id });
         if (entity) {
-            await this.repository.extendOneWithEA(entity);
+            await this.extendOneWithEA(entity);
         }
         return entity;
     }
@@ -73,7 +88,7 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
 
         const entity = await qb.getOne();
         if (entity) {
-            await this.repository.extendOneWithEA(entity);
+            await this.extendOneWithEA(entity);
         }
         return entity;
     }
@@ -109,12 +124,43 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
         attributes?: Record<string, any>,
         options?: { keepAll?: boolean },
     ): Promise<IdentityProvider> {
-        await this.repository.saveOneWithEA(entity, attributes, options);
+        const record = entity as unknown as Record<string, unknown>;
+        const stored = attributes ? { ...attributes } : undefined;
+        // the extra-attribute adapter also lifts every non-column property
+        // off the entity into the attribute rows, so a secret that rides
+        // the entity is protected in place and its plaintext put back below
+        const own: Record<string, string> = {};
+
+        for (const name of IDENTITY_PROVIDER_SECRET_ATTRIBUTES) {
+            if (stored && typeof stored[name] === 'string' && stored[name].length > 0) {
+                stored[name] = await this.protect(stored[name], entity.realmId);
+            }
+
+            const value = record[name];
+            if (typeof value === 'string' && value.length > 0) {
+                own[name] = value;
+                record[name] = await this.protect(value, entity.realmId);
+            }
+        }
+
+        await this.repository.saveOneWithEA(entity, stored, options);
+
+        // the adapter hands the stored values back onto the entity; the
+        // caller, and the response built from it, gets the plaintext it gave
+        for (const name of IDENTITY_PROVIDER_SECRET_ATTRIBUTES) {
+            if (attributes && typeof attributes[name] === 'string') {
+                record[name] = attributes[name];
+            } else if (name in own) {
+                record[name] = own[name];
+            }
+        }
+
         return entity;
     }
 
     async extendOneWithEA(entity: IdentityProvider): Promise<void> {
         await this.repository.extendOneWithEA(entity);
+        await this.reveal(entity);
     }
 
     async remove(entity: IdentityProvider): Promise<void> {
@@ -155,6 +201,56 @@ export class IdentityProviderRepositoryAdapter implements IIdentityProviderRepos
 
         const entities = await qb.getMany();
         await this.repository.extendManyWithEA(entities);
+        for (const entity of entities) {
+            await this.reveal(entity);
+        }
         return entities;
+    }
+
+    /**
+     * Encrypt a secret for storage. A value that already is a blob is
+     * kept (a caller echoing what it read), and without a cipher the value
+     * is stored as given, which is the pre-plan-070 behaviour.
+     */
+    private async protect(value: string, realmId: string): Promise<string> {
+        if (!this.cipher || isRealmCipherBlob(value)) {
+            return value;
+        }
+
+        return this.cipher.encrypt(value, realmId);
+    }
+
+    /**
+     * Decrypt the secret-bearing attributes a read extended onto the
+     * entity. A legacy plaintext passes through untouched and is encrypted
+     * by the next save. A blob the cipher cannot open (an unknown, disabled
+     * or foreign key) is dropped: the provider stays readable, the secret is
+     * not recoverable right now, and a login through it fails closed rather
+     * than presenting ciphertext to the upstream.
+     */
+    private async reveal(entity: IdentityProvider): Promise<void> {
+        const record = entity as unknown as Record<string, unknown>;
+
+        for (const name of IDENTITY_PROVIDER_SECRET_ATTRIBUTES) {
+            const value = record[name];
+            if (typeof value !== 'string' || !isRealmCipherBlob(value)) {
+                continue;
+            }
+
+            if (!this.cipher) {
+                Reflect.deleteProperty(record, name);
+                continue;
+            }
+
+            try {
+                record[name] = await this.cipher.decrypt(value, entity.realmId);
+            } catch (e) {
+                if (!isRealmCipherBlobError(e)) {
+                    throw e;
+                }
+
+                Reflect.deleteProperty(record, name);
+            }
+        }
     }
 }

--- a/apps/server-core/src/app/modules/database/repositories/key/repository.ts
+++ b/apps/server-core/src/app/modules/database/repositories/key/repository.ts
@@ -27,6 +27,7 @@ import { getRandomValues } from 'uncrypto';
 import {
     ClientEntity,
     DatabaseConflictError,
+    IdentityProviderAttributeEntity,
     KeyEntity,
     RealmEntity,
     UserAuthenticatorEntity,
@@ -423,15 +424,17 @@ export class KeyRepositoryAdapter implements IKeyRepository, IKeyStore {
     }
 
     async countBlobReferences(keyId: string): Promise<number> {
-        // every consumer of the realm cipher: the MFA seeds and the client
-        // secrets stored in encrypted mode.
+        // every consumer of the realm cipher: the MFA seeds, the client
+        // secrets stored in encrypted mode and the identity-provider
+        // secrets (the OAuth2 client secret, the LDAP bind password).
         const pattern = Like(`${REALM_CIPHER_BLOB_VERSION}.${keyId}.%`);
-        const [authenticators, clients] = await Promise.all([
+        const [authenticators, clients, providerAttributes] = await Promise.all([
             this.dataSource.getRepository(UserAuthenticatorEntity).countBy({ secret: pattern }),
             this.dataSource.getRepository(ClientEntity).countBy({ secret: pattern }),
+            this.dataSource.getRepository(IdentityProviderAttributeEntity).countBy({ value: pattern }),
         ]);
 
-        return authenticators + clients;
+        return authenticators + clients + providerAttributes;
     }
 
     async findHighestPriority(realmId: string, use: string): Promise<number | null> {

--- a/apps/server-core/src/app/modules/http/modules/controller.ts
+++ b/apps/server-core/src/app/modules/http/modules/controller.ts
@@ -30,7 +30,6 @@ import {
     ClientPermissionEntity,
     ClientRoleEntity,
     ClientScopeEntity,
-    IdentityProviderRepository,
     IdentityProviderRoleMappingEntity,
     KeyEntity,
     PermissionEntity,
@@ -55,7 +54,6 @@ import {
     ClientScopeRepositoryAdapter,
     DatabaseInjectionKey,
     IdentityProviderAccountRepositoryAdapter,
-    IdentityProviderRepositoryAdapter,
     IdentityProviderRoleMappingRepositoryAdapter,
     PermissionDatabaseProvider,
     PermissionPolicyRepositoryAdapter,
@@ -549,7 +547,6 @@ export class HTTPControllerModule {
 
     createIdentityProvider(container: IContainer) {
         const config = container.resolve(ConfigInjectionKey);
-        const dataSource = container.resolve(DatabaseInjectionKey.DataSource);
 
         const accountManager = container.resolve(IdentityInjectionKey.ProviderAccountManager);
         const linkStore = container.resolve(IdentityInjectionKey.ProviderAccountLinkStore);
@@ -560,10 +557,7 @@ export class HTTPControllerModule {
 
         const realmRepository = container.resolve<Repository<Realm>>(RealmEntity);
 
-        const repository = new IdentityProviderRepositoryAdapter({
-            repository: new IdentityProviderRepository(dataSource),
-            realmRepository,
-        });
+        const repository = container.resolve(IdentityInjectionKey.ProviderRepository);
 
         const logger = container.resolve(LoggerInjectionKey);
         const eventService = container.resolve(DatabaseInjectionKey.EventService);

--- a/apps/server-core/src/app/modules/identity/constants.ts
+++ b/apps/server-core/src/app/modules/identity/constants.ts
@@ -10,6 +10,7 @@ import type {
     IIdentityPermissionProvider,
     IIdentityProviderAccountLinkStore,
     IIdentityProviderAccountManager,
+    IIdentityProviderRepository,
     IIdentityResolver,
     IIdentityRoleProvider,
     IdentityProviderLdapCollectionAuthenticator,
@@ -22,4 +23,5 @@ export const IdentityInjectionKey = {
     ProviderAccountManager: new TypedToken<IIdentityProviderAccountManager>('AccountManager'),
     ProviderAccountLinkStore: new TypedToken<IIdentityProviderAccountLinkStore>('ProviderAccountLinkStore'),
     ProviderLdapCollectionAuthenticator: new TypedToken<IdentityProviderLdapCollectionAuthenticator>('ProviderLdapCollectionAuthenticator'),
+    ProviderRepository: new TypedToken<IIdentityProviderRepository>('ProviderRepository'),
 } as const;

--- a/apps/server-core/src/app/modules/identity/module.ts
+++ b/apps/server-core/src/app/modules/identity/module.ts
@@ -52,6 +52,7 @@ import {
     IdentityRoleProvider,
 } from '../../../core/index.ts';
 import { LDAPInjectionKey } from '../ldap/index.ts';
+import { OAuth2InjectionToken } from '../oauth2/constants.ts';
 import { LoggerInjectionKey } from '../logger/index.ts';
 import { CacheInjectionKey } from '../cache/index.ts';
 
@@ -156,13 +157,21 @@ export class IdentityModule implements IModule {
 
         // ---------------------------------------------
 
-        const identityProviderRepository = new IdentityProviderRepositoryAdapter({
-            repository: new IdentityProviderRepository(dataSource),
-            realmRepository: container.resolve<Repository<Realm>>(RealmEntity),
+        // Resolved lazily: the realm cipher that protects the provider
+        // secrets at rest is registered by the oauth2 module, which is set
+        // up after this one, so it can only be looked up on first use.
+        container.register(IdentityInjectionKey.ProviderRepository, {
+            useFactory: (c) => new IdentityProviderRepositoryAdapter({
+                repository: new IdentityProviderRepository(dataSource),
+                realmRepository: c.resolve<Repository<Realm>>(RealmEntity),
+                cipher: c.has(OAuth2InjectionToken.RealmCipher) ?
+                    c.resolve(OAuth2InjectionToken.RealmCipher) :
+                    undefined,
+            }),
         });
         container.register(IdentityInjectionKey.ProviderLdapCollectionAuthenticator, {
             useFactory: (c) => new IdentityProviderLdapCollectionAuthenticator({
-                repository: identityProviderRepository,
+                repository: c.resolve(IdentityInjectionKey.ProviderRepository),
                 accountManager: c.resolve(IdentityInjectionKey.ProviderAccountManager),
                 clientFactory: c.resolve(LDAPInjectionKey.ClientFactory),
             }),

--- a/apps/server-core/src/core/identity/provider/constants.ts
+++ b/apps/server-core/src/core/identity/provider/constants.ts
@@ -9,3 +9,12 @@ export enum IdentityProviderIdentityOperation {
     CREATE = 'create',
     UPDATE = 'update',
 }
+
+/**
+ * The attribute names that carry a secret authup presents to the provider:
+ * the OAuth2/OIDC client secret and the LDAP bind password. The repository
+ * adapter encrypts exactly these at rest under the provider realm's
+ * encryption key (plan 070 Stage 2); every other attribute is stored as
+ * written.
+ */
+export const IDENTITY_PROVIDER_SECRET_ATTRIBUTES = ['clientSecret', 'password'] as const;

--- a/apps/server-core/src/core/identity/provider/index.ts
+++ b/apps/server-core/src/core/identity/provider/index.ts
@@ -6,6 +6,7 @@
  */
 
 export * from './account/index.ts';
+export * from './constants.ts';
 export * from './authentication/index.ts';
 export * from './mapper/index.ts';
 export * from './types.ts';

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/secrets.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/secrets.spec.ts
@@ -107,6 +107,31 @@ describe('src/http/controllers/identity-provider (secrets at rest)', () => {
         expect((reread as OAuth2IdentityProvider).clientSecret).toEqual('legacy-plain');
     });
 
+    it('encrypts a secret that starts with the blob prefix instead of trusting it', async () => {
+        // the adapter never sniffs its input: a caller cannot write a raw
+        // value by prefixing it, and an upstream secret that genuinely
+        // starts with `v1.` round-trips like any other
+        const oauth2 = createFakeOAuth2IdentityProvider({ clientSecret: 'v1.looks-like-a-blob' });
+        const { data: created } = await suite.client.identityProvider.create(oauth2);
+
+        const value = await stored(created.id, 'clientSecret');
+        expect(value).not.toEqual(oauth2.clientSecret);
+        expect(isRealmCipherBlob(value!)).toBe(true);
+
+        const { data: read } = await suite.client.identityProvider.getOne(created.id);
+        expect((read as OAuth2IdentityProvider).clientSecret).toEqual('v1.looks-like-a-blob');
+
+        const ldap = createFakeLdapIdentityProvider({ password: 'v1.key.payload' });
+        const { data: createdLdap } = await suite.client.identityProvider.create(ldap);
+
+        const password = await stored(createdLdap.id, 'password');
+        expect(password).not.toEqual(ldap.password);
+        expect(isRealmCipherBlob(password!)).toBe(true);
+
+        const { data: readLdap } = await suite.client.identityProvider.getOne(createdLdap.id);
+        expect((readLdap as LdapIdentityProvider).password).toEqual('v1.key.payload');
+    });
+
     it('stores the LDAP bind password as a blob and answers the plaintext', async () => {
         const input = createFakeLdapIdentityProvider();
         const { data: created } = await suite.client.identityProvider.create(input);

--- a/apps/server-core/test/unit/http/controllers/entities/identity-provider/secrets.spec.ts
+++ b/apps/server-core/test/unit/http/controllers/entities/identity-provider/secrets.spec.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2026.
+ * Author Peter Placzek (tada5hi)
+ * For the full copyright and license information,
+ * view the LICENSE file that was distributed with this source code.
+ */
+
+import type { LdapIdentityProvider, OAuth2IdentityProvider } from '@authup/core-kit';
+import { KeyStatus } from '@authup/core-kit';
+import type { DataSource } from 'typeorm';
+import {
+    afterAll,
+    beforeAll,
+    describe,
+    expect,
+    it,
+} from 'vitest';
+import { IdentityProviderAttributeEntity } from '../../../../../../src/adapters/database/index.ts';
+import { DatabaseInjectionKey } from '../../../../../../src/app/modules/database/index.ts';
+import { isRealmCipherBlob } from '../../../../../../src/core/index.ts';
+import { createTestApplication } from '../../../../../app';
+import {
+    createFakeLdapIdentityProvider,
+    createFakeOAuth2IdentityProvider,
+    expectClientError,
+} from '../../../../../utils';
+
+const suite = createTestApplication();
+
+describe('src/http/controllers/identity-provider (secrets at rest)', () => {
+    let dataSource: DataSource;
+
+    beforeAll(async () => {
+        await suite.setup();
+
+        dataSource = suite.container.resolve(DatabaseInjectionKey.DataSource);
+    });
+
+    afterAll(async () => {
+        await suite.teardown();
+    });
+
+    async function stored(providerId: string, name: string): Promise<string | null> {
+        const row = await dataSource
+            .getRepository(IdentityProviderAttributeEntity)
+            .findOneByOrFail({ providerId, name });
+
+        return row.value;
+    }
+
+    it('stores the OAuth2 client secret as a realm cipher blob and answers the plaintext', async () => {
+        const input = createFakeOAuth2IdentityProvider();
+        const { data: created } = await suite.client.identityProvider.create(input);
+
+        // the write answers what it was given, never the blob
+        expect((created as OAuth2IdentityProvider).clientSecret).toEqual(input.clientSecret);
+
+        const value = await stored(created.id, 'clientSecret');
+        expect(value).not.toEqual(input.clientSecret);
+        expect(isRealmCipherBlob(value!)).toBe(true);
+
+        const { data: read } = await suite.client.identityProvider.getOne(created.id);
+        expect((read as OAuth2IdentityProvider).clientSecret).toEqual(input.clientSecret);
+    });
+
+    it('re-encrypts a rotated secret and keeps an untouched one readable across a partial update', async () => {
+        const input = createFakeOAuth2IdentityProvider();
+        const { data: created } = await suite.client.identityProvider.create(input);
+        const before = await stored(created.id, 'clientSecret');
+
+        await suite.client.identityProvider.update(created.id, { ...input, clientSecret: 'rotated-secret' });
+        const rotated = await stored(created.id, 'clientSecret');
+        expect(rotated).not.toEqual(before);
+        expect(isRealmCipherBlob(rotated!)).toBe(true);
+
+        // a partial update that says nothing about the secret leaves the blob
+        // as it is (keepAll), and the read still decrypts it
+        await suite.client.identityProvider.update(created.id, {
+            ...input, 
+            clientSecret: undefined, 
+            displayName: 'renamed', 
+        });
+        expect(await stored(created.id, 'clientSecret')).toEqual(rotated);
+
+        const { data: read } = await suite.client.identityProvider.getOne(created.id);
+        expect((read as OAuth2IdentityProvider).clientSecret).toEqual('rotated-secret');
+    });
+
+    it('passes a legacy plaintext through and encrypts it on the next save', async () => {
+        const input = createFakeOAuth2IdentityProvider();
+        const { data: created } = await suite.client.identityProvider.create(input);
+
+        // a row written by a release before the secrets were encrypted
+        await dataSource
+            .getRepository(IdentityProviderAttributeEntity)
+            .update({ providerId: created.id, name: 'clientSecret' }, { value: 'legacy-plain' });
+
+        const { data: read } = await suite.client.identityProvider.getOne(created.id);
+        expect((read as OAuth2IdentityProvider).clientSecret).toEqual('legacy-plain');
+
+        await suite.client.identityProvider.update(created.id, { ...input, clientSecret: 'legacy-plain' });
+        const value = await stored(created.id, 'clientSecret');
+        expect(value).not.toEqual('legacy-plain');
+        expect(isRealmCipherBlob(value!)).toBe(true);
+
+        const { data: reread } = await suite.client.identityProvider.getOne(created.id);
+        expect((reread as OAuth2IdentityProvider).clientSecret).toEqual('legacy-plain');
+    });
+
+    it('stores the LDAP bind password as a blob and answers the plaintext', async () => {
+        const input = createFakeLdapIdentityProvider();
+        const { data: created } = await suite.client.identityProvider.create(input);
+
+        const value = await stored(created.id, 'password');
+        expect(value).not.toEqual(input.password);
+        expect(isRealmCipherBlob(value!)).toBe(true);
+
+        const { data: read } = await suite.client.identityProvider.getOne(created.id);
+        expect((read as LdapIdentityProvider).password).toEqual(input.password);
+    });
+
+    it('binds the secret to the realm encryption key\'s lifecycle', async () => {
+        const input = createFakeOAuth2IdentityProvider();
+        const { data: created } = await suite.client.identityProvider.create(input);
+
+        // the blob names the key it was encrypted under: v1.<key_id>.<payload>
+        const keyId = (await stored(created.id, 'clientSecret'))!.split('.')[1];
+
+        // a provider secret is a live reference, like an MFA seed or an
+        // encrypted client secret
+        await expectClientError(
+            () => suite.client.key.delete(keyId),
+            { status: 409 },
+        );
+
+        // disabled: the provider stays readable, the secret is withheld
+        await suite.client.key.update(keyId, { status: KeyStatus.DISABLED });
+        const { data: withheld } = await suite.client.identityProvider.getOne(created.id);
+        expect(withheld.id).toEqual(created.id);
+        expect((withheld as OAuth2IdentityProvider).clientSecret).toBeUndefined();
+
+        // re-enabled: recoverable again, the blob was never touched
+        await suite.client.key.update(keyId, { status: KeyStatus.ACTIVE });
+        const { data: recovered } = await suite.client.identityProvider.getOne(created.id);
+        expect((recovered as OAuth2IdentityProvider).clientSecret).toEqual(input.clientSecret);
+
+        // crypto-shredded: the provider survives, its secret does not
+        await suite.client.key.delete(keyId, { force: true });
+        const { data: shredded } = await suite.client.identityProvider.getOne(created.id);
+        expect((shredded as OAuth2IdentityProvider).clientSecret).toBeUndefined();
+    });
+});

--- a/docs/src/guide/deployment/configuration-server-core.md
+++ b/docs/src/guide/deployment/configuration-server-core.md
@@ -509,8 +509,9 @@ export default {
          * Optional base64-encoded 32-byte key (AES-256-GCM) wrapping the
          * realm key store's material at rest — the per-realm JWT signing
          * private keys and the auto-generated per-realm encryption keys
-         * that protect MFA seeds and client secrets stored in encrypted
-         * mode. Without it those values are encrypted under a key that
+         * that protect MFA seeds, client secrets stored in encrypted
+         * mode and identity-provider secrets (the OAuth2 client secret,
+         * the LDAP bind password). Without it those values are encrypted under a key that
          * sits unwrapped in the same database. Generate one with:
          * openssl rand -base64 32
          * or:

--- a/docs/src/guide/deployment/upgrading.md
+++ b/docs/src/guide/deployment/upgrading.md
@@ -7,6 +7,28 @@ either requires operator action or deliberately changes behavior.
 
 ## Next release (after v1.0.0-beta.64)
 
+### Identity-provider secrets are encrypted at rest
+
+The OAuth2/OIDC `clientSecret` and the LDAP bind `password` of an identity
+provider are stored as cipher blobs under the provider realm's encryption key,
+the automatically generated per-realm key that already protects MFA seeds and
+client secrets in encrypted mode. Nothing changes on the API: a reader whose
+permissions cover the provider (`GET /identity-providers/:id`) gets the
+plaintext back, the login and link flows present it to the upstream as before,
+and the admin console's edit form is unaffected.
+
+A provider saved before this release keeps its plaintext until it is next
+saved; the value is encrypted on that save, whether the secret changed or not.
+To finish the migration, open and save each OAuth2, OIDC and LDAP provider
+once, or update it through the API.
+
+The secret is tied to the key's lifecycle: while the realm's encryption key is
+disabled, a login through the provider fails (the secret is not recoverable),
+and `DELETE /keys/:id` answers `409` while provider secrets reference the key,
+as it already does for client secrets and MFA seeds; `force` destroys them and
+the providers need a new secret. Set `secretsEncryptionKey`
+(`SECRETS_ENCRYPTION_KEY`) so the realm key itself is wrapped at rest.
+
 ### A hashed client secret is read-gated like a plaintext one
 
 A reader projecting `secret` (`?fields=+secret` on `/clients`, or

--- a/docs/src/guide/development/api-oauth2.md
+++ b/docs/src/guide/development/api-oauth2.md
@@ -51,7 +51,8 @@ decrypted secret back on any read that projects the field
 `plain` secret; a read never returns the ciphertext. The secret is tied to that key's lifecycle:
 while the key is disabled such clients cannot authenticate, and deleting the
 key destroys their secrets, so `DELETE /keys/:id` answers `409` while client
-secrets reference it and needs `force` to proceed. Set `secretsEncryptionKey`
+secrets (or identity-provider secrets, which the same key protects) reference
+it and needs `force` to proceed. Set `secretsEncryptionKey`
 (`SECRETS_ENCRYPTION_KEY`, see the
 [server configuration](../deployment/configuration-server-core.md)) so the
 realm key itself is wrapped at rest. Declaring `secretHashed` and


### PR DESCRIPTION
Plan 070 Stage 2, the last of the realm-cipher consumers.

## Summary

- The OAuth2/OIDC `clientSecret` and the LDAP bind `password` of an identity provider are stored as realm cipher blobs (`v1.<key_id>.<payload>`) under the provider realm's encryption key, the same auto-generated per-realm key that protects MFA seeds and client secrets in encrypted mode. Exactly these two attribute names (`IDENTITY_PROVIDER_SECRET_ATTRIBUTES`) are affected; every other attribute is stored as written.
- `IdentityProviderRepositoryAdapter` is the one choke point: no API writes provider attributes directly, so `saveWithEA` encrypts on a copy (and any secret riding the entity in place, since the extra-attribute adapter lifts non-column properties into the rows too) and puts the plaintext back on the returned entity, so the write's response and the admin form never see a blob; every extra-attribute extension (`findOneById`, `findOneByName`, `extendOneWithEA`, `findByProtocol`) decrypts afterwards, so the protocol factories and the account manager are untouched. A legacy plaintext passes through a read and is encrypted by the next save (no migration; the blob prefix is the discriminator, as for client secrets). A blob the cipher cannot open (unknown, disabled or foreign key) is dropped from the entity, so a login through that provider fails closed rather than presenting ciphertext upstream.
- The adapter moved behind `IdentityInjectionKey.ProviderRepository` as a lazy factory: the identity module is set up before the oauth2 module that registers `OAuth2InjectionToken.RealmCipher`, so the cipher can only be resolved on first use. The controller factory and the LDAP collection authenticator both resolve the token; the duplicate construction in the controller factory is gone.
- `KeyRepositoryAdapter.countBlobReferences` counts provider attribute blobs, so `DELETE /keys/:id` answers `409` while a provider depends on the key and `force` crypto-shreds the secret like an MFA seed.
- Read surface unchanged, per the plan's leaning and the plan-105 precedent: a reader the #3480 gate admits gets the plaintext back on `GET /identity-providers/:id`; masking would break the console's edit form for a reader who could rotate the value anyway.
- Docs: `upgrading.md` (what changes, the lazy re-encrypt and how to finish it, the key-lifecycle coupling), `configuration-server-core.md` and `api-oauth2.md` (the KEK and the 409 now cover provider secrets), `architecture.md` (Realm Key Store consumers).

## Verification

- New `test/unit/http/controllers/entities/identity-provider/secrets.spec.ts`: the OAuth2 secret and the LDAP password are stored as blobs and answered as plaintext on create and read; a rotation re-encrypts and a partial update that omits the secret keeps the blob and still decrypts; a legacy plaintext row passes through and is encrypted by the next save; the realm key's lifecycle binds the secret (delete answers 409, disabled withholds it, re-enabled recovers it, `force` shreds it).
- The provider CRUD, account-link, cookie-login, federated authorize-grant, account-manager and key specs pass unchanged, so the encrypted secret reaches the fake upstream exactly as the plaintext did.
- Full server-core sqlite suite, `check:types`, lint and the docs build green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * OAuth2/OIDC client secrets and LDAP passwords are now encrypted at rest.
  * Existing plaintext provider secrets remain readable and are encrypted when the provider is next saved.
  * Disabled or deleted encryption keys prevent provider authentication and may block key deletion while secrets remain referenced.

* **Documentation**
  * Updated configuration, upgrade, and API guidance to explain identity-provider secret encryption and migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->